### PR TITLE
ci: create a GitHub Release alongside every npm publish

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -105,8 +105,8 @@ Do not create or push a tag in this phase.
 2. **Confirm with the user before doing anything irreversible.** State
    plainly: pushing tag `vX.Y.Z` triggers `.github/workflows/publish.yml`,
    which publishes `@kavo/core`, `@kavo/typeorm`, and `@kavo/nest` to the
-   public npm registry — this cannot be meaningfully undone. Wait for an
-   explicit go-ahead.
+   public npm registry and creates a GitHub Release for the tag — this
+   cannot be meaningfully undone. Wait for an explicit go-ahead.
 
 3. **Tag and push:**
 
@@ -125,5 +125,6 @@ Do not create or push a tag in this phase.
    a failed OIDC trusted-publisher match or a stale npm CLI version are the
    most likely causes.
 
-5. **Report**: the tag, the workflow run URL, and (once it finishes) the
-   published package versions.
+5. **Report**: the tag, the workflow run URL, the published package
+   versions, and the GitHub Release URL
+   (`gh release view vX.Y.Z --json url --jq .url`).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -72,3 +72,15 @@ jobs:
 
       - name: Publish @kavo/nest
         run: npm publish /tmp/kavo-tarballs/kavo-nest-*.tgz --access public
+
+      # Only runs once every publish above succeeded. Attaches the exact
+      # published tarballs as release assets and lets GitHub generate the
+      # notes from merged PRs since the previous tag.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            /tmp/kavo-tarballs/*.tgz \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Adds a final `Create GitHub Release` step to `.github/workflows/publish.yml`, gated behind all three npm publishes succeeding: `gh release create` for the pushed tag, attaching the exact published tarballs as release assets, with `--generate-notes` for the changelog.
- Bumps workflow permissions from `contents: read` to `contents: write` — required for the default `GITHUB_TOKEN` to create a release.
- Updates the `/publish` command's tag-phase docs to mention the release step and report its URL.

## Test plan
- [x] `pnpm check` green.
- [x] `pnpm format:check` green.
- Will backfill GitHub Releases for the already-published `v0.1.0` and `v0.1.1` tags separately (this workflow only affects future tag pushes).