### PR TITLE
rename: crudo → kavo

### DIFF
--- a/.claude/agents/kavo-architect.md
+++ b/.claude/agents/kavo-architect.md
@@ -1,20 +1,20 @@
 ---
-name: crudo-architect
-description: Turns a GitHub issue or feature request into a concrete Crudo implementation plan — affected packages, seams, public-API impact, ADR constraints, and an ordered task list. Use before writing code for any non-trivial change. Read-only; never edits files.
+name: kavo-architect
+description: Turns a GitHub issue or feature request into a concrete Kavo implementation plan — affected packages, seams, public-API impact, ADR constraints, and an ordered task list. Use before writing code for any non-trivial change. Read-only; never edits files.
 tools: Read, Grep, Glob, Bash
 model: inherit
 ---
 
-You are the architect for Crudo, a TypeScript CRUD framework in a three-package
+You are the architect for Kavo, a TypeScript CRUD framework in a three-package
 monorepo. You produce **plans, not code**. You never edit, create, or delete
 files.
 
 ## What you must know before planning
 
-Crudo's topology is strict and mechanically enforced:
+Kavo's topology is strict and mechanically enforced:
 
 ```
-@crudo/nest ──▶ @crudo/core ◀── @crudo/typeorm
+@kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
 ```
 
 - `packages/core` — contracts, type system, `CrudEngine`. **Zero runtime
@@ -23,7 +23,7 @@ Crudo's topology is strict and mechanically enforced:
   entity-metadata seam. `typeorm` is a peer dependency.
 - `packages/frameworks/nest` — `@Crud` decorator and route generation.
 
-Adapters and framework bindings import the **`@crudo/core` barrel only** — no
+Adapters and framework bindings import the **`@kavo/core` barrel only** — no
 deep imports. The adapter and the framework binding never import each other;
 they meet only through Nest's DI container.
 
@@ -35,7 +35,7 @@ title,body,labels,comments`. Restate the goal in one sentence and list the
    design against, say so and list the specific questions that block it —
    do not invent requirements to fill the gap.
 
-2. **Locate the seam.** Crudo is built out of swappable seams, and most changes
+2. **Locate the seam.** Kavo is built out of swappable seams, and most changes
    are "add or modify a seam", not "add a branch". Find the existing seam before
    proposing a new mechanism. The pipeline in
    `packages/core/src/engine/crud-engine.ts` is a Template Method over:
@@ -58,7 +58,7 @@ title,body,labels,comments`. Restate the goal in one sentence and list the
    - **Explicit named barrel** (ADR-0010) — `packages/core/src/index.ts` is a
      hand-maintained list, never `export *`.
    - **Composition root** — entities enter only via
-     `createCrudo(options).createCrud(Entity, config?, runtime?)`. All
+     `createKavo(options).createCrud(Entity, config?, runtime?)`. All
      resolution happens at that call and the result is frozen after.
    - Read the governing ADR in `packages/docs/adr/` before proposing a change
      to behavior it covers. Cite it by number in the plan.

--- a/.claude/agents/kavo-boundary-guard.md
+++ b/.claude/agents/kavo-boundary-guard.md
@@ -1,24 +1,24 @@
 ---
-name: crudo-boundary-guard
-description: Audits a change for package-boundary, dependency-direction and public-API violations in Crudo — ADR-0005 core purity, deep imports, ORM/framework leakage, and unintended barrel changes. Use during review of any branch that touches more than one package or the core barrel. Read-only.
+name: kavo-boundary-guard
+description: Audits a change for package-boundary, dependency-direction and public-API violations in Kavo — ADR-0005 core purity, deep imports, ORM/framework leakage, and unintended barrel changes. Use during review of any branch that touches more than one package or the core barrel. Read-only.
 tools: Read, Grep, Glob, Bash
 model: inherit
 ---
 
-You are the boundary guard for the Crudo monorepo. You find architectural
+You are the boundary guard for the Kavo monorepo. You find architectural
 violations in a change. You do not fix them and you do not edit files.
 
 ## The rules you enforce
 
 ```
-@crudo/nest ──▶ @crudo/core ◀── @crudo/typeorm
+@kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
 ```
 
-1. **`@crudo/core` imports nothing** — zero runtime dependencies (ADR-0005).
+1. **`@kavo/core` imports nothing** — zero runtime dependencies (ADR-0005).
    Not TypeORM, not Nest, not a utility library. Type-only imports from outside
    core are violations too: core owns its contracts.
-2. **Barrel-only consumption** — `@crudo/typeorm` and `@crudo/nest` import from
-   the `@crudo/core` barrel. Any `@crudo/core/src/...` or relative reach into
+2. **Barrel-only consumption** — `@kavo/typeorm` and `@kavo/nest` import from
+   the `@kavo/core` barrel. Any `@kavo/core/src/...` or relative reach into
    core's internals is a violation.
 3. **The spokes never meet** — the TypeORM adapter must not import the Nest
    binding, and vice versa. They compose only through Nest's DI container.
@@ -39,7 +39,7 @@ violations in a change. You do not fix them and you do not edit files.
    `pnpm depcruise`. A pass here does **not** end your review: dependency-cruiser
    catches import graphs, not type leakage or barrel intent.
 3. Grep the changed files for the leak patterns: imports of `typeorm`,
-   `@nestjs/*`, or `@crudo/core/` (deep) in the wrong package; `export *`
+   `@nestjs/*`, or `@kavo/core/` (deep) in the wrong package; `export *`
    anywhere in core's barrel.
 4. Diff the barrel specifically: `git diff main...HEAD -- packages/core/src/index.ts`.
    For each added export, ask whether it is meant to be public. For each removed

--- a/.claude/agents/kavo-reviewer.md
+++ b/.claude/agents/kavo-reviewer.md
@@ -1,15 +1,15 @@
 ---
-name: crudo-reviewer
-description: Reviews a Crudo branch for correctness, engine/registry design invariants and naming-convention compliance. Use as the main review pass before opening or merging a PR. Read-only; reports findings and never edits.
+name: kavo-reviewer
+description: Reviews a Kavo branch for correctness, engine/registry design invariants and naming-convention compliance. Use as the main review pass before opening or merging a PR. Read-only; reports findings and never edits.
 tools: Read, Grep, Glob, Bash
 model: inherit
 ---
 
-You are the primary code reviewer for Crudo. You review a change for
+You are the primary code reviewer for Kavo. You review a change for
 correctness and design fit. You report findings; you never edit files.
 
-Boundaries and public-API surface are `crudo-boundary-guard`'s job, and test
-coverage is `crudo-test-auditor`'s — do not duplicate them. Stay on
+Boundaries and public-API surface are `kavo-boundary-guard`'s job, and test
+coverage is `kavo-test-auditor`'s — do not duplicate them. Stay on
 correctness, engine design, and naming.
 
 ## Procedure
@@ -27,7 +27,7 @@ correctness, engine design, and naming.
 - Does the change do what the issue asked, including the parts that are
   inconvenient?
 - Error paths: does it throw the right `*Exception` with a stable
-  `CRUDO_SNAKE_CASE` code, or does it leak a raw driver error? Adapter errors
+  `KAVO_SNAKE_CASE` code, or does it leak a raw driver error? Adapter errors
   must be mapped, not propagated.
 - Edge cases the query engine keeps producing: empty result sets, `null` vs.
   missing, zero/negative pagination values, the field-path recursion cap
@@ -65,7 +65,7 @@ correctness, engine design, and naming.
   `<verb>Many`. "Bulk" is a feature term, never a method prefix.
 - Filter operators: `SCREAMING_SNAKE` in the AST enum, camelCase on the wire,
   exact-case matched.
-- Exceptions are `*Exception` with stable `CRUDO_SNAKE_CASE` codes.
+- Exceptions are `*Exception` with stable `KAVO_SNAKE_CASE` codes.
 - Config keys are camelCase with positively-phrased booleans (`exposeInternals`,
   never `hideInternals`). No `I` prefix on interfaces.
 - One canonical name per concept — check `packages/docs/glossary.md`. A synonym

--- a/.claude/agents/kavo-test-auditor.md
+++ b/.claude/agents/kavo-test-auditor.md
@@ -1,11 +1,11 @@
 ---
-name: crudo-test-auditor
-description: Audits test coverage and test quality for a Crudo change — missing error/edge paths, tests that assert implementation instead of behavior, and misplaced test files. Use during review, or when deciding what tests a change still needs. Read-only.
+name: kavo-test-auditor
+description: Audits test coverage and test quality for a Kavo change — missing error/edge paths, tests that assert implementation instead of behavior, and misplaced test files. Use during review, or when deciding what tests a change still needs. Read-only.
 tools: Read, Grep, Glob, Bash
 model: inherit
 ---
 
-You audit tests for Crudo. You judge whether a change is actually pinned down
+You audit tests for Kavo. You judge whether a change is actually pinned down
 by its tests. You do not write or edit tests — you report the gaps precisely
 enough that someone else can close them.
 
@@ -13,7 +13,7 @@ enough that someone else can close them.
 
 - Tests live in each package's `tests/` directory, **never in `src/`**, so they
   are not shipped in `dist/`.
-- Vitest aliases `@crudo/*` to package `src/` directly (see `vitest.config.ts`),
+- Vitest aliases `@kavo/*` to package `src/` directly (see `vitest.config.ts`),
   so tests exercise sources — there is no stale-`dist` hazard, and no test
   should ever import from `dist/`.
 - The SWC vitest plugin is required: TypeORM entities and Nest DI need
@@ -34,7 +34,7 @@ enough that someone else can close them.
 ## What counts as a gap
 
 - **Error paths untested.** Every new `*Exception` needs a test asserting the
-  thrown type _and_ its `CRUDO_SNAKE_CASE` code — the code is a public contract,
+  thrown type _and_ its `KAVO_SNAKE_CASE` code — the code is a public contract,
   and a test that only checks the message lets the code drift.
 - **Edge cases untested.** Empty results, `null` vs. absent, boundary pagination
   values, the recursion cap, unknown include paths, non-allowlisted filter

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -25,9 +25,9 @@ instructions: **$ARGUMENTS**
    adds, overrides, or disables an operation.
 
    Hold the line on the invariants while you work:
-   - `@crudo/core` imports nothing (ADR-0005) — no TypeORM, no Nest, not even
+   - `@kavo/core` imports nothing (ADR-0005) — no TypeORM, no Nest, not even
      type-only.
-   - Adapters and bindings import the `@crudo/core` **barrel only**, never deep
+   - Adapters and bindings import the `@kavo/core` **barrel only**, never deep
      paths. The TypeORM adapter and the Nest binding never import each other.
    - Operations come from the registry (ADR-0006). No per-verb special-casing in
      the engine or the route generator.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -35,7 +35,7 @@ or private.
    - **Context** — why this is worth doing, in two or three sentences.
    - **Acceptance criteria** — a checklist of what must be true when it is done.
      These must be verifiable, not aspirational.
-   - **Affected packages** — `@crudo/core`, `@crudo/typeorm`, `@crudo/nest`,
+   - **Affected packages** — `@kavo/core`, `@kavo/typeorm`, `@kavo/nest`,
      docs, or a combination.
    - **Constraints** — the invariants that must survive: ADR-0005 core purity,
      registry-driven operations (ADR-0006), the explicit barrel (ADR-0010),

--- a/.claude/commands/next.md
+++ b/.claude/commands/next.md
@@ -23,7 +23,7 @@ Argument (may be empty): **$ARGUMENTS**
    why** before going further. Read it in full:
    `gh issue view <n> --json title,body,labels,comments`.
 
-3. **Plan it.** Launch the `crudo-architect` agent with the issue number and its
+3. **Plan it.** Launch the `kavo-architect` agent with the issue number and its
    full text. It is read-only and returns a plan: goal, acceptance criteria,
    affected packages and files, design and the seam it uses, the invariants and
    ADRs in play, public-API impact, an ordered task list, a test plan, and risks.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -29,11 +29,11 @@ Review this branch. Focus, if given: **$ARGUMENTS**
 3. **Run the three reviewers in parallel**, in a single message. They are
    read-only and deliberately non-overlapping:
 
-   - `crudo-reviewer` — correctness, engine and registry design invariants,
+   - `kavo-reviewer` — correctness, engine and registry design invariants,
      naming compliance. Also runs `pnpm check`.
-   - `crudo-boundary-guard` — ADR-0005 core purity, deep imports, ORM/framework
+   - `kavo-boundary-guard` — ADR-0005 core purity, deep imports, ORM/framework
      leakage, barrel and breaking-change audit.
-   - `crudo-test-auditor` — coverage gaps, weak tests, misplaced test files.
+   - `kavo-test-auditor` — coverage gaps, weak tests, misplaced test files.
 
 4. **Consolidate.** Merge their findings into one ranked list and drop the
    duplicates. Do not just paste three reports.

--- a/.claude/skills/add-operation/SKILL.md
+++ b/.claude/skills/add-operation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: add-operation
-description: The end-to-end procedure for adding, overriding, or disabling a Crudo operation — registry entry, DTO slots, handler, route metadata, and tests. Use when a change introduces a new CRUD operation or a custom per-entity operation.
+description: The end-to-end procedure for adding, overriding, or disabling a Kavo operation — registry entry, DTO slots, handler, route metadata, and tests. Use when a change introduces a new CRUD operation or a custom per-entity operation.
 ---
 
 # Adding an operation
 
-The whole point of Crudo's design is that **adding an operation is adding a
+The whole point of Kavo's design is that **adding an operation is adding a
 registry entry** (ADR-0006). The engine loops over registry entries and
-`@crudo/nest` generates one route per enabled entry from the same registry. If
+`@kavo/nest` generates one route per enabled entry from the same registry. If
 your change needs a new `if` in the engine or in the route generator, the design
 is wrong — stop and reconsider.
 
@@ -44,7 +44,7 @@ Every entry is an `OperationDescriptor`
 ## Route metadata
 
 Core knows nothing about HTTP. Routes are expressed through `meta`, which
-`@crudo/nest` augments:
+`@kavo/nest` augments:
 
 ```ts
 meta: {
@@ -69,7 +69,7 @@ meta: {
 - DTO classes: request bodies `<Verb><Entity>Dto`; query/response shapes
   `<Entity><Slot>Dto`. Every wire-crossing shape carries `Dto`; behavioral
   contracts never do.
-- New exceptions are `*Exception` with a stable `CRUDO_SNAKE_CASE` code.
+- New exceptions are `*Exception` with a stable `KAVO_SNAKE_CASE` code.
 
 ## Where the work lands
 

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: write-tests
-description: How to write tests for the Crudo monorepo — file placement, Vitest/SWC setup, fixtures, and the cases every change must pin down. Use when adding or updating tests in packages/core, packages/orms/typeorm, or packages/frameworks/nest.
+description: How to write tests for the Kavo monorepo — file placement, Vitest/SWC setup, fixtures, and the cases every change must pin down. Use when adding or updating tests in packages/core, packages/orms/typeorm, or packages/frameworks/nest.
 ---
 
-# Writing tests for Crudo
+# Writing tests for Kavo
 
 ## Placement and setup
 
 - Tests go in each package's `tests/` directory — **never in `src/`**, so they
   are not shipped in `dist/`. The layout is flat: `packages/core/tests/*.spec.ts`,
   with shared fixtures in `packages/core/tests/support/`.
-- Vitest aliases `@crudo/*` to package `src/` (see `vitest.config.ts`), so tests
+- Vitest aliases `@kavo/*` to package `src/` (see `vitest.config.ts`), so tests
   import the package by name and exercise sources directly. **Never import from
   `dist/`.**
 - The SWC vitest plugin is mandatory: TypeORM entities and Nest DI need
@@ -32,7 +32,7 @@ is usually a fixture that already exists.
 
 ## Test through the real seams
 
-Crudo is built from injected seams — handlers, serializer/deserializer, query
+Kavo is built from injected seams — handlers, serializer/deserializer, query
 normalizer, pagination strategies, error handler. Prefer driving the **real
 engine** with a test adapter over mocking the pipeline. A test that mocks the
 thing it is testing passes when the implementation is wrong.
@@ -49,7 +49,7 @@ silently regressed:
   `toBeDefined()`.
 - **Validation** — rejected input produces the right rejection, not a crash.
 - **Error path** — assert the thrown `*Exception` type **and** its
-  `CRUDO_SNAKE_CASE` code. The code is a public contract; asserting only the
+  `KAVO_SNAKE_CASE` code. The code is a public contract; asserting only the
   message lets the code drift silently.
 - **Edge cases** — empty results, `null` vs. absent, boundary pagination values,
   the field-path recursion cap (ADR-0008), unknown include paths,

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -4,9 +4,9 @@
  *
  * The rules here are the executable form of the dependency graph:
  *
- *   @crudo/nest ──▶ @crudo/core ◀── @crudo/typeorm
+ *   @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
  *
- * `@crudo/core` imports nothing. Adapters and framework bindings import the
+ * `@kavo/core` imports nothing. Adapters and framework bindings import the
  * core barrel only — deep imports are not API. An illegal import fails CI
  * here, not in code review.
  */
@@ -16,9 +16,9 @@ module.exports = {
       name: "core-imports-nothing",
       severity: "error",
       comment:
-        "@crudo/core is the dependency-free hub: no other workspace package, " +
+        "@kavo/core is the dependency-free hub: no other workspace package, " +
         "no node_modules — zero runtime dependencies (ADR-0005). Scoped to " +
-        "`src`: core's own tests legitimately import the `@crudo/core` barrel " +
+        "`src`: core's own tests legitimately import the `@kavo/core` barrel " +
         "and vitest, and are governed by the `tests-*` rules below instead.",
       from: { path: "^packages/core/src" },
       to: {
@@ -30,36 +30,36 @@ module.exports = {
       name: "typeorm-only-imports-core",
       severity: "error",
       comment:
-        "@crudo/typeorm may depend on @crudo/core and the typeorm peer — " +
-        "never on @crudo/nest (ADR-0002). Both spellings are matched: a " +
+        "@kavo/typeorm may depend on @kavo/core and the typeorm peer — " +
+        "never on @kavo/nest (ADR-0002). Both spellings are matched: a " +
         "workspace package specifier does not resolve to a path here, so a " +
-        'path-only rule would miss `from "@crudo/nest"` — the spelling ' +
+        'path-only rule would miss `from "@kavo/nest"` — the spelling ' +
         "anyone would actually write.",
       from: { path: "^packages/orms/typeorm/src" },
-      to: { path: "^(packages/frameworks|@crudo/nest)" },
+      to: { path: "^(packages/frameworks|@kavo/nest)" },
     },
     {
       name: "nest-only-imports-core",
       severity: "error",
       comment:
-        "@crudo/nest may depend on @crudo/core and the @nestjs/* peers — " +
+        "@kavo/nest may depend on @kavo/core and the @nestjs/* peers — " +
         "never on an ORM adapter (ADR-0002). Adapters reach Nest's container " +
         "via DI, not via imports. Package-specifier form matched too, per the " +
         "note on typeorm-only-imports-core.",
       from: { path: "^packages/frameworks/nest/src" },
-      to: { path: "^(packages/orms|@crudo/typeorm)" },
+      to: { path: "^(packages/orms|@kavo/typeorm)" },
     },
     {
       name: "no-cross-package-deep-imports-core",
       severity: "error",
       comment:
-        "Cross-package imports go through the package barrel (@crudo/core), " +
+        "Cross-package imports go through the package barrel (@kavo/core), " +
         "which is an explicit named list (ADR-0010). Deep imports into " +
         "another package's src are not API — matched as a relative path and " +
-        "as a `@crudo/core/...` subpath. `packages/examples` is in scope: it " +
+        "as a `@kavo/core/...` subpath. `packages/examples` is in scope: it " +
         "is the reference app, so an illegal import there teaches one.",
       from: { path: "^packages/(orms|frameworks|examples)" },
-      to: { path: "^(packages/core/src/.+|@crudo/core/.+)" },
+      to: { path: "^(packages/core/src/.+|@kavo/core/.+)" },
     },
     {
       name: "no-cross-package-deep-imports-adapters",
@@ -72,7 +72,7 @@ module.exports = {
       name: "tests-no-other-package-internals",
       severity: "error",
       comment:
-        "A test file may import its own package's source and the @crudo/* " +
+        "A test file may import its own package's source and the @kavo/* " +
         "barrels — never another package's `src` or `tests`. Sharing a " +
         "fixture by reaching into a sibling package's tests is the same " +
         "boundary violation as doing it in production code (ADR-0002), and " +
@@ -96,7 +96,7 @@ module.exports = {
         "core's tests may use the barrel and vitest; this keeps the part that " +
         "still matters — no adapter, no framework — enforced for them too.",
       from: { path: "^packages/core/tests" },
-      to: { path: "^(@crudo/(typeorm|nest)|packages/(orms|frameworks))" },
+      to: { path: "^(@kavo/(typeorm|nest)|packages/(orms|frameworks))" },
     },
     {
       name: "no-circular",

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -19,7 +19,7 @@ labels: ""
 
 ## Affected packages
 
-<!-- @crudo/core | @crudo/typeorm | @crudo/nest | docs -->
+<!-- @kavo/core | @kavo/typeorm | @kavo/nest | docs -->
 
 ## Constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## What Crudo is
+## What Kavo is
 
 A production-grade CRUD framework for TypeScript: define an entity once (via TypeORM) and get the full REST CRUD surface — filtering, sorting, pagination, nested includes, field selection, optional per-operation DTOs, transactions, and problem-details errors — behind generated NestJS routes, configurable at global → entity → operation → per-call scope.
 
 The authoritative sources are `packages/docs/` (architecture notes and ADRs) and the **Conventions** section below, which is normative — naming deviations are review findings. Consult the governing ADR before changing behavior it covers, rather than inventing behavior.
 
-Crudo was originally built from a phased plan (`crudo-phases-v6.md`), now retired. `Phase N` references survive in code comments and docs as historical provenance; the remaining unbuilt work lives in [`packages/docs/roadmap.md`](packages/docs/roadmap.md).
+Kavo was originally built from a phased plan (`kavo-phases-v6.md`), now retired. `Phase N` references survive in code comments and docs as historical provenance; the remaining unbuilt work lives in [`packages/docs/roadmap.md`](packages/docs/roadmap.md).
 
 ## Commands
 
@@ -29,7 +29,7 @@ pnpm vitest run packages/core/tests/filter-parser.spec.ts
 pnpm vitest run -t "coerces numeric ids"
 ```
 
-Tests live in each package's `tests/` directory (never in `src/`, so they are not shipped in `dist/`). Vitest aliases `@crudo/*` to package `src/` directly (see `vitest.config.ts`), so tests exercise sources with no stale-`dist` hazard. The SWC vitest plugin is required — TypeORM entities and Nest DI need decorator metadata that esbuild cannot emit.
+Tests live in each package's `tests/` directory (never in `src/`, so they are not shipped in `dist/`). Vitest aliases `@kavo/*` to package `src/` directly (see `vitest.config.ts`), so tests exercise sources with no stale-`dist` hazard. The SWC vitest plugin is required — TypeORM entities and Nest DI need decorator metadata that esbuild cannot emit.
 
 Because the build compiles `src` only, each package also has a `tsconfig.tests.json` (`noEmit`, `include: ["tests"]`, `paths` mirroring the vitest aliases) that `pnpm typecheck` runs. That is what makes the type-level acceptance tests in `packages/*/tests/types/*.test-d.ts` real: they end in `.test-d.ts`, so vitest never collects them and nothing executes — `expectTypeOf` assertions and `@ts-expect-error` directives are checked by `tsc` alone. An unused `@ts-expect-error` is itself an error, so those tests fail in both directions.
 
@@ -38,14 +38,14 @@ Because the build compiles `src` only, each package also has a `tsconfig.tests.j
 Three packages in a strict hub-and-spoke topology (`pnpm-workspace.yaml`):
 
 ```
-@crudo/nest ──▶ @crudo/core ◀── @crudo/typeorm
+@kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
 ```
 
-- **`@crudo/core`** (`packages/core`) — all contracts, the type system, and the request engine. **Zero runtime dependencies** and imports nothing (ADR-0005). It has no knowledge of TypeORM or Nest.
-- **`@crudo/typeorm`** (`packages/orms/typeorm`) — implements core's `RepositoryAdapter` and feeds core's entity-metadata seam from TypeORM metadata. `typeorm` is a peer dependency.
-- **`@crudo/nest`** (`packages/frameworks/nest`) — the `@Crud` decorator and NestJS route generation.
+- **`@kavo/core`** (`packages/core`) — all contracts, the type system, and the request engine. **Zero runtime dependencies** and imports nothing (ADR-0005). It has no knowledge of TypeORM or Nest.
+- **`@kavo/typeorm`** (`packages/orms/typeorm`) — implements core's `RepositoryAdapter` and feeds core's entity-metadata seam from TypeORM metadata. `typeorm` is a peer dependency.
+- **`@kavo/nest`** (`packages/frameworks/nest`) — the `@Crud` decorator and NestJS route generation.
 
-These boundaries are **mechanically enforced** by `.dependency-cruiser.cjs`, not just convention: core may import nothing, adapters and framework bindings import the `@crudo/core` barrel only (no deep imports), and the adapter never imports the framework or vice versa — they meet only through Nest's DI container. An illegal import fails `pnpm depcruise` (part of `pnpm check`), not code review.
+These boundaries are **mechanically enforced** by `.dependency-cruiser.cjs`, not just convention: core may import nothing, adapters and framework bindings import the `@kavo/core` barrel only (no deep imports), and the adapter never imports the framework or vice versa — they meet only through Nest's DI container. An illegal import fails `pnpm depcruise` (part of `pnpm check`), not code review.
 
 ### The request pipeline (the spine)
 
@@ -60,7 +60,7 @@ Nothing is special-cased per verb. Operations come from an **operation registry*
 
 ### Composition root
 
-`createCrudo(options).createCrud(Entity, config?, runtime?)` (`packages/core/src/crudo.ts`) is the **only** way entities enter the system. All resolution (config precedence merge, DTO derivation, registry construction) happens at that call — bootstrap — and the result is frozen after. Core needs an explicit `infrastructure` (adapter + metadata); `@crudo/typeorm`'s `createTypeOrmInfrastructure(dataSource)` / `createTypeOrmCrudo` is the sugar that derives both from a `DataSource`.
+`createKavo(options).createCrud(Entity, config?, runtime?)` (`packages/core/src/kavo.ts`) is the **only** way entities enter the system. All resolution (config precedence merge, DTO derivation, registry construction) happens at that call — bootstrap — and the result is frozen after. Core needs an explicit `infrastructure` (adapter + metadata); `@kavo/typeorm`'s `createTypeOrmInfrastructure(dataSource)` / `createTypeOrmKavo` is the sugar that derives both from a `DataSource`.
 
 ### Route generation is registry-driven and happens at decoration time
 
@@ -74,7 +74,7 @@ Standard operations delegate to the typed `DefaultCrudService` surface; custom o
 
 ### Wiring an app
 
-See `packages/examples/src/app.module.ts`: `CrudoModule.forRootAsync({ useFactory: () => ({ infrastructure: createTypeOrmInfrastructure(dataSource), defaults: {...} }) })` supplies the global scope, and `CrudoModule.forFeature([...Controllers])` registers the `@Crud` controllers. The app is what hands Nest its infrastructure — the packages never import each other.
+See `packages/examples/src/app.module.ts`: `KavoModule.forRootAsync({ useFactory: () => ({ infrastructure: createTypeOrmInfrastructure(dataSource), defaults: {...} }) })` supplies the global scope, and `KavoModule.forFeature([...Controllers])` registers the `@Crud` controllers. The app is what hands Nest its infrastructure — the packages never import each other.
 
 ## Conventions (normative)
 
@@ -83,8 +83,8 @@ See `packages/examples/src/app.module.ts`: `CrudoModule.forRootAsync({ useFactor
 - **Operations** are camelCase and always name cardinality: `<verb>One` / `<verb>Many`. "Bulk" is the feature term (config key `bulk`, `/bulk` routes, `BulkResultDto`), never a method prefix.
 - **Filter operators**: AST enum in `SCREAMING_SNAKE` (`EQ`…`IS_NOT_NULL`); wire tokens in camelCase (`eq`…`isNotNull`), exact-case matched. The mapping table in `packages/docs/architecture/05-query-grammar.md` is the single source of truth.
 - **Envelope fields**: `items`, `limit`, `offset`, `total`, `meta` — the default pagination wire params use the same `limit`/`offset` names, so request and response mirror each other.
-- **Factories** are `create*` (`createCrudo`, `createCrud`). **Data access**: `EntityReader` (reads) + `EntityWriter` (writes); `RepositoryAdapter` is both, and adapters are named for what they adapt (`TypeOrmRepositoryAdapter`).
-- **Exceptions**: `*Exception` classes with stable `CRUDO_SNAKE_CASE` codes.
+- **Factories** are `create*` (`createKavo`, `createCrud`). **Data access**: `EntityReader` (reads) + `EntityWriter` (writes); `RepositoryAdapter` is both, and adapters are named for what they adapt (`TypeOrmRepositoryAdapter`).
+- **Exceptions**: `*Exception` classes with stable `KAVO_SNAKE_CASE` codes.
 - **Config keys**: camelCase, booleans phrased positively (`exposeInternals`, never `hideInternals`).
 - **No `I` prefix** on interfaces.
 - The core barrel (`packages/core/src/index.ts`) is a **deliberate explicit named list** (no `export *`) — the public surface changes only on purpose. Add exports there intentionally.
@@ -95,9 +95,9 @@ Work moves one issue at a time, on one branch, through slash commands in `.claud
 
 ```
 /issue "rough idea"   →  a plannable GitHub issue (acceptance criteria, affected packages, constraints)
-/next [n]             →  crudo-architect plans it  →  YOU APPROVE  →  branch created off main
+/next [n]             →  kavo-architect plans it  →  YOU APPROVE  →  branch created off main
 /implement            →  code + tests written here, in the main thread  →  pnpm check  →  commit
-/review               →  crudo-reviewer ‖ crudo-boundary-guard ‖ crudo-test-auditor, consolidated
+/review               →  kavo-reviewer ‖ kavo-boundary-guard ‖ kavo-test-auditor, consolidated
 /ship                 →  pnpm check  →  push  →  PR opened, "Closes #n"
 /merge                →  CI verified  →  squash merge  →  branch deleted  →  back on green main
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Crudo
+# Kavo
 
 A production-grade CRUD framework for TypeScript: define an entity once
 (via TypeORM) and get the full REST CRUD surface — filtering, sorting,
@@ -12,11 +12,11 @@ conventions in [`CLAUDE.md`](CLAUDE.md) are normative.
 
 ## Packages
 
-| Package                                   | Role                                                       |
-| ----------------------------------------- | ---------------------------------------------------------- |
-| [`@crudo/core`](packages/core)            | Contracts, type system, engine — zero runtime dependencies |
-| [`@crudo/typeorm`](packages/orms/typeorm) | TypeORM adapter (`RepositoryAdapter` implementation)       |
-| [`@crudo/nest`](packages/frameworks/nest) | NestJS binding (`@Crud` decorator, route generation)       |
+| Package                                  | Role                                                       |
+| ---------------------------------------- | ---------------------------------------------------------- |
+| [`@kavo/core`](packages/core)            | Contracts, type system, engine — zero runtime dependencies |
+| [`@kavo/typeorm`](packages/orms/typeorm) | TypeORM adapter (`RepositoryAdapter` implementation)       |
+| [`@kavo/nest`](packages/frameworks/nest) | NestJS binding (`@Crud` decorator, route generation)       |
 
 Design docs, glossary, and ADRs live in [`packages/docs`](packages/docs).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "crudo",
+  "name": "kavo",
   "private": true,
-  "description": "Crudo — a production-grade CRUD framework for TypeScript (monorepo root).",
+  "description": "Kavo — a production-grade CRUD framework for TypeScript (monorepo root).",
   "packageManager": "pnpm@9.15.0",
   "engines": {
     "node": ">=20"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
-# @crudo/core
+# @kavo/core
 
-Framework- and ORM-independent contracts and type system for Crudo.
+Framework- and ORM-independent contracts and type system for Kavo.
 
 **Zero runtime dependencies** — this package must not depend on NestJS or
 TypeORM, directly or transitively (enforced by `.dependency-cruiser.cjs`).
@@ -25,7 +25,7 @@ src/
 └─ index.ts        Explicit named barrel — the public API surface
 ```
 
-Only the barrel (`@crudo/core`) is public API; deep imports are not.
+Only the barrel (`@kavo/core`) is public API; deep imports are not.
 
 See `packages/docs/architecture/03-core-contracts-and-type-system.md` for
 the generic-parameter table, `FieldPath` notes, and the module-augmentation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@crudo/core",
+  "name": "@kavo/core",
   "version": "0.0.0",
-  "description": "Crudo core — framework- and ORM-independent contracts and type system. Zero runtime dependencies.",
+  "description": "Kavo core — framework- and ORM-independent contracts and type system. Zero runtime dependencies.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -1,11 +1,11 @@
-import type { CrudoSettings } from "./settings.js";
+import type { KavoSettings } from "./settings.js";
 
 /**
  * The built-in defaults — the base of the precedence chain
  * `built-in defaults → global → entity → operation → per-call` (Phase 8).
  * The zero-config `createCrud(Entity)` path runs on exactly these values.
  */
-export const BUILT_IN_DEFAULTS: CrudoSettings = Object.freeze({
+export const BUILT_IN_DEFAULTS: KavoSettings = Object.freeze({
   pagination: Object.freeze({
     defaultLimit: 20,
     maxLimit: 100,

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -1,4 +1,4 @@
-import type { CrudoSettings } from "./settings.js";
+import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
 import type { FieldPath } from "../types/field-path.js";
 import type { QueryContext } from "../query/query-context.js";
@@ -25,7 +25,7 @@ export interface QueryAllowlists<Entity = unknown> {
  * Settings keys override entity scope for this operation only; `false` in
  * the parent `operations` record disables the operation outright.
  */
-export interface OperationConfig<Entity = unknown> extends DeepPartial<CrudoSettings> {
+export interface OperationConfig<Entity = unknown> extends DeepPartial<KavoSettings> {
   /**
    * Turn the operation on or off explicitly, overriding its default. The
    * long form of the `false` / `true` shorthands in the parent
@@ -43,7 +43,7 @@ export interface OperationConfig<Entity = unknown> extends DeepPartial<CrudoSett
  * A developer-defined operation (Phase 13). Unlike an override, a custom
  * operation declares its own input/output DTOs — its shape isn't
  * guaranteed CRUD-like. Route generation (including the `http: false`
- * service-only mode) is expressed through `meta` by `@crudo/nest`'s
+ * service-only mode) is expressed through `meta` by `@kavo/nest`'s
  * `OperationMetadata` augmentation.
  */
 export interface CustomOperationConfig<Entity = unknown> {
@@ -55,7 +55,7 @@ export interface CustomOperationConfig<Entity = unknown> {
 
 /**
  * Raw entity-scope configuration — the second argument to `createCrud`.
- * Settings keys (inherited from `DeepPartial<CrudoSettings>`) override
+ * Settings keys (inherited from `DeepPartial<KavoSettings>`) override
  * global scope for this entity.
  */
 export interface EntityConfig<
@@ -66,7 +66,7 @@ export interface EntityConfig<
   QueryDto = QueryContext<Entity>,
   ItemDto = Entity,
   ListDto = ItemDto,
-> extends DeepPartial<CrudoSettings> {
+> extends DeepPartial<KavoSettings> {
   readonly dto?: OperationDtoMap<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>;
   readonly allowlists?: QueryAllowlists<Entity>;
   /**

--- a/packages/core/src/config/global-config.ts
+++ b/packages/core/src/config/global-config.ts
@@ -1,13 +1,13 @@
-import type { CrudoSettings } from "./settings.js";
+import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
 
 /**
  * Raw global (framework-scope) configuration — the argument to
- * `createCrudo`. The bare `createCrud(Entity)` zero-config path is an
+ * `createKavo`. The bare `createCrud(Entity)` zero-config path is an
  * implicit root instance of this with built-in defaults; nothing about
  * global config may tax the zero-config case.
  */
 export interface GlobalConfig {
   /** Framework-wide defaults, merged below entity/operation scope. */
-  readonly defaults?: DeepPartial<CrudoSettings>;
+  readonly defaults?: DeepPartial<KavoSettings>;
 }

--- a/packages/core/src/config/merge-settings.ts
+++ b/packages/core/src/config/merge-settings.ts
@@ -1,4 +1,4 @@
-import type { CrudoSettings } from "./settings.js";
+import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
 
 /**
@@ -10,18 +10,18 @@ import type { DeepPartial } from "../types/utility.js";
  *   (`softDelete: false`): the `false` replaces the whole subtree.
  * - Arrays replace wholesale (no element merging).
  *
- * The base is always a *complete* `CrudoSettings`, so the result is too.
+ * The base is always a *complete* `KavoSettings`, so the result is too.
  */
 export function mergeSettings(
-  base: CrudoSettings,
-  ...overrides: readonly (DeepPartial<CrudoSettings> | undefined)[]
-): CrudoSettings {
+  base: KavoSettings,
+  ...overrides: readonly (DeepPartial<KavoSettings> | undefined)[]
+): KavoSettings {
   let result: Record<string, unknown> = { ...base };
   for (const override of overrides) {
     if (override === undefined) continue;
     result = mergeLevel(result, override as Record<string, unknown>);
   }
-  return result as unknown as CrudoSettings;
+  return result as unknown as KavoSettings;
 }
 
 function mergeLevel(base: Record<string, unknown>, override: Record<string, unknown>): Record<string, unknown> {

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -1,4 +1,4 @@
-import type { CrudoSettings } from "./settings.js";
+import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
 import type { EntityConfig, OperationConfig } from "./entity-config.js";
 import type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./resolved-entity-config.js";
@@ -19,20 +19,20 @@ const SETTINGS_KEYS = [
   "errors",
   "relations",
   "softDelete",
-] as const satisfies readonly (keyof CrudoSettings)[];
+] as const satisfies readonly (keyof KavoSettings)[];
 
 /**
  * An `EntityConfig`/`OperationConfig` mixes settings keys with structural
  * keys (`dto`, `allowlists`, `handler`, …); only the settings subset
  * participates in the merge algebra.
  */
-function pickSettings(config: Readonly<Record<string, unknown>> | undefined): DeepPartial<CrudoSettings> | undefined {
+function pickSettings(config: Readonly<Record<string, unknown>> | undefined): DeepPartial<KavoSettings> | undefined {
   if (config === undefined) return undefined;
   const picked: Record<string, unknown> = {};
   for (const key of SETTINGS_KEYS) {
     if (config[key] !== undefined) picked[key] = config[key];
   }
-  return picked as DeepPartial<CrudoSettings>;
+  return picked as DeepPartial<KavoSettings>;
 }
 
 /**
@@ -44,7 +44,7 @@ function pickSettings(config: Readonly<Record<string, unknown>> | undefined): De
 export function resolveEntityConfig<Entity extends object>(
   metadata: EntityMetadata<Entity>,
   entityConfig: EntityConfig<Entity> | undefined,
-  globalDefaults: DeepPartial<CrudoSettings> | undefined,
+  globalDefaults: DeepPartial<KavoSettings> | undefined,
 ): ResolvedEntityConfig<Entity> {
   const entityName = metadata.name;
   const entitySettings = mergeSettings(
@@ -57,7 +57,7 @@ export function resolveEntityConfig<Entity extends object>(
   // Per-operation settings views, precomputed for every operation that
   // declares overrides. `false` (disabled) contributes no settings — the
   // registry handles disabling.
-  const perOperation = new Map<OperationId, CrudoSettings>();
+  const perOperation = new Map<OperationId, KavoSettings>();
   for (const [operation, config] of Object.entries(entityConfig?.operations ?? {}) as [
     StandardOperationId,
     OperationConfig<Entity> | boolean,
@@ -82,7 +82,7 @@ export function resolveEntityConfig<Entity extends object>(
   const resolved: ResolvedEntityConfig<Entity> = {
     entityName,
     settings: deepFreeze(entitySettings),
-    settingsFor(operation: OperationId): CrudoSettings {
+    settingsFor(operation: OperationId): KavoSettings {
       return perOperation.get(operation) ?? entitySettings;
     },
     allowlists,

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -1,4 +1,4 @@
-import type { CrudoSettings } from "./settings.js";
+import type { KavoSettings } from "./settings.js";
 import type { FieldPath } from "../types/field-path.js";
 import type { DtoResolver } from "../dto/dto.js";
 import type { OperationId } from "../operations/operation.js";
@@ -24,9 +24,9 @@ export interface ResolvedQueryAllowlists<Entity = unknown> {
 export interface ResolvedEntityConfig<Entity = unknown> {
   readonly entityName: string;
   /** Entity-scope settings (global already merged in). */
-  readonly settings: CrudoSettings;
+  readonly settings: KavoSettings;
   /** Per-operation settings view: entity settings + operation overrides. */
-  settingsFor(operation: OperationId): CrudoSettings;
+  settingsFor(operation: OperationId): KavoSettings;
   readonly allowlists: ResolvedQueryAllowlists<Entity>;
   /**
    * The delete strategy resolved for this scope (Phase 14) — `hard` with

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -4,8 +4,8 @@ import type { RelationLoadStrategy } from "../relations/relation-descriptor.js";
  * The complete, canonical settings schema — one schema for every scope.
  *
  * These interfaces describe *resolved* (complete) settings. Input scopes —
- * global (`createCrudo`), entity (`createCrud`), operation, and per-call —
- * all accept `DeepPartial<CrudoSettings>` of this same shape; there is
+ * global (`createKavo`), entity (`createCrud`), operation, and per-call —
+ * all accept `DeepPartial<KavoSettings>` of this same shape; there is
  * never a second config mechanism (Phase 8 schema-extensibility rule).
  * Later feature phases add keys here, reserved in the schema now.
  */
@@ -76,7 +76,7 @@ export interface SoftDeleteSettings {
 }
 
 /** The full settings tree. */
-export interface CrudoSettings {
+export interface KavoSettings {
   readonly pagination: PaginationSettings;
   readonly query: QuerySettings;
   readonly errors: ErrorSettings;

--- a/packages/core/src/config/validate-settings.ts
+++ b/packages/core/src/config/validate-settings.ts
@@ -1,4 +1,4 @@
-import type { CrudoSettings } from "./settings.js";
+import type { KavoSettings } from "./settings.js";
 import { ConfigurationException } from "../errors/exceptions.js";
 
 /**
@@ -6,7 +6,7 @@ import { ConfigurationException } from "../errors/exceptions.js";
  * entity, the key path, and the offending value — config errors surface at
  * startup, never as mysterious runtime behavior.
  */
-export function validateSettings(entityName: string, settings: CrudoSettings): void {
+export function validateSettings(entityName: string, settings: KavoSettings): void {
   const positiveInt = (path: string, value: unknown): void => {
     if (!Number.isInteger(value) || (value as number) <= 0) {
       throw new ConfigurationException(entityName, path, `expected a positive integer, got ${JSON.stringify(value)}`);

--- a/packages/core/src/context/crud-context.ts
+++ b/packages/core/src/context/crud-context.ts
@@ -32,7 +32,7 @@ export interface CrudContext<Entity = unknown> {
   readonly config: ResolvedEntityConfig<Entity>;
   /**
    * The authenticated caller — opaque to core. Set by the framework layer
-   * (`@crudo/nest` from the request), available to custom operation
+   * (`@kavo/nest` from the request), available to custom operation
    * handlers; core never inspects it (v6 ships no policy layer).
    */
   readonly principal: unknown;

--- a/packages/core/src/context/crud-request.ts
+++ b/packages/core/src/context/crud-request.ts
@@ -6,7 +6,7 @@ import type { CrudCallOptions } from "../service/crud-call-options.js";
 
 /**
  * The transport-agnostic request envelope handed to the engine — what the
- * framework layer (`@crudo/nest`) builds from an HTTP request, and what
+ * framework layer (`@kavo/nest`) builds from an HTTP request, and what
  * programmatic callers are sugar for. Which members are populated depends
  * on the operation: `id` for `*One` targets, `body` for writes,
  * `query` for reads.

--- a/packages/core/src/context/default-crud-context.ts
+++ b/packages/core/src/context/default-crud-context.ts
@@ -23,7 +23,7 @@ export class DefaultCrudContextState implements CrudContextState {
 
 /**
  * Web Crypto is a runtime global on every supported platform (Node ≥ 20,
- * browsers), but `@crudo/core` compiles against pure ES lib types with
+ * browsers), but `@kavo/core` compiles against pure ES lib types with
  * zero imports (ADR-0005) — hence the typed accessor instead of a
  * `node:crypto` import.
  */

--- a/packages/core/src/engine/crud-engine.ts
+++ b/packages/core/src/engine/crud-engine.ts
@@ -10,7 +10,7 @@ import type { QueryContext } from "../query/query-context.js";
 import type { OperationDescriptor, OperationRegistry } from "../operations/operation-registry.js";
 import type { StandardOperationId } from "../operations/operation.js";
 import type { ResolvedEntityConfig } from "../config/resolved-entity-config.js";
-import type { CrudoSettings } from "../config/settings.js";
+import type { KavoSettings } from "../config/settings.js";
 import { OperationDisabledException, QueryValidationException } from "../errors/exceptions.js";
 import { QueryNormalizer } from "../query/query-normalizer.js";
 import { createCrudContext, randomUuid } from "../context/default-crud-context.js";
@@ -21,7 +21,7 @@ import type { FindManyResult } from "./built-in-handlers.js";
 
 /**
  * Marker wrapping *raw wire params* (`filter[age][gte]=18` as flat keys).
- * The framework layer (`@crudo/nest`) hands the engine one of these so the
+ * The framework layer (`@kavo/nest`) hands the engine one of these so the
  * full Phase 5 parse-and-coerce pipeline runs; programmatic callers pass a
  * typed `QueryContext` instead, which normalizes without coercion.
  */
@@ -134,7 +134,7 @@ export class CrudEngine<Entity extends object> {
     const { config } = this.deps;
     const base = config.settingsFor(request.operation);
     const overrides = request.options?.settings;
-    let settings: CrudoSettings = base;
+    let settings: KavoSettings = base;
     if (overrides !== undefined) {
       settings = mergeSettings(base, overrides);
       validateSettings(`${config.entityName} (per-call)`, settings);
@@ -210,7 +210,7 @@ export class CrudEngine<Entity extends object> {
     if (Number.isNaN(value)) {
       throw QueryValidationException.single({
         field: metadata.idField,
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: `Value '${id}' for field '${metadata.idField}' is not a valid number.`,
       });
     }

--- a/packages/core/src/errors/crud-exception.ts
+++ b/packages/core/src/errors/crud-exception.ts
@@ -6,7 +6,7 @@ import type { OperationId } from "../operations/operation.js";
  * Phase 6, and renaming a code is a breaking change (Phase 18 semver
  * policy).
  */
-export type CrudoErrorCode = `CRUDO_${string}`;
+export type KavoErrorCode = `KAVO_${string}`;
 
 /** Where an error happened — attached to exceptions and problem details. */
 export interface ErrorContext {
@@ -16,16 +16,16 @@ export interface ErrorContext {
 }
 
 /**
- * Contract every Crudo exception class (Phase 6) satisfies. Deliberately
- * an interface, not a base class: `@crudo/core` in Milestone A ships types
- * only, and downstream layers (the `@crudo/nest` exception filter) program
+ * Contract every Kavo exception class (Phase 6) satisfies. Deliberately
+ * an interface, not a base class: `@kavo/core` in Milestone A ships types
+ * only, and downstream layers (the `@kavo/nest` exception filter) program
  * against this shape, never against `instanceof`.
  *
  * Human-readable text is built from `messageKey` + `messageParams` so a
  * consumer can localize; `detail` carries the English default.
  */
 export interface CrudException {
-  readonly code: CrudoErrorCode;
+  readonly code: KavoErrorCode;
   /** HTTP status this error maps to (from the Phase 6 catalog). */
   readonly status: number;
   readonly messageKey: string;
@@ -41,7 +41,7 @@ export interface CrudException {
 }
 
 /**
- * Maps arbitrary thrown values to Crudo exceptions at the engine boundary.
+ * Maps arbitrary thrown values to Kavo exceptions at the engine boundary.
  * Adapter errors are translated by the adapter's own mapping table
  * (Phase 9); anything unrecognized becomes a `PersistenceException` with
  * the original as `cause`.

--- a/packages/core/src/errors/default-error-handler.ts
+++ b/packages/core/src/errors/default-error-handler.ts
@@ -1,10 +1,10 @@
 import type { ErrorContext, ErrorHandler, CrudException } from "./crud-exception.js";
-import { CrudoException, PersistenceException } from "./exceptions.js";
+import { KavoException, PersistenceException } from "./exceptions.js";
 
 /**
  * The engine-boundary error mapper (Phase 6). Adapter-specific errors were
  * already translated by the adapter's own mapping table (Phase 9) into
- * Crudo exceptions; whatever still arrives untranslated becomes a
+ * Kavo exceptions; whatever still arrives untranslated becomes a
  * `PersistenceException` with the original as `cause` — never swallowed.
  *
  * Context enrichment: an exception thrown deep in the pipeline may not
@@ -13,7 +13,7 @@ import { CrudoException, PersistenceException } from "./exceptions.js";
  */
 export class DefaultErrorHandler implements ErrorHandler {
   handle(error: unknown, context: ErrorContext): CrudException {
-    if (error instanceof CrudoException) {
+    if (error instanceof KavoException) {
       return this.enrich(error, context);
     }
     return new PersistenceException({
@@ -23,7 +23,7 @@ export class DefaultErrorHandler implements ErrorHandler {
     });
   }
 
-  private enrich(exception: CrudoException, context: ErrorContext): CrudException {
+  private enrich(exception: KavoException, context: ErrorContext): CrudException {
     const merged: ErrorContext = {
       entityName: exception.context.entityName ?? context.entityName,
       operation: exception.context.operation ?? context.operation,

--- a/packages/core/src/errors/error-catalog.ts
+++ b/packages/core/src/errors/error-catalog.ts
@@ -1,4 +1,4 @@
-import type { CrudoErrorCode } from "./crud-exception.js";
+import type { KavoErrorCode } from "./crud-exception.js";
 
 /**
  * One catalog entry: everything stable about an error code. Codes are API
@@ -8,7 +8,7 @@ import type { CrudoErrorCode } from "./crud-exception.js";
  * this object, so code and docs cannot drift.
  */
 export interface ErrorCatalogEntry {
-  /** HTTP status the `@crudo/nest` filter responds with. */
+  /** HTTP status the `@kavo/nest` filter responds with. */
   readonly status: number;
   /** RFC 9457 `title`: short, human-readable summary of the problem type. */
   readonly title: string;
@@ -26,77 +26,77 @@ export interface ErrorCatalogEntry {
  * into the hierarchy reserved for them without renumbering anything.
  */
 export const ERROR_CATALOG = {
-  CRUDO_QUERY_INVALID: {
+  KAVO_QUERY_INVALID: {
     status: 400,
     title: "Invalid query",
     message: "The request query is invalid.",
   },
-  CRUDO_QUERY_INVALID_FIELD: {
+  KAVO_QUERY_INVALID_FIELD: {
     status: 400,
     title: "Invalid query field",
     message: "Field '{field}' cannot be used for {usage}.",
   },
-  CRUDO_QUERY_INVALID_OPERATOR: {
+  KAVO_QUERY_INVALID_OPERATOR: {
     status: 400,
     title: "Invalid filter operator",
     message: "Unknown filter operator '{operator}' on field '{field}'.",
   },
-  CRUDO_QUERY_INVALID_VALUE: {
+  KAVO_QUERY_INVALID_VALUE: {
     status: 400,
     title: "Invalid query value",
     message: "Value '{value}' for field '{field}' is not a valid {expected}.",
   },
-  CRUDO_QUERY_LIMIT_EXCEEDED: {
+  KAVO_QUERY_LIMIT_EXCEEDED: {
     status: 400,
     title: "Query limit exceeded",
     message: "{limit} exceeds the configured maximum of {max}.",
   },
-  CRUDO_QUERY_UNSUPPORTED_PARAM: {
+  KAVO_QUERY_UNSUPPORTED_PARAM: {
     status: 400,
     title: "Unsupported query parameter",
     message: "Query parameter '{param}' is not supported: {reason}",
   },
-  CRUDO_NOT_FOUND: {
+  KAVO_NOT_FOUND: {
     status: 404,
     title: "Not found",
     message: "{entity} with id '{id}' was not found.",
   },
-  CRUDO_CONFLICT: {
+  KAVO_CONFLICT: {
     status: 409,
     title: "Conflict",
     message: "The operation conflicts with the current state of {entity}.",
   },
-  CRUDO_ALREADY_DELETED: {
+  KAVO_ALREADY_DELETED: {
     status: 409,
     title: "Already deleted",
     message: "{entity} with id '{id}' is already deleted.",
   },
-  CRUDO_NOT_DELETED: {
+  KAVO_NOT_DELETED: {
     status: 409,
     title: "Not deleted",
     message: "{entity} with id '{id}' is not deleted.",
   },
-  CRUDO_OPERATION_DISABLED: {
+  KAVO_OPERATION_DISABLED: {
     status: 405,
     title: "Operation disabled",
     message: "Operation '{operation}' is disabled for {entity}.",
   },
-  CRUDO_PERSISTENCE_FAILED: {
+  KAVO_PERSISTENCE_FAILED: {
     status: 500,
     title: "Persistence failure",
     message: "The persistence layer failed while executing '{operation}'.",
   },
-  CRUDO_TRANSACTION_FAILED: {
+  KAVO_TRANSACTION_FAILED: {
     status: 500,
     title: "Transaction failure",
     message: "The transaction could not be completed.",
   },
-  CRUDO_CONFIG_INVALID: {
+  KAVO_CONFIG_INVALID: {
     status: 500,
     title: "Invalid configuration",
     message: "Invalid configuration for entity '{entity}' at '{path}': {problem}",
   },
-} as const satisfies Record<CrudoErrorCode, ErrorCatalogEntry>;
+} as const satisfies Record<KavoErrorCode, ErrorCatalogEntry>;
 
 /** A code present in the shipped catalog. */
 export type CatalogedErrorCode = keyof typeof ERROR_CATALOG;

--- a/packages/core/src/errors/exceptions.ts
+++ b/packages/core/src/errors/exceptions.ts
@@ -4,7 +4,7 @@ import type { CatalogedErrorCode } from "./error-catalog.js";
 import { ERROR_CATALOG, renderMessage } from "./error-catalog.js";
 
 /** Constructor input shared by every exception class. */
-export interface CrudoExceptionOptions {
+export interface KavoExceptionOptions {
   readonly messageParams?: Readonly<Record<string, string | number>>;
   readonly context?: ErrorContext;
   readonly cause?: unknown;
@@ -16,11 +16,11 @@ export interface CrudoExceptionOptions {
  * from the catalog, so an exception cannot disagree with it.
  *
  * Downstream layers should keep programming against the `CrudException`
- * *shape* (the `@crudo/nest` filter catches this class only as a
+ * *shape* (the `@kavo/nest` filter catches this class only as a
  * convenience at the HTTP boundary) — the hierarchy is extensible by
  * adding leaves, never by editing existing ones.
  */
-export abstract class CrudoException extends Error implements CrudException {
+export abstract class KavoException extends Error implements CrudException {
   readonly code: CatalogedErrorCode;
   readonly status: number;
   readonly messageKey: string;
@@ -29,7 +29,7 @@ export abstract class CrudoException extends Error implements CrudException {
   readonly context: ErrorContext;
   override readonly cause?: unknown;
 
-  protected constructor(code: CatalogedErrorCode, options: CrudoExceptionOptions = {}) {
+  protected constructor(code: CatalogedErrorCode, options: KavoExceptionOptions = {}) {
     const params = options.messageParams ?? {};
     const detail = renderMessage(code, params);
     super(detail);
@@ -50,54 +50,54 @@ export abstract class CrudoException extends Error implements CrudException {
  * Bad filter/sort/fields/pagination input (Phase 5 grammar violations).
  * Carries field-level issues that serialize into the problem-details
  * `errors[]` extension. The exception's own code is the generic
- * `CRUDO_QUERY_INVALID`; each issue carries its precise sub-code.
+ * `KAVO_QUERY_INVALID`; each issue carries its precise sub-code.
  */
-export class QueryValidationException extends CrudoException {
+export class QueryValidationException extends KavoException {
   readonly issues: readonly QueryIssueDto[];
 
-  constructor(issues: readonly QueryIssueDto[], options: CrudoExceptionOptions = {}) {
-    super("CRUDO_QUERY_INVALID", options);
+  constructor(issues: readonly QueryIssueDto[], options: KavoExceptionOptions = {}) {
+    super("KAVO_QUERY_INVALID", options);
     this.issues = issues;
   }
 
   /** Convenience for the common single-issue case. */
-  static single(issue: QueryIssueDto, options: CrudoExceptionOptions = {}): QueryValidationException {
+  static single(issue: QueryIssueDto, options: KavoExceptionOptions = {}): QueryValidationException {
     return new QueryValidationException([issue], options);
   }
 }
 
-export class NotFoundException extends CrudoException {
-  constructor(options: CrudoExceptionOptions = {}) {
-    super("CRUDO_NOT_FOUND", options);
+export class NotFoundException extends KavoException {
+  constructor(options: KavoExceptionOptions = {}) {
+    super("KAVO_NOT_FOUND", options);
   }
 }
 
-export class ConflictException extends CrudoException {
-  constructor(options: CrudoExceptionOptions = {}) {
-    super("CRUDO_CONFLICT", options);
+export class ConflictException extends KavoException {
+  constructor(options: KavoExceptionOptions = {}) {
+    super("KAVO_CONFLICT", options);
   }
 }
 
-export class PersistenceException extends CrudoException {
-  constructor(options: CrudoExceptionOptions = {}) {
-    super("CRUDO_PERSISTENCE_FAILED", options);
+export class PersistenceException extends KavoException {
+  constructor(options: KavoExceptionOptions = {}) {
+    super("KAVO_PERSISTENCE_FAILED", options);
   }
 }
 
-export class TransactionException extends CrudoException {
+export class TransactionException extends KavoException {
   /** Whether retrying the whole transaction may succeed (deadlocks do). */
   readonly retryable: boolean;
 
-  constructor(options: CrudoExceptionOptions & { readonly retryable?: boolean } = {}) {
-    super("CRUDO_TRANSACTION_FAILED", options);
+  constructor(options: KavoExceptionOptions & { readonly retryable?: boolean } = {}) {
+    super("KAVO_TRANSACTION_FAILED", options);
     this.retryable = options.retryable ?? false;
   }
 }
 
 /** Soft-deleting a row that is already soft-deleted (Phase 14) → 409. */
-export class AlreadyDeletedException extends CrudoException {
-  constructor(options: CrudoExceptionOptions = {}) {
-    super("CRUDO_ALREADY_DELETED", options);
+export class AlreadyDeletedException extends KavoException {
+  constructor(options: KavoExceptionOptions = {}) {
+    super("KAVO_ALREADY_DELETED", options);
   }
 }
 
@@ -106,16 +106,16 @@ export class AlreadyDeletedException extends CrudoException {
  * Both operations act on soft-deleted rows only; a live row is a state
  * conflict, not a missing one.
  */
-export class NotDeletedException extends CrudoException {
-  constructor(options: CrudoExceptionOptions = {}) {
-    super("CRUDO_NOT_DELETED", options);
+export class NotDeletedException extends KavoException {
+  constructor(options: KavoExceptionOptions = {}) {
+    super("KAVO_NOT_DELETED", options);
   }
 }
 
 /** Calling an operation whose registry entry is disabled (Phase 13). */
-export class OperationDisabledException extends CrudoException {
-  constructor(options: CrudoExceptionOptions = {}) {
-    super("CRUDO_OPERATION_DISABLED", options);
+export class OperationDisabledException extends KavoException {
+  constructor(options: KavoExceptionOptions = {}) {
+    super("KAVO_OPERATION_DISABLED", options);
   }
 }
 
@@ -124,9 +124,9 @@ export class OperationDisabledException extends CrudoException {
  * before the app serves traffic, and it must name the entity, the key
  * path, and the offending value (Phase 8 error quality bar).
  */
-export class ConfigurationException extends CrudoException {
+export class ConfigurationException extends KavoException {
   constructor(entity: string, path: string, problem: string) {
-    super("CRUDO_CONFIG_INVALID", {
+    super("KAVO_CONFIG_INVALID", {
       messageParams: { entity, path, problem },
       context: { entityName: entity },
     });

--- a/packages/core/src/errors/problem-details-serializer.ts
+++ b/packages/core/src/errors/problem-details-serializer.ts
@@ -4,9 +4,9 @@ import { ERROR_CATALOG } from "./error-catalog.js";
 import { QueryValidationException } from "./exceptions.js";
 
 /** Base URI under which every problem `type` lives (ADR-0009). */
-const PROBLEM_TYPE_BASE = "https://crudo.dev/errors/";
+const PROBLEM_TYPE_BASE = "https://kavo.dev/errors/";
 
-/** `CRUDO_NOT_FOUND` → `https://crudo.dev/errors/crudo-not-found`. */
+/** `KAVO_NOT_FOUND` → `https://kavo.dev/errors/kavo-not-found`. */
 function problemTypeFor(code: string): string {
   return PROBLEM_TYPE_BASE + code.toLowerCase().replace(/_/g, "-");
 }
@@ -20,7 +20,7 @@ export interface ProblemDetailsOptions {
 }
 
 /**
- * Serialize a Crudo exception into the RFC 9457 problem-details document
+ * Serialize a Kavo exception into the RFC 9457 problem-details document
  * (Phase 6). This is the default wire shape; a consumer wanting a
  * different one swaps this serializer, never the exception hierarchy.
  */
@@ -37,7 +37,7 @@ export function toProblemDetails(exception: CrudException, options: ProblemDetai
     status: exception.status,
     detail,
     ...(exception.context.correlationId !== undefined && {
-      instance: `urn:crudo:request:${exception.context.correlationId}`,
+      instance: `urn:kavo:request:${exception.context.correlationId}`,
     }),
     code: exception.code,
     ...(exception instanceof QueryValidationException && {

--- a/packages/core/src/errors/problem-details.ts
+++ b/packages/core/src/errors/problem-details.ts
@@ -1,16 +1,16 @@
-import type { CrudoErrorCode } from "./crud-exception.js";
+import type { KavoErrorCode } from "./crud-exception.js";
 
 /** One field-level query issue (`errors[]` extension). */
 export interface QueryIssueDto {
   /** The offending field or parameter as it appeared on the wire. */
   readonly field: string;
-  readonly code: CrudoErrorCode;
+  readonly code: KavoErrorCode;
   readonly detail: string;
 }
 
 /**
  * Default serialized error shape: an RFC 9457 problem-details document
- * with Crudo extensions. The `@crudo/nest` exception filter maps it 1:1;
+ * with Kavo extensions. The `@kavo/nest` exception filter maps it 1:1;
  * anyone who wants a different wire shape swaps the serializer, not the
  * exception hierarchy.
  */
@@ -23,8 +23,8 @@ export interface ProblemDetailsDto {
   readonly detail: string;
   /** URI reference identifying this occurrence (correlation). */
   readonly instance?: string;
-  /** Crudo extension: the stable catalog code. */
-  readonly code: CrudoErrorCode;
-  /** Crudo extension: field-level query issues (400s from Phase 5). */
+  /** Kavo extension: the stable catalog code. */
+  readonly code: KavoErrorCode;
+  /** Kavo extension: field-level query issues (400s from Phase 5). */
   readonly errors?: readonly QueryIssueDto[];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @crudo/core — framework- and ORM-independent contracts and type system.
+ * @kavo/core — framework- and ORM-independent contracts and type system.
  *
  * This barrel is an **explicit named list**, kept deliberately (no
  * `export *`): the public surface should only ever change on purpose, the
@@ -36,12 +36,12 @@ export type { DtoClass, DtoSlot, Dto, DtoResolver, OperationDtoMap } from "./dto
 export type { ListMetaDto, ListResultDto } from "./dto/list-result.js";
 
 // ── Errors ────────────────────────────────────────────────────────────
-export type { CrudoErrorCode, CrudException, ErrorContext, ErrorHandler } from "./errors/crud-exception.js";
+export type { KavoErrorCode, CrudException, ErrorContext, ErrorHandler } from "./errors/crud-exception.js";
 export type { ProblemDetailsDto, QueryIssueDto } from "./errors/problem-details.js";
 
 // ── Configuration ─────────────────────────────────────────────────────
 export type {
-  CrudoSettings,
+  KavoSettings,
   ErrorSettings,
   PaginationSettings,
   QuerySettings,
@@ -118,14 +118,14 @@ export {
   AlreadyDeletedException,
   ConfigurationException,
   ConflictException,
-  CrudoException,
+  KavoException,
   NotDeletedException,
   NotFoundException,
   OperationDisabledException,
   PersistenceException,
   QueryValidationException,
   TransactionException,
-  type CrudoExceptionOptions,
+  type KavoExceptionOptions,
 } from "./errors/exceptions.js";
 export { toProblemDetails, type ProblemDetailsOptions } from "./errors/problem-details-serializer.js";
 export { DefaultErrorHandler } from "./errors/default-error-handler.js";
@@ -166,4 +166,4 @@ export { DefaultRelationRegistry } from "./relations/default-relation-registry.j
 
 // ── Service & root factory ────────────────────────────────────────────
 export { DefaultCrudService } from "./service/default-crud-service.js";
-export { createCrud, createCrudo, type CrudRuntime, type CrudoInstance, type CrudoOptions } from "./crudo.js";
+export { createCrud, createKavo, type CrudRuntime, type KavoInstance, type KavoOptions } from "./kavo.js";

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -28,7 +28,7 @@ import { STANDARD_OPERATIONS } from "./operations/default-operation-registry.js"
  * ORM package plugs in (`createTypeOrmInfrastructure(dataSource)`) without
  * core ever importing it.
  */
-export interface CrudoOptions extends GlobalConfig {
+export interface KavoOptions extends GlobalConfig {
   readonly infrastructure?: CrudInfrastructure;
   /** Custom pagination strategies, addressable via `pagination.strategy`. */
   readonly paginationStrategies?: readonly PaginationStrategy[];
@@ -41,12 +41,12 @@ export interface CrudRuntime<Entity extends object> {
 }
 
 /**
- * A Crudo root instance: one merged global scope plus the entity registry
+ * A Kavo root instance: one merged global scope plus the entity registry
  * built from it. `createCrud` is the only way entities enter the system;
  * everything it resolves (config, DTOs, registry) happens at that call —
  * bootstrap — and is frozen after.
  */
-export interface CrudoInstance {
+export interface KavoInstance {
   createCrud<
     Entity extends object,
     CreateDto = EntityInput<Entity>,
@@ -66,11 +66,11 @@ export interface CrudoInstance {
 }
 
 /**
- * Create a Crudo root instance (Phase 8's `createCrudo`). The zero-config
- * path is `createCrudo({ infrastructure }).createCrud(Entity)` — built-in
+ * Create a Kavo root instance (Phase 8's `createKavo`). The zero-config
+ * path is `createKavo({ infrastructure }).createCrud(Entity)` — built-in
  * defaults, derived DTOs and allowlists, standard operations.
  */
-export function createCrudo(options: CrudoOptions = {}): CrudoInstance {
+export function createKavo(options: KavoOptions = {}): KavoInstance {
   const registered = new Map<string, Record<string, unknown>>();
   // The cross-entity view nested includes resolve against (Phase 15).
   // Entities that never go through `createCrud` are derived from
@@ -88,9 +88,9 @@ export function createCrudo(options: CrudoOptions = {}): CrudoInstance {
         throw new ConfigurationException(
           entity.name,
           "infrastructure",
-          "no metadata source: pass `infrastructure` to createCrudo " +
+          "no metadata source: pass `infrastructure` to createKavo " +
             "(e.g. createTypeOrmInfrastructure(dataSource) from " +
-            "@crudo/typeorm) or `runtime.metadata` to createCrud",
+            "@kavo/typeorm) or `runtime.metadata` to createCrud",
         );
       }
       const adapter = runtime?.adapter ?? options.infrastructure?.adapterFor(entity);
@@ -98,7 +98,7 @@ export function createCrudo(options: CrudoOptions = {}): CrudoInstance {
         throw new ConfigurationException(
           metadata.name,
           "infrastructure",
-          "no repository adapter: pass `infrastructure` to createCrudo or " + "`runtime.adapter` to createCrud",
+          "no repository adapter: pass `infrastructure` to createKavo or " + "`runtime.adapter` to createCrud",
         );
       }
 
@@ -170,8 +170,8 @@ function requireSoftDeletable<Entity extends object>(
  * The bare zero-config path (Phase 8): `createCrud(Entity, config?,
  * runtime)` — an implicit root instance with built-in defaults. At the
  * core level the runtime (adapter + metadata) must be explicit, because
- * core has no ORM to derive them from; `@crudo/typeorm`'s
- * `createTypeOrmCrudo` is the sugar that makes it disappear.
+ * core has no ORM to derive them from; `@kavo/typeorm`'s
+ * `createTypeOrmKavo` is the sugar that makes it disappear.
  */
 export function createCrud<
   Entity extends object,
@@ -186,5 +186,5 @@ export function createCrud<
   config?: EntityConfig<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>,
   runtime?: CrudRuntime<Entity>,
 ): DefaultCrudService<Entity, EntityId, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto> {
-  return createCrudo().createCrud(entity, config, runtime);
+  return createKavo().createCrud(entity, config, runtime);
 }

--- a/packages/core/src/metadata/entity-catalog.ts
+++ b/packages/core/src/metadata/entity-catalog.ts
@@ -1,5 +1,5 @@
 import type { ClassRef, DeepPartial } from "../types/utility.js";
-import type { CrudoSettings } from "../config/settings.js";
+import type { KavoSettings } from "../config/settings.js";
 import type { EntityMetadata } from "./entity-metadata.js";
 import type { ResolvedEntityConfig } from "../config/resolved-entity-config.js";
 import { resolveEntityConfig } from "../config/resolve-entity-config.js";
@@ -34,7 +34,7 @@ export interface EntityCatalog {
 export type MetadataSource = (entity: ClassRef) => EntityMetadata<object> | undefined;
 
 /**
- * The catalog a Crudo root instance keeps. Entities registered through
+ * The catalog a Kavo root instance keeps. Entities registered through
  * `createCrud` are served with their real configuration; anything else a
  * relation points at is *derived* from ORM metadata plus global defaults —
  * so an unregistered target is readable (its own scalar columns) but opens
@@ -46,7 +46,7 @@ export class DefaultEntityCatalog implements EntityCatalog {
 
   constructor(
     private readonly metadataSource: MetadataSource = () => undefined,
-    private readonly globalDefaults?: DeepPartial<CrudoSettings>,
+    private readonly globalDefaults?: DeepPartial<KavoSettings>,
   ) {}
 
   register(entity: ClassRef, info: EntityRuntimeInfo): void {

--- a/packages/core/src/metadata/entity-metadata.ts
+++ b/packages/core/src/metadata/entity-metadata.ts
@@ -28,7 +28,7 @@ export interface FieldMetadata {
  * The ORM-independent entity description every adapter package supplies
  * (from its ORM's own metadata) and core consumes for DTO derivation,
  * allowlist defaults, and query-value coercion. This is the seam that
- * keeps `@crudo/core` free of ORM imports while still being
+ * keeps `@kavo/core` free of ORM imports while still being
  * metadata-driven.
  */
 export interface EntityMetadata<Entity = unknown> {
@@ -41,7 +41,7 @@ export interface EntityMetadata<Entity = unknown> {
   readonly relations: readonly RelationDescriptor[];
   /**
    * The delete-marker column the ORM itself declares (`@DeleteDateColumn`
-   * in `@crudo/typeorm`), or `null`/absent when it declares none. This is
+   * in `@kavo/typeorm`), or `null`/absent when it declares none. This is
    * the detection half of Phase 14's strategy resolution; explicit
    * `softDelete.field` configuration wins over it.
    */
@@ -49,10 +49,10 @@ export interface EntityMetadata<Entity = unknown> {
 }
 
 /**
- * What a Crudo root instance needs from an ORM integration: metadata and a
- * repository adapter per entity. `@crudo/typeorm` exports
+ * What a Kavo root instance needs from an ORM integration: metadata and a
+ * repository adapter per entity. `@kavo/typeorm` exports
  * `createTypeOrmInfrastructure(dataSource)`; a test can hand in an
- * in-memory fake. Passed to `createCrudo` once — individual `createCrud`
+ * in-memory fake. Passed to `createKavo` once — individual `createCrud`
  * calls may still override the adapter per entity.
  */
 export interface CrudInfrastructure {

--- a/packages/core/src/operations/default-operation-registry.ts
+++ b/packages/core/src/operations/default-operation-registry.ts
@@ -65,7 +65,7 @@ interface StandardOperationShape {
 /**
  * The standard operation table. The engine dispatches every operation
  * through the registry — these are just its default entries (ADR-0006),
- * and `@crudo/nest` route generation walks the same registry.
+ * and `@kavo/nest` route generation walks the same registry.
  *
  * `enabled` here is the *unconditional* default;
  * `restoreOne`/`purgeOne` layer the Phase 14 soft-delete rule on top (see
@@ -109,14 +109,14 @@ const unboundHandler = (id: OperationId): OperationHandler<unknown> => ({
  * declares soft delete (`softDelete.strategy: "soft"` or an explicit
  * `softDelete.field`), `purgeOne` only when named outright. Route
  * generation runs at decoration time, where no ORM metadata exists
- * (ADR-0012), so both registry builds — engine and `@crudo/nest` — must
+ * (ADR-0012), so both registry builds — engine and `@kavo/nest` — must
  * reach the same answer from the same input (ADR-0013). Enabling either
  * on an entity that does not resolve to a soft delete strategy is a
  * bootstrap error, raised in `createCrud` where metadata is known.
  *
  * `handlers` binds the built-in behaviors; when omitted the entries carry
  * throwing placeholders — that mode exists for consumers that only need
- * the table (`@crudo/nest` route generation), never for execution.
+ * the table (`@kavo/nest` route generation), never for execution.
  */
 export function createOperationRegistry<Entity extends object>(
   config: EntityConfig<Entity> | undefined,

--- a/packages/core/src/operations/operation-handler.ts
+++ b/packages/core/src/operations/operation-handler.ts
@@ -6,12 +6,12 @@ import type { CrudContext } from "../context/crud-context.js";
  * precedence (global routes → entity → operation), and hand it to the
  * framework layer.
  *
- * Consumers type their keys via declaration merging — `@crudo/nest`
+ * Consumers type their keys via declaration merging — `@kavo/nest`
  * augments it with route options:
  *
  * ```ts
- * // in @crudo/nest
- * declare module "@crudo/core" {
+ * // in @kavo/nest
+ * declare module "@kavo/core" {
  *   interface OperationMetadata {
  *     routes?: {
  *       method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";

--- a/packages/core/src/operations/operation-registry.ts
+++ b/packages/core/src/operations/operation-registry.ts
@@ -10,7 +10,7 @@ export interface OperationDescriptor<Entity = unknown, Input = unknown, Output =
   /**
    * Disabled entries stay in the registry (so tooling can report them) but
    * never execute — calling one raises `OperationDisabledException`, and
-   * `@crudo/nest` generates no route for it.
+   * `@kavo/nest` generates no route for it.
    */
   readonly enabled: boolean;
   readonly handler: OperationHandler<Entity, Input, Output>;
@@ -26,7 +26,7 @@ export interface OperationDescriptor<Entity = unknown, Input = unknown, Output =
  * operation through this registry — the built-in CRUD handlers are just
  * default entries, nothing about them is special-cased. Phase 13's
  * disable/override/custom config is a control surface over this registry,
- * and `@crudo/nest` route generation reads it — which is what makes later
+ * and `@kavo/nest` route generation reads it — which is what makes later
  * operations appear as routes with zero changes to the generator.
  */
 export interface OperationRegistry<Entity = unknown> {

--- a/packages/core/src/persistence/repository-adapter.ts
+++ b/packages/core/src/persistence/repository-adapter.ts
@@ -7,7 +7,7 @@ import type { EntityWriter } from "./entity-writer.js";
  * writes. Split into {@link EntityReader} / {@link EntityWriter} so
  * read-only consumers (and read-only decorators) can depend on half the
  * surface. Adapters are named for what they adapt:
- * `TypeOrmRepositoryAdapter` (`@crudo/typeorm`, Phases 9–10).
+ * `TypeOrmRepositoryAdapter` (`@kavo/typeorm`, Phases 9–10).
  */
 export interface RepositoryAdapter<Entity = unknown, Id extends EntityId = EntityId>
   extends EntityReader<Entity, Id>, EntityWriter<Entity, Id> {}

--- a/packages/core/src/persistence/soft-delete.ts
+++ b/packages/core/src/persistence/soft-delete.ts
@@ -1,4 +1,4 @@
-import type { CrudoSettings } from "../config/settings.js";
+import type { KavoSettings } from "../config/settings.js";
 import type { EntityMetadata } from "../metadata/entity-metadata.js";
 import { ConfigurationException } from "../errors/exceptions.js";
 
@@ -54,13 +54,13 @@ export const HARD_DELETE: ResolvedSoftDelete = Object.freeze({
  *
  * The marker field is the configured name when the entity has such a
  * column, else the one the ORM declares (`@DeleteDateColumn` in
- * `@crudo/typeorm`, surfaced as `EntityMetadata.softDeleteField`).
+ * `@kavo/typeorm`, surfaced as `EntityMetadata.softDeleteField`).
  * Explicit configuration therefore wins over ORM detection, and an entity
  * with neither costs nothing.
  */
 export function resolveSoftDelete<Entity>(
   metadata: EntityMetadata<Entity>,
-  settings: CrudoSettings,
+  settings: KavoSettings,
   scope: string = metadata.name,
 ): ResolvedSoftDelete {
   const softDelete = settings.softDelete;

--- a/packages/core/src/persistence/transaction-manager.ts
+++ b/packages/core/src/persistence/transaction-manager.ts
@@ -16,7 +16,7 @@ export interface TransactionContext {
   readonly id: string;
   /**
    * The adapter's native transaction object (a TypeORM `QueryRunner` in
-   * `@crudo/typeorm`) — opaque to core, meaningful only to the adapter
+   * `@kavo/typeorm`) — opaque to core, meaningful only to the adapter
    * that created it.
    */
   readonly handle: unknown;
@@ -31,7 +31,7 @@ export interface TransactionOptions {
  * Commit on resolve, rollback on reject — no partial outcomes.
  *
  * @remarks
- * Intentionally unimplemented, not dead — but read the caveat. Crudo has no
+ * Intentionally unimplemented, not dead — but read the caveat. Kavo has no
  * standalone cross-cutting transaction system: multi-write atomicity was
  * scoped down to a narrow adapter-level hook, and the only consumer it ever
  * had was the optional batch surface, which this build dropped outright —

--- a/packages/core/src/query/default-filter-parser.ts
+++ b/packages/core/src/query/default-filter-parser.ts
@@ -96,7 +96,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
       if (depth > maxDepth) {
         issues.push({
           field: "filter",
-          code: "CRUDO_QUERY_LIMIT_EXCEEDED",
+          code: "KAVO_QUERY_LIMIT_EXCEEDED",
           detail: `Filter depth ${depth} exceeds the configured maximum of ${maxDepth}.`,
         });
       }
@@ -131,13 +131,13 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
       }
       issues.push({
         field: "filter",
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: "JSON filter must be an object.",
       });
     } catch {
       issues.push({
         field: "filter",
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: "filter is not valid JSON.",
       });
     }
@@ -179,7 +179,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
     if (typeof value !== "object" || value === null) {
       issues.push({
         field: `filter[${token}]`,
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: `'${token}' must carry nested filter groups.`,
       });
       return;
@@ -198,7 +198,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
       if (typeof branch !== "object" || branch === null) {
         issues.push({
           field: `filter[${token}]`,
-          code: "CRUDO_QUERY_INVALID_VALUE",
+          code: "KAVO_QUERY_INVALID_VALUE",
           detail: `Each '${token}' branch must be a filter group.`,
         });
         continue;
@@ -225,7 +225,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
     if (!(config.allowlists.filterable as readonly string[]).includes(field)) {
       issues.push({
         field,
-        code: "CRUDO_QUERY_INVALID_FIELD",
+        code: "KAVO_QUERY_INVALID_FIELD",
         detail: `Field '${field}' cannot be used for filtering.`,
       });
       return;
@@ -233,7 +233,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
     if (typeof value !== "object" || value === null || Array.isArray(value)) {
       issues.push({
         field,
-        code: "CRUDO_QUERY_INVALID_OPERATOR",
+        code: "KAVO_QUERY_INVALID_OPERATOR",
         detail: `filter[${field}] must use the filter[${field}][operator]=value form.`,
       });
       return;
@@ -255,7 +255,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
     if (operator === undefined) {
       issues.push({
         field,
-        code: "CRUDO_QUERY_INVALID_OPERATOR",
+        code: "KAVO_QUERY_INVALID_OPERATOR",
         detail: `Unknown filter operator '${token}' on field '${field}'.`,
       });
       return null;
@@ -272,7 +272,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
         if (flag !== "true" && flag !== "false") {
           issues.push({
             field,
-            code: "CRUDO_QUERY_INVALID_VALUE",
+            code: "KAVO_QUERY_INVALID_VALUE",
             detail: `'${token}' takes true or false, got '${flag}'.`,
           });
           return null;
@@ -288,7 +288,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
         if (parts.length > max) {
           issues.push({
             field,
-            code: "CRUDO_QUERY_LIMIT_EXCEEDED",
+            code: "KAVO_QUERY_LIMIT_EXCEEDED",
             detail: `'${token}' carries ${parts.length} values; the maximum is ${max}.`,
           });
           return null;
@@ -302,7 +302,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
         if (parts.length !== 2) {
           issues.push({
             field,
-            code: "CRUDO_QUERY_INVALID_VALUE",
+            code: "KAVO_QUERY_INVALID_VALUE",
             detail: `'between' takes exactly two comma-separated bounds, got ${parts.length}.`,
           });
           return null;
@@ -316,7 +316,7 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
         if (metadata !== undefined && metadata.kind !== "string") {
           issues.push({
             field,
-            code: "CRUDO_QUERY_INVALID_VALUE",
+            code: "KAVO_QUERY_INVALID_VALUE",
             detail: `'${token}' applies to string columns; '${field}' is ${metadata.kind}.`,
           });
           return null;

--- a/packages/core/src/query/filter-builder.ts
+++ b/packages/core/src/query/filter-builder.ts
@@ -2,7 +2,7 @@ import type { Filter } from "./filter.js";
 
 /**
  * Translates a validated filter AST into an ORM-native query, implemented
- * by adapter packages (`@crudo/typeorm`'s `FilterTranslator` targets
+ * by adapter packages (`@kavo/typeorm`'s `FilterTranslator` targets
  * TypeORM's `QueryBuilder`).
  *
  * The target query object is bound by the implementer at construction

--- a/packages/core/src/query/filter.ts
+++ b/packages/core/src/query/filter.ts
@@ -16,7 +16,7 @@ import type { FieldPath } from "../types/field-path.js";
  *
  * The union is kept honest by `OPERATOR_TOKENS` in `default-filter-parser`
  * (every operator must have a wire token) and by the exhaustive switch in
- * `@crudo/typeorm`'s `FilterTranslator` (every operator must translate).
+ * `@kavo/typeorm`'s `FilterTranslator` (every operator must translate).
  */
 export type FilterOperator =
   | "EQ"

--- a/packages/core/src/query/pagination-strategies.ts
+++ b/packages/core/src/query/pagination-strategies.ts
@@ -55,7 +55,7 @@ function readBoundedInt(raw: unknown, param: string, minimum: number): number | 
   if (!Number.isInteger(value) || value < minimum) {
     throw QueryValidationException.single({
       field: param,
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
       detail: `'${param}' must be an integer ≥ ${minimum}, got '${String(raw)}'.`,
     });
   }

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -133,7 +133,7 @@ export class QueryNormalizer<Entity = unknown> {
     if (limit < 1 || offset < 0 || !Number.isInteger(limit) || !Number.isInteger(offset)) {
       issues.push({
         field: limit < 1 || !Number.isInteger(limit) ? "limit" : "offset",
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: `Pagination values must be integers (limit ≥ 1, offset ≥ 0).`,
       });
     }
@@ -199,7 +199,7 @@ export class QueryNormalizer<Entity = unknown> {
 function unsupportedIssue(param: string): QueryIssueDto {
   return {
     field: param,
-    code: "CRUDO_QUERY_UNSUPPORTED_PARAM",
+    code: "KAVO_QUERY_UNSUPPORTED_PARAM",
     detail: `Query parameter '${param}' is not supported: this entity has no relation graph to resolve it against.`,
   };
 }
@@ -218,7 +218,7 @@ function parseIncludePaths(raw: unknown, issues: QueryIssueDto[]): readonly stri
     if (typeof token !== "string") {
       issues.push({
         field: "include",
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: "'include' must be a comma-separated list of relation paths.",
       });
       continue;
@@ -247,7 +247,7 @@ function parseWithDeleted<Entity>(
   if (raw !== true && raw !== "true" && raw !== "1") {
     issues.push({
       field: "withDeleted",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
       detail: `Value '${String(raw)}' for field 'withDeleted' is not a valid boolean.`,
     });
     return false;
@@ -255,7 +255,7 @@ function parseWithDeleted<Entity>(
   if (config.softDelete.strategy !== "soft") {
     issues.push({
       field: "withDeleted",
-      code: "CRUDO_QUERY_UNSUPPORTED_PARAM",
+      code: "KAVO_QUERY_UNSUPPORTED_PARAM",
       detail:
         `Query parameter 'withDeleted' is not supported: ` +
         `${config.entityName} is not soft-deletable, so no rows are excluded.`,
@@ -274,7 +274,7 @@ function parseSort<Entity>(
   if (typeof raw !== "string") {
     issues.push({
       field: "sort",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
       detail: "'sort' must be a comma-separated field list.",
     });
     return [];
@@ -326,7 +326,7 @@ function collapseFieldSelection<Entity>(
   if (input === null || typeof input !== "object") {
     issues.push({
       field: "fields",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
       detail: "'fields' must be an array, or an object of relation fieldsets.",
     });
     return { root: null, relations: {} };
@@ -337,7 +337,7 @@ function collapseFieldSelection<Entity>(
     for (const key of unknownKeys) {
       issues.push({
         field: `fields.${key}`,
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: `'fields.${key}' cannot be mixed with 'root'/'relations' — use 'relations.${key}' instead.`,
       });
     }
@@ -362,7 +362,7 @@ function parseFields<Entity>(
     if (typeof value !== "string") {
       issues.push({
         field: key,
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: `'${key}' must be a comma-separated field list.`,
       });
       continue;
@@ -377,7 +377,7 @@ function parseFields<Entity>(
   if (typeof raw !== "string") {
     issues.push({
       field: "fields",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
       detail: "'fields' must be a comma-separated field list.",
     });
     return { root: null, relations };
@@ -401,7 +401,7 @@ function validateExpression<Entity>(
   if (depth > config.settings.query.maxFilterDepth) {
     issues.push({
       field: "filter",
-      code: "CRUDO_QUERY_LIMIT_EXCEEDED",
+      code: "KAVO_QUERY_LIMIT_EXCEEDED",
       detail: `Filter depth exceeds the configured maximum of ${config.settings.query.maxFilterDepth}.`,
     });
     return;
@@ -412,7 +412,7 @@ function validateExpression<Entity>(
     if (Array.isArray(value) && value.length > config.settings.query.maxInValues) {
       issues.push({
         field: expression.field as string,
-        code: "CRUDO_QUERY_LIMIT_EXCEEDED",
+        code: "KAVO_QUERY_LIMIT_EXCEEDED",
         detail: `'${expression.operator}' carries ${value.length} values; the maximum is ${config.settings.query.maxInValues}.`,
       });
     }
@@ -432,7 +432,7 @@ function requireAllowlisted(
   if ((allowlist as readonly string[]).includes(field)) return true;
   issues.push({
     field,
-    code: "CRUDO_QUERY_INVALID_FIELD",
+    code: "KAVO_QUERY_INVALID_FIELD",
     detail: `Field '${field}' cannot be used for ${usage}.`,
   });
   return false;

--- a/packages/core/src/query/value-coercion.ts
+++ b/packages/core/src/query/value-coercion.ts
@@ -75,7 +75,7 @@ export function isIssue(value: FilterScalar | QueryIssueDto): value is QueryIssu
 function issue(field: string, value: string, expected: FieldKind | string): QueryIssueDto {
   return {
     field,
-    code: "CRUDO_QUERY_INVALID_VALUE",
+    code: "KAVO_QUERY_INVALID_VALUE",
     detail: `Value '${value}' for field '${field}' is not a valid ${expected}.`,
   };
 }

--- a/packages/core/src/relations/default-include-resolver.ts
+++ b/packages/core/src/relations/default-include-resolver.ts
@@ -88,7 +88,7 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
       if (relation === undefined || !relation.includable) {
         issues.push({
           field: draft.path,
-          code: "CRUDO_QUERY_INVALID_FIELD",
+          code: "KAVO_QUERY_INVALID_FIELD",
           detail: `Field '${draft.path}' cannot be used for inclusion.`,
         });
         continue;
@@ -96,7 +96,7 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
       if (depthBudget < 1) {
         issues.push({
           field: draft.path,
-          code: "CRUDO_QUERY_LIMIT_EXCEEDED",
+          code: "KAVO_QUERY_LIMIT_EXCEEDED",
           detail:
             `Include path '${draft.path}' is deeper than the configured maximum ` +
             `of ${owner.settings.relations.maxIncludeDepth}.`,
@@ -106,7 +106,7 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
       if (nodeBudget.remaining < 1) {
         issues.push({
           field: draft.path,
-          code: "CRUDO_QUERY_LIMIT_EXCEEDED",
+          code: "KAVO_QUERY_LIMIT_EXCEEDED",
           detail: `Include tree exceeds the configured maximum of ${owner.settings.relations.maxIncludedNodes} nodes.`,
         });
         continue;
@@ -148,10 +148,10 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
     if (target === undefined) {
       issues.push({
         field: draft.path,
-        code: "CRUDO_QUERY_UNSUPPORTED_PARAM",
+        code: "KAVO_QUERY_UNSUPPORTED_PARAM",
         detail:
           `Query parameter 'include' cannot resolve '${draft.path}': the target entity is ` +
-          `unknown to this Crudo instance.`,
+          `unknown to this Kavo instance.`,
       });
     }
     return target;
@@ -181,7 +181,7 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
     if (!Array.isArray(requested)) {
       issues.push({
         field: draft.path,
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
         detail: `'fields.${draft.path}' must be an array of field names.`,
       });
       return null;
@@ -195,7 +195,7 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
       }
       issues.push({
         field: `${draft.path}.${field}`,
-        code: "CRUDO_QUERY_INVALID_FIELD",
+        code: "KAVO_QUERY_INVALID_FIELD",
         detail: `Field '${field}' cannot be used for selection on '${draft.path}'.`,
       });
     }
@@ -209,7 +209,7 @@ function addPath(drafts: Map<string, DraftNode>, path: string, issues: QueryIssu
   if (segments.some((segment) => segment === "")) {
     issues.push({
       field: "include",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
       detail: `Include path '${path}' is malformed: segments must be non-empty, dot-separated relation names.`,
     });
     return;

--- a/packages/core/src/service/crud-call-options.ts
+++ b/packages/core/src/service/crud-call-options.ts
@@ -1,4 +1,4 @@
-import type { CrudoSettings } from "../config/settings.js";
+import type { KavoSettings } from "../config/settings.js";
 import type { DeepPartial } from "../types/utility.js";
 import type { TransactionContext } from "../persistence/transaction-manager.js";
 
@@ -13,5 +13,5 @@ export interface CrudCallOptions {
   /** Caller identity to expose on `CrudContext.principal`. */
   readonly principal?: unknown;
   /** Per-call settings overrides (e.g. a one-off `pagination.count`). */
-  readonly settings?: DeepPartial<CrudoSettings>;
+  readonly settings?: DeepPartial<KavoSettings>;
 }

--- a/packages/core/src/types/entity-id.ts
+++ b/packages/core/src/types/entity-id.ts
@@ -1,5 +1,5 @@
 /**
- * Identifier types Crudo accepts for entity primary keys.
+ * Identifier types Kavo accepts for entity primary keys.
  *
  * Composite keys are out of scope for v6; an entity exposes exactly one
  * primary identifier, of one of these types.

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -1,9 +1,9 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import * as barrel from "@crudo/core";
+import * as barrel from "@kavo/core";
 
 /**
- * The public surface of `@crudo/core`, as a manifest.
+ * The public surface of `@kavo/core`, as a manifest.
  *
  * ADR-0010 makes the barrel a deliberate explicit named list so the public
  * surface "changes only on purpose", and the Phase 18 api-extractor gate
@@ -39,12 +39,12 @@ const PUBLIC_SURFACE: readonly string[] = [
   "CrudResponse",
   "CrudRuntime",
   "CrudService",
-  "CrudoErrorCode",
-  "CrudoException",
-  "CrudoExceptionOptions",
-  "CrudoInstance",
-  "CrudoOptions",
-  "CrudoSettings",
+  "KavoErrorCode",
+  "KavoException",
+  "KavoExceptionOptions",
+  "KavoInstance",
+  "KavoOptions",
+  "KavoSettings",
   "CustomOperationConfig",
   "DeepPartial",
   "DefaultCrudContextState",
@@ -169,7 +169,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "builtInPaginationStrategies",
   "createCrud",
   "createCrudContext",
-  "createCrudo",
+  "createKavo",
   "createOperationRegistry",
   "deepFreeze",
   "describeResolvedConfig",
@@ -198,7 +198,7 @@ function exportedNames(): string[] {
   return names;
 }
 
-describe("@crudo/core public surface (ADR-0010)", () => {
+describe("@kavo/core public surface (ADR-0010)", () => {
   it("exports exactly the manifest", () => {
     expect([...exportedNames()].sort()).toEqual([...PUBLIC_SURFACE].sort());
   });

--- a/packages/core/tests/config-validation.spec.ts
+++ b/packages/core/tests/config-validation.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { CrudoSettings, DeepPartial } from "@crudo/core";
-import { BUILT_IN_DEFAULTS, ConfigurationException, mergeSettings, validateSettings } from "@crudo/core";
+import type { KavoSettings, DeepPartial } from "@kavo/core";
+import { BUILT_IN_DEFAULTS, ConfigurationException, mergeSettings, validateSettings } from "@kavo/core";
 
 /**
  * Validate one override merged onto the built-in defaults, returning the
@@ -10,7 +10,7 @@ import { BUILT_IN_DEFAULTS, ConfigurationException, mergeSettings, validateSetti
  */
 function rejectionOf(override: unknown): ConfigurationException {
   try {
-    validateSettings("User", mergeSettings(BUILT_IN_DEFAULTS, override as DeepPartial<CrudoSettings>));
+    validateSettings("User", mergeSettings(BUILT_IN_DEFAULTS, override as DeepPartial<KavoSettings>));
   } catch (error) {
     if (error instanceof ConfigurationException) return error;
     throw error;
@@ -21,13 +21,13 @@ function rejectionOf(override: unknown): ConfigurationException {
 /** Phase 8's error bar: every config error names entity, key path, and offending value. */
 function expectRejected(override: unknown, path: string, offending: unknown): void {
   const error = rejectionOf(override);
-  expect(error.code).toBe("CRUDO_CONFIG_INVALID");
+  expect(error.code).toBe("KAVO_CONFIG_INVALID");
   expect(error.messageParams).toMatchObject({ entity: "User", path });
   expect(String(error.messageParams["problem"])).toContain(JSON.stringify(offending));
 }
 
 function accept(override: unknown): void {
-  validateSettings("User", mergeSettings(BUILT_IN_DEFAULTS, override as DeepPartial<CrudoSettings>));
+  validateSettings("User", mergeSettings(BUILT_IN_DEFAULTS, override as DeepPartial<KavoSettings>));
 }
 
 /** Values no positive-integer setting may take. */
@@ -158,7 +158,7 @@ describe("validateSettings — relation edges (Phase 15 keys, Phase 8 rules)", (
     const error = rejectionOf({
       relations: { edges: { posts: { includable: false, defaultInclude: true } } },
     });
-    expect(error.code).toBe("CRUDO_CONFIG_INVALID");
+    expect(error.code).toBe("KAVO_CONFIG_INVALID");
     expect(error.messageParams).toMatchObject({ entity: "User", path: "relations.edges.posts" });
   });
 

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BUILT_IN_DEFAULTS, ConfigurationException, mergeSettings, resolveEntityConfig } from "@crudo/core";
+import { BUILT_IN_DEFAULTS, ConfigurationException, mergeSettings, resolveEntityConfig } from "@kavo/core";
 import { User, userMetadata } from "./support/user-fixture.js";
 
 describe("mergeSettings (Phase 8 merge algebra)", () => {

--- a/packages/core/tests/crud-service.spec.ts
+++ b/packages/core/tests/crud-service.spec.ts
@@ -9,14 +9,14 @@ import type {
   OperationId,
   RepositoryAdapter,
   TransactionContext,
-} from "@crudo/core";
+} from "@kavo/core";
 import {
   ConfigurationException,
   DefaultCrudService,
   OperationDisabledException,
   WireQuery,
-  createCrudo,
-} from "@crudo/core";
+  createKavo,
+} from "@kavo/core";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
 
 /**
@@ -139,9 +139,9 @@ class ContextRecordingAdapter implements RepositoryAdapter<User> {
   }
 }
 
-function makeCrud(config?: Parameters<ReturnType<typeof createCrudo>["createCrud"]>[1]) {
+function makeCrud(config?: Parameters<ReturnType<typeof createKavo>["createCrud"]>[1]) {
   const adapter = new ContextRecordingAdapter();
-  const crud = createCrudo().createCrud(User, config as never, {
+  const crud = createKavo().createCrud(User, config as never, {
     adapter,
     metadata: userMetadata,
   }) as DefaultCrudService<User>;
@@ -385,7 +385,7 @@ describe("CrudCallOptions — per-call settings (Phase 8)", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(ConfigurationException);
       expect(error).toMatchObject({
-        code: "CRUDO_CONFIG_INVALID",
+        code: "KAVO_CONFIG_INVALID",
         messageParams: { entity: expect.stringContaining("User"), path: "pagination.defaultLimit" },
       });
     }

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { NotFoundException, OperationDisabledException, createCrudo, toProblemDetails } from "@crudo/core";
+import { NotFoundException, OperationDisabledException, createKavo, toProblemDetails } from "@kavo/core";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
 
-function makeCrud(config?: Parameters<ReturnType<typeof createCrudo>["createCrud"]>[1]) {
+function makeCrud(config?: Parameters<ReturnType<typeof createKavo>["createCrud"]>[1]) {
   const adapter = new InMemoryUserAdapter();
-  const crudo = createCrudo();
-  const crud = crudo.createCrud(User, config as never, {
+  const kavo = createKavo();
+  const crud = kavo.createCrud(User, config as never, {
     adapter,
     metadata: userMetadata,
   });
-  return { crud, adapter, crudo };
+  return { crud, adapter, kavo };
 }
 
 describe("CrudEngine pipeline (Phase 7)", () => {
@@ -160,17 +160,17 @@ describe("CrudEngine pipeline (Phase 7)", () => {
       const problem = toProblemDetails(error as never);
       expect(problem).toMatchObject({
         status: 404,
-        code: "CRUDO_NOT_FOUND",
-        type: "https://crudo.dev/errors/crudo-not-found",
+        code: "KAVO_NOT_FOUND",
+        type: "https://kavo.dev/errors/kavo-not-found",
       });
       expect(problem.detail).toContain("123");
-      expect(problem.instance).toMatch(/^urn:crudo:request:/);
+      expect(problem.instance).toMatch(/^urn:kavo:request:/);
     }
   });
 
-  it("exposes the debug dump through crudo.describe", () => {
-    const { crudo } = makeCrud();
-    const dump = crudo.describe("User");
+  it("exposes the debug dump through kavo.describe", () => {
+    const { kavo } = makeCrud();
+    const dump = kavo.describe("User");
     expect(dump).toMatchObject({ entityName: "User" });
   });
 });

--- a/packages/core/tests/errors.spec.ts
+++ b/packages/core/tests/errors.spec.ts
@@ -1,11 +1,11 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import type { CatalogedErrorCode, CrudException, QueryIssueDto } from "@crudo/core";
+import type { CatalogedErrorCode, CrudException, QueryIssueDto } from "@kavo/core";
 import {
   AlreadyDeletedException,
   ConfigurationException,
   ConflictException,
-  CrudoException,
+  KavoException,
   DefaultErrorHandler,
   ERROR_CATALOG,
   NotDeletedException,
@@ -16,40 +16,40 @@ import {
   TransactionException,
   renderMessage,
   toProblemDetails,
-} from "@crudo/core";
+} from "@kavo/core";
 
 /**
  * The shipped catalog, pinned. Codes are API surface — renaming, restatusing
  * or dropping one is a breaking change (Phase 6; Phase 18 semver policy), so
  * it should cost a deliberate edit here.
  *
- * `CRUDO_BULK_FAILED` is absent on purpose: bulk was dropped, so the code is
+ * `KAVO_BULK_FAILED` is absent on purpose: bulk was dropped, so the code is
  * not shipped (doc 06's table still lists it as reserved).
  */
 const CATALOG: Readonly<Record<CatalogedErrorCode, { status: number; title: string }>> = {
-  CRUDO_QUERY_INVALID: { status: 400, title: "Invalid query" },
-  CRUDO_QUERY_INVALID_FIELD: { status: 400, title: "Invalid query field" },
-  CRUDO_QUERY_INVALID_OPERATOR: { status: 400, title: "Invalid filter operator" },
-  CRUDO_QUERY_INVALID_VALUE: { status: 400, title: "Invalid query value" },
-  CRUDO_QUERY_LIMIT_EXCEEDED: { status: 400, title: "Query limit exceeded" },
-  CRUDO_QUERY_UNSUPPORTED_PARAM: { status: 400, title: "Unsupported query parameter" },
-  CRUDO_NOT_FOUND: { status: 404, title: "Not found" },
-  CRUDO_CONFLICT: { status: 409, title: "Conflict" },
-  CRUDO_ALREADY_DELETED: { status: 409, title: "Already deleted" },
-  CRUDO_NOT_DELETED: { status: 409, title: "Not deleted" },
-  CRUDO_OPERATION_DISABLED: { status: 405, title: "Operation disabled" },
-  CRUDO_PERSISTENCE_FAILED: { status: 500, title: "Persistence failure" },
-  CRUDO_TRANSACTION_FAILED: { status: 500, title: "Transaction failure" },
-  CRUDO_CONFIG_INVALID: { status: 500, title: "Invalid configuration" },
+  KAVO_QUERY_INVALID: { status: 400, title: "Invalid query" },
+  KAVO_QUERY_INVALID_FIELD: { status: 400, title: "Invalid query field" },
+  KAVO_QUERY_INVALID_OPERATOR: { status: 400, title: "Invalid filter operator" },
+  KAVO_QUERY_INVALID_VALUE: { status: 400, title: "Invalid query value" },
+  KAVO_QUERY_LIMIT_EXCEEDED: { status: 400, title: "Query limit exceeded" },
+  KAVO_QUERY_UNSUPPORTED_PARAM: { status: 400, title: "Unsupported query parameter" },
+  KAVO_NOT_FOUND: { status: 404, title: "Not found" },
+  KAVO_CONFLICT: { status: 409, title: "Conflict" },
+  KAVO_ALREADY_DELETED: { status: 409, title: "Already deleted" },
+  KAVO_NOT_DELETED: { status: 409, title: "Not deleted" },
+  KAVO_OPERATION_DISABLED: { status: 405, title: "Operation disabled" },
+  KAVO_PERSISTENCE_FAILED: { status: 500, title: "Persistence failure" },
+  KAVO_TRANSACTION_FAILED: { status: 500, title: "Transaction failure" },
+  KAVO_CONFIG_INVALID: { status: 500, title: "Invalid configuration" },
 };
 
-/** Every `CRUDO_*` code literal appearing anywhere in core's source. */
+/** Every `KAVO_*` code literal appearing anywhere in core's source. */
 function codesUsedInSource(): string[] {
   const root = new URL("../src/", import.meta.url);
   const files = readdirSync(root, { recursive: true, encoding: "utf8" }).filter((name) => name.endsWith(".ts"));
   const codes = new Set<string>();
   for (const file of files) {
-    for (const match of readFileSync(new URL(file, root), "utf8").matchAll(/CRUDO_[A-Z][A-Z0-9_]*/g)) {
+    for (const match of readFileSync(new URL(file, root), "utf8").matchAll(/KAVO_[A-Z][A-Z0-9_]*/g)) {
       codes.add(match[0]);
     }
   }
@@ -58,7 +58,7 @@ function codesUsedInSource(): string[] {
 
 describe("ERROR_CATALOG completeness (Phase 6)", () => {
   it("catalogs every error code core's source actually uses", () => {
-    // `CrudoErrorCode` is an open template type, so the compiler cannot
+    // `KavoErrorCode` is an open template type, so the compiler cannot
     // close this gap: a new code with no catalog entry would render a title
     // of "Error" at runtime and go unnoticed.
     const used = codesUsedInSource();
@@ -89,19 +89,19 @@ describe("ERROR_CATALOG completeness (Phase 6)", () => {
 
 describe("renderMessage — message key + params (Phase 6)", () => {
   it("interpolates every {param} placeholder from the params bag", () => {
-    expect(renderMessage("CRUDO_NOT_FOUND", { entity: "User", id: "7" })).toBe("User with id '7' was not found.");
+    expect(renderMessage("KAVO_NOT_FOUND", { entity: "User", id: "7" })).toBe("User with id '7' was not found.");
   });
 
   it("stringifies numeric params", () => {
-    expect(renderMessage("CRUDO_NOT_FOUND", { entity: "User", id: 7 })).toContain("'7'");
+    expect(renderMessage("KAVO_NOT_FOUND", { entity: "User", id: 7 })).toContain("'7'");
   });
 
   it("returns a placeholder-free template untouched", () => {
-    expect(renderMessage("CRUDO_TRANSACTION_FAILED", {})).toBe(ERROR_CATALOG.CRUDO_TRANSACTION_FAILED.message);
+    expect(renderMessage("KAVO_TRANSACTION_FAILED", {})).toBe(ERROR_CATALOG.KAVO_TRANSACTION_FAILED.message);
   });
 
   it("ignores params the template does not name", () => {
-    expect(renderMessage("CRUDO_CONFLICT", { entity: "User", stray: "x" })).toBe(
+    expect(renderMessage("KAVO_CONFLICT", { entity: "User", stray: "x" })).toBe(
       "The operation conflicts with the current state of User.",
     );
   });
@@ -110,21 +110,21 @@ describe("renderMessage — message key + params (Phase 6)", () => {
     // The spec fixes key + params as the localization contract but is silent
     // on a missing param; keeping the placeholder is what core does, and it
     // keeps the gap legible in the rendered detail.
-    expect(renderMessage("CRUDO_NOT_FOUND", { entity: "User" })).toBe("User with id '{id}' was not found.");
+    expect(renderMessage("KAVO_NOT_FOUND", { entity: "User" })).toBe("User with id '{id}' was not found.");
   });
 });
 
 describe("exception hierarchy (Phase 6)", () => {
   const leaves = [
-    { exception: new NotFoundException(), code: "CRUDO_NOT_FOUND", status: 404 },
-    { exception: new ConflictException(), code: "CRUDO_CONFLICT", status: 409 },
-    { exception: new AlreadyDeletedException(), code: "CRUDO_ALREADY_DELETED", status: 409 },
-    { exception: new NotDeletedException(), code: "CRUDO_NOT_DELETED", status: 409 },
-    { exception: new OperationDisabledException(), code: "CRUDO_OPERATION_DISABLED", status: 405 },
-    { exception: new PersistenceException(), code: "CRUDO_PERSISTENCE_FAILED", status: 500 },
-    { exception: new TransactionException(), code: "CRUDO_TRANSACTION_FAILED", status: 500 },
-    { exception: new QueryValidationException([]), code: "CRUDO_QUERY_INVALID", status: 400 },
-    { exception: new ConfigurationException("User", "operations.x", "why"), code: "CRUDO_CONFIG_INVALID", status: 500 },
+    { exception: new NotFoundException(), code: "KAVO_NOT_FOUND", status: 404 },
+    { exception: new ConflictException(), code: "KAVO_CONFLICT", status: 409 },
+    { exception: new AlreadyDeletedException(), code: "KAVO_ALREADY_DELETED", status: 409 },
+    { exception: new NotDeletedException(), code: "KAVO_NOT_DELETED", status: 409 },
+    { exception: new OperationDisabledException(), code: "KAVO_OPERATION_DISABLED", status: 405 },
+    { exception: new PersistenceException(), code: "KAVO_PERSISTENCE_FAILED", status: 500 },
+    { exception: new TransactionException(), code: "KAVO_TRANSACTION_FAILED", status: 500 },
+    { exception: new QueryValidationException([]), code: "KAVO_QUERY_INVALID", status: 400 },
+    { exception: new ConfigurationException("User", "operations.x", "why"), code: "KAVO_CONFIG_INVALID", status: 500 },
   ] as const;
 
   it("binds each leaf to its catalog code and status", () => {
@@ -135,10 +135,10 @@ describe("exception hierarchy (Phase 6)", () => {
     }
   });
 
-  it("is catchable as an Error and through the CrudoException base token", () => {
+  it("is catchable as an Error and through the KavoException base token", () => {
     for (const { exception } of leaves) {
       expect(exception).toBeInstanceOf(Error);
-      expect(exception).toBeInstanceOf(CrudoException);
+      expect(exception).toBeInstanceOf(KavoException);
       expect(exception.name).toBe(exception.constructor.name);
     }
   });
@@ -175,16 +175,16 @@ describe("exception hierarchy (Phase 6)", () => {
 
   it("carries field-level issues on QueryValidationException under the aggregate code", () => {
     const issues: QueryIssueDto[] = [
-      { field: "age", code: "CRUDO_QUERY_INVALID_VALUE", detail: "bad" },
-      { field: "password", code: "CRUDO_QUERY_INVALID_FIELD", detail: "not allowlisted" },
+      { field: "age", code: "KAVO_QUERY_INVALID_VALUE", detail: "bad" },
+      { field: "password", code: "KAVO_QUERY_INVALID_FIELD", detail: "not allowlisted" },
     ];
     const exception = new QueryValidationException(issues);
-    expect(exception.code).toBe("CRUDO_QUERY_INVALID");
+    expect(exception.code).toBe("KAVO_QUERY_INVALID");
     expect(exception.issues).toEqual(issues);
   });
 
   it("wraps the single-issue case into the same issues array", () => {
-    const issue: QueryIssueDto = { field: "limit", code: "CRUDO_QUERY_INVALID_VALUE", detail: "bad" };
+    const issue: QueryIssueDto = { field: "limit", code: "KAVO_QUERY_INVALID_VALUE", detail: "bad" };
     const exception = QueryValidationException.single(issue);
     expect(exception).toBeInstanceOf(QueryValidationException);
     expect(exception.issues).toEqual([issue]);
@@ -211,11 +211,11 @@ describe("toProblemDetails — RFC 9457 document (Phase 6, ADR-0009)", () => {
   it("produces type, title, status, detail, and the code extension", () => {
     const exception = new NotFoundException({ messageParams: { entity: "User", id: 7 } });
     expect(toProblemDetails(exception)).toEqual({
-      type: "https://crudo.dev/errors/crudo-not-found",
+      type: "https://kavo.dev/errors/kavo-not-found",
       title: "Not found",
       status: 404,
       detail: "User with id '7' was not found.",
-      code: "CRUDO_NOT_FOUND",
+      code: "KAVO_NOT_FOUND",
     });
   });
 
@@ -229,21 +229,21 @@ describe("toProblemDetails — RFC 9457 document (Phase 6, ADR-0009)", () => {
         detail: "",
         context: {},
       });
-      expect(problem.type).toBe(`https://crudo.dev/errors/${code.toLowerCase().replace(/_/g, "-")}`);
+      expect(problem.type).toBe(`https://kavo.dev/errors/${code.toLowerCase().replace(/_/g, "-")}`);
       expect(problem.title).toBe(ERROR_CATALOG[code].title);
     }
   });
 
   it("emits one errors[] entry per issue of a multi-issue query failure", () => {
     const issues: QueryIssueDto[] = [
-      { field: "age", code: "CRUDO_QUERY_INVALID_VALUE", detail: "not a number" },
-      { field: "password", code: "CRUDO_QUERY_INVALID_FIELD", detail: "not filterable" },
+      { field: "age", code: "KAVO_QUERY_INVALID_VALUE", detail: "not a number" },
+      { field: "password", code: "KAVO_QUERY_INVALID_FIELD", detail: "not filterable" },
     ];
     const problem = toProblemDetails(new QueryValidationException(issues));
     expect(problem).toMatchObject({
-      type: "https://crudo.dev/errors/crudo-query-invalid",
+      type: "https://kavo.dev/errors/kavo-query-invalid",
       status: 400,
-      code: "CRUDO_QUERY_INVALID",
+      code: "KAVO_QUERY_INVALID",
     });
     expect(problem.errors).toEqual(issues);
   });
@@ -254,7 +254,7 @@ describe("toProblemDetails — RFC 9457 document (Phase 6, ADR-0009)", () => {
 
   it("reports the correlation id as the instance URN, and omits it when absent", () => {
     const correlated = toProblemDetails(new NotFoundException({ context: { correlationId: "req-1" } }));
-    expect(correlated.instance).toBe("urn:crudo:request:req-1");
+    expect(correlated.instance).toBe("urn:kavo:request:req-1");
     expect(toProblemDetails(new NotFoundException()).instance).toBeUndefined();
   });
 
@@ -268,11 +268,11 @@ describe("toProblemDetails — RFC 9457 document (Phase 6, ADR-0009)", () => {
 describe("DefaultErrorHandler — engine boundary mapping (Phase 6)", () => {
   const handler = new DefaultErrorHandler();
 
-  it("passes a Crudo exception through with its code, status, and payload intact", () => {
-    const original = new QueryValidationException([{ field: "age", code: "CRUDO_QUERY_INVALID_VALUE", detail: "x" }]);
+  it("passes a Kavo exception through with its code, status, and payload intact", () => {
+    const original = new QueryValidationException([{ field: "age", code: "KAVO_QUERY_INVALID_VALUE", detail: "x" }]);
     const handled = handler.handle(original, { entityName: "User", operation: "findMany" });
     expect(handled).toBeInstanceOf(QueryValidationException);
-    expect(handled).toMatchObject({ code: "CRUDO_QUERY_INVALID", status: 400, detail: original.detail });
+    expect(handled).toMatchObject({ code: "KAVO_QUERY_INVALID", status: 400, detail: original.detail });
     expect((handled as QueryValidationException).issues).toEqual(original.issues);
   });
 
@@ -294,7 +294,7 @@ describe("DefaultErrorHandler — engine boundary mapping (Phase 6)", () => {
     const driverError = new Error("ECONNRESET");
     const handled = handler.handle(driverError, { entityName: "User", operation: "createOne" });
     expect(handled).toBeInstanceOf(PersistenceException);
-    expect(handled.code).toBe("CRUDO_PERSISTENCE_FAILED");
+    expect(handled.code).toBe("KAVO_PERSISTENCE_FAILED");
     expect(handled.status).toBe(500);
     expect(handled.cause).toBe(driverError);
     expect(handled.context).toMatchObject({ entityName: "User", operation: "createOne" });
@@ -314,9 +314,9 @@ describe("DefaultErrorHandler — engine boundary mapping (Phase 6)", () => {
       correlationId: "req-2",
     });
     expect(toProblemDetails(handled)).toMatchObject({
-      type: "https://crudo.dev/errors/crudo-persistence-failed",
+      type: "https://kavo.dev/errors/kavo-persistence-failed",
       status: 500,
-      instance: "urn:crudo:request:req-2",
+      instance: "urn:kavo:request:req-2",
     });
   });
 });

--- a/packages/core/tests/filter-parser.spec.ts
+++ b/packages/core/tests/filter-parser.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { FilterCondition, FilterGroup } from "@crudo/core";
-import { DefaultFilterParser, resolveEntityConfig } from "@crudo/core";
+import type { FilterCondition, FilterGroup } from "@kavo/core";
+import { DefaultFilterParser, resolveEntityConfig } from "@kavo/core";
 import { userMetadata } from "./support/user-fixture.js";
 import { issuesOf } from "./support/query-issues.js";
 
@@ -77,7 +77,7 @@ describe("DefaultFilterParser — bracket grammar (Phase 5)", () => {
     const filter = parse({ "filter[age][between]": "18,65" }).root as FilterCondition;
     expect(filter.value).toEqual([18, 65]);
     const issues = issuesOf(() => parse({ "filter[age][between]": "1,2,3" }));
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 });
 
@@ -97,7 +97,7 @@ describe("DefaultFilterParser — JSON escape hatch", () => {
 
   it("rejects malformed JSON explicitly", () => {
     const issues = issuesOf(() => parse({ filter: "{nope" }));
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 });
 
@@ -106,30 +106,30 @@ describe("DefaultFilterParser — security posture", () => {
     const issues = issuesOf(() => parse({ "filter[password][eq]": "x" }));
     expect(issues[0]).toMatchObject({
       field: "password",
-      code: "CRUDO_QUERY_INVALID_FIELD",
+      code: "KAVO_QUERY_INVALID_FIELD",
     });
   });
 
   it("rejects unknown operators (exact-case, no aliases)", () => {
     const issues = issuesOf(() => parse({ "filter[age][GTE]": "18" }));
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_INVALID_OPERATOR");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_OPERATOR");
   });
 
   it("rejects coercion failures as field-level issues", () => {
     const issues = issuesOf(() => parse({ "filter[age][eq]": "abc" }));
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
     expect(issues[0]?.detail).toContain("abc");
   });
 
   it("rejects enum values outside the member list", () => {
     const issues = issuesOf(() => parse({ "filter[status][eq]": "vip" }));
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 
   it("enforces maxInValues", () => {
     const many = Array.from({ length: 101 }, (_, i) => String(i)).join(",");
     const issues = issuesOf(() => parse({ "filter[age][in]": many }));
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_LIMIT_EXCEEDED");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_LIMIT_EXCEEDED");
   });
 
   it("enforces maxFilterDepth", () => {
@@ -140,7 +140,7 @@ describe("DefaultFilterParser — security posture", () => {
         }),
       }),
     );
-    expect(issues.some((i) => i.code === "CRUDO_QUERY_LIMIT_EXCEEDED")).toBe(true);
+    expect(issues.some((i) => i.code === "KAVO_QUERY_LIMIT_EXCEEDED")).toBe(true);
   });
 
   it("collects every issue into one exception", () => {
@@ -155,6 +155,6 @@ describe("DefaultFilterParser — security posture", () => {
 
   it("restricts LIKE to string columns", () => {
     const issues = issuesOf(() => parse({ "filter[age][like]": "%1%" }));
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 });

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { ConfigurationException, QueryValidationException, createCrudo } from "@crudo/core";
+import { ConfigurationException, QueryValidationException, createKavo } from "@kavo/core";
 import type {
-  CrudoInstance,
-  CrudoOptions,
+  KavoInstance,
+  KavoOptions,
   DefaultCrudService,
   EntityConfig,
   EntityMetadata,
   IncludeNode,
   IncludePath,
-} from "@crudo/core";
+} from "@kavo/core";
 import {
   Author,
   Comment,
@@ -20,7 +20,7 @@ import {
 } from "./support/blog-fixture.js";
 
 interface Blog {
-  crudo: CrudoInstance;
+  kavo: KavoInstance;
   authors: DefaultCrudService<Author>;
   posts: DefaultCrudService<Post>;
   authorAdapter: SeededAdapter<Author>;
@@ -40,7 +40,7 @@ function blog(
     post?: EntityConfig<Post>;
     comment?: EntityConfig<Comment>;
   } = {},
-  options: CrudoOptions = {},
+  options: KavoOptions = {},
 ): Blog {
   const metadata = new Map<unknown, EntityMetadata<object>>([
     [Author, authorMetadata as EntityMetadata<object>],
@@ -55,18 +55,18 @@ function blog(
     [Post, postAdapter],
     [Comment, commentAdapter],
   ]);
-  const crudo = createCrudo({
+  const kavo = createKavo({
     ...options,
     infrastructure: {
       metadataFor: (entity) => metadata.get(entity) as never,
       adapterFor: (entity) => adapters.get(entity) as never,
     },
   });
-  const authors = crudo.createCrud(Author, configs.author as never) as DefaultCrudService<Author>;
-  const posts = crudo.createCrud(Post, configs.post as never) as DefaultCrudService<Post>;
-  crudo.createCrud(Comment, configs.comment as never);
+  const authors = kavo.createCrud(Author, configs.author as never) as DefaultCrudService<Author>;
+  const posts = kavo.createCrud(Post, configs.post as never) as DefaultCrudService<Post>;
+  kavo.createCrud(Comment, configs.comment as never);
   return {
-    crudo,
+    kavo,
     authors,
     posts,
     authorAdapter,
@@ -95,7 +95,7 @@ describe("include resolution (Phase 15)", () => {
     const fixture = blog();
     const { authors } = fixture;
     await expect(authors.findMany({ include: ["posts"] })).rejects.toMatchObject({
-      issues: [{ field: "posts", code: "CRUDO_QUERY_INVALID_FIELD" }],
+      issues: [{ field: "posts", code: "KAVO_QUERY_INVALID_FIELD" }],
     });
   });
 
@@ -174,7 +174,7 @@ describe("include resolution (Phase 15)", () => {
     );
     const { authors } = fixture;
     await expect(authors.findMany({ include: ["posts.comments"] })).rejects.toMatchObject({
-      issues: [{ field: "posts.comments", code: "CRUDO_QUERY_LIMIT_EXCEEDED" }],
+      issues: [{ field: "posts.comments", code: "KAVO_QUERY_LIMIT_EXCEEDED" }],
     });
   });
 
@@ -201,7 +201,7 @@ describe("include resolution (Phase 15)", () => {
     const { posts, postRows } = fixture;
     postRows.push(Object.assign(new Post(), { id: 10 }));
     await expect(posts.findMany({ include: ["author", "comments"] })).rejects.toMatchObject({
-      issues: [{ code: "CRUDO_QUERY_LIMIT_EXCEEDED" }],
+      issues: [{ code: "KAVO_QUERY_LIMIT_EXCEEDED" }],
     });
   });
 
@@ -215,7 +215,7 @@ describe("include resolution (Phase 15)", () => {
     // posts.author revisits Author — legal, because depth is the contract.
     await expect(authors.findMany({ include: ["posts.author"] })).resolves.toBeDefined();
     await expect(authors.findMany({ include: ["posts.author.posts"] })).rejects.toMatchObject({
-      issues: [{ code: "CRUDO_QUERY_LIMIT_EXCEEDED" }],
+      issues: [{ code: "KAVO_QUERY_LIMIT_EXCEEDED" }],
     });
   });
 
@@ -285,7 +285,7 @@ describe("include serialization (Phase 15)", () => {
     await expect(
       authors.findMany({ include: ["posts"], fields: { relations: { posts: ["title"] } } }),
     ).rejects.toMatchObject({
-      issues: [{ field: "posts.title", code: "CRUDO_QUERY_INVALID_FIELD" }],
+      issues: [{ field: "posts.title", code: "KAVO_QUERY_INVALID_FIELD" }],
     });
   });
 
@@ -301,7 +301,7 @@ describe("include serialization (Phase 15)", () => {
     await expect(
       authors.findMany({ include: ["posts"], fields: { relations: { posts: 5 as never } } }),
     ).rejects.toMatchObject({
-      issues: [{ field: "posts", code: "CRUDO_QUERY_INVALID_VALUE" }],
+      issues: [{ field: "posts", code: "KAVO_QUERY_INVALID_VALUE" }],
     });
   });
 

--- a/packages/core/tests/operation-registry.spec.ts
+++ b/packages/core/tests/operation-registry.spec.ts
@@ -5,13 +5,13 @@ import type {
   OperationHandler,
   OperationMetadata,
   StandardOperationId,
-} from "@crudo/core";
+} from "@kavo/core";
 import {
   ConfigurationException,
   DefaultOperationRegistry,
   STANDARD_OPERATIONS,
   createOperationRegistry,
-} from "@crudo/core";
+} from "@kavo/core";
 import { User, contextStub } from "./support/user-fixture.js";
 
 type UserConfig = EntityConfig<User>;
@@ -103,7 +103,7 @@ describe("DefaultOperationRegistry — the operation table (Phase 7, ADR-0006)",
       } catch (error) {
         expect(error).toBeInstanceOf(ConfigurationException);
         expect(error).toMatchObject({
-          code: "CRUDO_CONFIG_INVALID",
+          code: "KAVO_CONFIG_INVALID",
           messageParams: { path: "operations.ghost" },
         });
       }
@@ -178,7 +178,7 @@ describe("createOperationRegistry — inspection-only mode (ADR-0012)", () => {
     const registry = createOperationRegistry<User>(undefined);
     const handler = registry.get("createOne")?.handler;
     await expect(async () => handler?.execute({}, contextStub())).rejects.toMatchObject({
-      code: "CRUDO_CONFIG_INVALID",
+      code: "KAVO_CONFIG_INVALID",
       messageParams: { path: "operations.createOne" },
     });
     await expect(async () => handler?.execute({}, contextStub())).rejects.toBeInstanceOf(ConfigurationException);

--- a/packages/core/tests/pagination-strategies.spec.ts
+++ b/packages/core/tests/pagination-strategies.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { PaginationLimits } from "@crudo/core";
-import { OffsetPaginationStrategy, PagePaginationStrategy, builtInPaginationStrategies } from "@crudo/core";
+import type { PaginationLimits } from "@kavo/core";
+import { OffsetPaginationStrategy, PagePaginationStrategy, builtInPaginationStrategies } from "@kavo/core";
 import { issuesOf } from "./support/query-issues.js";
 
 const limits: PaginationLimits = { defaultLimit: 20, maxLimit: 100 };
@@ -35,12 +35,12 @@ describe("OffsetPaginationStrategy — flat limit/offset (Phase 5)", () => {
   it("rejects a non-numeric limit as a field-level query issue", () => {
     const issues = issuesOf(() => offset.normalize({ limit: "abc" }, limits));
     expect(issues).toHaveLength(1);
-    expect(issues[0]).toMatchObject({ field: "limit", code: "CRUDO_QUERY_INVALID_VALUE" });
+    expect(issues[0]).toMatchObject({ field: "limit", code: "KAVO_QUERY_INVALID_VALUE" });
   });
 
   it("names the offending param, so a bad offset does not report as 'limit'", () => {
     const issues = issuesOf(() => offset.normalize({ offset: "abc" }, limits));
-    expect(issues[0]).toMatchObject({ field: "offset", code: "CRUDO_QUERY_INVALID_VALUE" });
+    expect(issues[0]).toMatchObject({ field: "offset", code: "KAVO_QUERY_INVALID_VALUE" });
   });
 
   it("rejects fractional values on either param", () => {
@@ -56,15 +56,15 @@ describe("OffsetPaginationStrategy — flat limit/offset (Phase 5)", () => {
     expect(offset.normalize({ offset: "0" }, limits).offset).toBe(0);
   });
 
-  it("raises one aggregate CRUDO_QUERY_INVALID carrying the sub-coded issue", () => {
+  it("raises one aggregate KAVO_QUERY_INVALID carrying the sub-coded issue", () => {
     try {
       offset.normalize({ limit: "abc" }, limits);
       expect.unreachable();
     } catch (error) {
       expect(error).toMatchObject({
-        code: "CRUDO_QUERY_INVALID",
+        code: "KAVO_QUERY_INVALID",
         status: 400,
-        issues: [{ code: "CRUDO_QUERY_INVALID_VALUE" }],
+        issues: [{ code: "KAVO_QUERY_INVALID_VALUE" }],
       });
     }
   });
@@ -97,7 +97,7 @@ describe("PagePaginationStrategy — page[number]/page[size] (Phase 5)", () => {
   it("rejects page[number] below 1 — pages are 1-indexed", () => {
     expect(issuesOf(() => page.normalize({ "page[number]": "0" }, limits))[0]).toMatchObject({
       field: "page[number]",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
     });
   });
 
@@ -105,7 +105,7 @@ describe("PagePaginationStrategy — page[number]/page[size] (Phase 5)", () => {
     for (const size of ["abc", "0", "-2", "2.5"]) {
       expect(issuesOf(() => page.normalize({ "page[size]": size }, limits))[0]).toMatchObject({
         field: "page[size]",
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
       });
     }
   });

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { QueryNormalizer, resolveEntityConfig } from "@crudo/core";
+import { QueryNormalizer, resolveEntityConfig } from "@kavo/core";
 import { userMetadata } from "./support/user-fixture.js";
 import { issuesOf } from "./support/query-issues.js";
 
@@ -41,7 +41,7 @@ describe("QueryNormalizer — wire params (Phase 5 pipeline)", () => {
     const issues = issuesOf(() => normalizer.normalizeWire({ limit: "abc" }, config));
     expect(issues[0]).toMatchObject({
       field: "limit",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
     });
   });
 
@@ -49,7 +49,7 @@ describe("QueryNormalizer — wire params (Phase 5 pipeline)", () => {
     const issues = issuesOf(() => normalizer.normalizeWire({ sort: "-password" }, config));
     expect(issues[0]).toMatchObject({
       field: "password",
-      code: "CRUDO_QUERY_INVALID_FIELD",
+      code: "KAVO_QUERY_INVALID_FIELD",
     });
   });
 
@@ -59,7 +59,7 @@ describe("QueryNormalizer — wire params (Phase 5 pipeline)", () => {
   it("rejects include and withDeleted=true when neither is configured", () => {
     const issues = issuesOf(() => normalizer.normalizeWire({ include: "posts", withDeleted: "true" }, config));
     const codes = issues.map((issue) => issue.code);
-    expect(codes).toEqual(["CRUDO_QUERY_UNSUPPORTED_PARAM", "CRUDO_QUERY_UNSUPPORTED_PARAM"]);
+    expect(codes).toEqual(["KAVO_QUERY_UNSUPPORTED_PARAM", "KAVO_QUERY_UNSUPPORTED_PARAM"]);
   });
 
   it("accepts withDeleted=false (the default) without complaint", () => {
@@ -123,7 +123,7 @@ describe("QueryNormalizer — programmatic input", () => {
         config,
       ),
     );
-    expect(issues[0]?.code).toBe("CRUDO_QUERY_INVALID_FIELD");
+    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_FIELD");
   });
 });
 
@@ -160,7 +160,7 @@ describe("QueryNormalizer — the three fields spellings", () => {
     expect(relationKeyed).toEqual(structured);
     expect(relationKeyed[0]).toMatchObject({
       field: "include",
-      code: "CRUDO_QUERY_UNSUPPORTED_PARAM",
+      code: "KAVO_QUERY_UNSUPPORTED_PARAM",
     });
   });
 
@@ -169,7 +169,7 @@ describe("QueryNormalizer — the three fields spellings", () => {
       const issues = issuesOf(() => normalizer.normalizeInput({ fields } as never, config));
       expect(issues[0]).toMatchObject({
         field: "password",
-        code: "CRUDO_QUERY_INVALID_FIELD",
+        code: "KAVO_QUERY_INVALID_FIELD",
       });
     }
   });
@@ -182,7 +182,7 @@ describe("QueryNormalizer — the three fields spellings", () => {
       const issues = issuesOf(() => normalizer.normalizeInput({ fields: bad } as never, config));
       expect(issues[0]).toMatchObject({
         field: "fields",
-        code: "CRUDO_QUERY_INVALID_VALUE",
+        code: "KAVO_QUERY_INVALID_VALUE",
       });
     }
   });
@@ -193,7 +193,7 @@ describe("QueryNormalizer — the three fields spellings", () => {
     );
     expect(issues[0]).toMatchObject({
       field: "fields.posts",
-      code: "CRUDO_QUERY_INVALID_VALUE",
+      code: "KAVO_QUERY_INVALID_VALUE",
     });
   });
 });

--- a/packages/core/tests/serializer.spec.ts
+++ b/packages/core/tests/serializer.spec.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { CrudContext, IncludeNode, NormalizedQueryContext, ResolvedEntityConfig } from "@crudo/core";
+import type { CrudContext, IncludeNode, NormalizedQueryContext, ResolvedEntityConfig } from "@kavo/core";
 import {
   DefaultDeserializer,
   DefaultDtoResolver,
   DefaultSerializer,
   createCrudContext,
   resolveEntityConfig,
-} from "@crudo/core";
+} from "@kavo/core";
 import { User, contextStub, userMetadata } from "./support/user-fixture.js";
 import { Author, Post, postMetadata } from "./support/blog-fixture.js";
 

--- a/packages/core/tests/soft-delete.spec.ts
+++ b/packages/core/tests/soft-delete.spec.ts
@@ -6,12 +6,12 @@ import {
   NotDeletedException,
   NotFoundException,
   QueryValidationException,
-  createCrudo,
+  createKavo,
   createOperationRegistry,
   mergeSettings,
   resolveSoftDelete,
-} from "@crudo/core";
-import type { CrudoSettings, EntityConfig } from "@crudo/core";
+} from "@kavo/core";
+import type { KavoSettings, EntityConfig } from "@kavo/core";
 import {
   Account,
   InMemoryAccountAdapter,
@@ -20,7 +20,7 @@ import {
 } from "./support/account-fixture.js";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
 
-function settings(overrides: Parameters<typeof mergeSettings>[1] = {}): CrudoSettings {
+function settings(overrides: Parameters<typeof mergeSettings>[1] = {}): KavoSettings {
   return mergeSettings(BUILT_IN_DEFAULTS, overrides);
 }
 
@@ -28,7 +28,7 @@ type AccountConfig = EntityConfig<Account>;
 
 function makeAccountCrud(config?: AccountConfig, metadata = accountMetadata) {
   const adapter = new InMemoryAccountAdapter();
-  const crud = createCrudo().createCrud(Account, config as never, { adapter, metadata });
+  const crud = createKavo().createCrud(Account, config as never, { adapter, metadata });
   return { crud, adapter };
 }
 
@@ -94,12 +94,12 @@ describe("soft delete lifecycle (Phase 14)", () => {
   });
 
   it("rejects withDeleted on an entity that is not soft-deletable", async () => {
-    const crud = createCrudo().createCrud(User, undefined, {
+    const crud = createKavo().createCrud(User, undefined, {
       adapter: new InMemoryUserAdapter(),
       metadata: userMetadata,
     });
     await expect(crud.findMany({ withDeleted: true })).rejects.toMatchObject({
-      issues: [{ field: "withDeleted", code: "CRUDO_QUERY_UNSUPPORTED_PARAM" }],
+      issues: [{ field: "withDeleted", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }],
     });
   });
 
@@ -123,7 +123,7 @@ describe("soft delete lifecycle (Phase 14)", () => {
   it("purges only an already-deleted row, and only when enabled", async () => {
     const disabled = makeAccountCrud();
     await disabled.crud.createOne({ name: "acme" } as never);
-    await expect(disabled.crud.purgeOne(1)).rejects.toMatchObject({ code: "CRUDO_OPERATION_DISABLED" });
+    await expect(disabled.crud.purgeOne(1)).rejects.toMatchObject({ code: "KAVO_OPERATION_DISABLED" });
 
     const { crud, adapter } = makeAccountCrud({ operations: { purgeOne: true } });
     await crud.createOne({ name: "acme" } as never);
@@ -139,7 +139,7 @@ describe("soft delete lifecycle (Phase 14)", () => {
     await crud.createOne({ name: "acme" } as never);
     await crud.deleteOne(1);
     expect(adapter.rows).toHaveLength(0);
-    await expect(crud.restoreOne(1)).rejects.toMatchObject({ code: "CRUDO_OPERATION_DISABLED" });
+    await expect(crud.restoreOne(1)).rejects.toMatchObject({ code: "KAVO_OPERATION_DISABLED" });
   });
 
   it("applies a per-operation strategy override", async () => {

--- a/packages/core/tests/support/account-fixture.ts
+++ b/packages/core/tests/support/account-fixture.ts
@@ -1,10 +1,10 @@
-import type { CrudContext, EntityId, EntityMetadata, NormalizedQueryContext, RepositoryAdapter } from "@crudo/core";
-import { AlreadyDeletedException, NotDeletedException, NotFoundException } from "@crudo/core";
+import type { CrudContext, EntityId, EntityMetadata, NormalizedQueryContext, RepositoryAdapter } from "@kavo/core";
+import { AlreadyDeletedException, NotDeletedException, NotFoundException } from "@kavo/core";
 
 /**
  * Soft-deletable test entity (Phase 14): a `deletedAt` marker column, plus
  * `softDeleteField` on the metadata — the seam a real ORM fills from its
- * own declaration (`@DeleteDateColumn` in `@crudo/typeorm`).
+ * own declaration (`@DeleteDateColumn` in `@kavo/typeorm`).
  */
 export class Account {
   id = 0;

--- a/packages/core/tests/support/blog-fixture.ts
+++ b/packages/core/tests/support/blog-fixture.ts
@@ -5,8 +5,8 @@ import type {
   NormalizedQueryContext,
   RelationDescriptor,
   RepositoryAdapter,
-} from "@crudo/core";
-import { NotFoundException } from "@crudo/core";
+} from "@kavo/core";
+import { NotFoundException } from "@kavo/core";
 
 /**
  * A small relation graph for include tests (Phase 15):
@@ -82,7 +82,7 @@ export const commentMetadata: EntityMetadata<Comment> = {
 /**
  * Adapter that hands back whatever rows it was seeded with, already
  * stitched. Loading is a real adapter's job (covered against SQLite in
- * @crudo/typeorm); what these tests need from it is a row shaped the way
+ * @kavo/typeorm); what these tests need from it is a row shaped the way
  * a loader would produce one, so serialization can be observed.
  */
 export class SeededAdapter<Entity extends object> implements RepositoryAdapter<Entity> {

--- a/packages/core/tests/support/query-issues.ts
+++ b/packages/core/tests/support/query-issues.ts
@@ -1,4 +1,4 @@
-import { QueryValidationException } from "@crudo/core";
+import { QueryValidationException } from "@kavo/core";
 
 /**
  * Run `fn` and return the issues of the `QueryValidationException` it must

--- a/packages/core/tests/support/user-fixture.ts
+++ b/packages/core/tests/support/user-fixture.ts
@@ -1,5 +1,5 @@
-import type { CrudContext, EntityId, EntityMetadata, NormalizedQueryContext, RepositoryAdapter } from "@crudo/core";
-import { NotFoundException } from "@crudo/core";
+import type { CrudContext, EntityId, EntityMetadata, NormalizedQueryContext, RepositoryAdapter } from "@kavo/core";
+import { NotFoundException } from "@kavo/core";
 
 /** Test entity: plain class, fields initialized so shapes exist at runtime. */
 export class User {
@@ -35,7 +35,7 @@ export const userMetadata: EntityMetadata<User> = {
 /**
  * In-memory adapter for engine tests: honors pagination and records the
  * queries it receives; filter evaluation is the *database's* job and is
- * covered by the @crudo/typeorm integration tests, not re-implemented
+ * covered by the @kavo/typeorm integration tests, not re-implemented
  * here.
  */
 export class InMemoryUserAdapter implements RepositoryAdapter<User> {

--- a/packages/core/tests/types/entity-input.test-d.ts
+++ b/packages/core/tests/types/entity-input.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from "vitest";
-import type { EntityInput, ScalarKeys } from "@crudo/core";
+import type { EntityInput, ScalarKeys } from "@kavo/core";
 
 /**
  * Type-level acceptance tests for the write-shape default.

--- a/packages/core/tests/types/field-selection.test-d.ts
+++ b/packages/core/tests/types/field-selection.test-d.ts
@@ -1,4 +1,4 @@
-import type { FieldSelectionInput, QueryContext } from "@crudo/core";
+import type { FieldSelectionInput, QueryContext } from "@kavo/core";
 import { Author } from "../support/blog-fixture.js";
 
 /**

--- a/packages/core/tests/types/include-path.test-d.ts
+++ b/packages/core/tests/types/include-path.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from "vitest";
-import type { IncludePath } from "@crudo/core";
+import type { IncludePath } from "@kavo/core";
 import { Author, Comment, Post } from "../support/blog-fixture.js";
 
 /**

--- a/packages/core/tests/types/usage-full.test-d.ts
+++ b/packages/core/tests/types/usage-full.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from "vitest";
-import { createCrudo } from "@crudo/core";
-import type { CrudContext, ListResultDto, OperationHandler, QueryContext } from "@crudo/core";
+import { createKavo } from "@kavo/core";
+import type { CrudContext, ListResultDto, OperationHandler, QueryContext } from "@kavo/core";
 import { Author } from "../support/blog-fixture.js";
 
 /**
@@ -39,7 +39,7 @@ class PromoteResultDto {
   promoted = false;
 }
 
-const crudo = createCrudo({
+const kavo = createKavo({
   defaults: { pagination: { defaultLimit: 20, maxLimit: 100 } },
 });
 
@@ -51,7 +51,7 @@ const promote: OperationHandler<Author> = {
   },
 };
 
-const authors = crudo.createCrud(Author, {
+const authors = kavo.createCrud(Author, {
   dto: {
     create: CreateAuthorDto,
     update: UpdateAuthorDto,
@@ -91,7 +91,7 @@ void authors.createOne({});
 void authors.createOne({ name: "Ada", bio: "x" });
 
 // @ts-expect-error — an allowlist entry has to name a real field.
-void crudo.createCrud(Author, { allowlists: { filterable: ["nmae"] } });
+void kavo.createCrud(Author, { allowlists: { filterable: ["nmae"] } });
 
 // Custom operations dispatch through the engine, one pipeline either way.
 void authors.engine.execute({ operation: "promoteOne", id: 1, body: null, query: null, options: null });

--- a/packages/core/tests/types/usage-partial.test-d.ts
+++ b/packages/core/tests/types/usage-partial.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from "vitest";
-import { createCrudo } from "@crudo/core";
-import type { EntityInput, ListResultDto, QueryContext } from "@crudo/core";
+import { createKavo } from "@kavo/core";
+import type { EntityInput, ListResultDto, QueryContext } from "@kavo/core";
 import { Author } from "../support/blog-fixture.js";
 
 /**
@@ -22,9 +22,9 @@ class AuthorListDto {
   id = 0;
 }
 
-const crudo = createCrudo({ defaults: { pagination: { maxLimit: 50 } } });
+const kavo = createKavo({ defaults: { pagination: { maxLimit: 50 } } });
 
-const authors = crudo.createCrud(Author, {
+const authors = kavo.createCrud(Author, {
   dto: { item: AuthorItemDto, list: AuthorListDto },
 });
 

--- a/packages/core/tests/types/usage-zero-config.test-d.ts
+++ b/packages/core/tests/types/usage-zero-config.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from "vitest";
-import { createCrud } from "@crudo/core";
-import type { EntityInput, ListResultDto } from "@crudo/core";
+import { createCrud } from "@kavo/core";
+import type { EntityInput, ListResultDto } from "@kavo/core";
 import { Author } from "../support/blog-fixture.js";
 
 /**

--- a/packages/core/tests/value-coercion.spec.ts
+++ b/packages/core/tests/value-coercion.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { FieldKind, FieldMetadata, IncludeRequest, IncludeResolver, IncludeTree } from "@crudo/core";
-import { QueryNormalizer, parseBracketKey, resolveEntityConfig } from "@crudo/core";
+import type { FieldKind, FieldMetadata, IncludeRequest, IncludeResolver, IncludeTree } from "@kavo/core";
+import { QueryNormalizer, parseBracketKey, resolveEntityConfig } from "@kavo/core";
 // `coerceScalar`/`isIssue` are internal to the query pipeline and not on the
 // public barrel (ADR-0010), so the unit test reaches into its own package's
 // source — the one place that import is legal.
@@ -38,13 +38,13 @@ describe("coerceScalar — locale-independent wire coercion (Phase 5)", () => {
   });
 
   it("rejects a non-numeric value rather than yielding NaN", () => {
-    expect(issueOf(coerce("number", "abc")).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issueOf(coerce("number", "abc")).code).toBe("KAVO_QUERY_INVALID_VALUE");
     expect(Number.isNaN(coerce("number", "abc") as number)).toBe(false);
   });
 
   it("rejects blank and locale-formatted numbers — no separators are honored", () => {
     for (const raw of ["", "   ", "1,5", "1 000"]) {
-      expect(issueOf(coerce("number", raw)).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+      expect(issueOf(coerce("number", raw)).code).toBe("KAVO_QUERY_INVALID_VALUE");
     }
   });
 
@@ -57,7 +57,7 @@ describe("coerceScalar — locale-independent wire coercion (Phase 5)", () => {
 
   it("rejects any other boolean spelling, including case variants", () => {
     for (const raw of ["TRUE", "False", "yes", "on", ""]) {
-      expect(issueOf(coerce("boolean", raw)).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+      expect(issueOf(coerce("boolean", raw)).code).toBe("KAVO_QUERY_INVALID_VALUE");
     }
   });
 
@@ -68,23 +68,23 @@ describe("coerceScalar — locale-independent wire coercion (Phase 5)", () => {
 
   it("rejects an unparseable date rather than yielding Invalid Date", () => {
     const result = coerce("date", "not-a-date");
-    expect(issueOf(result).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issueOf(result).code).toBe("KAVO_QUERY_INVALID_VALUE");
     expect(result).not.toBeInstanceOf(Date);
   });
 
   it("accepts enum members by exact match only", () => {
     const members = { enumValues: ["active", "pending"] as const };
     expect(coerce("enum", "active", members)).toBe("active");
-    expect(issueOf(coerce("enum", "Active", members)).code).toBe("CRUDO_QUERY_INVALID_VALUE");
-    expect(issueOf(coerce("enum", "vip", members)).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issueOf(coerce("enum", "Active", members)).code).toBe("KAVO_QUERY_INVALID_VALUE");
+    expect(issueOf(coerce("enum", "vip", members)).code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 
   it("accepts nothing for an enum column that declares no members", () => {
-    expect(issueOf(coerce("enum", "active")).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issueOf(coerce("enum", "active")).code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 
   it("refuses to compare json columns at all", () => {
-    expect(issueOf(coerce("json", "{}")).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issueOf(coerce("json", "{}")).code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 
   it("coerces null and the literal 'null' to SQL NULL on a nullable column", () => {
@@ -94,8 +94,8 @@ describe("coerceScalar — locale-independent wire coercion (Phase 5)", () => {
   });
 
   it("rejects null on a column that is not nullable", () => {
-    expect(issueOf(coerce("string", null)).code).toBe("CRUDO_QUERY_INVALID_VALUE");
-    expect(issueOf(coerce("string", "null")).code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issueOf(coerce("string", null)).code).toBe("KAVO_QUERY_INVALID_VALUE");
+    expect(issueOf(coerce("string", "null")).code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 
   it("passes a value with no column metadata through as a string", () => {
@@ -109,13 +109,13 @@ describe("coerceScalar — locale-independent wire coercion (Phase 5)", () => {
     const issue = issueOf(coerceScalar("abc", "age", column("number", { name: "age" })));
     expect(Object.keys(issue).sort()).toEqual(["code", "detail", "field"]);
     expect(issue.field).toBe("age");
-    expect(issue.code).toBe("CRUDO_QUERY_INVALID_VALUE");
+    expect(issue.code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
 });
 
 describe("isIssue — the parser's success/failure discriminator (Phase 5)", () => {
   it("recognizes an issue object", () => {
-    expect(isIssue({ field: "age", code: "CRUDO_QUERY_INVALID_VALUE", detail: "…" })).toBe(true);
+    expect(isIssue({ field: "age", code: "KAVO_QUERY_INVALID_VALUE", detail: "…" })).toBe(true);
   });
 
   it("treats a coerced SQL NULL as a value, not a failure", () => {

--- a/packages/core/tsconfig.tests.json
+++ b/packages/core/tsconfig.tests.json
@@ -12,7 +12,7 @@
     "types": ["node"],
     // Mirrors the vitest aliases: tests exercise sources, not `dist/`.
     "paths": {
-      "@crudo/core": ["./src/index.ts"]
+      "@kavo/core": ["./src/index.ts"]
     }
   },
   "include": ["tests"]

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,6 +1,6 @@
-# Crudo documentation
+# Kavo documentation
 
-Design documentation for the Crudo framework, maintained alongside the code.
+Design documentation for the Kavo framework, maintained alongside the code.
 
 These documents and the [ADRs](adr/) are authoritative. The `(Phase N)` tags
 below are historical provenance from the retired build plan; remaining unbuilt

--- a/packages/docs/adr/0001-clean-architecture-core-owns-contracts.md
+++ b/packages/docs/adr/0001-clean-architecture-core-owns-contracts.md
@@ -4,20 +4,20 @@
 
 ## Context
 
-Crudo must stay usable if the ORM or web framework changes, yet v6 builds
+Kavo must stay usable if the ORM or web framework changes, yet v6 builds
 exactly one of each (TypeORM, NestJS). The temptation is to let the edges
 define their own interfaces and have core adapt.
 
 ## Decision
 
 Every contract (`CrudService`, `RepositoryAdapter`, `TransactionManager`,
-…) is declared in `@crudo/core`. Edge packages implement or consume core
+…) is declared in `@kavo/core`. Edge packages implement or consume core
 contracts; core never imports an edge. Dependency inversion is strict and
 mechanically enforced (dependency-cruiser + project references).
 
 ## Consequences
 
-- The adapter seam is real: `@crudo/typeorm` is replaceable by
+- The adapter seam is real: `@kavo/typeorm` is replaceable by
   construction, even though no second adapter ships in v6.
 - Core contracts must be designed before edge implementations exist
   (Milestone A precedes B) — accepted cost of a stable surface.

--- a/packages/docs/adr/0002-package-topology.md
+++ b/packages/docs/adr/0002-package-topology.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-v6 ships `@crudo/core`, `@crudo/typeorm`, `@crudo/nest` — nothing else.
+v6 ships `@kavo/core`, `@kavo/typeorm`, `@kavo/nest` — nothing else.
 But the architecture claims ORM/framework independence, and a flat layout
 would make a future second adapter an awkward restructuring.
 

--- a/packages/docs/adr/0004-lockstep-versioning.md
+++ b/packages/docs/adr/0004-lockstep-versioning.md
@@ -5,17 +5,17 @@
 ## Context
 
 Independent versioning lets an untouched package skip releases, but forces
-a compatibility matrix ("which `@crudo/typeorm` works with which
-`@crudo/core`?") that every consumer and every bug report must consult.
+a compatibility matrix ("which `@kavo/typeorm` works with which
+`@kavo/core`?") that every consumer and every bug report must consult.
 
 ## Decision
 
-All `@crudo/*` packages share one version and release together. Peer
+All `@kavo/*` packages share one version and release together. Peer
 ranges between them pin the same version line.
 
 ## Consequences
 
-- "Crudo 0.4" fully identifies a consumer's setup; cross-package bugs are
+- "Kavo 0.4" fully identifies a consumer's setup; cross-package bugs are
   reproducible from one number.
 - Occasional no-op bumps of untouched packages — trivially cheap in an
   automated pipeline (Phase 18 changesets).

--- a/packages/docs/adr/0005-core-zero-runtime-dependencies.md
+++ b/packages/docs/adr/0005-core-zero-runtime-dependencies.md
@@ -1,17 +1,17 @@
-# ADR-0005 — Zero runtime dependencies in `@crudo/core`
+# ADR-0005 — Zero runtime dependencies in `@kavo/core`
 
 **Status:** accepted (Phases 1–3)
 
 ## Context
 
-Core is imported by every Crudo package and every consumer app. Each
+Core is imported by every Kavo package and every consumer app. Each
 dependency it carried would be imposed on all of them (conflicts, weight,
 supply chain), and third-party types tend to leak into public signatures,
-making someone else's types part of Crudo's API.
+making someone else's types part of Kavo's API.
 
 ## Decision
 
-`@crudo/core` has **no** runtime dependencies — not TypeORM, not NestJS,
+`@kavo/core` has **no** runtime dependencies — not TypeORM, not NestJS,
 not utility libraries, directly or transitively. If core needs a helper,
 core writes it. Enforced by dependency-cruiser's `core-imports-nothing`
 rule, not by convention.

--- a/packages/docs/adr/0006-registry-driven-operations.md
+++ b/packages/docs/adr/0006-registry-driven-operations.md
@@ -13,7 +13,7 @@ new one — plus route generation could each grow their own mechanism
 The engine dispatches **every** operation through
 `OperationRegistry<TEntity>`. Built-in CRUD handlers are ordinary default
 entries — nothing about them is special-cased. Disable = deactivate an
-entry; override = swap its handler; custom = add an entry. `@crudo/nest`
+entry; override = swap its handler; custom = add an entry. `@kavo/nest`
 generates routes by reading the registry, never from a verb list.
 
 ## Consequences

--- a/packages/docs/adr/0007-module-augmentable-operation-metadata.md
+++ b/packages/docs/adr/0007-module-augmentable-operation-metadata.md
@@ -13,7 +13,7 @@ configuration, but core must stay route-ignorant. Alternatives: a typed
 
 Every registry entry carries `meta: OperationMetadata` — an empty
 interface in core, typed via TypeScript declaration merging by whoever
-consumes it. `@crudo/nest` augments it with a `routes` key. Core's whole
+consumes it. `@kavo/nest` augments it with a `routes` key. Core's whole
 contract: store it, merge it per Phase 8 precedence, hand it over.
 
 ## Consequences

--- a/packages/docs/adr/0009-problem-details-error-shape.md
+++ b/packages/docs/adr/0009-problem-details-error-shape.md
@@ -11,10 +11,10 @@ details document.
 ## Decision
 
 The default serialized error is an RFC 9457 problem-details document
-(`ProblemDetailsDto`) with Crudo extensions: a stable `code`
-(`CRUDO_*`, catalog in Phase 6 — codes are API surface), `errors[]` for
-field-level query issues, `items[]` for per-index bulk failures. Crudo
-exceptions never extend Nest's; the `@crudo/nest` exception filter is the
+(`ProblemDetailsDto`) with Kavo extensions: a stable `code`
+(`KAVO_*`, catalog in Phase 6 — codes are API surface), `errors[]` for
+field-level query issues, `items[]` for per-index bulk failures. Kavo
+exceptions never extend Nest's; the `@kavo/nest` exception filter is the
 boundary that maps them.
 
 ## Consequences

--- a/packages/docs/adr/0010-explicit-named-barrel.md
+++ b/packages/docs/adr/0010-explicit-named-barrel.md
@@ -1,4 +1,4 @@
-# ADR-0010 — Explicit named barrel in `@crudo/core`
+# ADR-0010 — Explicit named barrel in `@kavo/core`
 
 **Status:** accepted (Phase 3)
 

--- a/packages/docs/adr/0011-entity-metadata-infrastructure-seam.md
+++ b/packages/docs/adr/0011-entity-metadata-infrastructure-seam.md
@@ -16,7 +16,7 @@ Core defines an ORM-independent description —
 `EntityMetadata`/`FieldMetadata` (`core/src/metadata/`) — and a
 `CrudInfrastructure` contract (`metadataFor` + `adapterFor` per entity).
 Adapter packages implement it (`createTypeOrmInfrastructure(dataSource)`
-translates TypeORM metadata); `createCrudo` receives it once, and
+translates TypeORM metadata); `createKavo` receives it once, and
 `createCrud` may override per entity (`runtime.adapter`/`runtime.metadata`),
 which is also the unit-test path (in-memory fakes, no ORM).
 
@@ -26,8 +26,8 @@ which is also the unit-test path (in-memory fakes, no ORM).
   the dependency direction of ADR-0001 holds with runtime code.
 - One extra concept for adapter authors, but it is the entire adapter
   bootstrap contract — everything else is `RepositoryAdapter`.
-- `@crudo/nest` receives infrastructure through DI options
-  (`CrudoModule.forRoot({ infrastructure })`), not an `orm: "typeorm"`
+- `@kavo/nest` receives infrastructure through DI options
+  (`KavoModule.forRoot({ infrastructure })`), not an `orm: "typeorm"`
   string — no name registry, no framework→adapter import, any future
   adapter plugs in unchanged.
 - Field kinds are deliberately coarse (`string`/`number`/`boolean`/

--- a/packages/docs/adr/0012-decoration-time-route-generation.md
+++ b/packages/docs/adr/0012-decoration-time-route-generation.md
@@ -1,4 +1,4 @@
-# ADR-0012 — Decoration-time route generation in @crudo/nest
+# ADR-0012 — Decoration-time route generation in @kavo/nest
 
 **Status:** accepted (Phases 11–12)
 

--- a/packages/docs/adr/0013-config-declared-soft-delete-operations.md
+++ b/packages/docs/adr/0013-config-declared-soft-delete-operations.md
@@ -15,7 +15,7 @@ registry entry, from a registry built by the same
 `createOperationRegistry` the engine uses. If enablement of `restoreOne`
 and `purgeOne` depended on metadata, the two registry builds would
 disagree: the engine would enable an operation the router never mapped.
-Making `@crudo/nest` read TypeORM metadata to close the gap is exactly
+Making `@kavo/nest` read TypeORM metadata to close the gap is exactly
 the boundary Phase 2 forbids.
 
 ## Decision
@@ -46,7 +46,7 @@ exclude deleted rows; only the extra routes wait on the declaration.
 
 - Both registry builds reach the same answer from the same input; the
   route table and the service surface cannot drift.
-- `@crudo/nest` needs no ORM knowledge, and the generator itself needed
+- `@kavo/nest` needs no ORM knowledge, and the generator itself needed
   no change for Phase 14 — restore/purge appeared by enabling entries.
 - Cost: zero-config soft delete is not _entirely_ zero-config. An entity
   gets soft deletes and exclusion for free, but its restore route takes

--- a/packages/docs/adr/0014-associate-by-id-not-deep-writes.md
+++ b/packages/docs/adr/0014-associate-by-id-not-deep-writes.md
@@ -45,7 +45,7 @@ Deep nested writes are **out of scope**, not merely unimplemented.
   rule, and the failure behavior for that specific case.
 - ORM caveat, deliberately not papered over: setting a _to-many_ by id
   only persists where the ORM supports it from the non-owning side
-  (TypeORM needs `cascade` or the owning side / a join table). Crudo maps
+  (TypeORM needs `cascade` or the owning side / a join table). Kavo maps
   the payload; it does not synthesize writes the ORM declined to make.
 - The extension point, if a later version wants deep writes: they belong
   at the deserializer seam plus an explicit per-relation `write` policy

--- a/packages/docs/architecture/01-system-architecture.md
+++ b/packages/docs/architecture/01-system-architecture.md
@@ -1,6 +1,6 @@
 # 01 — System Architecture (Phase 1)
 
-Crudo lets a developer define an entity once (via TypeORM) and get the full
+Kavo lets a developer define an entity once (via TypeORM) and get the full
 CRUD surface — `createOne` … `purgeOne`, the `*Many` batch variants
 (contracted and registered, but disabled: bulk is the optional half of
 Phase 14 and this build dropped it), and arbitrary custom operations —
@@ -10,7 +10,7 @@ transactions, and error handling, configurable at global, entity,
 operation, and per-call scope.
 
 v6 scope is deliberately narrow: REST only, three packages
-(`@crudo/core`, `@crudo/typeorm`, `@crudo/nest`), no validation subsystem,
+(`@kavo/core`, `@kavo/typeorm`, `@kavo/nest`), no validation subsystem,
 no hooks/events, no policy layer, no audit trail.
 
 ## 1. Layers and boundaries (C4 level 2)
@@ -21,14 +21,14 @@ flowchart TB
         C[Controllers / services / entities]
     end
 
-    subgraph nest["@crudo/nest — framework binding"]
-        N1["@Crud decorator + CrudoModule"]
+    subgraph nest["@kavo/nest — framework binding"]
+        N1["@Crud decorator + KavoModule"]
         N2[Route generation from operation registry]
         N3[Exception filter → problem details]
         N4[Swagger integration]
     end
 
-    subgraph core["@crudo/core — the hub (zero dependencies)"]
+    subgraph core["@kavo/core — the hub (zero dependencies)"]
         E["CrudEngine (request lifecycle)"]
         Q[Query model: filter AST, pagination, sort, fields]
         D[DTO resolution + serialization]
@@ -37,10 +37,10 @@ flowchart TB
         X[Exception hierarchy + error catalog]
     end
 
-    subgraph typeorm["@crudo/typeorm — ORM adapter"]
+    subgraph typeorm["@kavo/typeorm — ORM adapter"]
         T1[TypeOrmRepositoryAdapter]
         T2[Filter AST → QueryBuilder translation]
-        T3[Driver-error → Crudo-exception mapping]
+        T3[Driver-error → Kavo-exception mapping]
     end
 
     C --> N1
@@ -51,7 +51,7 @@ flowchart TB
     typeorm -->|imports| core
 ```
 
-Both outer packages depend on `@crudo/core`; core depends on nothing. The
+Both outer packages depend on `@kavo/core`; core depends on nothing. The
 adapter reaches the engine only through contracts it implements
 (`RepositoryAdapter`), and the framework binding reaches it only through
 contracts it consumes (`CrudService`, `OperationRegistry`). This is
@@ -61,16 +61,16 @@ technology.
 ## 2. Dependency graph (who may import whom)
 
 ```
-@crudo/nest ──▶ @crudo/core ◀── @crudo/typeorm
+@kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
      │                                │
      ▼ (peer)                         ▼ (peer)
   @nestjs/*                        typeorm
 ```
 
-- `@crudo/core` imports **nothing** (ADR-0005).
-- `@crudo/typeorm` imports `@crudo/core` + `typeorm` (peer). Never `@crudo/nest`.
-- `@crudo/nest` imports `@crudo/core` + `@nestjs/*` (peers). Never
-  `@crudo/typeorm` — adapters enter Nest's DI container as providers;
+- `@kavo/core` imports **nothing** (ADR-0005).
+- `@kavo/typeorm` imports `@kavo/core` + `typeorm` (peer). Never `@kavo/nest`.
+- `@kavo/nest` imports `@kavo/core` + `@nestjs/*` (peers). Never
+  `@kavo/typeorm` — adapters enter Nest's DI container as providers;
   the binding programs against `RepositoryAdapter` only.
 - Cross-package imports go through package barrels; deep imports are not API.
 
@@ -79,11 +79,11 @@ references — an illegal import fails CI, not code review.
 
 ## 3. Package overview
 
-| Package          | Owns                                                                                    | Must never depend on         |
-| ---------------- | --------------------------------------------------------------------------------------- | ---------------------------- |
-| `@crudo/core`    | Contracts, type system, engine, query model, DTO resolution, config merging, exceptions | anything (zero runtime deps) |
-| `@crudo/typeorm` | `RepositoryAdapter`/`FilterBuilder` over TypeORM; error mapping; relation loading       | NestJS, `@crudo/nest`        |
-| `@crudo/nest`    | `@Crud` decorator, module wiring, route generation, exception filter, Swagger           | TypeORM, `@crudo/typeorm`    |
+| Package         | Owns                                                                                    | Must never depend on         |
+| --------------- | --------------------------------------------------------------------------------------- | ---------------------------- |
+| `@kavo/core`    | Contracts, type system, engine, query model, DTO resolution, config merging, exceptions | anything (zero runtime deps) |
+| `@kavo/typeorm` | `RepositoryAdapter`/`FilterBuilder` over TypeORM; error mapping; relation loading       | NestJS, `@kavo/nest`         |
+| `@kavo/nest`    | `@Crud` decorator, module wiring, route generation, exception filter, Swagger           | TypeORM, `@kavo/typeorm`     |
 
 ORM independence inside core is a structural discipline even though only
 TypeORM is built — it is what keeps the core clean.
@@ -105,12 +105,12 @@ Request
 
 Deliberately lean: no validation stage, no hook/event stages, no policy
 stage. Cross-cutting behavior lives in the consumer's own controller/
-service code around Crudo — the v6 tradeoff, chosen for simplicity. Every
+service code around Kavo — the v6 tradeoff, chosen for simplicity. Every
 stage boundary is a seam with a plain default in it until its phase lands
 — seams, not TODOs — which is what makes Milestone B shippable without
 stubbing Milestones C–D as hacks.
 
-## 5. Module responsibilities (inside `@crudo/core`)
+## 5. Module responsibilities (inside `@kavo/core`)
 
 | Module           | Responsibility                                                                                               |
 | ---------------- | ------------------------------------------------------------------------------------------------------------ |
@@ -138,11 +138,11 @@ pattern; classes that merely resemble one are not in the table.
 | **Template Method**           | `CrudEngine.execute`/`run` (`core/src/engine/crud-engine.ts`)                                                                                                                                                                                                                                                             | —                                                                                                                         | One fixed stage order with swappable stage internals beats a free-form middleware chain: ordering bugs become impossible, and the pipeline stays inspectable. Variability comes from injected collaborators, not subclass overrides — `run` is `private` and nothing extends `CrudEngine`. |
 | **Strategy**                  | `PaginationStrategy` (`core/src/query/pagination-strategies.ts`), `Serializer`/`Deserializer` (`core/src/serialization/`), `ErrorHandler` (`core/src/errors/default-error-handler.ts`), `OperationHandler` (`core/src/engine/built-in-handlers.ts`), `IncludeResolver` (`core/src/relations/default-include-resolver.ts`) | —                                                                                                                         | Open/Closed: new behavior = new implementation of a core contract, never an engine edit. Each is a core-declared interface with a `Default*`/built-in implementation, injected through `CrudEngineDependencies`.                                                                           |
 | **Registry (dispatch table)** | `DefaultOperationRegistry` + `createOperationRegistry` (`core/src/operations/default-operation-registry.ts`)                                                                                                                                                                                                              | [0006](../adr/0006-registry-driven-operations.md), [0007](../adr/0007-module-augmentable-operation-metadata.md)           | One mechanism for built-in, overridden, and custom operations (Phase 13's "one mechanism, several behaviors"); route generation reads the same table, so features get routes for free.                                                                                                     |
-| **Composition Root**          | `createCrudo`/`createCrud` (`core/src/crudo.ts`); framework-layer roots in `nest/src/crudo.module.ts` and `typeorm/src/infrastructure.ts`                                                                                                                                                                                 | —                                                                                                                         | Every `new` in the object graph happens once at bootstrap, so resolution order is a single readable function and the result can be frozen; no service locator, and no per-request construction.                                                                                            |
+| **Composition Root**          | `createKavo`/`createCrud` (`core/src/kavo.ts`); framework-layer roots in `nest/src/kavo.module.ts` and `typeorm/src/infrastructure.ts`                                                                                                                                                                                    | —                                                                                                                         | Every `new` in the object graph happens once at bootstrap, so resolution order is a single readable function and the result can be frozen; no service locator, and no per-request construction.                                                                                            |
 | **Adapter**                   | `TypeOrmRepositoryAdapter` (`typeorm/src/typeorm-repository-adapter.ts`) against core's `RepositoryAdapter`; `CrudInfrastructure` (`metadataFor` + `adapterFor`) supplies adapter _and_ metadata as one family                                                                                                            | [0001](../adr/0001-clean-architecture-core-owns-contracts.md), [0011](../adr/0011-entity-metadata-infrastructure-seam.md) | Core states persistence in its own vocabulary and the ORM package translates, which is what lets core keep zero runtime dependencies (ADR-0005) and stay testable with an in-memory fake.                                                                                                  |
 | **Specification**             | Filter AST (`core/src/query/filter.ts`)                                                                                                                                                                                                                                                                                   | —                                                                                                                         | Composable, provider-independent query trees that each adapter translates once, instead of per-ORM query fragments leaking upward. Composition only — the AST is pure data with no evaluation method; evaluation is the adapter's job (next row).                                          |
 | **Interpreter**               | `FilterTranslator.toBrackets` (`typeorm/src/filter-translator.ts`)                                                                                                                                                                                                                                                        | —                                                                                                                         | The AST is walked into `QueryBuilder` calls; keeps translation local to the adapter.                                                                                                                                                                                                       |
-| **Dependency Injection**      | `CrudEngineDependencies` (`core/src/engine/crud-engine.ts`); container wiring only in `nest/src/crudo.module.ts`                                                                                                                                                                                                          | —                                                                                                                         | Core receives its collaborators; only the framework binding knows the container.                                                                                                                                                                                                           |
+| **Dependency Injection**      | `CrudEngineDependencies` (`core/src/engine/crud-engine.ts`); container wiring only in `nest/src/kavo.module.ts`                                                                                                                                                                                                           | —                                                                                                                         | Core receives its collaborators; only the framework binding knows the container.                                                                                                                                                                                                           |
 | **Facade**                    | `DefaultCrudService` (`core/src/service/default-crud-service.ts`)                                                                                                                                                                                                                                                         | —                                                                                                                         | One narrow, typed entry point over engine + registry + config machinery; its methods are sugar over the same `CrudRequest` envelope the generated routes build.                                                                                                                            |
 
 Rejected: Active Record (couples entities to persistence — kills ORM
@@ -166,7 +166,7 @@ sequenceDiagram
     E->>D: deserialize(body, CreateDto)
     D-->>E: create input
     E->>A: create(data, ctx)
-    A-->>E: entity (or mapped CrudoException)
+    A-->>E: entity (or mapped KavoException)
     E->>S: serializeItem(entity, ItemDto, ctx)
     S-->>C: item DTO (201)
 ```
@@ -227,7 +227,7 @@ sequenceDiagram
 
 ## 8. Non-goals (scope-creep insurance)
 
-Crudo is **not**:
+Kavo is **not**:
 
 - an ORM — it sits on one; it never maps columns or runs migrations;
 - a query language beyond the CRUD surface — no aggregations, projections
@@ -246,14 +246,14 @@ Crudo is **not**:
 | [0002](../adr/0002-package-topology.md)                       | Three packages under `orms/` / `frameworks/` parents      |
 | [0003](../adr/0003-pnpm-plain-scripts-tsc-build.md)           | pnpm workspaces, plain scripts, `tsc -b` — no task runner |
 | [0004](../adr/0004-lockstep-versioning.md)                    | Lockstep versioning                                       |
-| [0005](../adr/0005-core-zero-runtime-dependencies.md)         | Zero runtime dependencies in `@crudo/core`                |
+| [0005](../adr/0005-core-zero-runtime-dependencies.md)         | Zero runtime dependencies in `@kavo/core`                 |
 | [0006](../adr/0006-registry-driven-operations.md)             | Registry-driven operation dispatch                        |
 | [0007](../adr/0007-module-augmentable-operation-metadata.md)  | Module-augmentable `OperationMetadata`                    |
 | [0008](../adr/0008-field-path-recursion-cap.md)               | `FieldPath` recursion cap (default 3, max 5)              |
 | [0009](../adr/0009-problem-details-error-shape.md)            | RFC 9457 problem details as the wire error shape          |
 | [0010](../adr/0010-explicit-named-barrel.md)                  | Explicit named barrel in core                             |
 | [0011](../adr/0011-entity-metadata-infrastructure-seam.md)    | Entity-metadata & infrastructure seam                     |
-| [0012](../adr/0012-decoration-time-route-generation.md)       | Decoration-time route generation in `@crudo/nest`         |
+| [0012](../adr/0012-decoration-time-route-generation.md)       | Decoration-time route generation in `@kavo/nest`          |
 | [0013](../adr/0013-config-declared-soft-delete-operations.md) | Soft-delete operations enabled from config, not metadata  |
 | [0014](../adr/0014-associate-by-id-not-deep-writes.md)        | Write-side relations: associate by id, no deep writes     |
 

--- a/packages/docs/architecture/02-monorepo-and-packages.md
+++ b/packages/docs/architecture/02-monorepo-and-packages.md
@@ -3,22 +3,22 @@
 ## 1. Structure
 
 ```
-crudo/
+kavo/
 ├─ package.json               # root: build/check scripts, dev tooling
 ├─ pnpm-workspace.yaml
 ├─ tsconfig.base.json         # shared strict compiler options
 ├─ tsconfig.json              # solution file: project-reference graph
 ├─ .dependency-cruiser.cjs    # mechanical boundary enforcement
 └─ packages/
-   ├─ core/                   # @crudo/core
+   ├─ core/                   # @kavo/core
    │  ├─ src/{types,query,dto,errors,config,operations,
    │  │       relations,context,serialization,persistence,service}/
    │  └─ src/index.ts         # explicit named barrel
    ├─ orms/
-   │  └─ typeorm/             # @crudo/typeorm (scaffold until Phase 10)
+   │  └─ typeorm/             # @kavo/typeorm (scaffold until Phase 10)
    │     └─ src/index.ts
    ├─ frameworks/
-   │  └─ nest/                # @crudo/nest (scaffold until Phase 12)
+   │  └─ nest/                # @kavo/nest (scaffold until Phase 12)
    │     └─ src/index.ts
    ├─ examples/               # Phase 17 reference application (empty)
    └─ docs/                   # this documentation
@@ -30,17 +30,17 @@ exactly three packages.
 
 ## 2. Responsibility statements
 
-- **`@crudo/core`** exists to own every contract and all ORM/framework-
+- **`@kavo/core`** exists to own every contract and all ORM/framework-
   independent runtime (engine, config merging, query parsing, DTO
   resolution, exceptions). It can't depend on **anything** — not TypeORM,
   not NestJS, not utility libraries. If core needs a helper, core writes it.
-- **`@crudo/typeorm`** exists to translate core's persistence contracts to
+- **`@kavo/typeorm`** exists to translate core's persistence contracts to
   TypeORM (adapter, filter translation, error mapping, transactions). It
-  can't depend on NestJS or `@crudo/nest` — an adapter must be usable from
+  can't depend on NestJS or `@kavo/nest` — an adapter must be usable from
   any future framework binding.
-- **`@crudo/nest`** exists to bind Crudo to NestJS (module, decorator,
+- **`@kavo/nest`** exists to bind Kavo to NestJS (module, decorator,
   route generation, exception filter, Swagger). It can't depend on TypeORM
-  or `@crudo/typeorm` — it sees persistence only as an injected
+  or `@kavo/typeorm` — it sees persistence only as an injected
   `RepositoryAdapter`.
 
 Every package earns its place: core is the hub, and the two edges each
@@ -63,13 +63,13 @@ Two independent enforcement layers:
 
    - **Both spellings are matched.** A workspace package specifier does not
      resolve to a path for dependency-cruiser, so a path-only rule silently
-     misses `from "@crudo/nest"` — the spelling anyone would actually write.
+     misses `from "@kavo/nest"` — the spelling anyone would actually write.
      The rules match the bare specifier as well as the relative path.
      `packages/examples` is in scope too: it is the reference app.
    - **`tests/` is cruised, not exempt.** Test files were once excluded
      entirely, which left the boundary convention-only exactly where fixture
      sharing tempts a shortcut. A test file may import its own package's
-     source and the `@crudo/*` barrels, never another package's `src` or
+     source and the `@kavo/*` barrels, never another package's `src` or
      `tests`; core's tests additionally may not reach an adapter or framework
      package, because core's ignorance of both is what its suite exists to
      prove.
@@ -108,12 +108,12 @@ dual ESM+CJS output is Phase 18's deliverable.
 `tsc -b` against the solution file: incremental (`.tsbuildinfo`),
 project-reference-ordered (core → typeorm/nest), each package emitting
 `dist/` with declarations + declaration maps. Consumers inside the
-workspace resolve `@crudo/*` via pnpm workspace links to the built
+workspace resolve `@kavo/*` via pnpm workspace links to the built
 `dist`, exactly as external consumers will.
 
 ## 7. Versioning: lockstep (ADR-0004)
 
-All `@crudo/*` packages share one version number and release together.
+All `@kavo/*` packages share one version number and release together.
 The packages form one tightly coupled contract surface — a core contract
 change almost always touches an edge package, and a single version answers
 "which adapter works with which core" permanently. Cost: occasional no-op
@@ -123,11 +123,11 @@ publish order) are Phase 18.
 
 ## 8. Dependency classification (decided now, executed in Phase 18)
 
-| Package          | `dependencies` | `peerDependencies`                                              |
-| ---------------- | -------------- | --------------------------------------------------------------- |
-| `@crudo/core`    | — (none, ever) | —                                                               |
-| `@crudo/typeorm` | `@crudo/core`  | `typeorm`                                                       |
-| `@crudo/nest`    | `@crudo/core`  | `@nestjs/common`, `@nestjs/core` (+ `@nestjs/swagger` optional) |
+| Package         | `dependencies` | `peerDependencies`                                              |
+| --------------- | -------------- | --------------------------------------------------------------- |
+| `@kavo/core`    | — (none, ever) | —                                                               |
+| `@kavo/typeorm` | `@kavo/core`   | `typeorm`                                                       |
+| `@kavo/nest`    | `@kavo/core`   | `@nestjs/common`, `@nestjs/core` (+ `@nestjs/swagger` optional) |
 
 Peers, not dependencies, because the consumer's app owns the TypeORM/Nest
 instance — a second copy via a nested dependency would fracture

--- a/packages/docs/architecture/03-core-contracts-and-type-system.md
+++ b/packages/docs/architecture/03-core-contracts-and-type-system.md
@@ -4,7 +4,7 @@ All contracts live in `packages/core/src` and are exported through the
 explicit barrel. **Types only** — no classes, no implementations; the
 first runtime code lands in Milestone B. Contracts whose implementations
 land in Milestone C (relations, transactions, bulk, operation control) are
-declared now so later phases never mutate `@crudo/core` types.
+declared now so later phases never mutate `@kavo/core` types.
 
 ## 1. Generic parameters
 
@@ -118,7 +118,7 @@ relations?: never }`) — without that exclusion it structurally satisfies
 structured form's own spell-checking (`{ root: ['nope'] }` would typecheck).
 At runtime, `QueryNormalizer`'s collapse step rejects — rather than
 silently drops — any relation-keyed key mixed into a structured literal, so
-a caller who blends the two spellings gets a `CRUDO_QUERY_INVALID_VALUE`
+a caller who blends the two spellings gets a `KAVO_QUERY_INVALID_VALUE`
 issue naming the stray key, not a quietly ignored fieldset. A malformed
 `fields` value (not an array, not an object) is also an issue, never a
 thrown error. The same guarantee holds one level down: a per-relation
@@ -138,12 +138,12 @@ the same allowlist validation.
 `OperationMetadata` is an intentionally empty interface on every
 operation registry entry. Core stores it, merges it per Phase 8
 precedence, and hands it to the framework layer — it never reads it. A
-consumer types its keys via declaration merging; `@crudo/nest` declares a
+consumer types its keys via declaration merging; `@kavo/nest` declares a
 `routes` key:
 
 ```ts
 // packages/frameworks/nest/src/operation-metadata.ts (Phase 11)
-declare module "@crudo/core" {
+declare module "@kavo/core" {
   interface OperationMetadata {
     routes?: {
       method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -170,15 +170,15 @@ createCrud(UserEntity, {
 
 This pattern requires a stable augmentation target — one reason the barrel
 is an explicit named list (ADR-0010) and the `exports` map exposes exactly
-one module id, `@crudo/core`.
+one module id, `@kavo/core`.
 
 ## 4. Why zero runtime dependencies (ADR-0005)
 
-`@crudo/core` is imported by every Crudo package and every consumer app.
+`@kavo/core` is imported by every Kavo package and every consumer app.
 Any dependency it carried would be forced on all of them — version
 conflicts, install weight, supply-chain surface — and utility libraries in
 particular tend to leak types into public signatures, making third-party
-types part of Crudo's API contract. Framework/ORM independence is the same
+types part of Kavo's API contract. Framework/ORM independence is the same
 rule at its extreme: core not importing TypeORM or NestJS (directly or
 transitively) is what makes the adapter seam real rather than aspirational.
 Enforced by dependency-cruiser (`core-imports-nothing`), not convention.
@@ -192,8 +192,8 @@ Enforced by dependency-cruiser (`core-imports-nothing`), not convention.
 | Transactions  | `TransactionManager`, `TransactionContext`, `TransactionOptions`                                                                                                       | Not implemented — see below        |
 | Query         | `Filter*`, `FilterExpression`, `Sort`, `Pagination`, `PaginationStrategy`, `FieldSelection`, `QueryContext`, `NormalizedQueryContext`, `FilterParser`, `FilterBuilder` | Phase 5 (parse), Phase 10 (build)  |
 | DTO           | `Dto`, `DtoClass`, `OperationDtoMap`, `DtoResolver`, `ListResultDto`, `ListMetaDto`, `BulkResultDto`                                                                   | Phase 4 (bulk reserved)            |
-| Errors        | `CrudException`, `CrudoErrorCode`, `ErrorHandler`, `ProblemDetailsDto`                                                                                                 | Phase 6                            |
-| Config        | `CrudoSettings` (+ per-area settings), `GlobalConfig`, `EntityConfig`, `OperationConfig`, `CustomOperationConfig`, `ResolvedEntityConfig`                              | Phase 8 (operations Phase 13)      |
+| Errors        | `CrudException`, `KavoErrorCode`, `ErrorHandler`, `ProblemDetailsDto`                                                                                                  | Phase 6                            |
+| Config        | `KavoSettings` (+ per-area settings), `GlobalConfig`, `EntityConfig`, `OperationConfig`, `CustomOperationConfig`, `ResolvedEntityConfig`                               | Phase 8 (operations Phase 13)      |
 | Operations    | `OperationId`, `OperationHandler`, `OperationMetadata`, `OperationDescriptor`, `OperationRegistry`                                                                     | Phase 7 (control surface Phase 13) |
 | Relations     | `RelationDescriptor`, `RelationRegistry`, `IncludeTree`, `IncludeNode`, `IncludeResolver`, `EntityCatalog`                                                             | Phase 15                           |
 | Context       | `CrudContext`, `CrudContextState`, `StateKey`, `CrudRequest`, `CrudResponse`                                                                                           | Phase 7                            |

--- a/packages/docs/architecture/04-dto-system.md
+++ b/packages/docs/architecture/04-dto-system.md
@@ -77,5 +77,5 @@ projection ∩ selection, applied to every item and list element.
 
 When a response embeds an included relation, the node's shape resolves
 from the **target entity's own registered `item`/`list` DTOs** when that
-entity has a Crudo config, else its entity-derived default. There is no
+entity has a Kavo config, else its entity-derived default. There is no
 per-include DTO slot — the related resource owns its own contract.

--- a/packages/docs/architecture/05-query-grammar.md
+++ b/packages/docs/architecture/05-query-grammar.md
@@ -96,7 +96,7 @@ fields:     root: [id, name, email]
 - **Soft delete:** `withDeleted=true` includes soft-deleted rows, which
   are otherwise excluded from every read (Phase 14, doc 11). On an entity
   that is not soft-deletable it is rejected with
-  `CRUDO_QUERY_UNSUPPORTED_PARAM`, not ignored; a non-boolean value is a
+  `KAVO_QUERY_UNSUPPORTED_PARAM`, not ignored; a non-boolean value is a
   field-level 400.
 - **Includes:** `include=posts.comments,profile` — comma-separated
   dot-paths, merged into one validated tree (Phase 15, doc 12). A
@@ -109,7 +109,7 @@ fields:     root: [id, name, email]
   lists at bootstrap — explicitly configured, or defaulting to the
   entity's **own scalar columns** (relation paths are never allowlisted
   implicitly). Anything outside a list → 400
-  (`CRUDO_QUERY_INVALID_FIELD`), never a silent drop. Programmatic
+  (`KAVO_QUERY_INVALID_FIELD`), never a silent drop. Programmatic
   callers (`findMany({ filter })`) pass through the **same** allowlist
   and limit checks — typed input skips coercion, not security.
 - **Limits** (configurable per scope, Phase 8): `query.maxFilterDepth`

--- a/packages/docs/architecture/06-error-handling.md
+++ b/packages/docs/architecture/06-error-handling.md
@@ -7,7 +7,7 @@ leaves; nothing existing changes.
 ## 1. Hierarchy
 
 ```
-CrudoException (abstract; implements the CrudException contract)
+KavoException (abstract; implements the CrudException contract)
 ├─ QueryValidationException     carries issues[] → errors[] extension
 ├─ NotFoundException
 ├─ ConflictException
@@ -23,7 +23,7 @@ CrudoException (abstract; implements the CrudException contract)
 Every leaf binds exactly one catalog code; status, title, and the English
 message template come from the catalog, so an exception cannot disagree
 with it. Downstream layers program against the `CrudException` shape;
-`@crudo/nest`'s filter uses the base class only as its catch token.
+`@kavo/nest`'s filter uses the base class only as its catch token.
 
 ## 2. Error-code catalog
 
@@ -31,23 +31,23 @@ Codes are API surface — renaming one is a breaking change (Phase 18
 semver policy). Source of truth: `ERROR_CATALOG` in
 `core/src/errors/error-catalog.ts`.
 
-| Code                            | HTTP | Fires when                                                                         | Payload extensions                |
-| ------------------------------- | ---- | ---------------------------------------------------------------------------------- | --------------------------------- |
-| `CRUDO_QUERY_INVALID`           | 400  | Any query grammar/allowlist/limit violation (aggregate)                            | `errors[]` of the sub-codes below |
-| `CRUDO_QUERY_INVALID_FIELD`     | 400  | Field not on the filter/sort/select allowlist                                      | issue-level                       |
-| `CRUDO_QUERY_INVALID_OPERATOR`  | 400  | Unknown or misspelled wire operator                                                | issue-level                       |
-| `CRUDO_QUERY_INVALID_VALUE`     | 400  | Coercion failure, malformed bounds, bad pagination value                           | issue-level                       |
-| `CRUDO_QUERY_LIMIT_EXCEEDED`    | 400  | maxFilterDepth / maxInValues exceeded                                              | issue-level                       |
-| `CRUDO_QUERY_UNSUPPORTED_PARAM` | 400  | `withDeleted` on a hard-delete entity; `include` when no include resolver is wired | issue-level                       |
-| `CRUDO_NOT_FOUND`               | 404  | Target row missing on findOne/update/patch/delete                                  | —                                 |
-| `CRUDO_CONFLICT`                | 409  | Unique/FK violation mapped by the adapter                                          | —                                 |
-| `CRUDO_ALREADY_DELETED`         | 409  | Soft-deleting an already-deleted row                                               | —                                 |
-| `CRUDO_NOT_DELETED`             | 409  | Restoring or purging a row that is not deleted                                     | —                                 |
-| `CRUDO_OPERATION_DISABLED`      | 405  | Programmatic call to a disabled registry entry (no route exists over HTTP)         | —                                 |
-| `CRUDO_BULK_FAILED`             | 422  | Atomic bulk failure (reserved — bulk is not built)                                 | `items[]` per-index issues        |
-| `CRUDO_PERSISTENCE_FAILED`      | 500  | Unrecognized adapter/driver error                                                  | `cause` kept internally           |
-| `CRUDO_TRANSACTION_FAILED`      | 500  | Deadlock/serialization failure                                                     | `retryable` flag                  |
-| `CRUDO_CONFIG_INVALID`          | 500  | Bootstrap config error (fails startup, not a response)                             | —                                 |
+| Code                           | HTTP | Fires when                                                                         | Payload extensions                |
+| ------------------------------ | ---- | ---------------------------------------------------------------------------------- | --------------------------------- |
+| `KAVO_QUERY_INVALID`           | 400  | Any query grammar/allowlist/limit violation (aggregate)                            | `errors[]` of the sub-codes below |
+| `KAVO_QUERY_INVALID_FIELD`     | 400  | Field not on the filter/sort/select allowlist                                      | issue-level                       |
+| `KAVO_QUERY_INVALID_OPERATOR`  | 400  | Unknown or misspelled wire operator                                                | issue-level                       |
+| `KAVO_QUERY_INVALID_VALUE`     | 400  | Coercion failure, malformed bounds, bad pagination value                           | issue-level                       |
+| `KAVO_QUERY_LIMIT_EXCEEDED`    | 400  | maxFilterDepth / maxInValues exceeded                                              | issue-level                       |
+| `KAVO_QUERY_UNSUPPORTED_PARAM` | 400  | `withDeleted` on a hard-delete entity; `include` when no include resolver is wired | issue-level                       |
+| `KAVO_NOT_FOUND`               | 404  | Target row missing on findOne/update/patch/delete                                  | —                                 |
+| `KAVO_CONFLICT`                | 409  | Unique/FK violation mapped by the adapter                                          | —                                 |
+| `KAVO_ALREADY_DELETED`         | 409  | Soft-deleting an already-deleted row                                               | —                                 |
+| `KAVO_NOT_DELETED`             | 409  | Restoring or purging a row that is not deleted                                     | —                                 |
+| `KAVO_OPERATION_DISABLED`      | 405  | Programmatic call to a disabled registry entry (no route exists over HTTP)         | —                                 |
+| `KAVO_BULK_FAILED`             | 422  | Atomic bulk failure (reserved — bulk is not built)                                 | `items[]` per-index issues        |
+| `KAVO_PERSISTENCE_FAILED`      | 500  | Unrecognized adapter/driver error                                                  | `cause` kept internally           |
+| `KAVO_TRANSACTION_FAILED`      | 500  | Deadlock/serialization failure                                                     | `retryable` flag                  |
+| `KAVO_CONFIG_INVALID`          | 500  | Bootstrap config error (fails startup, not a response)                             | —                                 |
 
 ## 3. Error context & message strategy
 
@@ -61,7 +61,7 @@ params; core ships the English defaults.
 ## 4. Mapping strategy
 
 Adapter errors are translated by the adapter's own table
-(`@crudo/typeorm`'s `mapDriverError`, doc 09 §5) _inside_ the adapter;
+(`@kavo/typeorm`'s `mapDriverError`, doc 09 §5) _inside_ the adapter;
 whatever reaches the engine unrecognized becomes `PersistenceException`
 with the original as `cause` — never swallowed. Whether `cause` details
 leak into responses is governed by `errors.exposeInternals` (default
@@ -70,10 +70,10 @@ leak into responses is governed by `errors.exposeInternals` (default
 ## 5. Problem-details serialization
 
 `toProblemDetails(exception, { exposeInternals })` produces the wire
-document: `type` (`https://crudo.dev/errors/<kebab-code>`), `title` and
+document: `type` (`https://kavo.dev/errors/<kebab-code>`), `title` and
 `status` from the catalog, `detail`, `instance`
-(`urn:crudo:request:<correlationId>`), `code`, plus `errors[]`
-(query issues) and `items[]` (bulk, reserved). The `@crudo/nest` filter
+(`urn:kavo:request:<correlationId>`), `code`, plus `errors[]`
+(query issues) and `items[]` (bulk, reserved). The `@kavo/nest` filter
 maps it 1:1 with `Content-Type: application/problem+json`; a different
 wire shape means swapping this serializer, never the hierarchy. Core
 never depends on NestJS exceptions — the filter is the boundary.

--- a/packages/docs/architecture/07-crud-engine.md
+++ b/packages/docs/architecture/07-crud-engine.md
@@ -24,7 +24,7 @@ CrudResponse
 
 Deliberately lean: no validation stage, no hooks, no policy stage — the
 v6 tradeoff. Cross-cutting behavior lives in the consumer's own code
-around Crudo.
+around Kavo.
 
 ## 2. `CrudContext` contents
 
@@ -64,12 +64,12 @@ files and the ADR behind each, is
 - **Strategy** — repository adapter, serializer/deserializer, pagination
   strategies, error handler: all constructor-injected interfaces.
 - **Dependency Injection** — `CrudEngineDependencies` is plain
-  constructor injection; no container in core (`@crudo/nest` provides
+  constructor injection; no container in core (`@kavo/nest` provides
   one at the framework layer).
 
-## 5. Root factory (`createCrudo` / `createCrud`)
+## 5. Root factory (`createKavo` / `createCrud`)
 
-`createCrudo(options)` holds the global scope; `createCrud(Entity,
+`createKavo(options)` holds the global scope; `createCrud(Entity,
 config?, runtime?)` is bootstrap: resolve config (doc 08), build the
 registry with built-in handlers, wire serializer/deserializer/normalizer
 from entity metadata, and return the bound service. Metadata and adapter

--- a/packages/docs/architecture/08-configuration.md
+++ b/packages/docs/architecture/08-configuration.md
@@ -1,9 +1,9 @@
 # 08 — Configuration System (Phase 8)
 
-One layered model, one schema (`CrudoSettings`), one precedence chain:
+One layered model, one schema (`KavoSettings`), one precedence chain:
 
 ```
-built-in defaults → global (createCrudo) → entity (createCrud)
+built-in defaults → global (createKavo) → entity (createCrud)
                   → operation (operations.<id>) → per-call (CrudCallOptions)
 ```
 
@@ -64,15 +64,15 @@ pagination strategies, missing infrastructure, non-`@Crud` controllers in
 
 ## 5. Root factory and framework skin
 
-`createCrudo({ defaults, infrastructure, paginationStrategies })` is the
+`createKavo({ defaults, infrastructure, paginationStrategies })` is the
 core entry point; the bare `createCrud(Entity, config?, runtime)` is an
 implicit root instance with built-in defaults — the zero-config path pays
-nothing for any of this. `CrudoModule.forRoot` (doc 10) is a thin skin:
+nothing for any of this. `KavoModule.forRoot` (doc 10) is a thin skin:
 it passes `defaults` through untouched and contributes only its own
 route concerns via the `OperationMetadata` augmentation (ADR-0007).
 
 ## 6. Debug dump
 
-`crudo.describe(entityName)` (backed by `describeResolvedConfig`) returns
+`kavo.describe(entityName)` (backed by `describeResolvedConfig`) returns
 the frozen result for one entity — settings, allowlists, relations, and
 every per-operation view — as a plain printable object.

--- a/packages/docs/architecture/09-typeorm-adapter.md
+++ b/packages/docs/architecture/09-typeorm-adapter.md
@@ -1,11 +1,11 @@
 # 09 — TypeORM Adapter (Phases 9–10)
 
-`@crudo/typeorm` implements `RepositoryAdapter` (= `EntityReader` +
+`@kavo/typeorm` implements `RepositoryAdapter` (= `EntityReader` +
 `EntityWriter`) over a TypeORM `DataSource` and feeds core's metadata
 seam. Skeleton scope: CRUD with hard delete, filtering (incl. `NOT` and
 relation paths), sorting, pagination, optional counting; Phases 14–15 added
 soft delete/restore/purge (§3) and relation loading (§6). `typeorm` is a
-peerDependency; `@crudo/core` never imports it.
+peerDependency; `@kavo/core` never imports it.
 
 ## 1. The metadata seam
 
@@ -16,7 +16,7 @@ column — composite keys rejected at bootstrap), scalar columns with
 update/delete-date, version columns), enum members, and relation
 descriptors (`includable: false` always — ORM metadata supplies shape,
 never permission). `createTypeOrmInfrastructure(dataSource)` packages
-metadata + adapters, cached per entity; `createTypeOrmCrudo` is the
+metadata + adapters, cached per entity; `createTypeOrmKavo` is the
 zero-config sugar.
 
 ## 2. Query translation (Filter AST → QueryBuilder)

--- a/packages/docs/architecture/10-nestjs-integration.md
+++ b/packages/docs/architecture/10-nestjs-integration.md
@@ -1,6 +1,6 @@
 # 10 — NestJS Integration (Phases 11–12)
 
-`@crudo/nest` turns one decorator into a full CRUD controller:
+`@kavo/nest` turns one decorator into a full CRUD controller:
 
 ```ts
 @Crud(UserEntity)
@@ -14,16 +14,16 @@ boundary) — infrastructure arrives through DI.
 
 ## 1. Module design
 
-- **`CrudoModule.forRoot(options)`** (global): creates the Crudo root
-  instance (`createCrudo` skin — `defaults` passes through untouched),
+- **`KavoModule.forRoot(options)`** (global): creates the Kavo root
+  instance (`createKavo` skin — `defaults` passes through untouched),
   registers the problem-details exception filter app-wide (`APP_FILTER`),
-  and exposes `CRUDO_INSTANCE`. **`forRootAsync`** resolves the options
+  and exposes `KAVO_INSTANCE`. **`forRootAsync`** resolves the options
   via `useFactory`/`inject` — the checkpoint app uses it to wait for the
   `DataSource` before building `createTypeOrmInfrastructure(dataSource)`.
-- **`CrudoModule.forFeature(controllers)`**: for each `@Crud`-decorated
+- **`KavoModule.forFeature(controllers)`**: for each `@Crud`-decorated
   controller, registers the controller and provides the entity's service
   under `getCrudServiceToken(Entity)` (factory:
-  `crudo.createCrud(entity, config)` — bootstrap happens here, once).
+  `kavo.createCrud(entity, config)` — bootstrap happens here, once).
   A non-`@Crud` class fails fast with a `ConfigurationException`.
 
 **Singleton services, deliberately:** the engine threads every
@@ -73,10 +73,10 @@ bracket keys, making the binding query-parser-agnostic).
 
 ## 3. Exception mapping
 
-`CrudoExceptionFilter` (`@Catch(CrudoException)`) is the one boundary
-between Crudo's hierarchy and HTTP: catalog status +
+`KavoExceptionFilter` (`@Catch(KavoException)`) is the one boundary
+between Kavo's hierarchy and HTTP: catalog status +
 `application/problem+json` body via `toProblemDetails`, honoring
-`errors.exposeInternals`. Crudo exceptions never extend Nest's.
+`errors.exposeInternals`. Kavo exceptions never extend Nest's.
 
 ## 4. Swagger integration
 

--- a/packages/docs/architecture/11-soft-delete.md
+++ b/packages/docs/architecture/11-soft-delete.md
@@ -1,6 +1,6 @@
 # 11 — Soft Delete, Restore & Purge (Phase 14)
 
-Deleting a row can mean two things. Crudo resolves which one **per
+Deleting a row can mean two things. Kavo resolves which one **per
 entity, at bootstrap**, and every layer downstream reads that one answer
 instead of re-deciding.
 
@@ -29,7 +29,7 @@ instead of removing the row, and every read excludes stamped rows.
 The marker field is the configured `softDelete.field` when the entity has
 such a column, otherwise the one the ORM declares
 (`EntityMetadata.softDeleteField` — `@DeleteDateColumn` in
-`@crudo/typeorm`). Explicit configuration wins over detection; an entity
+`@kavo/typeorm`). Explicit configuration wins over detection; an entity
 with neither costs nothing, which is the phase's constraint.
 
 Resolution runs at every settings scope, so an operation or a single call
@@ -39,11 +39,11 @@ on that object — they never re-derive the decision.
 
 ## 2. Operations
 
-| Operation    | Behavior                                                                                                                          |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| `deleteOne`  | Hard or soft per the resolved strategy. Soft-deleting a deleted row → 409 `CRUDO_ALREADY_DELETED`.                                |
-| `restoreOne` | Clears the marker, returns the revived row in the **`item`** slot — no new DTO shape. A live row → 409 `CRUDO_NOT_DELETED`.       |
-| `purgeOne`   | Permanently removes an already-soft-deleted row. A live row → 409 `CRUDO_NOT_DELETED`. Under a hard strategy it is just a delete. |
+| Operation    | Behavior                                                                                                                         |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `deleteOne`  | Hard or soft per the resolved strategy. Soft-deleting a deleted row → 409 `KAVO_ALREADY_DELETED`.                                |
+| `restoreOne` | Clears the marker, returns the revived row in the **`item`** slot — no new DTO shape. A live row → 409 `KAVO_NOT_DELETED`.       |
+| `purgeOne`   | Permanently removes an already-soft-deleted row. A live row → 409 `KAVO_NOT_DELETED`. Under a hard strategy it is just a delete. |
 
 Enablement is config-declared, not metadata-driven (**ADR-0013**):
 `restoreOne` switches on with `softDelete: { strategy: "soft" }` (or an
@@ -63,10 +63,10 @@ row (reviving one is `restoreOne`'s job, not a side effect of a write).
 
 `withDeleted=true` opts back in, on both wire and programmatic paths. On
 an entity that is not soft-deletable the parameter is **rejected**
-(`CRUDO_QUERY_UNSUPPORTED_PARAM`) rather than ignored: a client that
+(`KAVO_QUERY_UNSUPPORTED_PARAM`) rather than ignored: a client that
 believes it is seeing deleted rows should be told it is not.
 
-In `@crudo/typeorm` the flag translates two ways, because a marker column
+In `@kavo/typeorm` the flag translates two ways, because a marker column
 is not always the ORM's own: for a `@DeleteDateColumn`, TypeORM already
 excludes deleted rows and the adapter opts in with `.withDeleted()`; for
 an ordinary column named through config, the adapter adds
@@ -77,7 +77,7 @@ an ordinary column named through config, the adapter adds
 **Unique constraints.** A soft-deleted row still occupies its unique
 indexes, so re-creating "the same" row raises a unique violation — mapped
 to a 409 like any other conflict, which is the honest answer: the value
-_is_ taken. Crudo does not rewrite indexes. The standard fix is a
+_is_ taken. Kavo does not rewrite indexes. The standard fix is a
 partial/filtered unique index over live rows only:
 
 ```sql

--- a/packages/docs/architecture/12-relations-and-includes.md
+++ b/packages/docs/architecture/12-relations-and-includes.md
@@ -36,11 +36,11 @@ looks exactly like working config until the first client asks.
 1. **Parse** dot-paths into a tree; overlapping paths merge, so `posts`
    and `posts.comments` produce one `posts` node with a `comments` child.
 2. **Validate** each edge against the registry of the entity that _owns_
-   it — unknown or non-includable → `CRUDO_QUERY_INVALID_FIELD` (400).
+   it — unknown or non-includable → `KAVO_QUERY_INVALID_FIELD` (400).
 3. **Limit**: `relations.maxIncludeDepth` (default 2) as a budget spent
    per level, a relation's own `maxDepth` replacing that budget for its
    subtree, and `relations.maxIncludedNodes` (default 10) across the whole
-   tree → `CRUDO_QUERY_LIMIT_EXCEEDED`.
+   tree → `KAVO_QUERY_LIMIT_EXCEEDED`.
 4. **Cycle guard is depth, and only depth.** `manager.manager.manager` is
    legal until the budget runs out. Visited-type tracking would forbid a
    legitimate self-relation, and depth is the rule a client can predict.
@@ -78,7 +78,7 @@ line: TypeORM's `skip`/`take` paginate root ids in a subquery first, and
 `count` is a dedicated query with no include joins at all. A page of one
 blog is one blog with all of its articles, never half a blog.
 
-In `@crudo/typeorm`, join aliases are deterministic (`Owner__pets__owner`)
+In `@kavo/typeorm`, join aliases are deterministic (`Owner__pets__owner`)
 and share `FilterTranslator`'s scheme, so `filter[blog.name][eq]=…`
 alongside `include=blog` reuses the one selecting join instead of adding a
 second, non-selecting one under a duplicate alias.

--- a/packages/docs/glossary.md
+++ b/packages/docs/glossary.md
@@ -27,11 +27,11 @@ themselves (prefixes, casing, suffixes) live in the Conventions section of
 | **Include tree**       | The validated tree of relation nodes handed to the adapter.                                                                              | include graph                   |
 | **Field selection**    | Sparse fieldsets (`fields=`, `fields[rel]=`), applied after DTO mapping.                                                                 | projection                      |
 | **Bulk**               | The feature term for batch operations (config key `bulk`, `/bulk` routes, `BulkResultDto`). Never a method prefix — methods are `*Many`. | batch (in API names)            |
-| **Settings**           | The layered config values (`CrudoSettings`) merged through the precedence chain.                                                         | options (reserved for per-call) |
+| **Settings**           | The layered config values (`KavoSettings`) merged through the precedence chain.                                                          | options (reserved for per-call) |
 | **Resolved config**    | The frozen per-entity merge result (`ResolvedEntityConfig`), computed once at bootstrap.                                                 | effective config                |
 | **Per-call options**   | The last precedence link, passed as parameters (`CrudCallOptions`) — never config writes.                                                | overrides object                |
 | **Principal**          | The authenticated caller carried opaquely on the context.                                                                                | user, actor                     |
 | **Problem details**    | The RFC 9457 error document (`ProblemDetailsDto`) all errors serialize to.                                                               | error response                  |
-| **Error code**         | The stable `CRUDO_*` string identifying an error kind; API surface.                                                                      | error type                      |
+| **Error code**         | The stable `KAVO_*` string identifying an error kind; API surface.                                                                       | error type                      |
 | **Soft delete**        | Marking a row deleted via the marker field instead of removing it (Phase 14, doc 11). `restore` un-deletes; `purge` permanently removes. | archive, trash                  |
 | **Include**            | Embedding a relation in a response (`include=posts.comments`), opt-in per relation (Phase 15, doc 12).                                   | expand, join, populate          |

--- a/packages/docs/roadmap.md
+++ b/packages/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap — remaining work
 
-Crudo was built from a phased build plan (`crudo-phases-v6.md`, retired once
+Kavo was built from a phased build plan (`kavo-phases-v6.md`, retired once
 Milestone C landed). Milestones A–C are done and their design is documented
 for real in [`architecture/`](architecture/) and [`adr/`](adr/) — those are now
 the authoritative sources, not a plan document.
@@ -29,8 +29,8 @@ Milestone C feature set.
 ```ts
 const userCrud = createCrud(UserEntity); // zero-config, implicit defaults
 
-const crudo = createCrudo({ defaults: { pagination: { maxLimit: 50 } } });
-const userCrud = crudo.createCrud(UserEntity, {
+const kavo = createKavo({ defaults: { pagination: { maxLimit: 50 } } });
+const userCrud = kavo.createCrud(UserEntity, {
   dto: { item: UserItemDto, list: UserListDto },
 });
 
@@ -42,7 +42,7 @@ const { items, total, limit, offset } = await userCrud.findMany({
 await userCrud.deleteOne(id); // soft delete, if UserEntity is SoftDeletable
 await userCrud.restoreOne(id);
 
-@Module({ imports: [CrudoModule.forFeature([UserEntity])] })
+@Module({ imports: [KavoModule.forFeature([UserEntity])] })
 export class UserModule {}
 ```
 
@@ -72,7 +72,7 @@ here is additive, never a tax on the simple case.
 **Depends on:** the Nest integration and Phase 16; exercises everything.
 
 **Goal:** one realistic application in `packages/examples/` that uses every
-shipped feature — living documentation and the `@crudo/nest` e2e bed at once,
+shipped feature — living documentation and the `@kavo/nest` e2e bed at once,
 grown from the existing example app.
 
 **Domain** (chosen to force the features): a project-management API — `User`,
@@ -98,7 +98,7 @@ or it is not in the app.
 
 **Depends on:** effectively everything. This is the shipping phase.
 
-**Goal:** ship `@crudo/core`, `@crudo/typeorm` and `@crudo/nest` to npm in a way
+**Goal:** ship `@kavo/core`, `@kavo/typeorm` and `@kavo/nest` to npm in a way
 that stays maintainable, not just one publishable release.
 
 **Deliverables**
@@ -106,10 +106,10 @@ that stays maintainable, not just one publishable release.
 1. **Build output:** dual ESM + CJS per package, correct `exports` map, shipped
    `.d.ts`. Address the dual-package pitfalls explicitly — default-export
    interop, and `instanceof` across module instances, which matters for the
-   exception hierarchy. Confirm tree-shakability for `@crudo/core`-only
+   exception hierarchy. Confirm tree-shakability for `@kavo/core`-only
    consumers.
 2. **Dependency classification:** `typeorm` and `@nestjs/*` as peer
-   dependencies of their own adapter packages, never of `@crudo/core`; regular
+   dependencies of their own adapter packages, never of `@kavo/core`; regular
    dependencies minimal everywhere; supported Node and peer ranges stated and
    CI-tested as a matrix.
 3. **API-surface gating:** api-extractor (or equivalent) produces a public API

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -1,14 +1,14 @@
 # examples
 
 The checkpoint app: a small Pet domain served over HTTP by the real stack
-— `@Crud(...)`-generated NestJS routes → CRUD engine → `@crudo/typeorm` →
+— `@Crud(...)`-generated NestJS routes → CRUD engine → `@kavo/typeorm` →
 in-memory SQLite — with filtering, sorting, pagination, DTO projections
 (`item` vs. leaner `list`), layered config, Swagger docs, and RFC 9457
 problem-details errors. `Cat` and `Dog` are single-table-inheritance
 subtypes of `Pet`; `Owner` is the relation side, and is soft-deletable.
 
 ```bash
-pnpm build && pnpm --filter @crudo/examples start
+pnpm build && pnpm --filter @kavo/examples start
 # → http://localhost:3000/cats   (Swagger at /docs)
 ```
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@crudo/examples",
+  "name": "@kavo/examples",
   "version": "0.0.0",
   "private": true,
-  "description": "Crudo reference application (Pet example: single-table inheritance, a relation, and full CRUD over HTTP).",
+  "description": "Kavo reference application (Pet example: single-table inheritance, a relation, and full CRUD over HTTP).",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -10,9 +10,9 @@
     "start": "node dist/main.js"
   },
   "dependencies": {
-    "@crudo/core": "workspace:*",
-    "@crudo/nest": "workspace:*",
-    "@crudo/typeorm": "workspace:*",
+    "@kavo/core": "workspace:*",
+    "@kavo/nest": "workspace:*",
+    "@kavo/typeorm": "workspace:*",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",

--- a/packages/examples/src/address/address.controller.ts
+++ b/packages/examples/src/address/address.controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "@nestjs/common";
-import { Crud } from "@crudo/nest";
+import { Crud } from "@kavo/nest";
 import { Address } from "./address.entity.js";
 import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
 

--- a/packages/examples/src/app.module.ts
+++ b/packages/examples/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
-import { CrudoModule } from "@crudo/nest";
-import { createTypeOrmInfrastructure } from "@crudo/typeorm";
+import { KavoModule } from "@kavo/nest";
+import { createTypeOrmInfrastructure } from "@kavo/typeorm";
 import type { DataSource } from "typeorm";
 import { DATA_SOURCE, DatabaseModule } from "./database.module.js";
 import { OwnerController } from "./owner/owner.controller.js";
@@ -10,13 +10,13 @@ import { TagController } from "./tag/tag.controller.js";
 import { AddressController } from "./address/address.controller.js";
 
 /**
- * Reference wiring: the app hands `@crudo/nest` its infrastructure (here
+ * Reference wiring: the app hands `@kavo/nest` its infrastructure (here
  * TypeORM's) — the packages never import each other (Phase 2 boundary;
  * adapters meet the framework in the DI container).
  */
 @Module({
   imports: [
-    CrudoModule.forRootAsync({
+    KavoModule.forRootAsync({
       imports: [DatabaseModule],
       inject: [DATA_SOURCE] as never[],
       useFactory: (dataSource: DataSource) => ({
@@ -27,7 +27,7 @@ import { AddressController } from "./address/address.controller.js";
         },
       }),
     }),
-    CrudoModule.forFeature([OwnerController, CatController, DogController, TagController, AddressController]),
+    KavoModule.forFeature([OwnerController, CatController, DogController, TagController, AddressController]),
   ],
 })
 export class AppModule {}

--- a/packages/examples/src/cat/cat.controller.ts
+++ b/packages/examples/src/cat/cat.controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "@nestjs/common";
-import { Crud } from "@crudo/nest";
+import { Crud } from "@kavo/nest";
 import { Cat } from "./cat.entity.js";
 import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.js";
 

--- a/packages/examples/src/cat/cat.dtos.ts
+++ b/packages/examples/src/cat/cat.dtos.ts
@@ -1,4 +1,4 @@
-import { enumProp } from "@crudo/nest";
+import { enumProp } from "@kavo/nest";
 import { PetSizeEnum } from "../pet/pet.entity.js";
 import { TagItemDto } from "../tag/tag.dtos.js";
 

--- a/packages/examples/src/dog/dog.controller.ts
+++ b/packages/examples/src/dog/dog.controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "@nestjs/common";
-import { Crud } from "@crudo/nest";
+import { Crud } from "@kavo/nest";
 import { Dog } from "./dog.entity.js";
 import { CreateDogDto, UpdateDogDto, DogItemDto, DogListDto } from "./dog.dtos.js";
 

--- a/packages/examples/src/dog/dog.dtos.ts
+++ b/packages/examples/src/dog/dog.dtos.ts
@@ -1,4 +1,4 @@
-import { enumProp } from "@crudo/nest";
+import { enumProp } from "@kavo/nest";
 import { PetSizeEnum } from "../pet/pet.entity.js";
 
 /**

--- a/packages/examples/src/main.ts
+++ b/packages/examples/src/main.ts
@@ -9,7 +9,7 @@ async function bootstrap(): Promise<void> {
   const document = SwaggerModule.createDocument(
     app,
     new DocumentBuilder()
-      .setTitle("Crudo — Pet example")
+      .setTitle("Kavo — Pet example")
       .setDescription(
         "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
           "sorting, pagination, layered config, and RFC 9457 problem-details " +
@@ -23,7 +23,7 @@ async function bootstrap(): Promise<void> {
   SwaggerModule.setup("docs", app, document);
 
   await app.listen(3000);
-  console.log("Crudo pet example: http://localhost:3000 — /cats /dogs /owners (docs at /docs)");
+  console.log("Kavo pet example: http://localhost:3000 — /cats /dogs /owners (docs at /docs)");
 }
 
 void bootstrap();

--- a/packages/examples/src/owner/owner.controller.ts
+++ b/packages/examples/src/owner/owner.controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "@nestjs/common";
-import { Crud } from "@crudo/nest";
+import { Crud } from "@kavo/nest";
 import { Owner } from "./owner.entity.js";
 import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./owner.dtos.js";
 

--- a/packages/examples/src/owner/owner.dtos.ts
+++ b/packages/examples/src/owner/owner.dtos.ts
@@ -1,4 +1,4 @@
-import { oneOfArray } from "@crudo/nest";
+import { oneOfArray } from "@kavo/nest";
 import { CatItemDto } from "../cat/cat.dtos.js";
 import { DogItemDto } from "../dog/dog.dtos.js";
 import { AddressItemDto } from "../address/address.dtos.js";

--- a/packages/examples/src/owner/owner.entity.ts
+++ b/packages/examples/src/owner/owner.entity.ts
@@ -1,4 +1,4 @@
-import type { SoftDeletable } from "@crudo/core";
+import type { SoftDeletable } from "@kavo/core";
 import {
   Column,
   CreateDateColumn,
@@ -20,7 +20,7 @@ import type { Address } from "../address/address.entity.js";
  * column types keep the entity independent of `emitDecoratorMetadata`.
  *
  * Owners are soft-deletable: `@DeleteDateColumn` is all the ORM needs to
- * say so, and `@crudo/typeorm` surfaces it as the delete-marker field, so
+ * say so, and `@kavo/typeorm` surfaces it as the delete-marker field, so
  * `DELETE /owners/:id` stamps the row instead of removing it (Phase 14).
  *
  * Caveat worth seeing in a reference app: a soft-deleted owner still

--- a/packages/examples/src/tag/tag.controller.ts
+++ b/packages/examples/src/tag/tag.controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "@nestjs/common";
-import { Crud } from "@crudo/nest";
+import { Crud } from "@kavo/nest";
 import { Tag } from "./tag.entity.js";
 import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.js";
 

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -11,7 +11,7 @@ import { AppModule } from "../src/app.module.js";
  * engine → TypeORM → SQLite — with filtering, sorting, pagination, DTO
  * projections, layered config, and problem-details errors. The schema
  * models single-table inheritance (Cat/Dog over one `pet` table) and an
- * Owner relation; crudo serves plain CRUD on each concrete entity, plus
+ * Owner relation; kavo serves plain CRUD on each concrete entity, plus
  * opt-in relation includes in both directions (asserted below).
  */
 let app: INestApplication;
@@ -122,12 +122,12 @@ describe("Pet example app", () => {
       .expect("Content-Type", /application\/problem\+json/);
     expect(response.body).toMatchObject({
       status: 400,
-      code: "CRUDO_QUERY_INVALID",
+      code: "KAVO_QUERY_INVALID",
       title: "Invalid query",
     });
     expect(response.body.errors).toEqual([
-      expect.objectContaining({ field: "password", code: "CRUDO_QUERY_INVALID_FIELD" }),
-      expect.objectContaining({ field: "age", code: "CRUDO_QUERY_INVALID_VALUE" }),
+      expect.objectContaining({ field: "password", code: "KAVO_QUERY_INVALID_FIELD" }),
+      expect.objectContaining({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" }),
     ]);
   });
 
@@ -136,8 +136,8 @@ describe("Pet example app", () => {
     // relation of Cat — both are told, not ignored.
     const response = await request(server()).get("/cats").query("include=pets&withDeleted=true").expect(400);
     expect(response.body.errors.map((e: { code: string }) => e.code)).toEqual([
-      "CRUDO_QUERY_UNSUPPORTED_PARAM",
-      "CRUDO_QUERY_INVALID_FIELD",
+      "KAVO_QUERY_UNSUPPORTED_PARAM",
+      "KAVO_QUERY_INVALID_FIELD",
     ]);
   });
 
@@ -357,7 +357,7 @@ describe("Pet example app", () => {
       .send({ name: "Second", email: "second@x.io", address: address.body.id })
       .expect(409)
       .expect("Content-Type", /application\/problem\+json/);
-    expect(conflict.body.code).toBe("CRUDO_CONFLICT");
+    expect(conflict.body.code).toBe("KAVO_CONFLICT");
   });
 
   it("rejects associating a nonexistent address id as a conflict, not a silent drop", async () => {
@@ -366,7 +366,7 @@ describe("Pet example app", () => {
       .send({ name: "Rex", email: "rex@x.io", address: 999999 })
       .expect(409)
       .expect("Content-Type", /application\/problem\+json/);
-    expect(created.body.code).toBe("CRUDO_CONFLICT");
+    expect(created.body.code).toBe("KAVO_CONFLICT");
 
     const owner = await request(server()).post("/owners").send({ name: "Sam", email: "sam@x.io" }).expect(201);
     const updateConflict = await request(server())
@@ -374,7 +374,7 @@ describe("Pet example app", () => {
       .send({ name: "Sam", email: "sam@x.io", address: 999999 })
       .expect(409)
       .expect("Content-Type", /application\/problem\+json/);
-    expect(updateConflict.body.code).toBe("CRUDO_CONFLICT");
+    expect(updateConflict.body.code).toBe("KAVO_CONFLICT");
   });
 
   it("refuses to delete an address still referenced by an owner (409, not a silent null or cascade)", async () => {
@@ -391,7 +391,7 @@ describe("Pet example app", () => {
       .delete(`/addresses/${address.body.id}`)
       .expect(409)
       .expect("Content-Type", /application\/problem\+json/);
-    expect(conflict.body.code).toBe("CRUDO_CONFLICT");
+    expect(conflict.body.code).toBe("KAVO_CONFLICT");
   });
 
   it("documents include=address and fields[address] in the OpenAPI schema", () => {
@@ -515,7 +515,7 @@ describe("Pet example app", () => {
       .send({ name: "BadTag", age: 1, size: "small", indoor: true, livesLeft: 9, tags: [999999] })
       .expect(409)
       .expect("Content-Type", /application\/problem\+json/);
-    expect(response.body.code).toBe("CRUDO_CONFLICT");
+    expect(response.body.code).toBe("KAVO_CONFLICT");
   });
 
   it("cleans up the join table when a still-referenced tag is deleted", async () => {
@@ -536,7 +536,7 @@ describe("Pet example app", () => {
     // Dogs never declared `tags` includable — same allowlist rule as any
     // other relation (Phase 15).
     const response = await request(server()).get("/dogs").query("include=tags").expect(400);
-    expect(response.body.errors.map((e: { code: string }) => e.code)).toEqual(["CRUDO_QUERY_INVALID_FIELD"]);
+    expect(response.body.errors.map((e: { code: string }) => e.code)).toEqual(["KAVO_QUERY_INVALID_FIELD"]);
   });
 
   it("counts and slices distinct roots under pagination even when a cat has several tags", async () => {

--- a/packages/examples/tsconfig.tests.json
+++ b/packages/examples/tsconfig.tests.json
@@ -10,9 +10,9 @@
     "useDefineForClassFields": false,
     "types": ["node"],
     "paths": {
-      "@crudo/core": ["../core/src/index.ts"],
-      "@crudo/typeorm": ["../orms/typeorm/src/index.ts"],
-      "@crudo/nest": ["../frameworks/nest/src/index.ts"]
+      "@kavo/core": ["../core/src/index.ts"],
+      "@kavo/typeorm": ["../orms/typeorm/src/index.ts"],
+      "@kavo/nest": ["../frameworks/nest/src/index.ts"]
     }
   },
   "include": ["tests"]

--- a/packages/frameworks/nest/README.md
+++ b/packages/frameworks/nest/README.md
@@ -1,11 +1,11 @@
-# @crudo/nest
+# @kavo/nest
 
-NestJS binding for Crudo: `CrudoModule.forRoot`/`forFeature`, the `@Crud`
+NestJS binding for Kavo: `KavoModule.forRoot`/`forFeature`, the `@Crud`
 decorator, registry-driven route generation (manual-method-wins), the
 problem-details exception filter, and Swagger integration.
 
-**May depend on:** `@crudo/core`, `@nestjs/*` (peers). **Never on:**
-`@crudo/typeorm` or any ORM — adapters enter Nest's DI container as
+**May depend on:** `@kavo/core`, `@nestjs/*` (peers). **Never on:**
+`@kavo/typeorm` or any ORM — adapters enter Nest's DI container as
 providers; this package programs against `RepositoryAdapter` only.
 
 Scaffold only in Milestone A — architecture lands in Phase 11,

--- a/packages/frameworks/nest/package.json
+++ b/packages/frameworks/nest/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@crudo/nest",
+  "name": "@kavo/nest",
   "version": "0.0.0",
-  "description": "Crudo NestJS binding — @Crud decorator, registry-driven route generation, problem-details exception filter, Swagger integration.",
+  "description": "Kavo NestJS binding — @Crud decorator, registry-driven route generation, problem-details exception filter, Swagger integration.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -18,7 +18,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@crudo/core": "workspace:*"
+    "@kavo/core": "workspace:*"
   },
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",

--- a/packages/frameworks/nest/src/crud.decorator.ts
+++ b/packages/frameworks/nest/src/crud.decorator.ts
@@ -7,14 +7,14 @@ import type {
   OperationDescriptor,
   QueryContext,
   StandardOperationId,
-} from "@crudo/core";
-import { WireQuery, createOperationRegistry } from "@crudo/core";
+} from "@kavo/core";
+import { WireQuery, createOperationRegistry } from "@kavo/core";
 import type { CrudHttpMethod, CrudRouteOptions } from "./operation-metadata.js";
 import { CRUD_CONTROLLER_METADATA, CRUD_SERVICE_PROPERTY, getCrudServiceToken } from "./tokens.js";
 import { flattenQuery } from "./flatten-query.js";
 import { applySwaggerMetadata } from "./swagger.js";
 
-/** What `@Crud` records on the controller for `CrudoModule.forFeature`. */
+/** What `@Crud` records on the controller for `KavoModule.forFeature`. */
 export interface CrudControllerMetadata {
   readonly entity: ClassRef;
   readonly config?: EntityConfig<object>;

--- a/packages/frameworks/nest/src/index.ts
+++ b/packages/frameworks/nest/src/index.ts
@@ -1,18 +1,18 @@
 /**
- * @crudo/nest — NestJS binding for Crudo (Phases 11–12).
+ * @kavo/nest — NestJS binding for Kavo (Phases 11–12).
  *
  * `@Crud(Entity)` generates routes from the entity's operation registry;
- * `CrudoModule.forRoot` hosts the Crudo root instance and the RFC 9457
+ * `KavoModule.forRoot` hosts the Kavo root instance and the RFC 9457
  * exception filter; `forFeature` binds services and controllers. This
  * package augments core's `OperationMetadata` with its `routes` key
  * (ADR-0007). `@nestjs/*` are peerDependencies; `@nestjs/swagger` is
  * optional.
  */
 export { Crud, type CrudControllerMetadata } from "./crud.decorator.js";
-export { CrudoModule, type CrudoModuleAsyncOptions } from "./crudo.module.js";
-export type { CrudoModuleOptions } from "./crudo-options.js";
-export { CrudoExceptionFilter } from "./crudo-exception.filter.js";
+export { KavoModule, type KavoModuleAsyncOptions } from "./kavo.module.js";
+export type { KavoModuleOptions } from "./kavo-options.js";
+export { KavoExceptionFilter } from "./kavo-exception.filter.js";
 export { flattenQuery } from "./flatten-query.js";
 export { enumProp, oneOfArray, type SchemaHint } from "./schema-hints.js";
-export { CRUDO_INSTANCE, CRUDO_MODULE_OPTIONS, getCrudServiceToken } from "./tokens.js";
+export { KAVO_INSTANCE, KAVO_MODULE_OPTIONS, getCrudServiceToken } from "./tokens.js";
 export type { CrudHttpMethod, CrudRouteOptions } from "./operation-metadata.js";

--- a/packages/frameworks/nest/src/kavo-exception.filter.ts
+++ b/packages/frameworks/nest/src/kavo-exception.filter.ts
@@ -1,8 +1,8 @@
 import type { ArgumentsHost, ExceptionFilter } from "@nestjs/common";
 import { Catch, Inject, Optional } from "@nestjs/common";
-import { CrudoException, toProblemDetails } from "@crudo/core";
-import { CRUDO_MODULE_OPTIONS } from "./tokens.js";
-import type { CrudoModuleOptions } from "./crudo-options.js";
+import { KavoException, toProblemDetails } from "@kavo/core";
+import { KAVO_MODULE_OPTIONS } from "./tokens.js";
+import type { KavoModuleOptions } from "./kavo-options.js";
 
 interface ProblemResponse {
   status(code: number): ProblemResponse;
@@ -11,23 +11,23 @@ interface ProblemResponse {
 }
 
 /**
- * The one boundary between Crudo's exception hierarchy and HTTP
- * (Phase 11): every `CrudoException` becomes its RFC 9457 problem-details
- * document with the status from the error catalog. Crudo exceptions never
+ * The one boundary between Kavo's exception hierarchy and HTTP
+ * (Phase 11): every `KavoException` becomes its RFC 9457 problem-details
+ * document with the status from the error catalog. Kavo exceptions never
  * extend Nest's — this filter is the mapping, not inheritance.
  *
- * Registered globally by `CrudoModule.forRoot`; consumers can also apply
+ * Registered globally by `KavoModule.forRoot`; consumers can also apply
  * it per controller with `@UseFilters`.
  */
-@Catch(CrudoException)
-export class CrudoExceptionFilter implements ExceptionFilter {
+@Catch(KavoException)
+export class KavoExceptionFilter implements ExceptionFilter {
   constructor(
     @Optional()
-    @Inject(CRUDO_MODULE_OPTIONS)
-    private readonly options?: CrudoModuleOptions,
+    @Inject(KAVO_MODULE_OPTIONS)
+    private readonly options?: KavoModuleOptions,
   ) {}
 
-  catch(exception: CrudoException, host: ArgumentsHost): void {
+  catch(exception: KavoException, host: ArgumentsHost): void {
     const response = host.switchToHttp().getResponse<ProblemResponse>();
     const body = toProblemDetails(exception, {
       exposeInternals: this.options?.defaults?.errors?.exposeInternals ?? false,

--- a/packages/frameworks/nest/src/kavo-options.ts
+++ b/packages/frameworks/nest/src/kavo-options.ts
@@ -1,18 +1,18 @@
-import type { CrudInfrastructure, CrudoSettings, DeepPartial, PaginationStrategy } from "@crudo/core";
+import type { CrudInfrastructure, KavoSettings, DeepPartial, PaginationStrategy } from "@kavo/core";
 
 /**
- * `CrudoModule.forRoot` options — the NestJS skin over core's
- * `createCrudo` (Phase 8): `defaults` is the same global-scope settings
+ * `KavoModule.forRoot` options — the NestJS skin over core's
+ * `createKavo` (Phase 8): `defaults` is the same global-scope settings
  * tree, passed through untouched.
  *
  * `infrastructure` arrives from the application (e.g.
  * `createTypeOrmInfrastructure(dataSource)`), not from an `orm: "typeorm"`
- * string: `@crudo/nest` must not import ORM adapters (the Phase 2
+ * string: `@kavo/nest` must not import ORM adapters (the Phase 2
  * boundary — adapters reach Nest via DI, not imports), and an explicit
  * object keeps the door open for any adapter without a registry of names.
  */
-export interface CrudoModuleOptions {
+export interface KavoModuleOptions {
   readonly infrastructure?: CrudInfrastructure;
-  readonly defaults?: DeepPartial<CrudoSettings>;
+  readonly defaults?: DeepPartial<KavoSettings>;
   readonly paginationStrategies?: readonly PaginationStrategy[];
 }

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -1,22 +1,22 @@
 import type { DynamicModule, ModuleMetadata, Provider, Type } from "@nestjs/common";
 import { Module } from "@nestjs/common";
 import { APP_FILTER } from "@nestjs/core";
-import type { CrudoInstance } from "@crudo/core";
-import { ConfigurationException, createCrudo } from "@crudo/core";
-import type { CrudoModuleOptions } from "./crudo-options.js";
+import type { KavoInstance } from "@kavo/core";
+import { ConfigurationException, createKavo } from "@kavo/core";
+import type { KavoModuleOptions } from "./kavo-options.js";
 import type { CrudControllerMetadata } from "./crud.decorator.js";
-import { CrudoExceptionFilter } from "./crudo-exception.filter.js";
-import { CRUDO_INSTANCE, CRUDO_MODULE_OPTIONS, CRUD_CONTROLLER_METADATA, getCrudServiceToken } from "./tokens.js";
+import { KavoExceptionFilter } from "./kavo-exception.filter.js";
+import { KAVO_INSTANCE, KAVO_MODULE_OPTIONS, CRUD_CONTROLLER_METADATA, getCrudServiceToken } from "./tokens.js";
 
-export interface CrudoModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> {
-  useFactory: (...args: never[]) => CrudoModuleOptions | Promise<CrudoModuleOptions>;
+export interface KavoModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> {
+  useFactory: (...args: never[]) => KavoModuleOptions | Promise<KavoModuleOptions>;
   inject?: readonly (string | symbol | Type)[];
 }
 
 /**
- * The Crudo dynamic module (Phases 11–12).
+ * The Kavo dynamic module (Phases 11–12).
  *
- * - `forRoot`/`forRootAsync` (global): create the Crudo root instance and
+ * - `forRoot`/`forRootAsync` (global): create the Kavo root instance and
  *   register the problem-details exception filter app-wide.
  * - `forFeature(controllers)`: for each `@Crud`-decorated controller,
  *   provide the entity's `CrudService` under `getCrudServiceToken(Entity)`
@@ -25,43 +25,43 @@ export interface CrudoModuleAsyncOptions extends Pick<ModuleMetadata, "imports">
  *   request scope would only cost throughput.
  */
 @Module({})
-export class CrudoModule {
-  static forRoot(options: CrudoModuleOptions = {}): DynamicModule {
+export class KavoModule {
+  static forRoot(options: KavoModuleOptions = {}): DynamicModule {
     return {
-      module: CrudoModule,
+      module: KavoModule,
       global: true,
       providers: [
-        { provide: CRUDO_MODULE_OPTIONS, useValue: options },
+        { provide: KAVO_MODULE_OPTIONS, useValue: options },
         {
-          provide: CRUDO_INSTANCE,
-          useFactory: (resolved: CrudoModuleOptions): CrudoInstance => createInstance(resolved),
-          inject: [CRUDO_MODULE_OPTIONS],
+          provide: KAVO_INSTANCE,
+          useFactory: (resolved: KavoModuleOptions): KavoInstance => createInstance(resolved),
+          inject: [KAVO_MODULE_OPTIONS],
         },
-        { provide: APP_FILTER, useClass: CrudoExceptionFilter },
+        { provide: APP_FILTER, useClass: KavoExceptionFilter },
       ],
-      exports: [CRUDO_INSTANCE, CRUDO_MODULE_OPTIONS],
+      exports: [KAVO_INSTANCE, KAVO_MODULE_OPTIONS],
     };
   }
 
-  static forRootAsync(options: CrudoModuleAsyncOptions): DynamicModule {
+  static forRootAsync(options: KavoModuleAsyncOptions): DynamicModule {
     return {
-      module: CrudoModule,
+      module: KavoModule,
       global: true,
       imports: [...(options.imports ?? [])],
       providers: [
         {
-          provide: CRUDO_MODULE_OPTIONS,
+          provide: KAVO_MODULE_OPTIONS,
           useFactory: options.useFactory,
           inject: [...(options.inject ?? [])] as never[],
         },
         {
-          provide: CRUDO_INSTANCE,
-          useFactory: (resolved: CrudoModuleOptions): CrudoInstance => createInstance(resolved),
-          inject: [CRUDO_MODULE_OPTIONS],
+          provide: KAVO_INSTANCE,
+          useFactory: (resolved: KavoModuleOptions): KavoInstance => createInstance(resolved),
+          inject: [KAVO_MODULE_OPTIONS],
         },
-        { provide: APP_FILTER, useClass: CrudoExceptionFilter },
+        { provide: APP_FILTER, useClass: KavoExceptionFilter },
       ],
-      exports: [CRUDO_INSTANCE, CRUDO_MODULE_OPTIONS],
+      exports: [KAVO_INSTANCE, KAVO_MODULE_OPTIONS],
     };
   }
 
@@ -73,17 +73,17 @@ export class CrudoModule {
           controller.name,
           "forFeature",
           `${controller.name} is not decorated with @Crud(Entity) — ` +
-            "CrudoModule.forFeature only accepts @Crud controllers",
+            "KavoModule.forFeature only accepts @Crud controllers",
         );
       }
       return {
         provide: getCrudServiceToken(metadata.entity),
-        useFactory: (crudo: CrudoInstance) => crudo.createCrud(metadata.entity, metadata.config),
-        inject: [CRUDO_INSTANCE],
+        useFactory: (kavo: KavoInstance) => kavo.createCrud(metadata.entity, metadata.config),
+        inject: [KAVO_INSTANCE],
       };
     });
     return {
-      module: CrudoModule,
+      module: KavoModule,
       controllers: [...controllers],
       providers,
       exports: providers,
@@ -91,8 +91,8 @@ export class CrudoModule {
   }
 }
 
-function createInstance(options: CrudoModuleOptions): CrudoInstance {
-  return createCrudo({
+function createInstance(options: KavoModuleOptions): KavoInstance {
+  return createKavo({
     ...(options.defaults !== undefined && { defaults: options.defaults }),
     ...(options.infrastructure !== undefined && {
       infrastructure: options.infrastructure,

--- a/packages/frameworks/nest/src/operation-metadata.ts
+++ b/packages/frameworks/nest/src/operation-metadata.ts
@@ -1,5 +1,5 @@
 /**
- * `@crudo/nest`'s module augmentation of core's opaque `OperationMetadata`
+ * `@kavo/nest`'s module augmentation of core's opaque `OperationMetadata`
  * (ADR-0007): route concerns attach to operation registry entries without
  * core knowing HTTP exists. Route generation reads `meta.routes`; core
  * only stores and merges the bag.
@@ -21,7 +21,7 @@ export interface CrudRouteOptions {
   readonly successStatus?: number;
 }
 
-declare module "@crudo/core" {
+declare module "@kavo/core" {
   interface OperationMetadata {
     routes?: CrudRouteOptions;
   }

--- a/packages/frameworks/nest/src/schema-hints.ts
+++ b/packages/frameworks/nest/src/schema-hints.ts
@@ -1,4 +1,4 @@
-import type { ClassRef } from "@crudo/core";
+import type { ClassRef } from "@kavo/core";
 
 /**
  * Schema hints let a DTO field carry richer OpenAPI shape than its plain
@@ -11,7 +11,7 @@ import type { ClassRef } from "@crudo/core";
  * (see `jsonSchemaForValue` in `swagger.ts`). The field keeps its declared
  * TypeScript type via each helper's return type.
  */
-const SCHEMA_HINT = Symbol.for("crudo.nest.schemaHint");
+const SCHEMA_HINT = Symbol.for("kavo.nest.schemaHint");
 
 /** The shape a schema hint documents. */
 export type SchemaHint =

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
-import type { ClassRef, DtoResolver, EntityConfig, OperationDescriptor, OperationDtoMap } from "@crudo/core";
-import { DefaultDtoResolver } from "@crudo/core";
+import type { ClassRef, DtoResolver, EntityConfig, OperationDescriptor, OperationDtoMap } from "@kavo/core";
+import { DefaultDtoResolver } from "@kavo/core";
 import type { CrudHttpMethod } from "./operation-metadata.js";
 import { isSchemaHint, readSchemaHint, type SchemaHint } from "./schema-hints.js";
 
@@ -26,7 +26,7 @@ let cached: SwaggerModule | null | undefined;
  * routes are documented (operation ids, the `:id` param, the Phase 5 query
  * params on list routes, registered DTO classes as body schemas, and the
  * problem-details error responses from the Phase 6 catalog); when it is
- * not, this whole module is a no-op — Crudo never forces the dependency.
+ * not, this whole module is a no-op — Kavo never forces the dependency.
  */
 function loadSwagger(): SwaggerModule | null {
   if (cached !== undefined) return cached;
@@ -42,12 +42,12 @@ function loadSwagger(): SwaggerModule | null {
 const PROBLEM_DETAILS_SCHEMA = {
   type: "object",
   properties: {
-    type: { type: "string", example: "https://crudo.dev/errors/crudo-not-found" },
+    type: { type: "string", example: "https://kavo.dev/errors/kavo-not-found" },
     title: { type: "string" },
     status: { type: "integer" },
     detail: { type: "string" },
     instance: { type: "string" },
-    code: { type: "string", example: "CRUDO_NOT_FOUND" },
+    code: { type: "string", example: "KAVO_NOT_FOUND" },
     errors: {
       type: "array",
       items: {
@@ -191,7 +191,7 @@ export function applySwaggerMetadata(
 }
 
 /**
- * Choose how `@ApiBody` documents a DTO. Crudo DTOs carry their shape in
+ * Choose how `@ApiBody` documents a DTO. Kavo DTOs carry their shape in
  * runtime field initializers (no `@ApiProperty` decorators, by design), and
  * `@nestjs/swagger` cannot read those — passing `{ type }` alone yields an
  * empty schema, so the request body renders with no fields. When a fresh
@@ -211,7 +211,7 @@ function bodyOptionsFor(bodyDto: ClassRef): object {
  * explicit JSON schema; decorated/declarative classes fall back to
  * Swagger's own `{ type }` introspection). Single-item operations document
  * the `item` DTO (or the entity when no `item` slot is registered);
- * `findMany` wraps the `list` element in Crudo's list envelope. `deleteOne`
+ * `findMany` wraps the `list` element in Kavo's list envelope. `deleteOne`
  * (204) and everything else keep the description-only response.
  */
 function successBodyFor(

--- a/packages/frameworks/nest/src/tokens.ts
+++ b/packages/frameworks/nest/src/tokens.ts
@@ -1,16 +1,16 @@
-import type { ClassRef } from "@crudo/core";
+import type { ClassRef } from "@kavo/core";
 
-/** DI token of the Crudo root instance created by `CrudoModule.forRoot`. */
-export const CRUDO_INSTANCE = Symbol("CRUDO_INSTANCE");
+/** DI token of the Kavo root instance created by `KavoModule.forRoot`. */
+export const KAVO_INSTANCE = Symbol("KAVO_INSTANCE");
 
-/** DI token of the resolved `CrudoModuleOptions`. */
-export const CRUDO_MODULE_OPTIONS = Symbol("CRUDO_MODULE_OPTIONS");
+/** DI token of the resolved `KavoModuleOptions`. */
+export const KAVO_MODULE_OPTIONS = Symbol("KAVO_MODULE_OPTIONS");
 
 /** Reflect metadata key the `@Crud` decorator writes on controllers. */
-export const CRUD_CONTROLLER_METADATA = "crudo:controller";
+export const CRUD_CONTROLLER_METADATA = "kavo:controller";
 
 /** Property the generated route methods read the injected service from. */
-export const CRUD_SERVICE_PROPERTY = "__crudoService";
+export const CRUD_SERVICE_PROPERTY = "__kavoService";
 
 const serviceTokens = new Map<ClassRef, string>();
 
@@ -22,7 +22,7 @@ const serviceTokens = new Map<ClassRef, string>();
 export function getCrudServiceToken(entity: ClassRef): string {
   let token = serviceTokens.get(entity);
   if (token === undefined) {
-    token = `CRUDO_SERVICE_${entity.name}`;
+    token = `KAVO_SERVICE_${entity.name}`;
     serviceTokens.set(entity, token);
   }
   return token;

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -4,16 +4,16 @@ import request from "supertest";
 import { Controller, Get, type INestApplication } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { Test } from "@nestjs/testing";
-import type { DefaultCrudService, NormalizedQueryContext, OperationHandler } from "@crudo/core";
-import type { CrudoModuleOptions } from "@crudo/nest";
-import { Crud, CrudoModule, enumProp, getCrudServiceToken, oneOfArray } from "@crudo/nest";
+import type { DefaultCrudService, NormalizedQueryContext, OperationHandler } from "@kavo/core";
+import type { KavoModuleOptions } from "@kavo/nest";
+import { Crud, KavoModule, enumProp, getCrudServiceToken, oneOfArray } from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 
 let app: INestApplication;
 let adapter: InMemoryTodoAdapter;
 
 interface BootstrapOptions {
-  readonly defaults?: CrudoModuleOptions["defaults"];
+  readonly defaults?: KavoModuleOptions["defaults"];
   /**
    * Serve the app behind the qs-"extended" query parser (Express 4's
    * default) instead of Express 5's "simple" one — the nested-object shape
@@ -26,8 +26,8 @@ async function bootstrap(controller: unknown, options: BootstrapOptions = {}): P
   adapter = new InMemoryTodoAdapter();
   const moduleRef = await Test.createTestingModule({
     imports: [
-      CrudoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), defaults: options.defaults }),
-      CrudoModule.forFeature([controller as never]),
+      KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), defaults: options.defaults }),
+      KavoModule.forFeature([controller as never]),
     ],
   }).compile();
   app = moduleRef.createNestApplication();
@@ -97,9 +97,9 @@ describe("@Crud route generation (Phases 11–12)", () => {
     // `?limit=1&limit=2` reaches the binding as an array; it must survive
     // flattening intact so the normalizer can call it a bad value.
     const response = await request(server()).get("/todos?limit=1&limit=2").expect(400);
-    expect(response.body).toMatchObject({ code: "CRUDO_QUERY_INVALID" });
+    expect(response.body).toMatchObject({ code: "KAVO_QUERY_INVALID" });
     expect(response.body.errors).toContainEqual(
-      expect.objectContaining({ field: "limit", code: "CRUDO_QUERY_INVALID_VALUE" }),
+      expect.objectContaining({ field: "limit", code: "KAVO_QUERY_INVALID_VALUE" }),
     );
   });
 
@@ -118,7 +118,7 @@ describe("@Crud route generation (Phases 11–12)", () => {
       .expect("Content-Type", /application\/problem\+json/);
     expect(response.body).toMatchObject({
       status: 400,
-      code: "CRUDO_QUERY_INVALID",
+      code: "KAVO_QUERY_INVALID",
     });
     expect(response.body.errors).toHaveLength(2);
   });
@@ -129,8 +129,8 @@ describe("@Crud route generation (Phases 11–12)", () => {
       .expect(404)
       .expect("Content-Type", /application\/problem\+json/);
     expect(response.body).toMatchObject({
-      code: "CRUDO_NOT_FOUND",
-      type: "https://crudo.dev/errors/crudo-not-found",
+      code: "KAVO_NOT_FOUND",
+      type: "https://kavo.dev/errors/kavo-not-found",
     });
     expect(response.body.detail).toContain("99");
   });
@@ -207,7 +207,7 @@ describe("@Crud page pagination over the wire (Phase 5)", () => {
       .expect(400)
       .expect("Content-Type", /application\/problem\+json/);
     expect(response.body.errors).toContainEqual(
-      expect.objectContaining({ field: "page[number]", code: "CRUDO_QUERY_INVALID_VALUE" }),
+      expect.objectContaining({ field: "page[number]", code: "KAVO_QUERY_INVALID_VALUE" }),
     );
   });
 });
@@ -315,7 +315,7 @@ describe("@Crud operation control surface", () => {
   });
 });
 
-describe("CrudoExceptionFilter — non-Crudo handler failures (Phase 6)", () => {
+describe("KavoExceptionFilter — non-Kavo handler failures (Phase 6)", () => {
   const exploding: OperationHandler<Todo> = {
     async execute() {
       throw new Error("connection to shard-7 refused");
@@ -337,10 +337,10 @@ describe("CrudoExceptionFilter — non-Crudo handler failures (Phase 6)", () => 
       .expect(500)
       .expect("Content-Type", /application\/problem\+json/);
     expect(response.body).toMatchObject({
-      type: "https://crudo.dev/errors/crudo-persistence-failed",
+      type: "https://kavo.dev/errors/kavo-persistence-failed",
       title: "Persistence failure",
       status: 500,
-      code: "CRUDO_PERSISTENCE_FAILED",
+      code: "KAVO_PERSISTENCE_FAILED",
     });
   });
 
@@ -359,7 +359,7 @@ describe("CrudoExceptionFilter — non-Crudo handler failures (Phase 6)", () => 
   it("reports the occurrence as a correlation URN", async () => {
     await bootstrap(ExplodingController);
     const response = await request(server()).post("/todos/explode").expect(500);
-    expect(response.body.instance).toMatch(/^urn:crudo:request:/);
+    expect(response.body.instance).toMatch(/^urn:kavo:request:/);
   });
 });
 
@@ -400,7 +400,7 @@ describe("@Crud soft-delete routes (Phase 14)", () => {
     const response = await request(server()).patch("/todos/1/restore").expect(409);
     expect(response.body).toMatchObject({
       status: 409,
-      code: "CRUDO_NOT_DELETED",
+      code: "KAVO_NOT_DELETED",
     });
   });
 
@@ -460,8 +460,8 @@ describe("@Crud relation includes (Phase 15)", () => {
     await bootstrap(ClosedController);
     const response = await request(server()).get("/todos?include=list").expect(400);
     expect(response.body).toMatchObject({
-      code: "CRUDO_QUERY_INVALID",
-      errors: [{ field: "list", code: "CRUDO_QUERY_INVALID_FIELD" }],
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "list", code: "KAVO_QUERY_INVALID_FIELD" }],
     });
   });
 

--- a/packages/frameworks/nest/tests/flatten-query.spec.ts
+++ b/packages/frameworks/nest/tests/flatten-query.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { flattenQuery } from "@crudo/nest";
+import { flattenQuery } from "@kavo/nest";
 
 /**
  * Each row is one Phase 5 query written the two ways a query parser can

--- a/packages/frameworks/nest/tests/support/fake-infrastructure.ts
+++ b/packages/frameworks/nest/tests/support/fake-infrastructure.ts
@@ -6,8 +6,8 @@ import type {
   EntityMetadata,
   NormalizedQueryContext,
   RepositoryAdapter,
-} from "@crudo/core";
-import { AlreadyDeletedException, NotDeletedException, NotFoundException } from "@crudo/core";
+} from "@kavo/core";
+import { AlreadyDeletedException, NotDeletedException, NotFoundException } from "@kavo/core";
 
 /**
  * Test entity for binding tests — no ORM anywhere near this package. The
@@ -68,7 +68,7 @@ export const todoListMetadata: EntityMetadata<TodoList> = {
  * In-memory adapter for the binding tests: pagination honored, the last
  * normalized query recorded so tests can assert the wire → AST wiring.
  * Filter *evaluation* belongs to real adapters (covered in
- * @crudo/typeorm's suite); the binding's job ends at handing the adapter
+ * @kavo/typeorm's suite); the binding's job ends at handing the adapter
  * a validated query.
  */
 export class InMemoryTodoAdapter implements RepositoryAdapter<Todo> {

--- a/packages/frameworks/nest/tests/types/crud-decorator.test-d.ts
+++ b/packages/frameworks/nest/tests/types/crud-decorator.test-d.ts
@@ -1,6 +1,6 @@
 import { Controller } from "@nestjs/common";
-import { Crud } from "@crudo/nest";
-import type { CrudContext, OperationHandler } from "@crudo/core";
+import { Crud } from "@kavo/nest";
+import type { CrudContext, OperationHandler } from "@kavo/core";
 import { expectTypeOf } from "vitest";
 
 /**

--- a/packages/frameworks/nest/tsconfig.tests.json
+++ b/packages/frameworks/nest/tsconfig.tests.json
@@ -10,8 +10,8 @@
     "useDefineForClassFields": false,
     "types": ["node"],
     "paths": {
-      "@crudo/core": ["../../core/src/index.ts"],
-      "@crudo/nest": ["./src/index.ts"]
+      "@kavo/core": ["../../core/src/index.ts"],
+      "@kavo/nest": ["./src/index.ts"]
     }
   },
   "include": ["tests"]

--- a/packages/orms/typeorm/README.md
+++ b/packages/orms/typeorm/README.md
@@ -1,12 +1,12 @@
-# @crudo/typeorm
+# @kavo/typeorm
 
-TypeORM adapter for Crudo: implements `RepositoryAdapter`
-(`EntityReader` + `EntityWriter`) and `FilterBuilder` from `@crudo/core`
+TypeORM adapter for Kavo: implements `RepositoryAdapter`
+(`EntityReader` + `EntityWriter`) and `FilterBuilder` from `@kavo/core`
 over TypeORM's Repository and QueryBuilder APIs. `TransactionManager` is
-not implemented — see the `@remarks` on that interface in `@crudo/core`.
+not implemented — see the `@remarks` on that interface in `@kavo/core`.
 
-**May depend on:** `@crudo/core`, `typeorm` (peer). **Never on:**
-`@crudo/nest` or any framework.
+**May depend on:** `@kavo/core`, `typeorm` (peer). **Never on:**
+`@kavo/nest` or any framework.
 
 Scaffold only in Milestone A — architecture lands in Phase 9,
 implementation in Phase 10.

--- a/packages/orms/typeorm/package.json
+++ b/packages/orms/typeorm/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@crudo/typeorm",
+  "name": "@kavo/typeorm",
   "version": "0.0.0",
-  "description": "Crudo TypeORM adapter — implements @crudo/core's RepositoryAdapter and TransactionManager over TypeORM.",
+  "description": "Kavo TypeORM adapter — implements @kavo/core's RepositoryAdapter and TransactionManager over TypeORM.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -18,7 +18,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@crudo/core": "workspace:*"
+    "@kavo/core": "workspace:*"
   },
   "peerDependencies": {
     "typeorm": "^0.3.20"

--- a/packages/orms/typeorm/src/error-mapping.ts
+++ b/packages/orms/typeorm/src/error-mapping.ts
@@ -1,9 +1,9 @@
-import type { ErrorContext } from "@crudo/core";
-import { ConflictException, CrudoException, PersistenceException, TransactionException } from "@crudo/core";
+import type { ErrorContext } from "@kavo/core";
+import { ConflictException, KavoException, PersistenceException, TransactionException } from "@kavo/core";
 import { QueryFailedError } from "typeorm";
 
 /**
- * The Phase 9 error-mapping table: driver error → Crudo exception.
+ * The Phase 9 error-mapping table: driver error → Kavo exception.
  *
  * | Driver condition                  | Exception                          |
  * | --------------------------------- | ---------------------------------- |
@@ -19,14 +19,14 @@ import { QueryFailedError } from "typeorm";
  * **Soft delete and unique indexes (Phase 14).** A soft-deleted row still
  * occupies its unique indexes, so re-creating "the same" row after a soft
  * delete raises a unique violation — mapped here to a 409 like any other
- * conflict, which is the honest answer: the value *is* taken. Crudo never
+ * conflict, which is the honest answer: the value *is* taken. Kavo never
  * rewrites indexes; the standard fix is a partial/filtered unique index
  * on the live rows only, e.g. in Postgres
  * `CREATE UNIQUE INDEX … ON owner (email) WHERE deleted_at IS NULL`
  * (SQLite supports the same form; MySQL needs a generated column).
  */
-export function mapDriverError(error: unknown, context: ErrorContext): CrudoException {
-  if (error instanceof CrudoException) return error;
+export function mapDriverError(error: unknown, context: ErrorContext): KavoException {
+  if (error instanceof KavoException) return error;
 
   const entity = context.entityName ?? "entity";
   if (error instanceof QueryFailedError) {

--- a/packages/orms/typeorm/src/filter-translator.ts
+++ b/packages/orms/typeorm/src/filter-translator.ts
@@ -1,5 +1,5 @@
-import type { Filter, FilterBuilder, FilterCondition, FilterExpression, FilterScalar } from "@crudo/core";
-import { assertNever } from "@crudo/core";
+import type { Filter, FilterBuilder, FilterCondition, FilterExpression, FilterScalar } from "@kavo/core";
+import { assertNever } from "@kavo/core";
 import { Brackets, NotBrackets, type WhereExpressionBuilder } from "typeorm";
 import type { SelectQueryBuilder, ObjectLiteral } from "typeorm";
 

--- a/packages/orms/typeorm/src/index.ts
+++ b/packages/orms/typeorm/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * @crudo/typeorm — TypeORM adapter for Crudo (Phases 9–10).
+ * @kavo/typeorm — TypeORM adapter for Kavo (Phases 9–10).
  *
- * Implements `@crudo/core`'s `RepositoryAdapter` over a TypeORM
+ * Implements `@kavo/core`'s `RepositoryAdapter` over a TypeORM
  * `DataSource` and feeds core's entity-metadata seam from TypeORM
- * metadata. `typeorm` is a peerDependency; `@crudo/core` never imports it.
+ * metadata. `typeorm` is a peerDependency; `@kavo/core` never imports it.
  */
 export { TypeOrmRepositoryAdapter } from "./typeorm-repository-adapter.js";
 export { FilterTranslator } from "./filter-translator.js";
 export { buildEntityMetadata } from "./metadata.js";
 export { mapDriverError } from "./error-mapping.js";
-export { createTypeOrmCrudo, createTypeOrmInfrastructure } from "./infrastructure.js";
+export { createTypeOrmKavo, createTypeOrmInfrastructure } from "./infrastructure.js";

--- a/packages/orms/typeorm/src/infrastructure.ts
+++ b/packages/orms/typeorm/src/infrastructure.ts
@@ -1,12 +1,12 @@
 import type {
   ClassRef,
   CrudInfrastructure,
-  CrudoInstance,
-  CrudoOptions,
+  KavoInstance,
+  KavoOptions,
   EntityMetadata,
   RepositoryAdapter,
-} from "@crudo/core";
-import { createCrudo } from "@crudo/core";
+} from "@kavo/core";
+import { createKavo } from "@kavo/core";
 import type { DataSource, ObjectLiteral } from "typeorm";
 import { buildEntityMetadata } from "./metadata.js";
 import { TypeOrmRepositoryAdapter } from "./typeorm-repository-adapter.js";
@@ -42,15 +42,15 @@ export function createTypeOrmInfrastructure(dataSource: DataSource): CrudInfrast
 }
 
 /**
- * Sugar for the common case: a Crudo root instance wired to one TypeORM
- * `DataSource`, so `crudo.createCrud(UserEntity)` is genuinely
+ * Sugar for the common case: a Kavo root instance wired to one TypeORM
+ * `DataSource`, so `kavo.createCrud(UserEntity)` is genuinely
  * zero-config.
  */
-export function createTypeOrmCrudo(
+export function createTypeOrmKavo(
   dataSource: DataSource,
-  options: Omit<CrudoOptions, "infrastructure"> = {},
-): CrudoInstance {
-  return createCrudo({
+  options: Omit<KavoOptions, "infrastructure"> = {},
+): KavoInstance {
+  return createKavo({
     ...options,
     infrastructure: createTypeOrmInfrastructure(dataSource),
   });

--- a/packages/orms/typeorm/src/metadata.ts
+++ b/packages/orms/typeorm/src/metadata.ts
@@ -1,5 +1,5 @@
-import type { ClassRef, EntityMetadata, FieldKind, FieldMetadata, RelationDescriptor } from "@crudo/core";
-import { ConfigurationException } from "@crudo/core";
+import type { ClassRef, EntityMetadata, FieldKind, FieldMetadata, RelationDescriptor } from "@kavo/core";
+import { ConfigurationException } from "@kavo/core";
 import type { DataSource } from "typeorm";
 import type { ColumnMetadata } from "typeorm/metadata/ColumnMetadata.js";
 
@@ -44,7 +44,7 @@ export function buildEntityMetadata<Entity extends object>(
     throw new ConfigurationException(
       metadata.name,
       "primaryColumns",
-      `Crudo v6 requires exactly one primary column; found ${metadata.primaryColumns.length}`,
+      `Kavo v6 requires exactly one primary column; found ${metadata.primaryColumns.length}`,
     );
   }
   const primary = metadata.primaryColumns[0]!;

--- a/packages/orms/typeorm/src/typeorm-repository-adapter.ts
+++ b/packages/orms/typeorm/src/typeorm-repository-adapter.ts
@@ -7,8 +7,8 @@ import type {
   NormalizedQueryContext,
   RepositoryAdapter,
   ResolvedSoftDelete,
-} from "@crudo/core";
-import { AlreadyDeletedException, ConfigurationException, NotDeletedException, NotFoundException } from "@crudo/core";
+} from "@kavo/core";
+import { AlreadyDeletedException, ConfigurationException, NotDeletedException, NotFoundException } from "@kavo/core";
 import type { DataSource, DeepPartial, ObjectLiteral, Repository, SelectQueryBuilder } from "typeorm";
 import { FilterTranslator } from "./filter-translator.js";
 import { mapDriverError } from "./error-mapping.js";

--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -7,10 +7,10 @@ import {
   NotFoundException,
   PersistenceException,
   QueryValidationException,
-  type CrudoInstance,
+  type KavoInstance,
   type DefaultCrudService,
-} from "@crudo/core";
-import { buildEntityMetadata, createTypeOrmCrudo } from "@crudo/typeorm";
+} from "@kavo/core";
+import { buildEntityMetadata, createTypeOrmKavo } from "@kavo/typeorm";
 
 // Explicit column types throughout: the swc test transform emits decorator
 // metadata, but explicit types keep entities transform-agnostic.
@@ -54,7 +54,7 @@ class Book {
 }
 
 let dataSource: DataSource;
-let crudo: CrudoInstance;
+let kavo: KavoInstance;
 let authors: DefaultCrudService<Author>;
 
 beforeAll(async () => {
@@ -65,8 +65,8 @@ beforeAll(async () => {
     synchronize: true,
   });
   await dataSource.initialize();
-  crudo = createTypeOrmCrudo(dataSource);
-  authors = crudo.createCrud(Author) as DefaultCrudService<Author>;
+  kavo = createTypeOrmKavo(dataSource);
+  authors = kavo.createCrud(Author) as DefaultCrudService<Author>;
 });
 
 afterAll(async () => {
@@ -281,7 +281,7 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
   });
 
   it("filters on relation paths when explicitly allowlisted", async () => {
-    const scoped = crudo.createCrud(Book, {
+    const scoped = kavo.createCrud(Book, {
       allowlists: { filterable: ["title", "author.name" as never] },
     }) as DefaultCrudService<Book>;
     await seed();

--- a/packages/orms/typeorm/tests/error-mapping.spec.ts
+++ b/packages/orms/typeorm/tests/error-mapping.spec.ts
@@ -1,15 +1,15 @@
 import "reflect-metadata";
 import { describe, expect, it } from "vitest";
 import { QueryFailedError } from "typeorm";
-import type { ErrorContext } from "@crudo/core";
+import type { ErrorContext } from "@kavo/core";
 import {
   ConflictException,
   NotFoundException,
   PersistenceException,
   QueryValidationException,
   TransactionException,
-} from "@crudo/core";
-import { mapDriverError } from "@crudo/typeorm";
+} from "@kavo/core";
+import { mapDriverError } from "@kavo/typeorm";
 
 interface DriverPayload {
   readonly code?: string;
@@ -66,7 +66,7 @@ describe("mapDriverError — unique violations (Phase 9 table)", () => {
     const error = queryFailed(driver);
     const mapped = mapDriverError(error, context);
     expect(mapped).toBeInstanceOf(ConflictException);
-    expect(mapped).toMatchObject({ code: "CRUDO_CONFLICT", status: 409 });
+    expect(mapped).toMatchObject({ code: "KAVO_CONFLICT", status: 409 });
   });
 
   it("names the entity in the conflict's message params", () => {
@@ -86,7 +86,7 @@ describe("mapDriverError — unique violations (Phase 9 table)", () => {
       queryFailed({ code: "SQLITE_CONSTRAINT_UNIQUE", message: "UNIQUE constraint failed: ticket.reference" }),
       { entityName: "Ticket", operation: "createOne" },
     );
-    expect(mapped.code).toBe("CRUDO_CONFLICT");
+    expect(mapped.code).toBe("KAVO_CONFLICT");
     expect(mapped.status).toBe(409);
   });
 });
@@ -95,7 +95,7 @@ describe("mapDriverError — foreign-key violations (Phase 9 table)", () => {
   it.each(foreignKeyViolations)("maps a %s to a 409 conflict", (_name, driver) => {
     const mapped = mapDriverError(queryFailed(driver), context);
     expect(mapped).toBeInstanceOf(ConflictException);
-    expect(mapped).toMatchObject({ code: "CRUDO_CONFLICT", status: 409 });
+    expect(mapped).toMatchObject({ code: "KAVO_CONFLICT", status: 409 });
   });
 
   it("leaves other SQLite constraint failures to the fallback row", () => {
@@ -114,7 +114,7 @@ describe("mapDriverError — serialization failures and deadlocks (Phase 9 table
   it.each(retryableFailures)("maps a %s to a retryable transaction failure", (_name, driver) => {
     const mapped = mapDriverError(queryFailed(driver), context);
     expect(mapped).toBeInstanceOf(TransactionException);
-    expect(mapped).toMatchObject({ code: "CRUDO_TRANSACTION_FAILED", status: 500 });
+    expect(mapped).toMatchObject({ code: "KAVO_TRANSACTION_FAILED", status: 500 });
     expect((mapped as TransactionException).retryable).toBe(true);
   });
 });
@@ -123,7 +123,7 @@ describe("mapDriverError — the fallback row (Phase 6/9)", () => {
   it("maps an unrecognized driver code to a persistence failure", () => {
     const mapped = mapDriverError(queryFailed({ code: "42P01" }), context);
     expect(mapped).toBeInstanceOf(PersistenceException);
-    expect(mapped).toMatchObject({ code: "CRUDO_PERSISTENCE_FAILED", status: 500 });
+    expect(mapped).toMatchObject({ code: "KAVO_PERSISTENCE_FAILED", status: 500 });
   });
 
   it("carries the failing operation from the error context", () => {
@@ -174,14 +174,14 @@ describe("mapDriverError — cause and context propagation (Phase 6)", () => {
   });
 });
 
-describe("mapDriverError — Crudo exceptions pass through (Phase 9)", () => {
+describe("mapDriverError — Kavo exceptions pass through (Phase 9)", () => {
   it("returns an already-mapped exception by identity, not a copy", () => {
     // The adapter raises `NotFoundException` itself (affected === 0); a
     // second trip through the table must not restate it as a 500.
     for (const original of [
       new NotFoundException({ messageParams: { entity: "Author", id: "7" } }),
       new ConflictException({ messageParams: { entity: "Author" } }),
-      new QueryValidationException([{ field: "age", code: "CRUDO_QUERY_INVALID_VALUE", detail: "bad" }]),
+      new QueryValidationException([{ field: "age", code: "KAVO_QUERY_INVALID_VALUE", detail: "bad" }]),
       new TransactionException({ retryable: true }),
     ]) {
       expect(mapDriverError(original, context)).toBe(original);

--- a/packages/orms/typeorm/tests/includes.spec.ts
+++ b/packages/orms/typeorm/tests/includes.spec.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Column, DataSource, DeleteDateColumn, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
-import type { CrudoInstance, DefaultCrudService } from "@crudo/core";
-import { createTypeOrmCrudo } from "@crudo/typeorm";
+import type { KavoInstance, DefaultCrudService } from "@kavo/core";
+import { createTypeOrmKavo } from "@kavo/typeorm";
 
 @Entity()
 class Blog {
@@ -47,7 +47,7 @@ class Note {
 }
 
 let dataSource: DataSource;
-let crudo: CrudoInstance;
+let kavo: KavoInstance;
 let blogs: DefaultCrudService<Blog>;
 let joinedBlogs: DefaultCrudService<Blog>;
 let articles: DefaultCrudService<Article>;
@@ -60,21 +60,21 @@ beforeAll(async () => {
     synchronize: true,
   });
   await dataSource.initialize();
-  crudo = createTypeOrmCrudo(dataSource);
-  blogs = crudo.createCrud(Blog, {
+  kavo = createTypeOrmKavo(dataSource);
+  blogs = kavo.createCrud(Blog, {
     relations: { edges: { articles: { includable: true } } },
   }) as DefaultCrudService<Blog>;
-  articles = crudo.createCrud(Article, {
+  articles = kavo.createCrud(Article, {
     softDelete: { strategy: "soft" },
     relations: { edges: { blog: { includable: true }, notes: { includable: true } } },
     // Filtering across a relation path is its own allowlist decision,
     // independent of whether the relation may be included.
     allowlists: { filterable: ["id", "title", "blog.name"] },
   } as never) as DefaultCrudService<Article>;
-  crudo.createCrud(Note, { relations: { edges: { article: { includable: true } } } });
+  kavo.createCrud(Note, { relations: { edges: { article: { includable: true } } } });
   // The same entity with the to-many forced to `join`: the case the
   // normative pagination rule exists for.
-  joinedBlogs = createTypeOrmCrudo(dataSource).createCrud(Blog, {
+  joinedBlogs = createTypeOrmKavo(dataSource).createCrud(Blog, {
     relations: { edges: { articles: { includable: true, strategy: "join" } } },
   }) as DefaultCrudService<Blog>;
 });
@@ -91,7 +91,7 @@ beforeEach(async () => {
 
 /** One blog, two articles, one note on the first article. */
 async function seed(): Promise<{ blogId: number; articleId: number }> {
-  const blog = await dataSource.getRepository(Blog).save({ name: "Crudo weekly" });
+  const blog = await dataSource.getRepository(Blog).save({ name: "Kavo weekly" });
   const first = await dataSource.getRepository(Article).save({ title: "Includes", blog });
   await dataSource.getRepository(Article).save({ title: "Soft delete", blog });
   await dataSource.getRepository(Note).save({ body: "typo on line 3", article: first });
@@ -102,7 +102,7 @@ describe("TypeOrmRepositoryAdapter — join loading (Phase 15)", () => {
   it("embeds a to-one relation from the main query", async () => {
     const { blogId } = await seed();
     const list = await articles.findMany({ include: ["blog"], sort: [{ field: "id", direction: "asc" }] });
-    expect(list.items[0]).toMatchObject({ title: "Includes", blog: { id: blogId, name: "Crudo weekly" } });
+    expect(list.items[0]).toMatchObject({ title: "Includes", blog: { id: blogId, name: "Kavo weekly" } });
   });
 
   it("supports include on findOne with identical semantics", async () => {
@@ -115,10 +115,10 @@ describe("TypeOrmRepositoryAdapter — join loading (Phase 15)", () => {
     await seed();
     const list = await articles.findMany({
       include: ["blog"],
-      filter: { kind: "condition", field: "blog.name" as never, operator: "EQ", value: "Crudo weekly" },
+      filter: { kind: "condition", field: "blog.name" as never, operator: "EQ", value: "Kavo weekly" },
     });
     expect(list.items).toHaveLength(2);
-    expect(list.items[0]).toMatchObject({ blog: { name: "Crudo weekly" } });
+    expect(list.items[0]).toMatchObject({ blog: { name: "Kavo weekly" } });
   });
 });
 
@@ -204,7 +204,7 @@ describe("Sparse fieldsets on included nodes (Phase 15)", () => {
     });
     expect(list.items[0]).toEqual({
       id: expect.any(Number),
-      name: "Crudo weekly",
+      name: "Kavo weekly",
       articles: [{ title: "Includes" }, { title: "Soft delete" }],
     });
   });

--- a/packages/orms/typeorm/tests/soft-delete.spec.ts
+++ b/packages/orms/typeorm/tests/soft-delete.spec.ts
@@ -7,8 +7,8 @@ import {
   NotDeletedException,
   NotFoundException,
   type DefaultCrudService,
-} from "@crudo/core";
-import { buildEntityMetadata, createTypeOrmCrudo } from "@crudo/typeorm";
+} from "@kavo/core";
+import { buildEntityMetadata, createTypeOrmKavo } from "@kavo/typeorm";
 
 /** Soft delete the ORM-declared way: one `@DeleteDateColumn`. */
 @Entity()
@@ -51,12 +51,12 @@ beforeAll(async () => {
     synchronize: true,
   });
   await dataSource.initialize();
-  const crudo = createTypeOrmCrudo(dataSource);
-  tickets = crudo.createCrud(Ticket, {
+  const kavo = createTypeOrmKavo(dataSource);
+  tickets = kavo.createCrud(Ticket, {
     softDelete: { strategy: "soft" },
     operations: { purgeOne: true },
   }) as DefaultCrudService<Ticket>;
-  invoices = crudo.createCrud(Invoice, {
+  invoices = kavo.createCrud(Invoice, {
     softDelete: { field: "archivedAt" },
   }) as DefaultCrudService<Invoice>;
 });
@@ -138,7 +138,7 @@ describe("TypeOrmRepositoryAdapter — soft delete (Phase 14)", () => {
 
   it("still conflicts on a unique index held by a deleted row", async () => {
     // Documented adapter guidance: a soft-deleted row keeps its unique
-    // index entries, and the fix is a partial index — not a Crudo rewrite.
+    // index entries, and the fix is a partial index — not a Kavo rewrite.
     const id = await newTicket("T-dup");
     await tickets.deleteOne(id);
     await expect(tickets.createOne({ reference: "T-dup", title: "again" } as never)).rejects.toBeInstanceOf(

--- a/packages/orms/typeorm/tsconfig.tests.json
+++ b/packages/orms/typeorm/tsconfig.tests.json
@@ -12,8 +12,8 @@
     "useDefineForClassFields": false,
     "types": ["node"],
     "paths": {
-      "@crudo/core": ["../../core/src/index.ts"],
-      "@crudo/typeorm": ["./src/index.ts"]
+      "@kavo/core": ["../../core/src/index.ts"],
+      "@kavo/typeorm": ["./src/index.ts"]
     }
   },
   "include": ["tests"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,13 +34,13 @@ importers:
 
   packages/examples:
     dependencies:
-      '@crudo/core':
+      '@kavo/core':
         specifier: workspace:*
         version: link:../core
-      '@crudo/nest':
+      '@kavo/nest':
         specifier: workspace:*
         version: link:../frameworks/nest
-      '@crudo/typeorm':
+      '@kavo/typeorm':
         specifier: workspace:*
         version: link:../orms/typeorm
       '@nestjs/common':
@@ -80,7 +80,7 @@ importers:
 
   packages/frameworks/nest:
     dependencies:
-      '@crudo/core':
+      '@kavo/core':
         specifier: workspace:*
         version: link:../../core
     devDependencies:
@@ -114,7 +114,7 @@ importers:
 
   packages/orms/typeorm:
     dependencies:
-      '@crudo/core':
+      '@kavo/core':
         specifier: workspace:*
         version: link:../../core
     devDependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,9 +24,9 @@ export default defineConfig({
   resolve: {
     // Tests exercise workspace sources directly — no stale-dist hazard.
     alias: {
-      "@crudo/core": new URL("./packages/core/src/index.ts", import.meta.url).pathname,
-      "@crudo/typeorm": new URL("./packages/orms/typeorm/src/index.ts", import.meta.url).pathname,
-      "@crudo/nest": new URL("./packages/frameworks/nest/src/index.ts", import.meta.url).pathname,
+      "@kavo/core": new URL("./packages/core/src/index.ts", import.meta.url).pathname,
+      "@kavo/typeorm": new URL("./packages/orms/typeorm/src/index.ts", import.meta.url).pathname,
+      "@kavo/nest": new URL("./packages/frameworks/nest/src/index.ts", import.meta.url).pathname,
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Rebrand the project from Crudo to Kavo throughout the monorepo: npm scope (`@crudo/*` → `@kavo/*`), root/package names, exported identifiers (`createCrudo` → `createKavo`, `CrudoModule` → `KavoModule`, `CrudoException` → `KavoException`, error codes `CRUDO_*` → `KAVO_*`, etc.), filenames (`crudo.ts` → `kavo.ts` and friends), docs/ADRs, `.dependency-cruiser.cjs` rules, and internal `.claude/` tooling (agents, commands, skills).
- `@Crud`/`CrudEngine`/`DefaultCrudService` and other names using the generic "Crud" (CRUD) acronym are untouched — only the "Crudo" brand name was renamed.
- Repo transferred from `hosseinsalemi/crudo` to `kavo-labs/kavo`; local remote and this PR target the new location.

## Test plan
- [x] `pnpm check` (build + typecheck + depcruise + test) is green — 459/459 tests pass, 0 dependency-boundary violations.
- [x] `pnpm prettify` run, no unexpected diffs.
- [x] Verified no remaining "crudo" references in tracked files (`git ls-files | xargs grep -il crudo` → empty).