### PR TITLE
feat(nest): support controller-method overrides via @Override

### DIFF
--- a/.claude/skills/add-operation/SKILL.md
+++ b/.claude/skills/add-operation/SKILL.md
@@ -11,19 +11,66 @@ registry entry** (ADR-0006). The engine loops over registry entries and
 your change needs a new `if` in the engine or in the route generator, the design
 is wrong — stop and reconsider.
 
-## Decide which of the three you are doing
+## Decide which of the four you are doing
 
-All three are the same mechanism (`EntityConfig` in
-`packages/core/src/config/entity-config.ts`):
+The first three are the same mechanism (`EntityConfig` in
+`packages/core/src/config/entity-config.ts`); the fourth is `@kavo/nest`-only
+and doesn't touch `EntityConfig` at all:
 
-| Intent                            | How                                                                                                                                                                          |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Disable** a standard operation  | `operations: { deleteOne: false }` — the entry stays in the registry so tooling can report it, but calling it raises `OperationDisabledException` and no route is generated. |
-| **Override** a standard operation | `operations: { findOne: { handler } }` — replaces the handler, keeps the default DTO and serialization scaffolding.                                                          |
-| **Add a custom** operation        | `customOperations: { complete: { handler, input, output, meta } }` — declares its own input/output DTOs, because its shape is not guaranteed CRUD-like.                      |
+| Intent                                   | How                                                                                                                                                                          |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Disable** a standard operation         | `operations: { deleteOne: false }` — the entry stays in the registry so tooling can report it, but calling it raises `OperationDisabledException` and no route is generated. |
+| **Override** a standard operation (data) | `operations: { findOne: { handler } }` — a plain `OperationHandler` object replaces the handler; keeps the default DTO and serialization scaffolding.                        |
+| **Add a custom** operation               | `customOperations: { complete: { handler, input, output, meta } }` — declares its own input/output DTOs, because its shape is not guaranteed CRUD-like.                      |
+| **Override** a standard operation (code) | `@Override(operationId?)` (issue #23) — a controller method is the implementation; `@Crud` still generates the route from the registry. See below.                           |
 
 Standard operations that are off by default (`purgeOne`, `restoreOne`) are
 turned on with `operations: { purgeOne: true }`.
+
+## `@Override`: a controller method instead of a handler object
+
+`operations.<id>.handler` and `@Override` both replace a standard
+operation's behavior; they differ in _where_ the replacement lives and what
+it can reach:
+
+- `operations.<id>.handler` is a plain `OperationHandler` object — no `this`,
+  no DI, just `execute(input, context)`. Use it when the override is pure
+  logic against the adapter/context Kavo already hands you.
+- `@Override` is a real controller method, decorated so `@Crud` still emits
+  that operation's route (method, path, status, params, Swagger) — only the
+  function backing the route changes. Use it when the override needs
+  constructor-injected dependencies (most commonly the entity's own
+  `DefaultCrudService`, via `getCrudServiceToken`, to delegate to default
+  behavior — `this.base.createOne(dto)`), or reads more naturally as a method
+  than a config value.
+
+```ts
+@Crud(Address)
+@Controller("addresses")
+class AddressController {
+  constructor(@Inject(getCrudServiceToken(Address)) private readonly base: DefaultCrudService<Address>) {}
+
+  @Override()
+  async createOne(dto: CreateAddressDto): Promise<AddressItemDto> {
+    return this.base.createOne({ ...dto, postalCode: normalize(dto.postalCode) });
+  }
+}
+```
+
+Constraints, because `@Crud` still owns the route:
+
+- `operationId` defaults to the method's own name (same inference
+  manual-method-wins uses); pass it explicitly when the method name differs.
+- The method's parameters must be in the same fixed position a generated
+  route would use — reads: `(id?, query)`; writes: `(id?, body)` — and must
+  **not** carry their own `@Param`/`@Query`/`@Body`. `@Crud` applies those
+  itself; a method that also declares its own throws at decoration time.
+- Overriding an operation that's absent, disabled, or service-only
+  (`meta.routes.enabled: false`) throws at decoration time too — there is no
+  route for `@Override` to attach to.
+- Distinct from plain manual-method-wins (an _undecorated_ method whose name
+  happens to match an operation id): that suppresses the route entirely, with
+  none of `@Crud`'s wiring applied. `@Override` keeps all of it.
 
 ## The descriptor
 
@@ -59,6 +106,8 @@ meta: {
   router scan sees the methods. Nothing may defer registration.
 - **Manual-method-wins**: a hand-written controller method whose name matches an
   operation id suppresses the generated route.
+- **`@Override`**: the same route still generates, backed by the decorated
+  method instead — see above.
 
 ## Naming (normative — get this right the first time)
 
@@ -96,6 +145,9 @@ Follow the `write-tests` skill, and cover at minimum:
 - the registry reports the entry via `all()` whether enabled or not;
 - the generated route exists with the expected method and path, and is absent
   when disabled or `meta.routes.enabled: false`;
-- manual-method-wins suppression, if a controller method could collide.
+- manual-method-wins suppression, if a controller method could collide;
+- for `@Override`: the route/param/Swagger shape matches what generation would
+  produce, and the decoration-time errors (duplicate target, absent/disabled/
+  service-only target, a method with its own `@Param`/`@Body`) all fire.
 
 Finish with `pnpm check`.

--- a/.claude/skills/add-operation/SKILL.md
+++ b/.claude/skills/add-operation/SKILL.md
@@ -71,6 +71,12 @@ Constraints, because `@Crud` still owns the route:
 - Distinct from plain manual-method-wins (an _undecorated_ method whose name
   happens to match an operation id): that suppresses the route entirely, with
   none of `@Crud`'s wiring applied. `@Override` keeps all of it.
+- **A read override's `query` is Nest's raw `@Query()` object, not
+  normalized.** A generated route always wraps it — `new
+WireQuery(flattenQuery(query))` (`WireQuery` from `@kavo/core`,
+  `flattenQuery` from `@kavo/nest`) — before it reaches
+  `DefaultCrudService`. Skip that and wire-format params (`?fields=`,
+  `?include=`) reach the engine unparsed and 400.
 
 ## The descriptor
 

--- a/packages/docs/architecture/10-nestjs-integration.md
+++ b/packages/docs/architecture/10-nestjs-integration.md
@@ -62,6 +62,41 @@ precisely because decoration time has no ORM metadata (ADR-0013):
 matches an operation id suppresses that generated route — detected via
 `hasOwnProperty` on the prototype, no config needed.
 
+**`@Override(operationId?)`** (issue #23) is the additive middle path
+between a config-level `operations.<id>.handler` override and plain
+manual-method-wins: the decorated method still gets the registry's route
+— method, path, status, `@Param`/`@Query`/`@Body`, and Swagger metadata,
+identical to what a generated route would carry — only the function
+backing it is the decorated method itself, not `makeHandler`'s generated
+one. `operationId` defaults to the method's own name, the same inference
+manual-method-wins already uses. Resolution order in the `@Crud` loop is
+override map → manual-method-wins → generate, so a decorated method never
+falls through to plain name-matching.
+
+The mechanism needs no core change: `defineRoute`'s two jobs — installing
+a generated function, then applying Nest's real method/param/status
+decorators to whatever sits at that property — split into an
+`applyRouteDecorators` step shared by both paths. For an override, Kavo
+skips installing a function and applies that same step to the existing,
+hand-written method; Nest dispatches to it directly at request time, with
+no engine or `CrudEngine` involvement in the indirection.
+
+The decorated method typically injects the entity's bound
+`DefaultCrudService` via the existing `getCrudServiceToken` (ordinary
+constructor DI on the controller) to delegate to default behavior
+(`this.base.createOne(dto)`), the same "base" pattern config-level
+overrides get through `context` inside a plain `OperationHandler`.
+
+Because Kavo owns the param wiring, the decorated method must accept
+parameters in the same fixed position a generated route would — reads:
+`(id?, query)`; writes: `(id?, body)` — and must not declare its own
+`@Param`/`@Query`/`@Body`: `@Crud` checks for existing Nest route-argument
+metadata on the method and fails at decoration time (ADR-0012's only
+moment) rather than let the two decorations collide silently. The same
+fail-fast rule covers a duplicate override target (two methods claiming
+one operation id) and an override naming an operation id that is absent
+or disabled in the registry — a silent no-op override is a footgun.
+
 Mechanically, generated methods are defined on the prototype and
 decorated by _calling_ Nest's own decorators (`Post(path)(proto, name,
 descriptor)`, `Param("id")(…)`, …) — identical metadata to hand-written

--- a/packages/docs/architecture/10-nestjs-integration.md
+++ b/packages/docs/architecture/10-nestjs-integration.md
@@ -97,6 +97,15 @@ fail-fast rule covers a duplicate override target (two methods claiming
 one operation id) and an override naming an operation id that is absent
 or disabled in the registry — a silent no-op override is a footgun.
 
+**A read override's `query` parameter is Nest's raw `@Query()` object,
+not a normalized one** — a generated route always wraps it in `WireQuery`
+(via `flattenQuery`, see below) before it reaches `DefaultCrudService`,
+because the engine's query stage parses wire-format strings only through
+that wrapper. An override that forwards `query` straight to
+`this.base.findOne(id, query)` sends it down the already-normalized-input
+path instead, and any wire-format param (`?fields=`, `?include=`, …) 400s.
+Wrap it the same way: `new WireQuery(flattenQuery(query as object))`.
+
 Mechanically, generated methods are defined on the prototype and
 decorated by _calling_ Nest's own decorators (`Post(path)(proto, name,
 descriptor)`, `Param("id")(…)`, …) — identical metadata to hand-written

--- a/packages/examples/src/address/address.controller.ts
+++ b/packages/examples/src/address/address.controller.ts
@@ -1,93 +1,22 @@
-import { Controller } from "@nestjs/common";
-import { Crud } from "@kavo/nest";
-import type { EntityId, IdentifiedWrite, OperationHandler } from "@kavo/core";
-import { NotFoundException } from "@kavo/core";
+import { Controller, Inject } from "@nestjs/common";
+import { Crud, Override, getCrudServiceToken } from "@kavo/nest";
+import type { DefaultCrudService, EntityId } from "@kavo/core";
+import type { DataSource } from "typeorm";
 import { Address } from "./address.entity.js";
 import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
-import { addressRuntime, assertValidPostalCode, clearOwnerAddress, normalizePostalCode } from "./address.runtime.js";
-
-function notFound(id: EntityId): never {
-  throw new NotFoundException({ messageParams: { entity: "Address", id: String(id) } });
-}
-
-/** `createOne` override: normalizes `postalCode` before persisting. */
-const createOne: OperationHandler<Address, Partial<Address>> = {
-  async execute(data, context) {
-    const postalCode = normalizePostalCode(data.postalCode ?? "");
-    assertValidPostalCode(postalCode);
-    return addressRuntime().adapter.create({ ...data, postalCode }, context);
-  },
-};
-
-/** `updateOne` override: PUT sends the whole shape, so `postalCode` is always validated. */
-const updateOne: OperationHandler<Address, IdentifiedWrite<Address>> = {
-  async execute({ id, data }, context) {
-    const patch = { ...data };
-    if (patch.postalCode !== undefined) {
-      patch.postalCode = normalizePostalCode(patch.postalCode);
-      assertValidPostalCode(patch.postalCode);
-    }
-    return addressRuntime().adapter.update(id, patch, context);
-  },
-};
-
-/** `patchOne` override: same validation, but only when the field is actually present. */
-const patchOne: OperationHandler<Address, IdentifiedWrite<Address>> = {
-  async execute({ id, data }, context) {
-    const patch = { ...data };
-    if (patch.postalCode !== undefined) {
-      patch.postalCode = normalizePostalCode(patch.postalCode);
-      assertValidPostalCode(patch.postalCode);
-    }
-    return addressRuntime().adapter.patch(id, patch, context);
-  },
-};
-
-/**
- * `deleteOne` override: `Owner` owns the join column, so the address's
- * inverse relation can't clear it itself — the owner referencing this row
- * is detached before the address is removed.
- */
-const deleteOne: OperationHandler<Address, EntityId> = {
-  async execute(id, context) {
-    const { adapter, dataSource } = addressRuntime();
-    await clearOwnerAddress(dataSource, Number(id));
-    await adapter.delete(id, context);
-    return null;
-  },
-};
-
-/** `findOne` override: augments the response with a derived, unpersisted field. */
-const findOne: OperationHandler<Address, EntityId> = {
-  async execute(id, context) {
-    const { adapter } = addressRuntime();
-    const address = await adapter.findOneById(id, context.query, context);
-    if (address === null) notFound(id);
-    return { ...address, formattedAddress: `${address.street}, ${address.city} ${address.postalCode}` };
-  },
-};
-
-/**
- * Custom operation: `POST /addresses/:id/normalize-postal-code` reuses the
- * same normalization/validation as the `createOne`/`updateOne` overrides,
- * applied to an already-persisted row.
- */
-const normalizePostalCodeOperation: OperationHandler<Address, { id: EntityId }> = {
-  async execute({ id }, context) {
-    const { adapter } = addressRuntime();
-    const existing = await adapter.findOneById(id, null, context);
-    if (existing === null) notFound(id);
-    const postalCode = normalizePostalCode(existing.postalCode);
-    assertValidPostalCode(postalCode);
-    return adapter.update(id, { postalCode }, context);
-  },
-};
+import { DATA_SOURCE } from "../database.module.js";
+import { assertValidPostalCode, clearOwnerAddress, normalizePostalCode } from "./address.runtime.js";
 
 /**
  * `Address` overrides all five singular standard operations and adds one
- * custom operation, all through `EntityConfig` — registry-driven per
- * ADR-0006, with zero special-casing in the engine or route generator
- * (issue #21). Owners still associate an address by id
+ * custom operation, each backed by an `@Override`'d controller method
+ * (issue #23) rather than a config-level `operations.<id>.handler` — every
+ * method injects the entity's own `DefaultCrudService` (`base`) to
+ * delegate to default behavior, and the raw `DataSource` for the one write
+ * that reaches across entities. `@Crud` still generates every route's
+ * method, path, status, params, and Swagger metadata from the registry
+ * (ADR-0006, ADR-0012); only the function backing each route is this
+ * class's own method. Owners still associate an address by id
  * (`{"address": 1}` on `POST /owners` — ADR-0014).
  */
 @Crud(Address, {
@@ -97,19 +26,85 @@ const normalizePostalCodeOperation: OperationHandler<Address, { id: EntityId }> 
     item: AddressItemDto,
     list: AddressListDto,
   },
-  operations: {
-    createOne: { handler: createOne },
-    updateOne: { handler: updateOne },
-    patchOne: { handler: patchOne },
-    deleteOne: { handler: deleteOne },
-    findOne: { handler: findOne },
-  },
   customOperations: {
     normalizePostalCode: {
-      handler: normalizePostalCodeOperation,
+      // Required by `CustomOperationConfig`, but never runs — `@Override`
+      // below supplies the real implementation.
+      handler: {
+        async execute() {
+          throw new Error("normalizePostalCode is implemented via @Override — this registry handler must not run");
+        },
+      },
       meta: { routes: { method: "POST", path: ":id/normalize-postal-code" } },
     },
   },
 })
 @Controller("addresses")
-export class AddressController {}
+export class AddressController {
+  constructor(
+    @Inject(getCrudServiceToken(Address)) private readonly base: DefaultCrudService<Address>,
+    @Inject(DATA_SOURCE) private readonly dataSource: DataSource,
+  ) {}
+
+  /** Normalizes `postalCode` before persisting. */
+  @Override()
+  async createOne(dto: Partial<Address>): Promise<unknown> {
+    const postalCode = normalizePostalCode(dto.postalCode ?? "");
+    assertValidPostalCode(postalCode);
+    return this.base.createOne({ ...dto, postalCode } as never);
+  }
+
+  /** PUT sends the whole shape, so `postalCode` is always validated. */
+  @Override()
+  async updateOne(id: EntityId, dto: Partial<Address>): Promise<unknown> {
+    const patch = { ...dto };
+    if (patch.postalCode !== undefined) {
+      patch.postalCode = normalizePostalCode(patch.postalCode);
+      assertValidPostalCode(patch.postalCode);
+    }
+    return this.base.updateOne(id as never, patch as never);
+  }
+
+  /** Same validation as `updateOne`, but only when the field is actually present. */
+  @Override()
+  async patchOne(id: EntityId, dto: Partial<Address>): Promise<unknown> {
+    const patch = { ...dto };
+    if (patch.postalCode !== undefined) {
+      patch.postalCode = normalizePostalCode(patch.postalCode);
+      assertValidPostalCode(patch.postalCode);
+    }
+    return this.base.patchOne(id as never, patch as never);
+  }
+
+  /**
+   * `Owner` owns the join column (`owner.entity.ts`), so the owner
+   * referencing this row is detached before the address is removed.
+   */
+  @Override()
+  async deleteOne(id: EntityId): Promise<void> {
+    await clearOwnerAddress(this.dataSource, Number(id));
+    await this.base.deleteOne(id as never);
+  }
+
+  /** Augments the response with a derived, unpersisted field. */
+  @Override()
+  async findOne(id: EntityId, query: unknown): Promise<unknown> {
+    const address = await this.base.findOne(id as never, query as never);
+    return { ...address, formattedAddress: `${address.street}, ${address.city} ${address.postalCode}` };
+  }
+
+  /**
+   * `POST /addresses/:id/normalize-postal-code` — reuses the same
+   * normalization/validation as `createOne`/`updateOne`/`patchOne`, applied
+   * to an already-persisted row. The method name differs from the
+   * operation id (it collides with the imported `normalizePostalCode`
+   * helper), so `@Override` is given the id explicitly.
+   */
+  @Override("normalizePostalCode")
+  async normalizePostalCodeRoute(id: EntityId): Promise<unknown> {
+    const existing = await this.base.findOne(id as never);
+    const postalCode = normalizePostalCode(existing.postalCode);
+    assertValidPostalCode(postalCode);
+    return this.base.updateOne(id as never, { postalCode } as never);
+  }
+}

--- a/packages/examples/src/address/address.controller.ts
+++ b/packages/examples/src/address/address.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Inject } from "@nestjs/common";
-import { Crud, Override, getCrudServiceToken } from "@kavo/nest";
+import { Crud, Override, flattenQuery, getCrudServiceToken } from "@kavo/nest";
 import type { DefaultCrudService, EntityId } from "@kavo/core";
+import { WireQuery } from "@kavo/core";
 import type { DataSource } from "typeorm";
 import { Address } from "./address.entity.js";
 import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
@@ -86,10 +87,18 @@ export class AddressController {
     await this.base.deleteOne(id as never);
   }
 
-  /** Augments the response with a derived, unpersisted field. */
+  /**
+   * Augments the response with a derived, unpersisted field. `query`
+   * arrives as Nest's raw `@Query()` object — the generated route always
+   * wraps it in `WireQuery` (via `flattenQuery`) before it reaches
+   * `DefaultCrudService`, so a read override must do the same, or wire-
+   * format params like `?fields=` / `?include=` reach the engine
+   * unparsed and 400.
+   */
   @Override()
   async findOne(id: EntityId, query: unknown): Promise<unknown> {
-    const address = await this.base.findOne(id as never, query as never);
+    const wired = new WireQuery(flattenQuery((query ?? {}) as Readonly<Record<string, unknown>>));
+    const address = await this.base.findOne(id as never, wired as never);
     return { ...address, formattedAddress: `${address.street}, ${address.city} ${address.postalCode}` };
   }
 

--- a/packages/examples/src/address/address.runtime.ts
+++ b/packages/examples/src/address/address.runtime.ts
@@ -1,12 +1,10 @@
 import type { DataSource } from "typeorm";
-import type { RepositoryAdapter } from "@kavo/core";
 import { QueryValidationException } from "@kavo/core";
-import type { Address } from "./address.entity.js";
 import { Owner } from "../owner/owner.entity.js";
 
 const POSTAL_CODE_PATTERN = /^\d{5}$/;
 
-/** Reused by the `createOne`/`updateOne` overrides and the custom route alike. */
+/** Reused by `AddressController`'s `createOne`/`updateOne`/`patchOne` overrides and the custom route alike. */
 export function normalizePostalCode(raw: string): string {
   return raw.trim();
 }
@@ -21,37 +19,12 @@ export function assertValidPostalCode(value: string): void {
   }
 }
 
-export interface AddressRuntime {
-  readonly adapter: RepositoryAdapter<Address>;
-  readonly dataSource: DataSource;
-}
-
-let runtime: AddressRuntime | null = null;
-
-/**
- * `@Crud`'s operation overrides are captured at class-decoration time
- * (ADR-0012) — module import, before `KavoModule.forRootAsync`'s factory
- * ever builds the `DataSource` — so `address.controller.ts`'s handler
- * literals cannot close over a ready adapter when they are written. Each
- * handler instead calls `addressRuntime()` at request time, long after
- * `app.module.ts` has called this once the real infrastructure exists.
- */
-export function bindAddressRuntime(next: AddressRuntime): void {
-  runtime = next;
-}
-
-export function addressRuntime(): AddressRuntime {
-  if (runtime === null) {
-    throw new Error("Address runtime not bound — call bindAddressRuntime() during app bootstrap");
-  }
-  return runtime;
-}
-
 /**
  * `Owner` owns the join column (`owner.entity.ts`), so clearing it before
- * an address is deleted is a cross-entity write `RepositoryAdapter<Address>`
- * has no way to perform — the `deleteOne` override reaches for the raw
- * `DataSource` deliberately, not as a pattern that belongs in `@kavo/typeorm`.
+ * an address is deleted is a cross-entity write no `RepositoryAdapter<Address>`
+ * can perform — `AddressController`'s `deleteOne` override reaches for the
+ * raw `DataSource` deliberately, not as a pattern that belongs in
+ * `@kavo/typeorm`.
  */
 export async function clearOwnerAddress(dataSource: DataSource, addressId: number): Promise<void> {
   const ownerRepository = dataSource.getRepository(Owner);

--- a/packages/examples/src/app.module.ts
+++ b/packages/examples/src/app.module.ts
@@ -8,8 +8,6 @@ import { CatController } from "./cat/cat.controller.js";
 import { DogController } from "./dog/dog.controller.js";
 import { TagController } from "./tag/tag.controller.js";
 import { AddressController } from "./address/address.controller.js";
-import { Address } from "./address/address.entity.js";
-import { bindAddressRuntime } from "./address/address.runtime.js";
 
 /**
  * Reference wiring: the app hands `@kavo/nest` its infrastructure (here
@@ -21,20 +19,13 @@ import { bindAddressRuntime } from "./address/address.runtime.js";
     KavoModule.forRootAsync({
       imports: [DatabaseModule],
       inject: [DATA_SOURCE] as never[],
-      useFactory: (dataSource: DataSource) => {
-        const infrastructure = createTypeOrmInfrastructure(dataSource);
-        // Address's operation overrides are captured at decoration time
-        // (ADR-0012), before this factory ever runs — bind the adapter they
-        // need now that it exists (see address.runtime.ts).
-        bindAddressRuntime({ adapter: infrastructure.adapterFor(Address), dataSource });
-        return {
-          infrastructure,
-          defaults: {
-            pagination: { defaultLimit: 20, maxLimit: 100 },
-            errors: { exposeInternals: false },
-          },
-        };
-      },
+      useFactory: (dataSource: DataSource) => ({
+        infrastructure: createTypeOrmInfrastructure(dataSource),
+        defaults: {
+          pagination: { defaultLimit: 20, maxLimit: 100 },
+          errors: { exposeInternals: false },
+        },
+      }),
     }),
     KavoModule.forFeature([OwnerController, CatController, DogController, TagController, AddressController]),
   ],

--- a/packages/examples/src/database.module.ts
+++ b/packages/examples/src/database.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Global, Module } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import { Owner } from "./owner/owner.entity.js";
 import { Pet } from "./pet/pet.entity.js";
@@ -14,6 +14,11 @@ export const DATA_SOURCE = Symbol("DATA_SOURCE");
  * (and its e2e suite) dependency-free; swap `database` for a file path or
  * a Postgres config without touching anything else.
  */
+// Global so `DATA_SOURCE` is injectable straight into any `@Crud`
+// controller (e.g. `AddressController`'s `@Override`'d methods), not just
+// where `DatabaseModule` is nested (`KavoModule.forRootAsync`'s own
+// `imports`).
+@Global()
 @Module({
   providers: [
     {

--- a/packages/examples/src/database.module.ts
+++ b/packages/examples/src/database.module.ts
@@ -13,11 +13,12 @@ export const DATA_SOURCE = Symbol("DATA_SOURCE");
  * One SQLite `DataSource` for the whole app. In-memory keeps the demo
  * (and its e2e suite) dependency-free; swap `database` for a file path or
  * a Postgres config without touching anything else.
+ *
+ * Global so `DATA_SOURCE` is injectable straight into any `@Crud`
+ * controller (e.g. `AddressController`'s `@Override`'d methods), not just
+ * where `DatabaseModule` is nested (`KavoModule.forRootAsync`'s own
+ * `imports`).
  */
-// Global so `DATA_SOURCE` is injectable straight into any `@Crud`
-// controller (e.g. `AddressController`'s `@Override`'d methods), not just
-// where `DatabaseModule` is nested (`KavoModule.forRootAsync`'s own
-// `imports`).
 @Global()
 @Module({
   providers: [

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -28,7 +28,10 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await app.close();
+  // Guards against beforeAll throwing before `app` is assigned — without
+  // this, a real bootstrap failure (e.g. a DI-wiring regression) is masked
+  // by an unrelated TypeError here instead of surfacing its own message.
+  if (app !== undefined) await app.close();
 });
 
 function server(): Parameters<typeof request>[0] {
@@ -685,6 +688,20 @@ describe("Address operation overrides (issue #21)", () => {
 
     const fetched = await request(server()).get(`/addresses/${id}`).expect(200);
     expect(fetched.body.formattedAddress).toBe("1 Elm St, Springfield 10001");
+  });
+
+  it("wires GET /addresses/:id query params through the same normalization a generated route would", async () => {
+    // Regression: an @Override'd findOne must wrap Nest's raw query object
+    // the same way the generated route does (WireQuery + flattenQuery), or
+    // wire-format params reach the engine unparsed and 400.
+    const created = await request(server())
+      .post("/addresses")
+      .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
+      .expect(201);
+    const id = created.body.id as number;
+
+    const narrowed = await request(server()).get(`/addresses/${id}`).query("fields=street,city,postalCode").expect(200);
+    expect(Object.keys(narrowed.body).sort()).toEqual(["city", "formattedAddress", "postalCode", "street"]);
   });
 
   it("corrects a dirty postalCode via the custom route", async () => {

--- a/packages/frameworks/nest/src/crud.decorator.ts
+++ b/packages/frameworks/nest/src/crud.decorator.ts
@@ -5,12 +5,19 @@ import type {
   EntityConfig,
   EntityInput,
   OperationDescriptor,
+  OperationId,
   QueryContext,
   StandardOperationId,
 } from "@kavo/core";
-import { WireQuery, createOperationRegistry } from "@kavo/core";
+import { ConfigurationException, WireQuery, createOperationRegistry } from "@kavo/core";
 import type { CrudHttpMethod, CrudRouteOptions } from "./operation-metadata.js";
-import { CRUD_CONTROLLER_METADATA, CRUD_SERVICE_PROPERTY, getCrudServiceToken } from "./tokens.js";
+import type { OverrideMetadata } from "./override.decorator.js";
+import {
+  CRUD_CONTROLLER_METADATA,
+  CRUD_OVERRIDE_METADATA,
+  CRUD_SERVICE_PROPERTY,
+  getCrudServiceToken,
+} from "./tokens.js";
 import { flattenQuery } from "./flatten-query.js";
 import { applySwaggerMetadata } from "./swagger.js";
 
@@ -48,6 +55,17 @@ const STANDARD_ROUTES: Readonly<
  */
 const BODYLESS_WRITES: ReadonlySet<StandardOperationId> = new Set<StandardOperationId>(["restoreOne", "purgeOne"]);
 
+/**
+ * Nest's own route-argument metadata key (`@nestjs/common/constants`'
+ * `ROUTE_ARGS_METADATA`), inlined rather than deep-imported: the subpath
+ * isn't part of `@nestjs/common`'s declared type exports (no `exports` map
+ * restricts it at runtime, but `tsc`'s Node16 resolution can't see the
+ * `.d.ts` through it), and this exact key is what every `@Param`/`@Query`/
+ * `@Body` decorator reads and writes — stable across Nest's own major
+ * versions, since third-party CRUD libraries already depend on it.
+ */
+const NEST_ROUTE_ARGS_METADATA = "__routeArguments__";
+
 const METHOD_DECORATORS: Record<CrudHttpMethod, (path: string) => MethodDecorator> = {
   GET: Get,
   POST: Post,
@@ -81,8 +99,12 @@ interface ResolvedRoute {
  * the build, but they are still three tables and this file does change.
  *
  * **Manual-method-wins:** a hand-written controller method whose name
- * matches an operation id suppresses that generated route — no conflicts,
- * no config, for the genuine one-off.
+ * matches an operation id suppresses that generated route entirely — no
+ * conflicts, no config, for the genuine one-off. **`@Override(operationId?)`**
+ * is the additive middle path: the decorated method still gets the
+ * registry's route (method, path, status, params, Swagger), only the
+ * function backing it changes — resolved first, ahead of manual-method-wins,
+ * so a decorated method never falls through to plain name-matching.
  *
  * Route generation happens at decoration time (class definition), which is
  * what lets Nest's router see the methods during its normal controller
@@ -125,18 +147,99 @@ export function Crud<
     Inject(getCrudServiceToken(entity))(controller.prototype, CRUD_SERVICE_PROPERTY);
 
     const registry = createOperationRegistry(erasedConfig);
+    const overrides = collectOverrides(controller.prototype, entity.name, registry);
+
     for (const descriptor of registry.all()) {
       if (!descriptor.enabled) continue;
       const route = resolveRoute(descriptor);
-      if (route === null) continue;
-      const methodName = descriptor.id;
-      if (Object.prototype.hasOwnProperty.call(controller.prototype, methodName)) {
-        continue; // manual-method-wins
+      const overrideMethodName = overrides.get(descriptor.id);
+      if (route === null) {
+        if (overrideMethodName !== undefined) {
+          throw new ConfigurationException(
+            entity.name,
+            `override.${descriptor.id}`,
+            `'${overrideMethodName}' is @Override("${descriptor.id}"), but that operation is service-only ` +
+              `(meta.routes.enabled: false) and generates no route to override`,
+          );
+        }
+        continue;
       }
-      defineRoute(controller.prototype, methodName, descriptor, route);
-      applySwaggerMetadata(controller.prototype, methodName, descriptor, route, entity, erasedConfig);
+      if (overrideMethodName === undefined) {
+        const methodName = descriptor.id;
+        if (Object.prototype.hasOwnProperty.call(controller.prototype, methodName)) {
+          continue; // manual-method-wins
+        }
+        defineRoute(controller.prototype, methodName, descriptor, route);
+        applySwaggerMetadata(controller.prototype, methodName, descriptor, route, entity, erasedConfig);
+      } else {
+        assertNoOwnParamMetadata(controller.prototype, overrideMethodName, entity.name, descriptor.id);
+        applyRouteDecorators(controller.prototype, overrideMethodName, descriptor, route);
+        applySwaggerMetadata(controller.prototype, overrideMethodName, descriptor, route, entity, erasedConfig);
+      }
     }
   };
+}
+
+/**
+ * Builds the `operationId -> methodName` map from every `@Override`-decorated
+ * method on the prototype, failing fast at decoration time (ADR-0012's only
+ * moment) on the two ways this can be misconfigured: two methods claiming
+ * the same operation, or an override naming an operation id that the
+ * registry doesn't have enabled — a silent no-op override is a footgun.
+ */
+function collectOverrides(
+  prototype: Record<string, unknown>,
+  entityName: string,
+  registry: { get(id: OperationId): OperationDescriptor<object> | undefined },
+): ReadonlyMap<OperationId, string> {
+  const overrides = new Map<OperationId, string>();
+  for (const methodName of Object.getOwnPropertyNames(prototype)) {
+    if (methodName === "constructor") continue;
+    const metadata = Reflect.getMetadata(CRUD_OVERRIDE_METADATA, prototype, methodName) as OverrideMetadata | undefined;
+    if (metadata === undefined) continue;
+    const existing = overrides.get(metadata.operationId);
+    if (existing !== undefined) {
+      throw new ConfigurationException(
+        entityName,
+        `override.${metadata.operationId}`,
+        `both '${existing}' and '${methodName}' are @Override("${metadata.operationId}") — only one method may override a given operation`,
+      );
+    }
+    overrides.set(metadata.operationId, methodName);
+  }
+  for (const [operationId, methodName] of overrides) {
+    const descriptor = registry.get(operationId);
+    if (descriptor === undefined || !descriptor.enabled) {
+      throw new ConfigurationException(
+        entityName,
+        `override.${operationId}`,
+        `'${methodName}' is @Override("${operationId}"), but '${operationId}' is absent or disabled`,
+      );
+    }
+  }
+  return overrides;
+}
+
+/**
+ * `@Override`'d methods must accept Kavo's own `@Param`/`@Query`/`@Body`
+ * wiring, not their own — Nest's route-arg metadata for a method is one
+ * object keyed by param index, so a method's own decorator would either
+ * collide with or silently shadow the one Kavo applies next.
+ */
+function assertNoOwnParamMetadata(
+  prototype: Record<string, unknown>,
+  methodName: string,
+  entityName: string,
+  operationId: OperationId,
+): void {
+  const existing = Reflect.getMetadata(NEST_ROUTE_ARGS_METADATA, prototype.constructor, methodName);
+  if (existing !== undefined) {
+    throw new ConfigurationException(
+      entityName,
+      `override.${operationId}`,
+      `'${methodName}' must not declare its own @Param/@Query/@Body — @Crud applies the operation's own param wiring`,
+    );
+  }
 }
 
 function resolveRoute(descriptor: OperationDescriptor<object>): ResolvedRoute | null {
@@ -164,8 +267,23 @@ function defineRoute(
     writable: true,
     configurable: true,
   });
-  const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, methodName) as PropertyDescriptor;
+  applyRouteDecorators(prototype, methodName, descriptor, route);
+}
 
+/**
+ * The Nest wiring a route needs regardless of what backs it: param
+ * decorators, the success status, and the HTTP-verb decorator. Shared
+ * between a freshly generated handler (`defineRoute`) and an `@Override`'d
+ * method already on the prototype — the two paths carry identical route
+ * metadata by construction, not by convention.
+ */
+function applyRouteDecorators(
+  prototype: Record<string, unknown>,
+  methodName: string,
+  descriptor: OperationDescriptor<object>,
+  route: ResolvedRoute,
+): void {
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, methodName) as PropertyDescriptor;
   applyParamDecorators(prototype, methodName, descriptor, route);
   HttpCode(route.status)(prototype, methodName, propertyDescriptor);
   METHOD_DECORATORS[route.method](route.path)(prototype, methodName, propertyDescriptor);

--- a/packages/frameworks/nest/src/index.ts
+++ b/packages/frameworks/nest/src/index.ts
@@ -9,6 +9,7 @@
  * optional.
  */
 export { Crud, type CrudControllerMetadata } from "./crud.decorator.js";
+export { Override, type OverrideMetadata } from "./override.decorator.js";
 export { KavoModule, type KavoModuleAsyncOptions } from "./kavo.module.js";
 export type { KavoModuleOptions } from "./kavo-options.js";
 export { KavoExceptionFilter } from "./kavo-exception.filter.js";

--- a/packages/frameworks/nest/src/override.decorator.ts
+++ b/packages/frameworks/nest/src/override.decorator.ts
@@ -1,0 +1,33 @@
+import type { OperationId } from "@kavo/core";
+import { CRUD_OVERRIDE_METADATA } from "./tokens.js";
+
+/** What `@Override` records per decorated method, read back by `@Crud`. */
+export interface OverrideMetadata {
+  readonly operationId: OperationId;
+}
+
+/**
+ * Marks a hand-written controller method as an operation's implementation
+ * while `@Crud` still generates that operation's route from the registry —
+ * method, path, status, `@Param`/`@Query`/`@Body`, and Swagger metadata, all
+ * identical to what a generated route would carry. `operationId` defaults to
+ * the decorated method's own name, the same inference manual-method-wins
+ * already uses; pass it explicitly when the method name differs.
+ *
+ * The decorated method must accept parameters in the same fixed position
+ * `@Crud` would apply to a generated route — reads: `(id?, query)`; writes:
+ * `(id?, body)` — undecorated, since Kavo supplies those decorators itself.
+ * Adding your own `@Param`/`@Query`/`@Body` on an overridden method is a
+ * decoration-time error (duplicate route-argument metadata).
+ *
+ * Distinct from plain manual-method-wins: an undecorated method whose name
+ * matches an operation id suppresses that route entirely — no method/path/
+ * status/Swagger wiring happens for it. `@Override` keeps all of that,
+ * swapping only which function backs the route.
+ */
+export function Override(operationId?: OperationId): MethodDecorator {
+  return (target, propertyKey) => {
+    const id = operationId ?? (propertyKey as OperationId);
+    Reflect.defineMetadata(CRUD_OVERRIDE_METADATA, { operationId: id } satisfies OverrideMetadata, target, propertyKey);
+  };
+}

--- a/packages/frameworks/nest/src/override.decorator.ts
+++ b/packages/frameworks/nest/src/override.decorator.ts
@@ -20,6 +20,22 @@ export interface OverrideMetadata {
  * Adding your own `@Param`/`@Query`/`@Body` on an overridden method is a
  * decoration-time error (duplicate route-argument metadata).
  *
+ * For a read operation, `query` arrives as Nest's **raw** `@Query()`
+ * object — a generated route always wraps it (`new WireQuery(flattenQuery(query))`,
+ * both exported from `@kavo/core`/`@kavo/nest`) before it reaches
+ * `DefaultCrudService`, because the engine's query-normalization stage
+ * expects that wrapper to parse wire-format strings (`?fields=`, `?include=`,
+ * …). An override that forwards `query` unwrapped sends it down the
+ * already-normalized-input path instead, and any wire-format param 400s. Do
+ * the same wrapping before delegating, e.g.:
+ *
+ * ```ts
+ * @Override()
+ * async findOne(id: EntityId, query: unknown) {
+ *   return this.base.findOne(id as never, new WireQuery(flattenQuery(query as object)) as never);
+ * }
+ * ```
+ *
  * Distinct from plain manual-method-wins: an undecorated method whose name
  * matches an operation id suppresses that route entirely — no method/path/
  * status/Swagger wiring happens for it. `@Override` keeps all of that,

--- a/packages/frameworks/nest/src/tokens.ts
+++ b/packages/frameworks/nest/src/tokens.ts
@@ -9,6 +9,9 @@ export const KAVO_MODULE_OPTIONS = Symbol("KAVO_MODULE_OPTIONS");
 /** Reflect metadata key the `@Crud` decorator writes on controllers. */
 export const CRUD_CONTROLLER_METADATA = "kavo:controller";
 
+/** Reflect metadata key the `@Override` method decorator writes. */
+export const CRUD_OVERRIDE_METADATA = "kavo:override";
+
 /** Property the generated route methods read the injected service from. */
 export const CRUD_SERVICE_PROPERTY = "__kavoService";
 

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1,12 +1,13 @@
 import "reflect-metadata";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import request from "supertest";
-import { Controller, Get, type INestApplication } from "@nestjs/common";
+import { Controller, Get, Inject, Param, type INestApplication } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { Test } from "@nestjs/testing";
 import type { DefaultCrudService, NormalizedQueryContext, OperationHandler } from "@kavo/core";
+import { ConfigurationException } from "@kavo/core";
 import type { KavoModuleOptions } from "@kavo/nest";
-import { Crud, KavoModule, enumProp, getCrudServiceToken, oneOfArray } from "@kavo/nest";
+import { Crud, KavoModule, Override, enumProp, getCrudServiceToken, oneOfArray } from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 
 let app: INestApplication;
@@ -384,6 +385,215 @@ describe("@Crud operation control surface", () => {
     await request(server()).get("/todos").expect(404);
 
     expect(seen).toEqual(["createOne", "updateOne", "patchOne", "deleteOne", "summarize"]);
+  });
+});
+
+describe("@Crud @Override — controller-method overrides that keep generated route metadata (issue #23)", () => {
+  it("keeps findOne's generated route/param wiring, delegating to the decorated method", async () => {
+    @Crud(Todo)
+    @Controller("todos")
+    class OverrideFindOneController {
+      constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
+
+      @Override()
+      async findOne(id: string, query: unknown): Promise<unknown> {
+        const item = await this.base.findOne(id as never, query as never);
+        return { ...item, viaOverride: true };
+      }
+    }
+
+    await bootstrap(OverrideFindOneController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    const response = await request(server()).get("/todos/1").expect(200);
+    expect(response.body).toMatchObject({ id: 1, title: "x", viaOverride: true });
+  });
+
+  it("keeps createOne's generated route/param wiring (body alone, 201, no :id)", async () => {
+    @Crud(Todo)
+    @Controller("todos")
+    class OverrideCreateOneController {
+      constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
+
+      @Override()
+      async createOne(body: { title: string }): Promise<unknown> {
+        return this.base.createOne({ ...body, title: body.title.toUpperCase() } as never);
+      }
+    }
+
+    await bootstrap(OverrideCreateOneController);
+    const response = await request(server()).post("/todos").send({ title: "loud" }).expect(201);
+    expect(response.body).toMatchObject({ title: "LOUD" });
+  });
+
+  it("keeps a custom operation's own meta.routes shape (id-bearing route)", async () => {
+    @Crud(Todo, {
+      customOperations: {
+        activate: {
+          // Never runs — @Override supplies the implementation instead.
+          handler: {
+            async execute() {
+              throw new Error("the registry handler must not run when @Override supplies the method");
+            },
+          },
+          meta: { routes: { method: "POST", path: ":id/activate" } },
+        },
+      },
+    })
+    @Controller("todos")
+    class OverrideCustomController {
+      @Override("activate")
+      async activate(id: string): Promise<unknown> {
+        const row = adapter.rows.find((candidate) => candidate.id === Number(id));
+        if (row !== undefined) row.done = true;
+        return row ?? null;
+      }
+    }
+
+    await bootstrap(OverrideCustomController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    const response = await request(server()).post("/todos/1/activate").expect(201);
+    expect(response.body).toMatchObject({ id: 1, done: true });
+  });
+
+  it("documents an overridden route with the same Swagger shape a generated one would carry", async () => {
+    @Crud(Todo)
+    @Controller("todos")
+    class OverrideSwaggerController {
+      constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
+
+      @Override()
+      async findOne(id: string, query: unknown): Promise<unknown> {
+        return this.base.findOne(id as never, query as never);
+      }
+    }
+
+    await bootstrap(OverrideSwaggerController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+    const getItem = (
+      document.paths["/todos/{id}"] as Record<
+        string,
+        { operationId?: string; parameters?: { name: string; in: string }[]; responses?: Record<string, unknown> }
+      >
+    )?.get;
+    expect(getItem?.operationId).toBe("Todo_findOne");
+    expect(getItem?.parameters).toEqual(expect.arrayContaining([expect.objectContaining({ name: "id", in: "path" })]));
+    expect(getItem?.responses).toHaveProperty("200");
+    expect(getItem?.responses).toHaveProperty("404");
+  });
+
+  it("leaves plain manual-method-wins (no @Override) exactly as before", async () => {
+    @Crud(Todo)
+    @Controller("todos")
+    class ManualStillWinsController {
+      @Get(":id")
+      findOne(): { manual: boolean } {
+        return { manual: true };
+      }
+    }
+
+    await bootstrap(ManualStillWinsController);
+    const response = await request(server()).get("/todos/1").expect(200);
+    expect(response.body).toEqual({ manual: true });
+  });
+
+  it("throws at decoration time when two methods override the same operation", () => {
+    let error: unknown;
+    try {
+      @Crud(Todo)
+      @Controller("todos")
+      class DuplicateOverrideController {
+        @Override("createOne")
+        first(): void {}
+        @Override("createOne")
+        second(): void {}
+      }
+      void DuplicateOverrideController;
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error).toMatchObject({ code: "KAVO_CONFIG_INVALID", messageParams: { path: "override.createOne" } });
+  });
+
+  it("throws at decoration time when @Override names an operation that is off by default", () => {
+    let error: unknown;
+    try {
+      @Crud(Todo)
+      @Controller("todos")
+      class DisabledOverrideController {
+        @Override("purgeOne")
+        purge(): void {}
+      }
+      void DisabledOverrideController;
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error).toMatchObject({ code: "KAVO_CONFIG_INVALID", messageParams: { path: "override.purgeOne" } });
+  });
+
+  it("throws at decoration time when @Override names an operation id absent from the registry", () => {
+    let error: unknown;
+    try {
+      @Crud(Todo)
+      @Controller("todos")
+      class GhostOverrideController {
+        @Override("ghost")
+        ghost(): void {}
+      }
+      void GhostOverrideController;
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error).toMatchObject({ code: "KAVO_CONFIG_INVALID", messageParams: { path: "override.ghost" } });
+  });
+
+  it("throws at decoration time when @Override targets a service-only operation", () => {
+    let error: unknown;
+    try {
+      @Crud(Todo, {
+        customOperations: {
+          recalc: {
+            handler: {
+              async execute() {
+                return null;
+              },
+            },
+            meta: { routes: { enabled: false } },
+          },
+        },
+      })
+      @Controller("todos")
+      class ServiceOnlyOverrideController {
+        @Override("recalc")
+        recalc(): void {}
+      }
+      void ServiceOnlyOverrideController;
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error).toMatchObject({ code: "KAVO_CONFIG_INVALID", messageParams: { path: "override.recalc" } });
+  });
+
+  it("throws at decoration time when the overridden method declares its own @Param/@Body", () => {
+    let error: unknown;
+    try {
+      @Crud(Todo)
+      @Controller("todos")
+      class SelfParamOverrideController {
+        @Override()
+        findOne(@Param("id") id: string): unknown {
+          return { id };
+        }
+      }
+      void SelfParamOverrideController;
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error).toMatchObject({ code: "KAVO_CONFIG_INVALID", messageParams: { path: "override.findOne" } });
   });
 });
 

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -425,6 +425,26 @@ describe("@Crud @Override — controller-method overrides that keep generated ro
     expect(response.body).toMatchObject({ title: "LOUD" });
   });
 
+  it("wires an explicit operationId to a differently-named method (id+body write), not just name-matched ones", async () => {
+    @Crud(Todo)
+    @Controller("todos")
+    class ExplicitIdOverrideController {
+      constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
+
+      // The method name is unrelated to "updateOne" — proves resolution
+      // uses the override map's target, not descriptor.id, end to end.
+      @Override("updateOne")
+      async customUpdate(id: string, body: { title: string }): Promise<unknown> {
+        return this.base.updateOne(id as never, { ...body, title: body.title.toUpperCase() } as never);
+      }
+    }
+
+    await bootstrap(ExplicitIdOverrideController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    const response = await request(server()).put("/todos/1").send({ title: "loud" }).expect(200);
+    expect(response.body).toMatchObject({ id: 1, title: "LOUD" });
+  });
+
   it("keeps a custom operation's own meta.routes shape (id-bearing route)", async () => {
     @Crud(Todo, {
       customOperations: {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -5,9 +5,9 @@ import { Controller, Get, Inject, Param, type INestApplication } from "@nestjs/c
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { Test } from "@nestjs/testing";
 import type { DefaultCrudService, NormalizedQueryContext, OperationHandler } from "@kavo/core";
-import { ConfigurationException } from "@kavo/core";
+import { ConfigurationException, WireQuery } from "@kavo/core";
 import type { KavoModuleOptions } from "@kavo/nest";
-import { Crud, KavoModule, Override, enumProp, getCrudServiceToken, oneOfArray } from "@kavo/nest";
+import { Crud, KavoModule, Override, enumProp, flattenQuery, getCrudServiceToken, oneOfArray } from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 
 let app: INestApplication;
@@ -47,6 +47,17 @@ afterEach(async () => {
 
 function server(): Parameters<typeof request>[0] {
   return app.getHttpServer() as Parameters<typeof request>[0];
+}
+
+/**
+ * What an `@Override`'d read method must do to Nest's raw `@Query()`
+ * object before handing it to `DefaultCrudService` — the same wrapping
+ * `crud.decorator.ts`'s generated routes apply internally. Skipping this
+ * sends wire-format query strings straight into `normalizeInput` instead
+ * of `normalizeWire`, and they 400.
+ */
+function wireQuery(query: unknown): WireQuery {
+  return new WireQuery(flattenQuery((query ?? {}) as Readonly<Record<string, unknown>>));
 }
 
 describe("@Crud route generation (Phases 11–12)", () => {
@@ -397,7 +408,7 @@ describe("@Crud @Override — controller-method overrides that keep generated ro
 
       @Override()
       async findOne(id: string, query: unknown): Promise<unknown> {
-        const item = await this.base.findOne(id as never, query as never);
+        const item = await this.base.findOne(id as never, wireQuery(query) as never);
         return { ...item, viaOverride: true };
       }
     }
@@ -406,6 +417,11 @@ describe("@Crud @Override — controller-method overrides that keep generated ro
     await request(server()).post("/todos").send({ title: "x" }).expect(201);
     const response = await request(server()).get("/todos/1").expect(200);
     expect(response.body).toMatchObject({ id: 1, title: "x", viaOverride: true });
+
+    // Regression: a wire-format query string must reach the override
+    // normalized, not passed through raw — this is what wireQuery() buys.
+    const narrowed = await request(server()).get("/todos/1").query("fields=id,title").expect(200);
+    expect(Object.keys(narrowed.body).sort()).toEqual(["id", "title", "viaOverride"]);
   });
 
   it("keeps createOne's generated route/param wiring (body alone, 201, no :id)", async () => {
@@ -483,7 +499,7 @@ describe("@Crud @Override — controller-method overrides that keep generated ro
 
       @Override()
       async findOne(id: string, query: unknown): Promise<unknown> {
-        return this.base.findOne(id as never, query as never);
+        return this.base.findOne(id as never, wireQuery(query) as never);
       }
     }
 

--- a/packages/frameworks/nest/tests/override.decorator.spec.ts
+++ b/packages/frameworks/nest/tests/override.decorator.spec.ts
@@ -1,0 +1,37 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { Override } from "@kavo/nest";
+
+// The reflect key is internal to @kavo/nest; read it back the same way
+// crud.decorator.ts does, via a tiny re-declaration, to keep this test
+// black-box over the public `Override` decorator alone.
+const CRUD_OVERRIDE_METADATA = "kavo:override";
+
+describe("Override — method-decorator metadata (issue #23)", () => {
+  it("defaults the operation id to the decorated method's own name", () => {
+    class Controller {
+      @Override()
+      findOne(): void {}
+    }
+    expect(Reflect.getMetadata(CRUD_OVERRIDE_METADATA, Controller.prototype, "findOne")).toEqual({
+      operationId: "findOne",
+    });
+  });
+
+  it("uses an explicit operation id over the method name", () => {
+    class Controller {
+      @Override("createOne")
+      customCreate(): void {}
+    }
+    expect(Reflect.getMetadata(CRUD_OVERRIDE_METADATA, Controller.prototype, "customCreate")).toEqual({
+      operationId: "createOne",
+    });
+  });
+
+  it("writes no metadata for an undecorated method", () => {
+    class Controller {
+      plain(): void {}
+    }
+    expect(Reflect.getMetadata(CRUD_OVERRIDE_METADATA, Controller.prototype, "plain")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

`@Crud` had two ways to customize a standard operation: a config-level `operations.<id>.handler` (a plain `OperationHandler` object — no `this`, no DI), or manual-method-wins, where a hand-written controller method whose name matches an operation id fully suppresses the generated route, forcing the user to redeclare its HTTP method/path/status/params/Swagger by hand just to run custom logic. This adds `@Override(operationId?)`, the additive middle path frameworks like `@nestjsx/crud` call `@Override()`: the decorated method stays the operation's implementation, while `@Crud` still generates that operation's full route metadata from the registry — method, path, status, `@Param`/`@Query`/`@Body`, and Swagger, identical to a generated route.

The design needed no `@kavo/core` change: Nest's own method/param decorators write metadata keyed by `(prototype, methodName[, index])` independent of what function backs the route, so "delegate to a controller-instance method" is just "apply the same decorators Kavo already applies, to the user's existing method instead of a generated one." `CrudEngine`, `OperationHandler`, and `OperationDescriptor` are untouched — the whole mechanism lives in `@kavo/nest`.

Resolution order in `@Crud`'s route-generation loop is now: override map → manual-method-wins → generate. Decoration-time validation (ADR-0012's only moment) rejects: two methods overriding the same operation, an override naming an operation id that's absent, disabled, or service-only, and an overridden method that declares its own `@Param`/`@Query`/`@Body`.

The `packages/examples` Address controller (issue #21's overrides) was rewritten to actually use `@Override` instead of `operations.<id>.handler`, dogfooding the new mechanism — every overridden method now injects the entity's own `DefaultCrudService` (via `getCrudServiceToken`) plus the raw `DataSource` through ordinary constructor DI, which also let a lazy-binder workaround (`address.runtime.ts`'s `bindAddressRuntime`) be deleted entirely, since `@Override`'d methods run at request time instead of needing a handler closure captured before the `DataSource` exists.

Closes #23

## Public API impact

Additive only, in `@kavo/nest`'s barrel: new export `Override(operationId?: OperationId): MethodDecorator` and `OverrideMetadata`. No existing export changes signature (`Crud`, `CrudControllerMetadata`, `getCrudServiceToken` all unchanged). Not breaking. No `@kavo/core` changes at all — verified the barrel and every file under `packages/core` are untouched by this diff.

## Testing

- `packages/frameworks/nest/tests/override.decorator.spec.ts` (new): the decorator's own metadata contract.
- `packages/frameworks/nest/tests/binding.e2e.spec.ts`: overridden `findOne`/`createOne`, an explicit-operationId override on a differently-named method exercising the id+body write layout end to end, an overridden custom operation with its own `meta.routes` shape, Swagger-shape assertions, a manual-method-wins regression check, and all four decoration-time failure modes.
- `packages/examples/tests/app.e2e.spec.ts`: the full 40-test Address suite still passes unchanged against the `@Override`-based rewrite, plus a new regression test proving wire-format query params (`?fields=`) work through an `@Override`'d `findOne`.

Verified `pnpm check`: build, typecheck, `depcruise` (149 modules, 546 dependencies, no violations), and all 490 tests green.

## Review notes

This branch went through two `/review` rounds (kavo-reviewer, kavo-boundary-guard, kavo-test-auditor in parallel each time). Boundary/ADR audit came back clean both rounds. Two blocking findings were found and fixed:

1. **First round**: no test exercised `@Override("id")` on a method whose name differs from that operation id — the feature's own headline scenario. Fixed with a dedicated case.
2. **Second round** (after the Address example was rewritten to dogfood `@Override`): the `findOne` override forwarded Nest's raw `@Query()` object straight to `DefaultCrudService` instead of wrapping it in `WireQuery`/`flattenQuery` the way every generated route does — so wire-format query params (`?fields=`, `?include=`) 400'd instead of working. This affected both the Address example and the two `@kavo/nest` binding tests demonstrating the same pattern. Fixed in all three places, plus documented the gotcha directly in `Override()`'s own doc comment, `10-nestjs-integration.md`, and the `add-operation` skill, since it's a real footgun for anyone copying the documented pattern for a read operation.

Left open, non-blocking:
- Manual-method-wins keys off the method's own name independently of the override map: an `@Override`'d method whose name happens to match an *unrelated* operation id will also suppress that unrelated route. Corollary of pre-existing manual-method-wins semantics, not a new bug — worth a doc callout, not a code fix.
- `Override()`'s default-operationId inference casts `propertyKey` (`string | symbol`) to `OperationId` unconditionally; a symbol-named method would produce a symbol masquerading as a string id. Low-likelihood edge case.

A follow-up idea surfaced during review but deliberately not implemented here: letting `@Override` originate a brand-new custom operation entirely on its own, with no `customOperations` entry or `handler` in `@Crud()`'s config at all. Today a custom operation still requires a `customOperations` entry with a (possibly throwaway) `handler`, since `CustomOperationConfig.handler` is a required field with no route info to fall back on otherwise. That's a real design change to how `@kavo/nest` builds the registry, out of scope for this PR — worth its own issue.