### PR TITLE
Add a one-to-one Address relation to Owner in the example app

### DIFF
--- a/packages/docs/architecture/12-relations-and-includes.md
+++ b/packages/docs/architecture/12-relations-and-includes.md
@@ -90,6 +90,11 @@ guarantee — the join table never reaches the main query. `Pet.tags` (the
 example app) is what first exercises this path; no adapter or core change
 was needed to support it.
 
+`Owner.address` (`@OneToOne`, owning side on `Owner`) is the example app's
+one-to-one relation: cardinality falls out of the metadata adapter's
+existing `isOneToMany || isManyToMany ? "many" : "one"` rule with no special
+case, and `auto` resolves it to `join` exactly like `Pet.owner`.
+
 ## 4. Interplay
 
 - **Sparse fieldsets:** keys needed for stitching are always fetched and

--- a/packages/examples/src/address/address.controller.ts
+++ b/packages/examples/src/address/address.controller.ts
@@ -1,0 +1,20 @@
+import { Controller } from "@nestjs/common";
+import { Crud } from "@crudo/nest";
+import { Address } from "./address.entity.js";
+import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
+
+/**
+ * Plain CRUD over `Address`. Owners associate an address by id
+ * (`{"address": 1}` on `POST /owners` — ADR-0014); this route is how one
+ * gets created in the first place.
+ */
+@Crud(Address, {
+  dto: {
+    create: CreateAddressDto,
+    update: UpdateAddressDto,
+    item: AddressItemDto,
+    list: AddressListDto,
+  },
+})
+@Controller("addresses")
+export class AddressController {}

--- a/packages/examples/src/address/address.dtos.ts
+++ b/packages/examples/src/address/address.dtos.ts
@@ -1,0 +1,33 @@
+/**
+ * DTO slots for the Address route. Plain initialized-field classes, same
+ * rationale as every other entity's DTOs (see cat.dtos.ts).
+ */
+
+/** `create` slot — request body for POST /addresses. */
+export class CreateAddressDto {
+  street = "";
+  city = "";
+  postalCode = "";
+}
+
+/** `update` slot — request body for PUT /addresses/:id (patch derives from it). */
+export class UpdateAddressDto {
+  street = "";
+  city = "";
+  postalCode = "";
+}
+
+/** `item` slot — the detail projection. */
+export class AddressItemDto {
+  id = 0;
+  street = "";
+  city = "";
+  postalCode = "";
+}
+
+/** `list` slot — a leaner projection for list responses. */
+export class AddressListDto {
+  id = 0;
+  street = "";
+  city = "";
+}

--- a/packages/examples/src/address/address.entity.ts
+++ b/packages/examples/src/address/address.entity.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+// Type-only import + string relation target keep the Owner↔Address cycle off
+// the runtime graph, same as Owner↔Pet (see owner.entity.ts).
+import type { Owner } from "../owner/owner.entity.js";
+
+/**
+ * The inverse side of the example's first one-to-one relation: `Owner` owns
+ * the join column (`owner.entity.ts`), so `Address` never writes an owner
+ * through its own routes — it only carries the inverse property TypeORM
+ * needs to resolve the mapping.
+ */
+@Entity()
+export class Address {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  street!: string;
+
+  @Column("varchar")
+  city!: string;
+
+  @Column("varchar")
+  postalCode!: string;
+
+  @OneToOne("Owner", (owner: Owner) => owner.address, { nullable: true })
+  owner!: Owner | null;
+}

--- a/packages/examples/src/app.module.ts
+++ b/packages/examples/src/app.module.ts
@@ -7,6 +7,7 @@ import { OwnerController } from "./owner/owner.controller.js";
 import { CatController } from "./cat/cat.controller.js";
 import { DogController } from "./dog/dog.controller.js";
 import { TagController } from "./tag/tag.controller.js";
+import { AddressController } from "./address/address.controller.js";
 
 /**
  * Reference wiring: the app hands `@crudo/nest` its infrastructure (here
@@ -26,7 +27,7 @@ import { TagController } from "./tag/tag.controller.js";
         },
       }),
     }),
-    CrudoModule.forFeature([OwnerController, CatController, DogController, TagController]),
+    CrudoModule.forFeature([OwnerController, CatController, DogController, TagController, AddressController]),
   ],
 })
 export class AppModule {}

--- a/packages/examples/src/database.module.ts
+++ b/packages/examples/src/database.module.ts
@@ -5,6 +5,7 @@ import { Pet } from "./pet/pet.entity.js";
 import { Cat } from "./cat/cat.entity.js";
 import { Dog } from "./dog/dog.entity.js";
 import { Tag } from "./tag/tag.entity.js";
+import { Address } from "./address/address.entity.js";
 
 export const DATA_SOURCE = Symbol("DATA_SOURCE");
 
@@ -21,7 +22,7 @@ export const DATA_SOURCE = Symbol("DATA_SOURCE");
         const dataSource = new DataSource({
           type: "better-sqlite3",
           database: ":memory:",
-          entities: [Owner, Pet, Cat, Dog, Tag],
+          entities: [Owner, Pet, Cat, Dog, Tag, Address],
           synchronize: true,
         });
         return dataSource.initialize();

--- a/packages/examples/src/owner/owner.controller.ts
+++ b/packages/examples/src/owner/owner.controller.ts
@@ -26,8 +26,9 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
   softDelete: { strategy: "soft" },
   // `include=pets` — opt-in per relation (Phase 15). Pets are a to-many,
   // so they batch-load: one extra query per page of owners, never a joined
-  // row explosion under pagination.
-  relations: { edges: { pets: { includable: true } } },
+  // row explosion under pagination. `address` is the to-one counterpart —
+  // it joins instead.
+  relations: { edges: { pets: { includable: true }, address: { includable: true } } },
   operations: {
     purgeOne: true,
   },

--- a/packages/examples/src/owner/owner.dtos.ts
+++ b/packages/examples/src/owner/owner.dtos.ts
@@ -1,6 +1,7 @@
 import { oneOfArray } from "@crudo/nest";
 import { CatItemDto } from "../cat/cat.dtos.js";
 import { DogItemDto } from "../dog/dog.dtos.js";
+import { AddressItemDto } from "../address/address.dtos.js";
 
 /**
  * DTO slots for the Owner route (Phase 4). See `cat.dtos.ts` for the
@@ -12,6 +13,9 @@ export class CreateOwnerDto {
   name = "";
   email = "";
   startedAt: Date | null = null;
+  // Association by id (ADR-0014): send the address's id, or an `{ id }`
+  // reference. Deep nested writes are deliberately out of scope.
+  address: number | null = null;
 }
 
 /** `update` slot — request body for PUT /owners/:id (patch derives from it). */
@@ -19,6 +23,7 @@ export class UpdateOwnerDto {
   name = "";
   email = "";
   startedAt: Date | null = null;
+  address: number | null = null;
 }
 
 /** `item` slot — the detail projection. */
@@ -32,6 +37,9 @@ export class OwnerItemDto {
   // shape, not the load: the field appears only when asked for with
   // `?include=pets`, so a plain GET does not pay for the relation.
   pets = oneOfArray<CatItemDto | DogItemDto>([CatItemDto, DogItemDto]);
+  // Documented the same way: shape only, present in the response solely
+  // when `?include=address` asks for it.
+  address: AddressItemDto | null = null;
 }
 
 /** `list` slot — a leaner projection for list responses. */

--- a/packages/examples/src/owner/owner.entity.ts
+++ b/packages/examples/src/owner/owner.entity.ts
@@ -1,8 +1,19 @@
 import type { SoftDeletable } from "@crudo/core";
-import { Column, CreateDateColumn, DeleteDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 // Type-only import + string relation target keep the Owner↔Pet cycle off the
 // runtime graph (TypeORM resolves "Pet" by entity name at metadata build).
 import type { Pet } from "../pet/pet.entity.js";
+// Same reasoning for Owner↔Address.
+import type { Address } from "../address/address.entity.js";
 
 /**
  * The relation side of the example: an Owner has many Pets. Explicit
@@ -34,6 +45,13 @@ export class Owner implements SoftDeletable {
 
   @OneToMany("Pet", (pet: Pet) => pet.owner)
   pets!: Pet[];
+
+  // The owning side of the one-to-one: Owner carries the (nullable, unique)
+  // join column. `@JoinColumn` is required explicitly here — unlike
+  // `@ManyToOne`, a one-to-one owning side does not get one implicitly.
+  @OneToOne("Address", (address: Address) => address.owner, { nullable: true })
+  @JoinColumn()
+  address!: Address | null;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -311,7 +311,9 @@ describe("Pet example app", () => {
 
     const list = await request(server())
       .get("/owners")
-      .query(`include=address&filter[or][0][id][eq]=${withAddress.body.id}&filter[or][1][id][eq]=${withoutAddress.body.id}&sort=name`)
+      .query(
+        `include=address&filter[or][0][id][eq]=${withAddress.body.id}&filter[or][1][id][eq]=${withoutAddress.body.id}&sort=name`,
+      )
       .expect(200);
     expect(list.body.items).toEqual([
       expect.objectContaining({ name: "Priya", address: expect.objectContaining({ id: address.body.id }) }),
@@ -332,10 +334,7 @@ describe("Pet example app", () => {
       await request(server()).post("/owners").send({ name, email, address: address.body.id }).expect(201);
     }
 
-    const withoutInclude = await request(server())
-      .get("/owners")
-      .query("filter[email][like]=%25fanout%25")
-      .expect(200);
+    const withoutInclude = await request(server()).get("/owners").query("filter[email][like]=%25fanout%25").expect(200);
     const withInclude = await request(server())
       .get("/owners")
       .query("include=address&filter[email][like]=%25fanout%25&limit=2")

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -229,6 +229,144 @@ describe("Pet example app", () => {
       .expect("Content-Type", /application\/problem\+json/);
   });
 
+  it("runs the full CRUD lifecycle over HTTP for addresses", async () => {
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Main St", city: "Springfield", postalCode: "00001" })
+      .expect(201);
+    expect(created.body).toMatchObject({ street: "1 Main St", city: "Springfield", postalCode: "00001" });
+    const id = created.body.id as number;
+
+    await request(server()).get(`/addresses/${id}`).expect(200);
+    await request(server())
+      .put(`/addresses/${id}`)
+      .send({ street: "2 Main St", city: "Shelbyville", postalCode: "00002" })
+      .expect(200);
+    await request(server()).delete(`/addresses/${id}`).expect(204);
+    await request(server()).get(`/addresses/${id}`).expect(404);
+  });
+
+  it("associates an owner with an address by id on create, and embeds it via include (one-to-one join)", async () => {
+    const address = await request(server())
+      .post("/addresses")
+      .send({ street: "10 Elm St", city: "Ogdenville", postalCode: "10001" })
+      .expect(201);
+    const addressId = address.body.id as number;
+
+    const owner = await request(server())
+      .post("/owners")
+      .send({ name: "Nadia", email: "nadia@x.io", address: addressId })
+      .expect(201);
+    const ownerId = owner.body.id as number;
+
+    // Plain read never embeds it — the include decides the load.
+    const plain = await request(server()).get(`/owners/${ownerId}`).expect(200);
+    expect(plain.body).not.toHaveProperty("address");
+
+    const included = await request(server()).get(`/owners/${ownerId}?include=address`).expect(200);
+    expect(included.body.address).toMatchObject({ id: addressId, street: "10 Elm St", city: "Ogdenville" });
+
+    // …and narrowed by a per-node fieldset, same as the to-one `owner` edge on cats.
+    const narrowed = await request(server())
+      .get(`/owners/${ownerId}?include=address&fields[address]=street,city`)
+      .expect(200);
+    expect(narrowed.body.address).toEqual({ street: "10 Elm St", city: "Ogdenville" });
+  });
+
+  it("associates, disassociates, and round-trips a null address on owners", async () => {
+    const noAddress = await request(server()).post("/owners").send({ name: "Otis", email: "otis@x.io" }).expect(201);
+    const id = noAddress.body.id as number;
+    const included = await request(server()).get(`/owners/${id}?include=address`).expect(200);
+    expect(included.body.address).toBeNull();
+
+    const address = await request(server())
+      .post("/addresses")
+      .send({ street: "5 Oak Ave", city: "Capital City", postalCode: "20002" })
+      .expect(201);
+    await request(server())
+      .put(`/owners/${id}`)
+      .send({ name: "Otis", email: "otis@x.io", address: address.body.id })
+      .expect(200);
+    const attached = await request(server()).get(`/owners/${id}?include=address`).expect(200);
+    expect(attached.body.address).toMatchObject({ id: address.body.id as number });
+
+    await request(server()).put(`/owners/${id}`).send({ name: "Otis", email: "otis@x.io", address: null }).expect(200);
+    const detached = await request(server()).get(`/owners/${id}?include=address`).expect(200);
+    expect(detached.body.address).toBeNull();
+  });
+
+  it("embeds addresses on the list route across a mix of populated and null owners", async () => {
+    const address = await request(server())
+      .post("/addresses")
+      .send({ street: "9 Birch Rd", city: "North Haverbrook", postalCode: "30003" })
+      .expect(201);
+    const withAddress = await request(server())
+      .post("/owners")
+      .send({ name: "Priya", email: "priya@x.io", address: address.body.id })
+      .expect(201);
+    const withoutAddress = await request(server())
+      .post("/owners")
+      .send({ name: "Quinn", email: "quinn@x.io" })
+      .expect(201);
+
+    const list = await request(server())
+      .get("/owners")
+      .query(`include=address&filter[or][0][id][eq]=${withAddress.body.id}&filter[or][1][id][eq]=${withoutAddress.body.id}&sort=name`)
+      .expect(200);
+    expect(list.body.items).toEqual([
+      expect.objectContaining({ name: "Priya", address: expect.objectContaining({ id: address.body.id }) }),
+      expect.objectContaining({ name: "Quinn", address: null }),
+    ]);
+  });
+
+  it("does not fan out root rows when paginating a joined to-one include", async () => {
+    for (const [name, email] of [
+      ["Fanout1", "fanout1@x.io"],
+      ["Fanout2", "fanout2@x.io"],
+      ["Fanout3", "fanout3@x.io"],
+    ] as const) {
+      const address = await request(server())
+        .post("/addresses")
+        .send({ street: `${name} St`, city: "Fanoutville", postalCode: "40004" })
+        .expect(201);
+      await request(server()).post("/owners").send({ name, email, address: address.body.id }).expect(201);
+    }
+
+    const withoutInclude = await request(server())
+      .get("/owners")
+      .query("filter[email][like]=%25fanout%25")
+      .expect(200);
+    const withInclude = await request(server())
+      .get("/owners")
+      .query("include=address&filter[email][like]=%25fanout%25&limit=2")
+      .expect(200);
+    expect(withInclude.body.total).toBe(withoutInclude.body.total);
+    expect(withInclude.body.items).toHaveLength(2);
+  });
+
+  it("maps a duplicate address association to a 409 conflict (unique join column)", async () => {
+    const address = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Shared Way", city: "Duplicity", postalCode: "50005" })
+      .expect(201);
+    await request(server())
+      .post("/owners")
+      .send({ name: "First", email: "first@x.io", address: address.body.id })
+      .expect(201);
+    await request(server())
+      .post("/owners")
+      .send({ name: "Second", email: "second@x.io", address: address.body.id })
+      .expect(409)
+      .expect("Content-Type", /application\/problem\+json/);
+  });
+
+  it("documents include=address and fields[address] in the OpenAPI schema", () => {
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/owners"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    expect(params.find((param) => param.name === "include")?.description).toContain("address");
+    expect(params.map((param) => param.name)).toContain("fields[address]");
+  });
+
   it("round-trips the nullable startedAt date on owners", async () => {
     const withDate = await request(server())
       .post("/owners")

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -353,11 +353,46 @@ describe("Pet example app", () => {
       .post("/owners")
       .send({ name: "First", email: "first@x.io", address: address.body.id })
       .expect(201);
-    await request(server())
+    const conflict = await request(server())
       .post("/owners")
       .send({ name: "Second", email: "second@x.io", address: address.body.id })
       .expect(409)
       .expect("Content-Type", /application\/problem\+json/);
+    expect(conflict.body.code).toBe("CRUDO_CONFLICT");
+  });
+
+  it("rejects associating a nonexistent address id as a conflict, not a silent drop", async () => {
+    const created = await request(server())
+      .post("/owners")
+      .send({ name: "Rex", email: "rex@x.io", address: 999999 })
+      .expect(409)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(created.body.code).toBe("CRUDO_CONFLICT");
+
+    const owner = await request(server()).post("/owners").send({ name: "Sam", email: "sam@x.io" }).expect(201);
+    const updateConflict = await request(server())
+      .put(`/owners/${owner.body.id}`)
+      .send({ name: "Sam", email: "sam@x.io", address: 999999 })
+      .expect(409)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(updateConflict.body.code).toBe("CRUDO_CONFLICT");
+  });
+
+  it("refuses to delete an address still referenced by an owner (409, not a silent null or cascade)", async () => {
+    const address = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Referenced Ln", city: "Bindingtown", postalCode: "60006" })
+      .expect(201);
+    await request(server())
+      .post("/owners")
+      .send({ name: "Tara", email: "tara@x.io", address: address.body.id })
+      .expect(201);
+
+    const conflict = await request(server())
+      .delete(`/addresses/${address.body.id}`)
+      .expect(409)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(conflict.body.code).toBe("CRUDO_CONFLICT");
   });
 
   it("documents include=address and fields[address] in the OpenAPI schema", () => {


### PR DESCRIPTION
## What & why

Adds an `Address` entity with plain CRUD, and wires it as the owning side of a one-to-one relation on `Owner` (`@OneToOne` + `@JoinColumn`, nullable, unique join column). This exercises the one-to-one/join-strategy path in the example app for the first time — no entity previously used `@OneToOne`, so the owning-side unique FK and the `join` load-strategy default were untested end-to-end.

`include=address` is opt-in and resolves through the existing generic seams: `@crudo/typeorm`'s cardinality rule (`metadata.ts:72`) already maps anything that isn't `isOneToMany`/`isManyToMany` to `"one"`, and the include resolver already defaults `"one"` to `join`. Association is by id only (`address: number | null` on the create/update DTOs), per ADR-0014.

Closes #13

## Public API impact

None. Everything is additive within `packages/examples` (unpublished). No changes to `@crudo/core`, `@crudo/typeorm`, or `@crudo/nest`'s exported surface, and `packages/core/src/index.ts` was not touched.

## Testing

Added to `packages/examples/tests/app.e2e.spec.ts`:
- Address CRUD lifecycle
- Associate/disassociate an owner's address by id (create and update), including the null round-trip
- List-include across a mix of populated/null owners, with `fields[address]` narrowing
- Pagination-safety: a joined to-one include doesn't fan out root rows
- Conflict paths on the new unique FK: duplicate address association, associating a nonexistent address id (create and update), and deleting an address still referenced by an owner — all asserted against the `CRUDO_CONFLICT` code, not just HTTP status
- Swagger coverage for `include=address` / `fields[address]`

One sentence added to `packages/docs/architecture/12-relations-and-includes.md` documenting the one-to-one example.

`pnpm check`: green — build, typecheck, depcruise (145 modules, 525 dependencies, 0 violations), and the full suite (459 tests, 21 files, all passing).

## Review notes

Full `/review` fan-out (crudo-reviewer, crudo-boundary-guard, crudo-test-auditor) ran in this branch's development. Boundary and correctness reviews came back clean. The test-auditor found 3 real coverage gaps (delete-while-referenced, nonexistent-id association on create/update, and a conflict test that only checked status/content-type) — all three were added in the second commit, verified against the running app before adding, and are now green.