### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kavo/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kavo core — framework- and ORM-independent contracts and type system. Zero runtime dependencies.",
   "license": "MIT",
   "repository": {

--- a/packages/frameworks/nest/package.json
+++ b/packages/frameworks/nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kavo/nest",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kavo NestJS binding — @Crud decorator, registry-driven route generation, problem-details exception filter, Swagger integration.",
   "license": "MIT",
   "repository": {

--- a/packages/orms/typeorm/package.json
+++ b/packages/orms/typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kavo/typeorm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kavo TypeORM adapter — implements @kavo/core's RepositoryAdapter and TransactionManager over TypeORM.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Bumps @kavo/core, @kavo/typeorm, and @kavo/nest from 0.1.0 to 0.1.1 (patch, lockstep per ADR-0004).

## Changes since v0.1.0
- docs(readme): add npm install instructions

## Test plan
- [x] `pnpm check` green (build, typecheck, depcruise, 459/459 tests).

Merge this, then run `/publish tag` (or `/publish`) from an updated `main` to tag and push `v0.1.1`, which triggers the npm publish workflow.