### PR TITLE
Add a Tag entity with a many-to-many relation to Pet

### DIFF
--- a/packages/docs/architecture/12-relations-and-includes.md
+++ b/packages/docs/architecture/12-relations-and-includes.md
@@ -83,6 +83,13 @@ and share `FilterTranslator`'s scheme, so `filter[blog.name][eq]=…`
 alongside `include=blog` reuses the one selecting join instead of adding a
 second, non-selecting one under a duplicate alias.
 
+A many-to-many edge is nothing special here: metadata maps
+`isManyToMany` to cardinality `"many"` exactly like `isOneToMany`, so it
+gets the same `batch` default and the same distinct-roots pagination
+guarantee — the join table never reaches the main query. `Pet.tags` (the
+example app) is what first exercises this path; no adapter or core change
+was needed to support it.
+
 ## 4. Interplay
 
 - **Sparse fieldsets:** keys needed for stitching are always fetched and

--- a/packages/examples/src/app.module.ts
+++ b/packages/examples/src/app.module.ts
@@ -6,6 +6,7 @@ import { DATA_SOURCE, DatabaseModule } from "./database.module.js";
 import { OwnerController } from "./owner/owner.controller.js";
 import { CatController } from "./cat/cat.controller.js";
 import { DogController } from "./dog/dog.controller.js";
+import { TagController } from "./tag/tag.controller.js";
 
 /**
  * Reference wiring: the app hands `@crudo/nest` its infrastructure (here
@@ -25,7 +26,7 @@ import { DogController } from "./dog/dog.controller.js";
         },
       }),
     }),
-    CrudoModule.forFeature([OwnerController, CatController, DogController]),
+    CrudoModule.forFeature([OwnerController, CatController, DogController, TagController]),
   ],
 })
 export class AppModule {}

--- a/packages/examples/src/cat/cat.controller.ts
+++ b/packages/examples/src/cat/cat.controller.ts
@@ -9,7 +9,9 @@ import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.j
  * child repository auto-write the `species` discriminator on create.
  * Routes: POST /cats, GET /cats, GET/PUT/DELETE /cats/:id (PATCH disabled).
  * `include=owner` embeds the owner; `owner` is also writable by id
- * (`{"owner": 1}` on create — ADR-0014).
+ * (`{"owner": 1}` on create — ADR-0014). `include=tags` embeds the cat's
+ * tags (a many-to-many, batch-loaded like any other to-many); `tags` is
+ * likewise writable by an array of ids.
  */
 @Crud(Cat, {
   dto: {
@@ -19,9 +21,10 @@ import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.j
     list: CatListDto,
   },
   pagination: { defaultLimit: 10, maxLimit: 50 },
-  // The to-one side of the same edge: `include=owner` joins, and
-  // `fields[owner]=id,name` narrows the embedded owner (Phase 15).
-  relations: { edges: { owner: { includable: true } } },
+  // The to-one side of the owner edge joins; `tags` is a to-many (many-to-
+  // many) and batches. `fields[owner]=id,name` / `fields[tags]=id,name`
+  // narrow each embedded relation (Phase 15).
+  relations: { edges: { owner: { includable: true }, tags: { includable: true } } },
   operations: {
     patchOne: false,
   },

--- a/packages/examples/src/cat/cat.dtos.ts
+++ b/packages/examples/src/cat/cat.dtos.ts
@@ -1,5 +1,6 @@
 import { enumProp } from "@crudo/nest";
 import { PetSizeEnum } from "../pet/pet.entity.js";
+import { TagItemDto } from "../tag/tag.dtos.js";
 
 /**
  * DTO slots for the Cat route (Phase 4). Fields are initialized so the
@@ -19,6 +20,9 @@ export class CreateCatDto {
   // Association by id (Phase 15, ADR-0014): send the owner's id, or an
   // `{ id }` reference. Deep nested writes are deliberately out of scope.
   owner: number | null = null;
+  // Same mechanism, over a to-many edge: an array of tag ids (or `{ id }`
+  // refs) replaces the full set of associated tags.
+  tags: number[] = [];
 }
 
 /** `update` slot — request body for PUT /cats/:id (patch derives from it). */
@@ -29,6 +33,7 @@ export class UpdateCatDto {
   indoor = false;
   livesLeft = 0;
   owner: number | null = null;
+  tags: number[] = [];
 }
 
 /** `item` slot — the detail projection. */
@@ -40,6 +45,9 @@ export class CatItemDto {
   indoor = false;
   livesLeft = 0;
   createdAt: Date = new Date(0);
+  // Documented as an array of tags; the shape is documentation, the include
+  // decides the load — absent from a plain GET (Phase 15).
+  tags: TagItemDto[] = [];
 }
 
 /** `list` slot — a leaner projection for list responses. */

--- a/packages/examples/src/database.module.ts
+++ b/packages/examples/src/database.module.ts
@@ -4,6 +4,7 @@ import { Owner } from "./owner/owner.entity.js";
 import { Pet } from "./pet/pet.entity.js";
 import { Cat } from "./cat/cat.entity.js";
 import { Dog } from "./dog/dog.entity.js";
+import { Tag } from "./tag/tag.entity.js";
 
 export const DATA_SOURCE = Symbol("DATA_SOURCE");
 
@@ -20,7 +21,7 @@ export const DATA_SOURCE = Symbol("DATA_SOURCE");
         const dataSource = new DataSource({
           type: "better-sqlite3",
           database: ":memory:",
-          entities: [Owner, Pet, Cat, Dog],
+          entities: [Owner, Pet, Cat, Dog, Tag],
           synchronize: true,
         });
         return dataSource.initialize();

--- a/packages/examples/src/pet/pet.entity.ts
+++ b/packages/examples/src/pet/pet.entity.ts
@@ -1,7 +1,19 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, TableInheritance } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  TableInheritance,
+} from "typeorm";
 // Type-only import + string relation target keep the Owner↔Pet cycle off the
 // runtime graph (TypeORM resolves "Owner" by entity name at metadata build).
 import type { Owner } from "../owner/owner.entity.js";
+// Tag carries no reference back to Pet, so there is no cycle to keep off the
+// runtime graph here — a plain, real import is fine.
+import { Tag } from "../tag/tag.entity.js";
 
 /**
  * The single-table inheritance base. `Pet` is never served directly — you
@@ -39,6 +51,13 @@ export abstract class Pet {
 
   @ManyToOne("Owner", (owner: Owner) => owner.pets, { nullable: true })
   owner!: Owner | null;
+
+  // Owning side of the many-to-many edge: `include=tags` batch-loads through
+  // the join table `@JoinTable()` creates (Phase 15). Unidirectional — `Tag`
+  // has no inverse `pets` field, since nothing browses pets from a tag.
+  @ManyToMany(() => Tag)
+  @JoinTable()
+  tags!: Tag[];
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/packages/examples/src/tag/tag.controller.ts
+++ b/packages/examples/src/tag/tag.controller.ts
@@ -1,0 +1,19 @@
+import { Controller } from "@nestjs/common";
+import { Crud } from "@crudo/nest";
+import { Tag } from "./tag.entity.js";
+import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.js";
+
+/**
+ * Plain CRUD over `Tag`, the many-to-many side pets associate by id
+ * (`include=tags` on `/cats`, Phase 15).
+ */
+@Crud(Tag, {
+  dto: {
+    create: CreateTagDto,
+    update: UpdateTagDto,
+    item: TagItemDto,
+    list: TagListDto,
+  },
+})
+@Controller("tags")
+export class TagController {}

--- a/packages/examples/src/tag/tag.dtos.ts
+++ b/packages/examples/src/tag/tag.dtos.ts
@@ -1,0 +1,26 @@
+/**
+ * DTO slots for the Tag route. See `cat.dtos.ts` for the rationale behind
+ * plain initialized-field classes.
+ */
+
+/** `create` slot — request body for POST /tags. */
+export class CreateTagDto {
+  name = "";
+}
+
+/** `update` slot — request body for PUT /tags/:id (patch derives from it). */
+export class UpdateTagDto {
+  name = "";
+}
+
+/** `item` slot — the detail projection. */
+export class TagItemDto {
+  id = 0;
+  name = "";
+}
+
+/** `list` slot — same shape as `item`; a tag has nothing left to trim. */
+export class TagListDto {
+  id = 0;
+  name = "";
+}

--- a/packages/examples/src/tag/tag.entity.ts
+++ b/packages/examples/src/tag/tag.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+/**
+ * A label shared across pets. Unidirectional: `Tag` carries no back-reference
+ * to `Pet` because nothing in this app browses pets from a tag — the owning
+ * `@ManyToMany` lives on `Pet` (Phase 15, ADR-0014's id-association path
+ * exercised over a many-to-many edge for the first time in this app).
+ */
+@Entity()
+export class Tag {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  name!: string;
+}

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -299,30 +299,69 @@ describe("Pet example app", () => {
     );
     expect(fetched.body.tags).toHaveLength(2);
 
+    // Narrowed by a per-node fieldset, same as the to-one `owner` edge.
+    const narrowed = await request(server())
+      .get(`/cats/${catId}?include=tags&fields[tags]=id`)
+      .expect(200);
+    expect(narrowed.body.tags).toEqual(
+      expect.arrayContaining([{ id: tagIdA }, { id: tagIdB }]),
+    );
+
     // Replacing the tag set on update: this is the case that would fail if
     // the join table needed the prior relation state preloaded before save.
-    await request(server()).put(`/cats/${catId}`).send({
-      name: "Tagged",
-      age: 2,
-      size: "small",
-      indoor: true,
-      livesLeft: 9,
-      tags: [tagIdB],
-    });
+    await request(server())
+      .put(`/cats/${catId}`)
+      .send({
+        name: "Tagged",
+        age: 2,
+        size: "small",
+        indoor: true,
+        livesLeft: 9,
+        tags: [tagIdB],
+      })
+      .expect(200);
     const afterUpdate = await request(server()).get(`/cats/${catId}?include=tags`).expect(200);
     expect(afterUpdate.body.tags).toEqual([expect.objectContaining({ id: tagIdB, name: "lazy" })]);
 
     // Clearing the set removes every association.
-    await request(server()).put(`/cats/${catId}`).send({
-      name: "Tagged",
-      age: 2,
-      size: "small",
-      indoor: true,
-      livesLeft: 9,
-      tags: [],
-    });
+    await request(server())
+      .put(`/cats/${catId}`)
+      .send({
+        name: "Tagged",
+        age: 2,
+        size: "small",
+        indoor: true,
+        livesLeft: 9,
+        tags: [],
+      })
+      .expect(200);
     const cleared = await request(server()).get(`/cats/${catId}?include=tags`).expect(200);
     expect(cleared.body.tags).toEqual([]);
+  });
+
+  it("rejects associating a nonexistent tag id as a conflict, not a silent drop", async () => {
+    // ADR-0014's association-by-id path has no existence check of its own —
+    // an unknown id surfaces as the join table's own FK-constraint violation.
+    const response = await request(server())
+      .post("/cats")
+      .send({ name: "BadTag", age: 1, size: "small", indoor: true, livesLeft: 9, tags: [999999] })
+      .expect(409)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body.code).toBe("CRUDO_CONFLICT");
+  });
+
+  it("cleans up the join table when a still-referenced tag is deleted", async () => {
+    const tag = await request(server()).post("/tags").send({ name: "temporary" }).expect(201);
+    const tagId = tag.body.id as number;
+    const cat = await request(server())
+      .post("/cats")
+      .send({ name: "Referencing", age: 1, size: "small", indoor: true, livesLeft: 9, tags: [tagId] })
+      .expect(201);
+
+    await request(server()).delete(`/tags/${tagId}`).expect(204);
+
+    const afterDelete = await request(server()).get(`/cats/${cat.body.id}?include=tags`).expect(200);
+    expect(afterDelete.body.tags).toEqual([]);
   });
 
   it("keeps include=tags an opt-in allowlist entry, not a free pass", async () => {
@@ -344,19 +383,26 @@ describe("Pet example app", () => {
       .post("/cats")
       .send({ name: "FanOut", age: 1, size: "small", indoor: true, livesLeft: 9, tags })
       .expect(201);
+    const fanOutId = fanOut.body.id as number;
 
+    // Sorted newest-first so the just-created fan-out cat is guaranteed to
+    // land inside the requested page, not merely outside its window.
     const page = await request(server())
       .get("/cats")
-      .query("include=tags&limit=2&offset=0")
+      .query("include=tags&sort=-id&limit=2&offset=0")
       .expect(200);
     // Root count/slice is over distinct cats, never joined (cat × tag) rows —
-    // a fan-out of 3 tags on one cat must not multiply `total` or the page.
+    // a fan-out of 3 tags on one cat must not multiply `total` or the page,
+    // and must not appear duplicated within the page either.
     expect(page.body.total).toBe(totalBefore + 1);
     expect(page.body.items).toHaveLength(2);
+    const fanOutInPage = page.body.items.filter((item: { id: number }) => item.id === fanOutId);
+    expect(fanOutInPage).toHaveLength(1);
+    expect(fanOutInPage[0].tags).toHaveLength(3);
 
-    const fanOutRow = (
-      await request(server()).get(`/cats/${fanOut.body.id}?include=tags`).expect(200)
-    ).body as { tags: unknown[] };
+    const fanOutRow = (await request(server()).get(`/cats/${fanOutId}?include=tags`).expect(200)).body as {
+      tags: unknown[];
+    };
     expect(fanOutRow.tags).toHaveLength(3);
   });
 

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -272,6 +272,94 @@ describe("Pet example app", () => {
     await request(server()).get(`/dogs/${dog.body.id}`).expect(200);
   });
 
+  it("associates tags by id and embeds them via a batched many-to-many include", async () => {
+    const tagA = await request(server()).post("/tags").send({ name: "playful" }).expect(201);
+    const tagB = await request(server()).post("/tags").send({ name: "lazy" }).expect(201);
+    const tagIdA = tagA.body.id as number;
+    const tagIdB = tagB.body.id as number;
+
+    const cat = await request(server())
+      .post("/cats")
+      .send({ name: "Tagged", age: 2, size: "small", indoor: true, livesLeft: 9, tags: [tagIdA, tagIdB] })
+      .expect(201);
+    const catId = cat.body.id as number;
+
+    // Not included until asked (Phase 15): the create response is the plain
+    // CatItemDto projection, and tags stay off a plain GET too.
+    expect(cat.body).not.toHaveProperty("tags");
+    const plain = await request(server()).get(`/cats/${catId}`).expect(200);
+    expect(plain.body).not.toHaveProperty("tags");
+
+    const fetched = await request(server()).get(`/cats/${catId}?include=tags`).expect(200);
+    expect(fetched.body.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: tagIdA, name: "playful" }),
+        expect.objectContaining({ id: tagIdB, name: "lazy" }),
+      ]),
+    );
+    expect(fetched.body.tags).toHaveLength(2);
+
+    // Replacing the tag set on update: this is the case that would fail if
+    // the join table needed the prior relation state preloaded before save.
+    await request(server()).put(`/cats/${catId}`).send({
+      name: "Tagged",
+      age: 2,
+      size: "small",
+      indoor: true,
+      livesLeft: 9,
+      tags: [tagIdB],
+    });
+    const afterUpdate = await request(server()).get(`/cats/${catId}?include=tags`).expect(200);
+    expect(afterUpdate.body.tags).toEqual([expect.objectContaining({ id: tagIdB, name: "lazy" })]);
+
+    // Clearing the set removes every association.
+    await request(server()).put(`/cats/${catId}`).send({
+      name: "Tagged",
+      age: 2,
+      size: "small",
+      indoor: true,
+      livesLeft: 9,
+      tags: [],
+    });
+    const cleared = await request(server()).get(`/cats/${catId}?include=tags`).expect(200);
+    expect(cleared.body.tags).toEqual([]);
+  });
+
+  it("keeps include=tags an opt-in allowlist entry, not a free pass", async () => {
+    // Dogs never declared `tags` includable — same allowlist rule as any
+    // other relation (Phase 15).
+    const response = await request(server()).get("/dogs").query("include=tags").expect(400);
+    expect(response.body.errors.map((e: { code: string }) => e.code)).toEqual(["CRUDO_QUERY_INVALID_FIELD"]);
+  });
+
+  it("counts and slices distinct roots under pagination even when a cat has several tags", async () => {
+    const before = await request(server()).get("/cats").query("limit=1").expect(200);
+    const totalBefore = before.body.total as number;
+
+    const tags = [];
+    for (const name of ["a", "b", "c"]) {
+      tags.push((await request(server()).post("/tags").send({ name }).expect(201)).body.id as number);
+    }
+    const fanOut = await request(server())
+      .post("/cats")
+      .send({ name: "FanOut", age: 1, size: "small", indoor: true, livesLeft: 9, tags })
+      .expect(201);
+
+    const page = await request(server())
+      .get("/cats")
+      .query("include=tags&limit=2&offset=0")
+      .expect(200);
+    // Root count/slice is over distinct cats, never joined (cat × tag) rows —
+    // a fan-out of 3 tags on one cat must not multiply `total` or the page.
+    expect(page.body.total).toBe(totalBefore + 1);
+    expect(page.body.items).toHaveLength(2);
+
+    const fanOutRow = (
+      await request(server()).get(`/cats/${fanOut.body.id}?include=tags`).expect(200)
+    ).body as { tags: unknown[] };
+    expect(fanOutRow.tags).toHaveLength(3);
+  });
+
   it("documents the size enum and the owner pets oneOf in the OpenAPI schema", () => {
     type Schema = {
       type?: string;

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -300,12 +300,8 @@ describe("Pet example app", () => {
     expect(fetched.body.tags).toHaveLength(2);
 
     // Narrowed by a per-node fieldset, same as the to-one `owner` edge.
-    const narrowed = await request(server())
-      .get(`/cats/${catId}?include=tags&fields[tags]=id`)
-      .expect(200);
-    expect(narrowed.body.tags).toEqual(
-      expect.arrayContaining([{ id: tagIdA }, { id: tagIdB }]),
-    );
+    const narrowed = await request(server()).get(`/cats/${catId}?include=tags&fields[tags]=id`).expect(200);
+    expect(narrowed.body.tags).toEqual(expect.arrayContaining([{ id: tagIdA }, { id: tagIdB }]));
 
     // Replacing the tag set on update: this is the case that would fail if
     // the join table needed the prior relation state preloaded before save.
@@ -387,10 +383,7 @@ describe("Pet example app", () => {
 
     // Sorted newest-first so the just-created fan-out cat is guaranteed to
     // land inside the requested page, not merely outside its window.
-    const page = await request(server())
-      .get("/cats")
-      .query("include=tags&sort=-id&limit=2&offset=0")
-      .expect(200);
+    const page = await request(server()).get("/cats").query("include=tags&sort=-id&limit=2&offset=0").expect(200);
     // Root count/slice is over distinct cats, never joined (cat × tag) rows —
     // a fan-out of 3 tags on one cat must not multiply `total` or the page,
     // and must not appear duplicated within the page either.


### PR DESCRIPTION
## What & why

Adds a `Tag` entity and an owning `@ManyToMany` + `@JoinTable()` relation from `Pet` in `packages/examples/`, plus a `TagController` and `include=tags` on `/cats`. This is the first entity in the codebase to use a many-to-many relation — `@crudo/typeorm`'s metadata adapter already mapped `isManyToMany` to cardinality `"many"`, but nothing had exercised the batch-load/id-association path over an actual join table until now.

Tags associate by id (`tags: number[]` on the Cat create/update DTOs), resolved through the existing generic relation-id deserializer (ADR-0014) — no new mechanism. `include=tags` embeds via the standard batch strategy, same as any other to-many.

Closes #12

## Public API impact

None. No changes to `@crudo/core`, `@crudo/typeorm`, or `@crudo/nest` — this is entirely `packages/examples` wiring plus a documentation note. The core barrel (`packages/core/src/index.ts`) is untouched.

## Testing

`pnpm check`: build + typecheck + depcruise (0 violations, 142 modules/515 deps) + tests — 450/450 passed.

New e2e coverage in `packages/examples/tests/app.e2e.spec.ts`:
- create-with-tags, embed via `include=tags`, replace and clear the tag set on update
- `fields[tags]=id` narrowing over the many-to-many embed
- `include=tags` opt-in allowlist enforcement (400 on `/dogs`, which never declared it)
- association-by-id error path: an unknown tag id surfaces as `409 CRUDO_CONFLICT`, not a silent drop
- deleting a still-referenced tag cleans up the join table
- distinct-root pagination under a 3-tag fan-out — the fanned-out cat is guaranteed into the page (sorted) and asserted to appear exactly once, with `total`/page size unaffected

## Review notes

Went through the full `/review` fan-out (crudo-reviewer, crudo-boundary-guard, crudo-test-auditor) — no blocking findings. All non-blocking findings from that pass (missing `.expect(200)` on two writes, untested invalid-id and cascade-delete paths, untested `fields[tags]` narrowing, a fan-out pagination test that didn't actually guarantee the fanned row landed in the page) were fixed in a follow-up commit, so nothing was deliberately left open.

One pre-existing pattern noted during review but *not* introduced by this PR: `CatItemDto.tags` is typed `TagItemDto[]` rather than `TagListDto[]`, matching the existing (if arguably doc-inconsistent) precedent of `OwnerItemDto.pets`. Worth a future cleanup pass across both, not scoped here.