### PR TITLE
test: override every standard operation on the Address example, plus a custom operation

### DIFF
--- a/packages/core/src/engine/crud-engine.ts
+++ b/packages/core/src/engine/crud-engine.ts
@@ -191,9 +191,15 @@ export class CrudEngine<Entity extends object> {
           id: this.coerceId(request.id),
           data: deserializer.deserialize(request.body, dto, context),
         };
-      default:
-        // createOne and custom operations: the (deserialized) body.
-        return deserializer.deserialize(request.body, dto, context);
+      default: {
+        // createOne and custom operations: the (deserialized) body — plus
+        // the request id when one is present, so a custom operation
+        // addressed by `:id` (cardinality "one", same as updateOne/patchOne)
+        // can identify its target instead of losing it. createOne never
+        // carries an id, so this falls through to the body alone there.
+        const body = deserializer.deserialize(request.body, dto, context);
+        return request.id === null ? body : { id: this.coerceId(request.id), body };
+      }
     }
   }
 

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -151,6 +151,30 @@ describe("CrudEngine pipeline (Phase 7)", () => {
     expect(response.item).toEqual({ id: 7, status: "active" });
   });
 
+  it("forwards the request id to a custom operation alongside its body, when the route carries one", async () => {
+    const seen: unknown[] = [];
+    const { crud } = makeCrud({
+      customOperations: {
+        activate: {
+          handler: {
+            async execute(input: unknown) {
+              seen.push(input);
+              return null;
+            },
+          },
+        },
+      },
+    } as never);
+
+    await crud.engine.execute({ operation: "activate", id: 7, body: { name: "go" }, query: null, options: null });
+    expect(seen).toEqual([{ id: 7, body: { name: "go" } }]);
+
+    // An id-less custom operation still receives the plain body, unchanged.
+    seen.length = 0;
+    await crud.engine.execute({ operation: "activate", id: null, body: { name: "go" }, query: null, options: null });
+    expect(seen).toEqual([{ name: "go" }]);
+  });
+
   it("maps NotFound into a problem-details document", async () => {
     const { crud } = makeCrud();
     try {

--- a/packages/core/tests/operation-overrides.spec.ts
+++ b/packages/core/tests/operation-overrides.spec.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import type { CrudContext, EntityId, NormalizedQueryContext, RepositoryAdapter } from "@kavo/core";
+import { createKavo } from "@kavo/core";
+import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
+
+/**
+ * Counts calls per adapter method, delegating actual persistence to the
+ * shared in-memory fixture — the seam this suite watches to prove an
+ * override *replaces* the built-in handler rather than merely running
+ * alongside it (issue #21: overriding all five singular standard
+ * operations, plus a custom operation, on one entity).
+ */
+class CountingUserAdapter implements RepositoryAdapter<User> {
+  readonly calls: Record<keyof RepositoryAdapter<User>, number> = {
+    findOneById: 0,
+    findOne: 0,
+    findMany: 0,
+    count: 0,
+    create: 0,
+    update: 0,
+    patch: 0,
+    delete: 0,
+    restore: 0,
+    purge: 0,
+  };
+
+  constructor(private readonly inner: InMemoryUserAdapter = new InMemoryUserAdapter()) {}
+
+  async findOneById(
+    id: EntityId,
+    _query: NormalizedQueryContext<User> | null,
+    _context: CrudContext<User>,
+  ): Promise<User | null> {
+    this.calls.findOneById++;
+    return this.inner.findOneById(id);
+  }
+
+  async findOne(query: NormalizedQueryContext<User>, _context: CrudContext<User>): Promise<User | null> {
+    this.calls.findOne++;
+    return this.inner.findOne(query);
+  }
+
+  async findMany(query: NormalizedQueryContext<User>, _context: CrudContext<User>): Promise<readonly User[]> {
+    this.calls.findMany++;
+    return this.inner.findMany(query);
+  }
+
+  async count(query: NormalizedQueryContext<User>, _context: CrudContext<User>): Promise<number> {
+    this.calls.count++;
+    return this.inner.count(query);
+  }
+
+  async create(data: Partial<User>, _context: CrudContext<User>): Promise<User> {
+    this.calls.create++;
+    return this.inner.create(data);
+  }
+
+  async update(id: EntityId, data: Partial<User>, _context: CrudContext<User>): Promise<User> {
+    this.calls.update++;
+    return this.inner.update(id, data);
+  }
+
+  async patch(id: EntityId, data: Partial<User>, _context: CrudContext<User>): Promise<User> {
+    this.calls.patch++;
+    return this.inner.patch(id, data);
+  }
+
+  async delete(id: EntityId, _context: CrudContext<User>): Promise<void> {
+    this.calls.delete++;
+    await this.inner.delete(id);
+  }
+
+  async restore(id: EntityId, _context: CrudContext<User>): Promise<User> {
+    this.calls.restore++;
+    return this.inner.restore();
+  }
+
+  async purge(id: EntityId, _context: CrudContext<User>): Promise<void> {
+    this.calls.purge++;
+    await this.inner.purge(id);
+  }
+}
+
+function makeCrud(config: Parameters<ReturnType<typeof createKavo>["createCrud"]>[1]) {
+  const adapter = new CountingUserAdapter();
+  const crud = createKavo().createCrud(User, config as never, { adapter, metadata: userMetadata });
+  return { crud, adapter };
+}
+
+const ADA = { name: "Ada", email: "ada@example.com", age: 36, status: "active" as const };
+
+describe("EntityConfig.operations — overriding every singular standard operation at once (issue #21)", () => {
+  it("replaces createOne: the override runs, the built-in adapter.create never does", async () => {
+    const sentinel = Object.assign(new User(), { id: 999, name: "from override" });
+    const { crud, adapter } = makeCrud({
+      operations: {
+        createOne: {
+          handler: {
+            async execute() {
+              return sentinel;
+            },
+          },
+        },
+      },
+    });
+
+    const result = await crud.createOne(ADA as never);
+    expect(result).toMatchObject({ id: 999, name: "from override" });
+    expect(adapter.calls.create).toBe(0);
+  });
+
+  it("replaces findOne: the override runs, the built-in adapter.findOneById never does", async () => {
+    const sentinel = Object.assign(new User(), { id: 5, name: "found by override" });
+    const { crud, adapter } = makeCrud({
+      operations: {
+        findOne: {
+          handler: {
+            async execute() {
+              return sentinel;
+            },
+          },
+        },
+      },
+    });
+
+    const result = await crud.findOne(5);
+    expect(result).toMatchObject({ id: 5, name: "found by override" });
+    expect(adapter.calls.findOneById).toBe(0);
+  });
+
+  it("replaces updateOne: the override runs, the built-in adapter.update never does", async () => {
+    const sentinel = Object.assign(new User(), { id: 1, name: "updated by override" });
+    const { crud, adapter } = makeCrud({
+      operations: {
+        updateOne: {
+          handler: {
+            async execute() {
+              return sentinel;
+            },
+          },
+        },
+      },
+    });
+
+    const result = await crud.updateOne(1, { name: "ignored" } as never);
+    expect(result).toMatchObject({ id: 1, name: "updated by override" });
+    expect(adapter.calls.update).toBe(0);
+  });
+
+  it("replaces patchOne: the override runs, the built-in adapter.patch never does", async () => {
+    const sentinel = Object.assign(new User(), { id: 1, name: "patched by override" });
+    const { crud, adapter } = makeCrud({
+      operations: {
+        patchOne: {
+          handler: {
+            async execute() {
+              return sentinel;
+            },
+          },
+        },
+      },
+    });
+
+    const result = await crud.patchOne(1, { name: "ignored" } as never);
+    expect(result).toMatchObject({ id: 1, name: "patched by override" });
+    expect(adapter.calls.patch).toBe(0);
+  });
+
+  it("replaces deleteOne: the override runs, the built-in adapter.delete never does", async () => {
+    let ran = false;
+    const { crud, adapter } = makeCrud({
+      operations: {
+        deleteOne: {
+          handler: {
+            async execute() {
+              ran = true;
+              return null;
+            },
+          },
+        },
+      },
+    });
+
+    await crud.deleteOne(1);
+    expect(ran).toBe(true);
+    expect(adapter.calls.delete).toBe(0);
+  });
+
+  it("overrides all five singular standard operations and adds a custom operation on one entity", async () => {
+    const calls: string[] = [];
+    const overrideHandler = (id: string) => ({
+      async execute() {
+        calls.push(id);
+        return Object.assign(new User(), { id: 1, name: id });
+      },
+    });
+
+    const { crud, adapter } = makeCrud({
+      operations: {
+        createOne: { handler: overrideHandler("createOne") },
+        findOne: { handler: overrideHandler("findOne") },
+        updateOne: { handler: overrideHandler("updateOne") },
+        patchOne: { handler: overrideHandler("patchOne") },
+        deleteOne: {
+          handler: {
+            async execute() {
+              calls.push("deleteOne");
+              return null;
+            },
+          },
+        },
+      },
+      customOperations: {
+        reindex: {
+          handler: {
+            async execute() {
+              calls.push("reindex");
+              return null;
+            },
+          },
+        },
+      },
+    });
+
+    await crud.createOne(ADA as never);
+    await crud.findOne(1);
+    await crud.updateOne(1, {} as never);
+    await crud.patchOne(1, {} as never);
+    await crud.deleteOne(1);
+    await crud.engine.execute({ operation: "reindex", id: null, body: {}, query: null, options: null });
+
+    expect(calls).toEqual(["createOne", "findOne", "updateOne", "patchOne", "deleteOne", "reindex"]);
+    // None of the overridden built-ins ever touched the adapter — the
+    // registry dispatched straight to the replacement handlers (ADR-0006).
+    expect(adapter.calls).toMatchObject({ create: 0, findOneById: 0, update: 0, patch: 0, delete: 0 });
+    // findMany was never overridden or called — the control surface only
+    // replaced what this config named.
+    expect(adapter.calls.findMany).toBe(0);
+  });
+});

--- a/packages/docs/architecture/07-crud-engine.md
+++ b/packages/docs/architecture/07-crud-engine.md
@@ -26,6 +26,12 @@ Deliberately lean: no validation stage, no hooks, no policy stage — the
 v6 tradeoff. Cross-cutting behavior lives in the consumer's own code
 around Kavo.
 
+`createOne` and custom operations share one input-resolution branch: the
+deserialized body alone when the request carries no id, or `{ id, body }`
+when it does (a custom operation addressed by `:id` — cardinality `"one"`,
+same as `updateOne`/`patchOne` — needs the id to identify its target, and
+`request.id` is simply absent for `createOne`).
+
 ## 2. `CrudContext` contents
 
 Entity + operation identity, the resolved config view (with per-call

--- a/packages/examples/src/address/address.controller.ts
+++ b/packages/examples/src/address/address.controller.ts
@@ -1,12 +1,94 @@
 import { Controller } from "@nestjs/common";
 import { Crud } from "@kavo/nest";
+import type { EntityId, IdentifiedWrite, OperationHandler } from "@kavo/core";
+import { NotFoundException } from "@kavo/core";
 import { Address } from "./address.entity.js";
 import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
+import { addressRuntime, assertValidPostalCode, clearOwnerAddress, normalizePostalCode } from "./address.runtime.js";
+
+function notFound(id: EntityId): never {
+  throw new NotFoundException({ messageParams: { entity: "Address", id: String(id) } });
+}
+
+/** `createOne` override: normalizes `postalCode` before persisting. */
+const createOne: OperationHandler<Address, Partial<Address>> = {
+  async execute(data, context) {
+    const postalCode = normalizePostalCode(data.postalCode ?? "");
+    assertValidPostalCode(postalCode);
+    return addressRuntime().adapter.create({ ...data, postalCode }, context);
+  },
+};
+
+/** `updateOne` override: PUT sends the whole shape, so `postalCode` is always validated. */
+const updateOne: OperationHandler<Address, IdentifiedWrite<Address>> = {
+  async execute({ id, data }, context) {
+    const patch = { ...data };
+    if (patch.postalCode !== undefined) {
+      patch.postalCode = normalizePostalCode(patch.postalCode);
+      assertValidPostalCode(patch.postalCode);
+    }
+    return addressRuntime().adapter.update(id, patch, context);
+  },
+};
+
+/** `patchOne` override: same validation, but only when the field is actually present. */
+const patchOne: OperationHandler<Address, IdentifiedWrite<Address>> = {
+  async execute({ id, data }, context) {
+    const patch = { ...data };
+    if (patch.postalCode !== undefined) {
+      patch.postalCode = normalizePostalCode(patch.postalCode);
+      assertValidPostalCode(patch.postalCode);
+    }
+    return addressRuntime().adapter.patch(id, patch, context);
+  },
+};
 
 /**
- * Plain CRUD over `Address`. Owners associate an address by id
- * (`{"address": 1}` on `POST /owners` — ADR-0014); this route is how one
- * gets created in the first place.
+ * `deleteOne` override: `Owner` owns the join column, so the address's
+ * inverse relation can't clear it itself — the owner referencing this row
+ * is detached before the address is removed.
+ */
+const deleteOne: OperationHandler<Address, EntityId> = {
+  async execute(id, context) {
+    const { adapter, dataSource } = addressRuntime();
+    await clearOwnerAddress(dataSource, Number(id));
+    await adapter.delete(id, context);
+    return null;
+  },
+};
+
+/** `findOne` override: augments the response with a derived, unpersisted field. */
+const findOne: OperationHandler<Address, EntityId> = {
+  async execute(id, context) {
+    const { adapter } = addressRuntime();
+    const address = await adapter.findOneById(id, context.query, context);
+    if (address === null) notFound(id);
+    return { ...address, formattedAddress: `${address.street}, ${address.city} ${address.postalCode}` };
+  },
+};
+
+/**
+ * Custom operation: `POST /addresses/:id/normalize-postal-code` reuses the
+ * same normalization/validation as the `createOne`/`updateOne` overrides,
+ * applied to an already-persisted row.
+ */
+const normalizePostalCodeOperation: OperationHandler<Address, { id: EntityId }> = {
+  async execute({ id }, context) {
+    const { adapter } = addressRuntime();
+    const existing = await adapter.findOneById(id, null, context);
+    if (existing === null) notFound(id);
+    const postalCode = normalizePostalCode(existing.postalCode);
+    assertValidPostalCode(postalCode);
+    return adapter.update(id, { postalCode }, context);
+  },
+};
+
+/**
+ * `Address` overrides all five singular standard operations and adds one
+ * custom operation, all through `EntityConfig` — registry-driven per
+ * ADR-0006, with zero special-casing in the engine or route generator
+ * (issue #21). Owners still associate an address by id
+ * (`{"address": 1}` on `POST /owners` — ADR-0014).
  */
 @Crud(Address, {
   dto: {
@@ -14,6 +96,19 @@ import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } fr
     update: UpdateAddressDto,
     item: AddressItemDto,
     list: AddressListDto,
+  },
+  operations: {
+    createOne: { handler: createOne },
+    updateOne: { handler: updateOne },
+    patchOne: { handler: patchOne },
+    deleteOne: { handler: deleteOne },
+    findOne: { handler: findOne },
+  },
+  customOperations: {
+    normalizePostalCode: {
+      handler: normalizePostalCodeOperation,
+      meta: { routes: { method: "POST", path: ":id/normalize-postal-code" } },
+    },
   },
 })
 @Controller("addresses")

--- a/packages/examples/src/address/address.dtos.ts
+++ b/packages/examples/src/address/address.dtos.ts
@@ -23,6 +23,8 @@ export class AddressItemDto {
   street = "";
   city = "";
   postalCode = "";
+  /** Derived by the `findOne` override — never a persisted column. */
+  formattedAddress = "";
 }
 
 /** `list` slot — a leaner projection for list responses. */

--- a/packages/examples/src/address/address.runtime.ts
+++ b/packages/examples/src/address/address.runtime.ts
@@ -1,0 +1,63 @@
+import type { DataSource } from "typeorm";
+import type { RepositoryAdapter } from "@kavo/core";
+import { QueryValidationException } from "@kavo/core";
+import type { Address } from "./address.entity.js";
+import { Owner } from "../owner/owner.entity.js";
+
+const POSTAL_CODE_PATTERN = /^\d{5}$/;
+
+/** Reused by the `createOne`/`updateOne` overrides and the custom route alike. */
+export function normalizePostalCode(raw: string): string {
+  return raw.trim();
+}
+
+export function assertValidPostalCode(value: string): void {
+  if (!POSTAL_CODE_PATTERN.test(value)) {
+    throw QueryValidationException.single({
+      field: "postalCode",
+      code: "KAVO_QUERY_INVALID_VALUE",
+      detail: `postalCode must be exactly 5 digits, got "${value}"`,
+    });
+  }
+}
+
+export interface AddressRuntime {
+  readonly adapter: RepositoryAdapter<Address>;
+  readonly dataSource: DataSource;
+}
+
+let runtime: AddressRuntime | null = null;
+
+/**
+ * `@Crud`'s operation overrides are captured at class-decoration time
+ * (ADR-0012) — module import, before `KavoModule.forRootAsync`'s factory
+ * ever builds the `DataSource` — so `address.controller.ts`'s handler
+ * literals cannot close over a ready adapter when they are written. Each
+ * handler instead calls `addressRuntime()` at request time, long after
+ * `app.module.ts` has called this once the real infrastructure exists.
+ */
+export function bindAddressRuntime(next: AddressRuntime): void {
+  runtime = next;
+}
+
+export function addressRuntime(): AddressRuntime {
+  if (runtime === null) {
+    throw new Error("Address runtime not bound — call bindAddressRuntime() during app bootstrap");
+  }
+  return runtime;
+}
+
+/**
+ * `Owner` owns the join column (`owner.entity.ts`), so clearing it before
+ * an address is deleted is a cross-entity write `RepositoryAdapter<Address>`
+ * has no way to perform — the `deleteOne` override reaches for the raw
+ * `DataSource` deliberately, not as a pattern that belongs in `@kavo/typeorm`.
+ */
+export async function clearOwnerAddress(dataSource: DataSource, addressId: number): Promise<void> {
+  const ownerRepository = dataSource.getRepository(Owner);
+  const owner = await ownerRepository.findOne({ where: { address: { id: addressId } } });
+  if (owner !== null) {
+    owner.address = null;
+    await ownerRepository.save(owner);
+  }
+}

--- a/packages/examples/src/app.module.ts
+++ b/packages/examples/src/app.module.ts
@@ -8,6 +8,8 @@ import { CatController } from "./cat/cat.controller.js";
 import { DogController } from "./dog/dog.controller.js";
 import { TagController } from "./tag/tag.controller.js";
 import { AddressController } from "./address/address.controller.js";
+import { Address } from "./address/address.entity.js";
+import { bindAddressRuntime } from "./address/address.runtime.js";
 
 /**
  * Reference wiring: the app hands `@kavo/nest` its infrastructure (here
@@ -19,13 +21,20 @@ import { AddressController } from "./address/address.controller.js";
     KavoModule.forRootAsync({
       imports: [DatabaseModule],
       inject: [DATA_SOURCE] as never[],
-      useFactory: (dataSource: DataSource) => ({
-        infrastructure: createTypeOrmInfrastructure(dataSource),
-        defaults: {
-          pagination: { defaultLimit: 20, maxLimit: 100 },
-          errors: { exposeInternals: false },
-        },
-      }),
+      useFactory: (dataSource: DataSource) => {
+        const infrastructure = createTypeOrmInfrastructure(dataSource);
+        // Address's operation overrides are captured at decoration time
+        // (ADR-0012), before this factory ever runs — bind the adapter they
+        // need now that it exists (see address.runtime.ts).
+        bindAddressRuntime({ adapter: infrastructure.adapterFor(Address), dataSource });
+        return {
+          infrastructure,
+          defaults: {
+            pagination: { defaultLimit: 20, maxLimit: 100 },
+            errors: { exposeInternals: false },
+          },
+        };
+      },
     }),
     KavoModule.forFeature([OwnerController, CatController, DogController, TagController, AddressController]),
   ],

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -4,7 +4,10 @@ import request from "supertest";
 import type { INestApplication } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { Test } from "@nestjs/testing";
+import type { DataSource } from "typeorm";
 import { AppModule } from "../src/app.module.js";
+import { DATA_SOURCE } from "../src/database.module.js";
+import { Address } from "../src/address/address.entity.js";
 
 /**
  * The Pet example served by the real stack — generated Nest routes →
@@ -684,14 +687,32 @@ describe("Address operation overrides (issue #21)", () => {
     expect(fetched.body.formattedAddress).toBe("1 Elm St, Springfield 10001");
   });
 
-  it("reuses the shared normalization logic on the custom normalize-postal-code route", async () => {
+  it("corrects a dirty postalCode via the custom route", async () => {
     const created = await request(server())
       .post("/addresses")
       .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
       .expect(201);
     const id = created.body.id as number;
 
+    // Every write path through the API already normalizes on the way in
+    // (createOne/updateOne/patchOne), so the only way to observe the
+    // custom route's own normalization actually doing something is to
+    // seed a dirty value directly, bypassing the controller entirely.
+    const dataSource = app.get<DataSource>(DATA_SOURCE);
+    await dataSource.getRepository(Address).update(id, { postalCode: " 20002 " });
+
     const response = await request(server()).post(`/addresses/${id}/normalize-postal-code`).expect(201);
-    expect(response.body.postalCode).toBe("10001");
+    expect(response.body.postalCode).toBe("20002");
+
+    const fetched = await request(server()).get(`/addresses/${id}`).expect(200);
+    expect(fetched.body.postalCode).toBe("20002");
+  });
+
+  it("404s when normalizing a nonexistent address", async () => {
+    const response = await request(server())
+      .post("/addresses/999999/normalize-postal-code")
+      .expect(404)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body.code).toBe("KAVO_NOT_FOUND");
   });
 });

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -377,21 +377,24 @@ describe("Pet example app", () => {
     expect(updateConflict.body.code).toBe("KAVO_CONFLICT");
   });
 
-  it("refuses to delete an address still referenced by an owner (409, not a silent null or cascade)", async () => {
+  it("clears the owning relation before deleting a referenced address (issue #21 deleteOne override)", async () => {
+    // Address's `deleteOne` is overridden (issue #21) to detach the owner's
+    // side of the join column first, rather than leaving the FK constraint
+    // to refuse the delete outright.
     const address = await request(server())
       .post("/addresses")
       .send({ street: "1 Referenced Ln", city: "Bindingtown", postalCode: "60006" })
       .expect(201);
-    await request(server())
+    const owner = await request(server())
       .post("/owners")
       .send({ name: "Tara", email: "tara@x.io", address: address.body.id })
       .expect(201);
 
-    const conflict = await request(server())
-      .delete(`/addresses/${address.body.id}`)
-      .expect(409)
-      .expect("Content-Type", /application\/problem\+json/);
-    expect(conflict.body.code).toBe("KAVO_CONFLICT");
+    await request(server()).delete(`/addresses/${address.body.id}`).expect(204);
+    await request(server()).get(`/addresses/${address.body.id}`).expect(404);
+
+    const detached = await request(server()).get(`/owners/${owner.body.id}?include=address`).expect(200);
+    expect(detached.body.address).toBeNull();
   });
 
   it("documents include=address and fields[address] in the OpenAPI schema", () => {
@@ -600,5 +603,95 @@ describe("Pet example app", () => {
     const pets = ownerItem?.properties?.pets;
     expect(pets?.type).toBe("array");
     expect(pets?.items?.oneOf?.map((variant) => variant.title)).toEqual(["CatItemDto", "DogItemDto"]);
+  });
+});
+
+/**
+ * `Address` overrides all five singular standard operations and adds one
+ * custom operation, entirely through `EntityConfig` (issue #21) — the
+ * example the `add-operation` skill's documented procedure was missing.
+ */
+describe("Address operation overrides (issue #21)", () => {
+  it("normalizes postalCode on create", async () => {
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: " 10001 " })
+      .expect(201);
+    expect(created.body.postalCode).toBe("10001");
+  });
+
+  it("rejects a malformed postalCode on create as a problem-details 400", async () => {
+    const response = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "abc" })
+      .expect(400)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body.errors).toEqual([
+      expect.objectContaining({ field: "postalCode", code: "KAVO_QUERY_INVALID_VALUE" }),
+    ]);
+  });
+
+  it("rejects a malformed postalCode on update, leaving the row unchanged", async () => {
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
+      .expect(201);
+    const id = created.body.id as number;
+
+    await request(server())
+      .put(`/addresses/${id}`)
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "bad" })
+      .expect(400)
+      .expect("Content-Type", /application\/problem\+json/);
+
+    const unchanged = await request(server()).get(`/addresses/${id}`).expect(200);
+    expect(unchanged.body.postalCode).toBe("10001");
+  });
+
+  it("is partial-field aware on patch: omitting postalCode never triggers validation", async () => {
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
+      .expect(201);
+    const id = created.body.id as number;
+
+    const patched = await request(server()).patch(`/addresses/${id}`).send({ city: "Shelbyville" }).expect(200);
+    expect(patched.body).toMatchObject({ city: "Shelbyville", postalCode: "10001" });
+  });
+
+  it("rejects a malformed postalCode on patch too, when the field is present", async () => {
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
+      .expect(201);
+    const id = created.body.id as number;
+
+    await request(server())
+      .patch(`/addresses/${id}`)
+      .send({ postalCode: "nope" })
+      .expect(400)
+      .expect("Content-Type", /application\/problem\+json/);
+  });
+
+  it("augments findOne with a derived formattedAddress field", async () => {
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
+      .expect(201);
+    const id = created.body.id as number;
+
+    const fetched = await request(server()).get(`/addresses/${id}`).expect(200);
+    expect(fetched.body.formattedAddress).toBe("1 Elm St, Springfield 10001");
+  });
+
+  it("reuses the shared normalization logic on the custom normalize-postal-code route", async () => {
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
+      .expect(201);
+    const id = created.body.id as number;
+
+    const response = await request(server()).post(`/addresses/${id}/normalize-postal-code`).expect(201);
+    expect(response.body.postalCode).toBe("10001");
   });
 });

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -278,10 +278,11 @@ describe("@Crud operation control surface", () => {
 
   it("generates routes for custom operations from meta.routes", async () => {
     const activate: OperationHandler<Todo> = {
-      async execute(_input, context) {
-        const service = context.state; // unused; handler works via adapter rows
-        void service;
-        const row = adapter.rows.find((r) => r.id === 1);
+      async execute(input) {
+        // Custom operations addressed by `:id` receive it alongside the
+        // deserialized body — the same id the route's `:id` segment named.
+        const { id } = input as { id: number };
+        const row = adapter.rows.find((r) => r.id === id);
         if (row !== undefined) row.done = true;
         return row ?? null;
       },
@@ -312,6 +313,77 @@ describe("@Crud operation control surface", () => {
     expect(response.body).toMatchObject({ id: 1, done: true });
     // Service-only: no route.
     await request(server()).post("/todos/recalculate").expect(404);
+  });
+
+  it("overrides all five singular standard operations and adds a custom operation, alongside manual-method-wins and a disabled operation (issue #21)", async () => {
+    const seen: string[] = [];
+    const overrideHandler = (id: string): OperationHandler<Todo> => ({
+      async execute() {
+        seen.push(id);
+        return { id: 1, title: id, done: false, priority: 0, deletedAt: null, list: null };
+      },
+    });
+
+    @Crud(Todo, {
+      operations: {
+        createOne: { handler: overrideHandler("createOne") },
+        updateOne: { handler: overrideHandler("updateOne") },
+        patchOne: { handler: overrideHandler("patchOne") },
+        deleteOne: {
+          handler: {
+            async execute() {
+              seen.push("deleteOne");
+              return null;
+            },
+          },
+        },
+        // Disabled alongside a full override set — a control surface that
+        // otherwise touches every id must not confuse the disable path.
+        findMany: false,
+      },
+      customOperations: {
+        summarize: {
+          handler: {
+            async execute() {
+              seen.push("summarize");
+              return null;
+            },
+          },
+          meta: { routes: { method: "POST", path: "summarize" } },
+        },
+      },
+    })
+    @Controller("todos")
+    class FullOverrideController {
+      // Manual-method-wins over the findOne override too: the two
+      // mechanisms are independent and must coexist without conflict.
+      @Get(":id")
+      findOne(): { manual: boolean } {
+        return { manual: true };
+      }
+    }
+
+    await bootstrap(FullOverrideController);
+
+    const created = await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    expect(created.body).toMatchObject({ title: "createOne" });
+
+    const found = await request(server()).get("/todos/1").expect(200);
+    expect(found.body).toEqual({ manual: true });
+
+    const updated = await request(server()).put("/todos/1").send({ title: "y" }).expect(200);
+    expect(updated.body).toMatchObject({ title: "updateOne" });
+
+    const patched = await request(server()).patch("/todos/1").send({ title: "z" }).expect(200);
+    expect(patched.body).toMatchObject({ title: "patchOne" });
+
+    await request(server()).delete("/todos/1").expect(204);
+    await request(server()).post("/todos/summarize").expect(201);
+
+    // Disabled alongside five overrides and a custom op: still no route.
+    await request(server()).get("/todos").expect(404);
+
+    expect(seen).toEqual(["createOne", "updateOne", "patchOne", "deleteOne", "summarize"]);
   });
 });
 


### PR DESCRIPTION
## What & why

`Address` (`packages/examples/src/address/`) was plain CRUD with no `operations`/`customOperations` config — no example entity demonstrated overriding a full set of standard verbs, or combined an override with a custom operation. This closes that gap: `AddressController` now overrides all five singular standard operations (`createOne`, `updateOne`, `patchOne`, `deleteOne`, `findOne`) via `EntityConfig.operations`, and adds one custom operation (`normalizePostalCode`, `POST /addresses/:id/normalize-postal-code`) via `customOperations` — entirely registry-driven (ADR-0006), with zero special-casing in the engine or route generator.

While wiring the custom route, found and fixed a real gap in `CrudEngine.resolveInput` (`packages/core/src/engine/crud-engine.ts`): custom operations previously discarded `request.id` entirely, so an id-bearing custom-operation route had no way to know which row to act on (the one pre-existing example, `activate` in the nest binding tests, papered over this by hardcoding row id `1`). The `default` branch now returns `{ id, body }` when an id is present, `body` alone otherwise — additive, since no existing id-bearing custom operation could have worked correctly before.

`deleteOne`'s override also clears the owning side of the `Owner`↔`Address` relation before removing the row (`Owner` owns the join column), which deliberately supersedes the old behavior where deleting a referenced address returned a 409 conflict — the existing test asserting that was rewritten to match the new intended behavior.

Closes #21

## Public API impact

None to `packages/core/src/index.ts` (barrel untouched, verified by the boundary-guard review). `AddressItemDto` gains one additive field (`formattedAddress`), scoped to the example package. The `CrudEngine.resolveInput` change to custom-operation input shape is a bugfix, not a breaking change — no existing custom operation could have relied on `request.id` being silently dropped.

## Testing

- `packages/core/tests/operation-overrides.spec.ts` (new): proves each of the five overrides replaces the built-in adapter call rather than running alongside it, plus a combined 5-override + custom-op dispatch test.
- `packages/core/tests/engine.spec.ts`: regression test for the `resolveInput` id-forwarding fix (id-present and id-absent cases).
- `packages/frameworks/nest/tests/binding.e2e.spec.ts`: the `activate` custom-op test now uses the forwarded id instead of a hardcoded row; new test overrides all five standard ops + one custom op + a disabled op + a manual-method-wins method on one entity, proving they all coexist.
- `packages/examples/tests/app.e2e.spec.ts`: full HTTP/TypeORM/SQLite coverage — normalization/validation on create/update/patch, the `deleteOne` relation-clearing behavior, `findOne`'s derived field, and the custom route (including a seeded-dirty-data case that actually exercises normalization, not just pass-through, plus its 404 path).

Verified `pnpm check`: build, typecheck, `depcruise` (147 modules, 541 dependencies, no violations), and all 475 tests green.

## Review notes

This branch went through `/review` (kavo-reviewer, kavo-boundary-guard, kavo-test-auditor in parallel). Boundary/ADR audit came back fully clean. Two findings were fixed before this PR: the custom route's normalization test only proved pass-through (now seeds dirty data via a direct repository write to actually exercise the handler), and the custom route's 404 path was untested (now covered).

Left open, non-blocking:
- `deleteOne`'s two writes (clearing the owner relation, then deleting) aren't wrapped in a transaction — a driver failure between them could leave a partial-commit state. The framework has no cross-cutting transaction system yet, and the resulting state (an address with no owner) isn't itself invalid data.
- `assertValidPostalCode` reuses `QueryValidationException`/`KAVO_QUERY_INVALID_VALUE`, which core documents as query-string grammar validation, for a request-body rule. Wire shape is correct (400, field-level `errors[]`); this was a deliberate tradeoff discussed during planning rather than adding a new exception/catalog entry for this issue.