### PR TITLE
chore(ci): widen check job matrix to node 20, lts, and current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22]
+        node: [20, "lts/*", "current"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What & why

Widens the `check` job's Node matrix in `.github/workflows/ci.yml` from the pinned `[20, 22]` to `[20, "lts/*", "current"]`, so CI exercises the floor-supported Node version plus whichever versions currently resolve as Active LTS and newest release line — without needing a manual matrix bump on every future Node release.

This deviates from issue #4's literal acceptance criteria, which asked to keep `20` and `22` pinned and add `24`/`26` explicitly. That tradeoff (floating aliases over pinned versions, dropping explicit `22` coverage) was discussed and explicitly chosen by the repo owner over the issue's original ask.

Closes #4

## Public API impact

None. Tooling-only change (`.github/workflows/ci.yml`); no package source touched, no barrel export changed.

## Testing

No test changes — this is CI configuration, not application behavior, so there's no unit/integration surface to add coverage to. Verified locally:

```
pnpm check
```

passes clean: build ✓, depcruise (131 modules, 485 dependencies, 0 violations) ✓, 437/437 tests ✓ (run on the sandbox's installed Node v26.5.0/v20, depending on run).

The actual proof of the matrix change (that `lts/*` and `current` resolve and pass in the real GitHub Actions environment) can only be confirmed by this PR's own CI run.

## Review notes

`/review` ran with `crudo-reviewer`, `crudo-boundary-guard`, and `crudo-test-auditor` in parallel. No blocking findings. Two non-blocking notes left open, worth a look before merge:

1. `lts/*`/`current` are floating aliases, so the effective matrix is time-dependent and will silently advance on future Node LTS releases with no corresponding commit — worth a one-line comment in the workflow explaining this was a deliberate choice, so a future reader doesn't "fix" it back to pinned versions.
2. Confirm the actual CI run on this PR shows three green `check` legs (20, lts/*, current) before merging — that's the only way to verify the alias resolution works as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)