### PR TITLE
chore(ci): track relative LTS aliases instead of a pinned Node major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, "lts/*", "current"]
+        # Relative LTS aliases rather than a hardcoded major: this matrix
+        # tracks "current LTS and the two before it" and shifts forward on
+        # every Node LTS transition automatically, so it never drifts onto
+        # an unsupported major the way a pinned literal (previously `20`)
+        # eventually does.
+        node: ["lts/-2", "lts/-1", "lts/*", "current"]
 
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +54,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
> **Draft** — one acceptance criterion is genuinely still open (see Review notes): `engines.node` needs the resolved Node versions from this PR's own CI run before it can be reconciled or explicitly left alone. Mark ready once that's checked.

## What & why

The `check` job's matrix pinned `node: [20, "lts/*", "current"]`. A hardcoded literal never advances as Node's LTS line moves forward, so it eventually tests a major that's fallen out of both LTS and upstream support — `20` and `lts/*` were already close to redundant.

Revised during planning from the issue's original proposal (drop to exactly `["lts/*", "current"]`): narrowing to two legs would have traded the redundancy for CI time, but a literal `20` was never really the fix. Replaces it with `lts/-2` and `lts/-1` instead, so the matrix tracks "current LTS and the two before it" and shifts forward automatically on every Node LTS transition — no future manual edit needed. The `format` job's `setup-node` step moves off its own hardcoded `node-version: 20` to `node-version: lts/*`, matching the check matrix.

Closes #9

## Public API impact

None. CI configuration only — no `packages/*/src`, barrel, or `package.json` `exports`/`engines` field a consumer depends on is touched. Not breaking.

## Testing

No test file needed adding or changing: this is a config-only diff with no testable behavior in `packages/*`, confirmed by searching for any `process.version` check or Node-major-gated test logic (none exists in the repo).

`pnpm check` — **green**: `tsc -b`, `pnpm typecheck` (4 projects), `depcruise` (139 modules, 506 deps, 0 violations), `vitest run` **445/445** across 21 files.

## Review notes

`/review` ran full three-reviewer fan-out; verdict was **no blocking findings**, confirmed independently by all three (one pulled `actions/setup-node`'s actual source to verify `lts/-n` syntax is real, not assumed — implemented via `resolveLtsAliasFromManifest`/`isLtsAlias`, just under-documented in the action's own README relative to `lts/*`).

**Still open, the reason this is a draft:** `package.json`'s `engines.node` (`>=20`) was deliberately left unchanged — issue #9's third acceptance criterion requires checking what `lts/-2` actually resolves to in the pushed Actions run before reconciling it, not guessing locally. Reviewers estimated `lts/-2` currently resolves to Node 20 given today's LTS lineage, which would make `>=20` exactly the matrix floor — but that can only be confirmed against the live `node-versions` manifest at CI runtime. Check the resolved versions in this PR's own Actions run before marking ready; if `>=20` no longer matches the floor, that's a follow-up commit here, not a separate issue.

**Non-blocking, left as-is:** the aliases are relative and the floor is fixed, so at the next Node LTS transition (~Oct 2026 per the current schedule) the matrix advances and Node 20 drops out of CI while `engines.node` would still claim `>=20` supported — untested without any accompanying signal. Not urgent since `@crudo/*` packages aren't published yet (roadmap), so no live consumer is misled today. Worth a comment next to `engines.node` at some point noting it should move in lockstep with the matrix, or revisiting at each LTS transition — not gating this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
