### PR TITLE
ci: publish @kavo/* to npm on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Same gate as CI — a release never ships on a red build.
+      - name: Check
+        run: pnpm check
+
+      - name: Verify tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./packages/core/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match @kavo/core version $PKG_VERSION" >&2
+            exit 1
+          fi
+
+      # Publishes every non-private workspace package (core, typeorm, nest;
+      # examples is private and skipped) in dependency order, so @kavo/core
+      # is always live before its dependents.
+      - name: Publish packages
+        run: pnpm -r publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,19 @@
 {
   "name": "@kavo/core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Kavo core — framework- and ORM-independent contracts and type system. Zero runtime dependencies.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kavo-labs/kavo.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/kavo-labs/kavo/tree/main/packages/core#readme",
   "type": "module",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/frameworks/nest/package.json
+++ b/packages/frameworks/nest/package.json
@@ -1,10 +1,19 @@
 {
   "name": "@kavo/nest",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Kavo NestJS binding — @Crud decorator, registry-driven route generation, problem-details exception filter, Swagger integration.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kavo-labs/kavo.git",
+    "directory": "packages/frameworks/nest"
+  },
+  "homepage": "https://github.com/kavo-labs/kavo/tree/main/packages/frameworks/nest#readme",
   "type": "module",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -18,7 +27,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@kavo/core": "workspace:*"
+    "@kavo/core": "workspace:^"
   },
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",

--- a/packages/orms/typeorm/package.json
+++ b/packages/orms/typeorm/package.json
@@ -1,10 +1,19 @@
 {
   "name": "@kavo/typeorm",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Kavo TypeORM adapter — implements @kavo/core's RepositoryAdapter and TransactionManager over TypeORM.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kavo-labs/kavo.git",
+    "directory": "packages/orms/typeorm"
+  },
+  "homepage": "https://github.com/kavo-labs/kavo/tree/main/packages/orms/typeorm#readme",
   "type": "module",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -18,7 +27,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@kavo/core": "workspace:*"
+    "@kavo/core": "workspace:^"
   },
   "peerDependencies": {
     "typeorm": "^0.3.20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
   packages/frameworks/nest:
     dependencies:
       '@kavo/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../core
     devDependencies:
       '@nestjs/common':
@@ -115,7 +115,7 @@ importers:
   packages/orms/typeorm:
     dependencies:
       '@kavo/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../core
     devDependencies:
       better-sqlite3:


### PR DESCRIPTION
## Summary
- New `Release` workflow (`.github/workflows/release.yml`) triggers on `v*.*.*` tags: runs `pnpm check`, verifies the tag matches `@kavo/core`'s version, then `pnpm -r publish --access public --provenance` — publishing core → nest/typeorm (dependency order), skipping the private `examples` package. Auth comes from the `NPM_TOKEN` repo secret via `actions/setup-node`'s `registry-url`; nothing is ever published from a developer machine, matching the "no manual publish steps" constraint in `packages/docs/roadmap.md` Phase 18.
- Bumps `@kavo/core`, `@kavo/typeorm`, `@kavo/nest` to `0.1.0` (first release) and adds `publishConfig.access: "public"` (required for a scoped package's first publish) plus `repository`/`homepage` metadata.
- Switches the internal `@kavo/core` dependency in `typeorm`/`nest` from `workspace:*` to `workspace:^`, so the published tarball carries a real `^0.1.0` range instead of the literal string `workspace:*`. Verified via `pnpm pack`.

## Not in scope (tracked in roadmap Phase 18)
Dual ESM+CJS builds, API-extractor surface gating, changesets automation, and full provenance/supply-chain hardening are follow-up work — this PR is the minimal "CI is the only path to npm" pipeline for a first `0.1.0` release.

## Test plan
- [x] `pnpm check` green (build, typecheck, depcruise, 459/459 tests).
- [x] `pnpm -r publish --dry-run` confirms correct package set (core, typeorm, nest; examples skipped) and publish order (core before its dependents).
- [x] `pnpm pack` on `@kavo/typeorm` confirms the tarball's `package.json` has `"@kavo/core": "^0.1.0"`, not `workspace:*`.
- [ ] Add an `NPM_TOKEN` secret (npm automation/granular token with publish rights on the `kavo` org) to this repo before merging — the workflow will fail without it.
- [ ] After merge, tag `v0.1.0` on `main` and push it to trigger the first real release.