### PR TITLE
feat(nest): auto-wire WireQuery for @Override'd read operations

### DIFF
--- a/.claude/agents/kavo-docs-auditor.md
+++ b/.claude/agents/kavo-docs-auditor.md
@@ -18,7 +18,7 @@ now does.
 - **`packages/docs/adr/0001`–`0014`** — one ADR per load-bearing decision.
   A change that introduces a new load-bearing invariant (a new seam, a new
   precedence rule, a new mechanically-enforced boundary) with no corresponding
-  ADR is a finding. A change that *contradicts* an existing ADR without
+  ADR is a finding. A change that _contradicts_ an existing ADR without
   superseding it (ADRs are point-in-time decisions; superseding one needs an
   explicit new ADR referencing the old one, not a silent code change) is a
   finding.

--- a/.claude/agents/kavo-perf-auditor.md
+++ b/.claude/agents/kavo-perf-auditor.md
@@ -9,8 +9,8 @@ You audit query-time performance for Kavo. A CRUD framework's entire job is
 turning declarative config into database queries, so the failure modes here
 are boring and severe: an endpoint that works in dev and falls over at
 production scale. You report findings; you never edit files. Correctness of
-results is `kavo-reviewer`'s job — stay on *how many queries* and *how much
-data* a request causes.
+results is `kavo-reviewer`'s job — stay on _how many queries_ and _how much
+data_ a request causes.
 
 ## What you check
 
@@ -22,7 +22,7 @@ data* a request causes.
    relation-loaded or joined query) is a finding — this is the classic N+1 and
    it's easy to reintroduce when adding a new relation-loading branch.
 2. **Unbounded relation depth or fan-out.** ADR-0008's recursion cap bounds
-   path *depth*, but check separately for fan-out: an include on a
+   path _depth_, but check separately for fan-out: an include on a
    one-to-many or many-to-many relation with no row limit can return an
    unbounded number of related rows per parent. If the change adds a new
    includable relation of that cardinality with no limit, flag it.

--- a/.claude/agents/kavo-security-auditor.md
+++ b/.claude/agents/kavo-security-auditor.md
@@ -14,7 +14,7 @@ to `kavo-reviewer`; stay on what an attacker-controlled request could reach.
 ## What you check
 
 1. **Filter/sort/select allowlist bypass.** `config.allowlists.{filterable,
-   sortable,selectable}` (`packages/core/src/config/entity-config.ts`,
+sortable,selectable}` (`packages/core/src/config/entity-config.ts`,
    enforced in `packages/core/src/query/query-normalizer.ts` and
    `default-filter-parser.ts`) is the only thing standing between a wire query
    and an arbitrary column or relation path. Any new code path that reads a

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -58,7 +58,7 @@ Push this branch and create or update its PR. Notes: **$ARGUMENTS**
      commits. Only touch the description if `$ARGUMENTS` gives new notes or the
      existing body is now stale (e.g. the testing/review-notes sections no
      longer reflect the latest commits); update it with `gh pr edit <n> --body
-     "..."` in that case. Do not needlessly rewrite an accurate description.
+"..."` in that case. Do not needlessly rewrite an accurate description.
 
 6. **Print the PR URL** and tell the user to run `/review` on it, then `/merge`
    once CI and review are green.

--- a/packages/docs/architecture/10-nestjs-integration.md
+++ b/packages/docs/architecture/10-nestjs-integration.md
@@ -97,23 +97,35 @@ fail-fast rule covers a duplicate override target (two methods claiming
 one operation id) and an override naming an operation id that is absent
 or disabled in the registry — a silent no-op override is a footgun.
 
-**A read override's `query` parameter is Nest's raw `@Query()` object,
-not a normalized one** — a generated route always wraps it in `WireQuery`
-(via `flattenQuery`, see below) before it reaches `DefaultCrudService`,
-because the engine's query stage parses wire-format strings only through
-that wrapper. An override that forwards `query` straight to
-`this.base.findOne(id, query)` sends it down the already-normalized-input
-path instead, and any wire-format param (`?fields=`, `?include=`, …) 400s.
-Wrap it the same way: `new WireQuery(flattenQuery(query as object))`.
+**A read override's `query` parameter arrives already wrapped in
+`WireQuery`** (issue #25) — `applyParamDecorators` is the single call site
+that decides a read operation's `@Query()` decorator, shared by a
+generated route and an `@Override`'d method alike, and it applies
+`Query(new WireQueryPipe())` rather than a bare `Query()`. Nest's pipe
+runs before either a generated handler or a hand-written override method
+body executes, so both receive the identical normalized value — an
+override does not need to (and should not) call `flattenQuery`/`WireQuery`
+itself:
+
+```ts
+@Override()
+async findOne(id: EntityId, query: WireQuery) {
+  return this.base.findOne(id, query);
+}
+```
+
+`flattenQuery`/`WireQuery` stay exported from `@kavo/nest`/`@kavo/core` for
+the rare caller wiring a query param manually outside this fixed position;
+the common case needs neither.
 
 Mechanically, generated methods are defined on the prototype and
 decorated by _calling_ Nest's own decorators (`Post(path)(proto, name,
 descriptor)`, `Param("id")(…)`, …) — identical metadata to hand-written
 syntax, so guards, interceptors, versioning, and prefixes compose
 normally. The service arrives by property injection under a private key;
-route handlers wrap `req.query` in core's `WireQuery` (after
-`flattenQuery` normalizes qs-extended nested objects back to flat
-bracket keys, making the binding query-parser-agnostic).
+`WireQueryPipe` (internal to `@kavo/nest`) wraps `req.query` in core's
+`WireQuery`, after `flattenQuery` normalizes qs-extended nested objects
+back to flat bracket keys, making the binding query-parser-agnostic.
 
 ## 3. Exception mapping
 

--- a/packages/examples/src/address/address.controller.ts
+++ b/packages/examples/src/address/address.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Inject } from "@nestjs/common";
-import { Crud, Override, flattenQuery, getCrudServiceToken } from "@kavo/nest";
-import type { DefaultCrudService, EntityId } from "@kavo/core";
-import { WireQuery } from "@kavo/core";
+import { Crud, Override, getCrudServiceToken } from "@kavo/nest";
+import type { DefaultCrudService, EntityId, WireQuery } from "@kavo/core";
 import type { DataSource } from "typeorm";
 import { Address } from "./address.entity.js";
 import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
@@ -89,16 +88,13 @@ export class AddressController {
 
   /**
    * Augments the response with a derived, unpersisted field. `query`
-   * arrives as Nest's raw `@Query()` object — the generated route always
-   * wraps it in `WireQuery` (via `flattenQuery`) before it reaches
-   * `DefaultCrudService`, so a read override must do the same, or wire-
-   * format params like `?fields=` / `?include=` reach the engine
-   * unparsed and 400.
+   * arrives already wired — `@Crud` applies the same `WireQuery`-producing
+   * pipe to an `@Override`'d read method's `query` param as it does to a
+   * generated route's.
    */
   @Override()
-  async findOne(id: EntityId, query: unknown): Promise<unknown> {
-    const wired = new WireQuery(flattenQuery((query ?? {}) as Readonly<Record<string, unknown>>));
-    const address = await this.base.findOne(id as never, wired as never);
+  async findOne(id: EntityId, query: WireQuery): Promise<unknown> {
+    const address = await this.base.findOne(id as never, query as never);
     return { ...address, formattedAddress: `${address.street}, ${address.city} ${address.postalCode}` };
   }
 

--- a/packages/examples/tests/app.e2e.spec.ts
+++ b/packages/examples/tests/app.e2e.spec.ts
@@ -691,9 +691,9 @@ describe("Address operation overrides (issue #21)", () => {
   });
 
   it("wires GET /addresses/:id query params through the same normalization a generated route would", async () => {
-    // Regression: an @Override'd findOne must wrap Nest's raw query object
-    // the same way the generated route does (WireQuery + flattenQuery), or
-    // wire-format params reach the engine unparsed and 400.
+    // Regression: an @Override'd findOne's query param is auto-wired into
+    // WireQuery the same way a generated route's is (issue #25) — the
+    // override itself does no manual flattenQuery/WireQuery wrapping.
     const created = await request(server())
       .post("/addresses")
       .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })

--- a/packages/frameworks/nest/src/crud.decorator.ts
+++ b/packages/frameworks/nest/src/crud.decorator.ts
@@ -9,7 +9,7 @@ import type {
   QueryContext,
   StandardOperationId,
 } from "@kavo/core";
-import { ConfigurationException, WireQuery, createOperationRegistry } from "@kavo/core";
+import { ConfigurationException, createOperationRegistry } from "@kavo/core";
 import type { CrudHttpMethod, CrudRouteOptions } from "./operation-metadata.js";
 import type { OverrideMetadata } from "./override.decorator.js";
 import {
@@ -18,7 +18,7 @@ import {
   CRUD_SERVICE_PROPERTY,
   getCrudServiceToken,
 } from "./tokens.js";
-import { flattenQuery } from "./flatten-query.js";
+import { WireQueryPipe } from "./wire-query.pipe.js";
 import { applySwaggerMetadata } from "./swagger.js";
 
 /** What `@Crud` records on the controller for `KavoModule.forFeature`. */
@@ -306,7 +306,7 @@ function applyParamDecorators(
     Param("id")(prototype, methodName, index++);
   }
   if (descriptor.kind === "read") {
-    Query()(prototype, methodName, index++);
+    Query(new WireQueryPipe())(prototype, methodName, index++);
   } else if (usesBody(route.method) && !BODYLESS_WRITES.has(descriptor.id as StandardOperationId)) {
     Body()(prototype, methodName, index++);
   }
@@ -335,11 +335,11 @@ function makeHandler(
       };
     case "findMany":
       return async function (this: BoundController, query: unknown) {
-        return this[CRUD_SERVICE_PROPERTY].findMany(wire(query) as never);
+        return this[CRUD_SERVICE_PROPERTY].findMany(query as never);
       };
     case "findOne":
       return async function (this: BoundController, id: unknown, query: unknown) {
-        return this[CRUD_SERVICE_PROPERTY].findOne(id as never, wire(query) as never);
+        return this[CRUD_SERVICE_PROPERTY].findOne(id as never, query as never);
       };
     case "updateOne":
       return async function (this: BoundController, id: unknown, body: unknown) {
@@ -375,8 +375,4 @@ function makeHandler(
         return response.item;
       };
   }
-}
-
-function wire(query: unknown): WireQuery {
-  return new WireQuery(flattenQuery((query ?? {}) as Readonly<Record<string, unknown>>));
 }

--- a/packages/frameworks/nest/src/flatten-query.ts
+++ b/packages/frameworks/nest/src/flatten-query.ts
@@ -1,3 +1,5 @@
+import { WireQuery } from "@kavo/core";
+
 /**
  * Normalize a parsed query object back to the flat bracket-key form the
  * Phase 5 grammar is specified against.
@@ -7,8 +9,20 @@
  * "extended" qs parser yields nested objects instead
  * (`{ filter: { age: { gte: "18" } } }`); flattening here makes the
  * binding parser-agnostic.
+ *
+ * Idempotent against an already-`WireQuery`-wrapped input (issue #25): since
+ * `@Crud` now wires an `@Override`'d read method's `query` param through
+ * `WireQueryPipe` automatically, a method still written against the pre-#25
+ * contract — calling `new WireQuery(flattenQuery(query))` itself — would
+ * otherwise flatten `WireQuery`'s own `params` property one bracket level
+ * too deep (`filter[status][eq]` becomes `params[filter[status][eq]]`),
+ * which the normalizer then silently drops instead of rejecting. Detecting
+ * `WireQuery` here and returning its already-flat `params` unchanged turns
+ * that stale call into a no-op instead of a silent loss of filtering,
+ * sorting, or field selection.
  */
 export function flattenQuery(query: Readonly<Record<string, unknown>>): Record<string, unknown> {
+  if (query instanceof WireQuery) return { ...query.params };
   const flat: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(query)) {
     flattenInto(flat, key, value);

--- a/packages/frameworks/nest/src/override.decorator.ts
+++ b/packages/frameworks/nest/src/override.decorator.ts
@@ -20,19 +20,16 @@ export interface OverrideMetadata {
  * Adding your own `@Param`/`@Query`/`@Body` on an overridden method is a
  * decoration-time error (duplicate route-argument metadata).
  *
- * For a read operation, `query` arrives as Nest's **raw** `@Query()`
- * object — a generated route always wraps it (`new WireQuery(flattenQuery(query))`,
- * both exported from `@kavo/core`/`@kavo/nest`) before it reaches
- * `DefaultCrudService`, because the engine's query-normalization stage
- * expects that wrapper to parse wire-format strings (`?fields=`, `?include=`,
- * …). An override that forwards `query` unwrapped sends it down the
- * already-normalized-input path instead, and any wire-format param 400s. Do
- * the same wrapping before delegating, e.g.:
+ * For a read operation, `query` arrives already wrapped in `WireQuery` — the
+ * same `Query(new WireQueryPipe())` decorator `@Crud` applies to a generated
+ * route is applied to the `@Override`'d method's `query` param too, since
+ * both go through the same `applyParamDecorators` call site. No manual
+ * `flattenQuery`/`WireQuery` wrapping is needed before delegating:
  *
  * ```ts
  * @Override()
- * async findOne(id: EntityId, query: unknown) {
- *   return this.base.findOne(id as never, new WireQuery(flattenQuery(query as object)) as never);
+ * async findOne(id: EntityId, query: WireQuery) {
+ *   return this.base.findOne(id as never, query as never);
  * }
  * ```
  *

--- a/packages/frameworks/nest/src/wire-query.pipe.ts
+++ b/packages/frameworks/nest/src/wire-query.pipe.ts
@@ -1,0 +1,21 @@
+import type { PipeTransform } from "@nestjs/common";
+import { WireQuery } from "@kavo/core";
+import { flattenQuery } from "./flatten-query.js";
+
+/**
+ * Backs every read-kind `@Query()` param `@Crud` applies — to a generated
+ * route and to an `@Override`'d method alike, since both go through the same
+ * `applyParamDecorators` call site. Wrapping this in Nest's own pipe seam
+ * (rather than wrapping the value inside `makeHandler`) is what lets an
+ * override receive an already-normalized `WireQuery`: Nest runs the pipe
+ * before *any* method body executes, including a hand-written one.
+ *
+ * `flattenQuery` is itself idempotent against an already-`WireQuery` input
+ * (see its docs) — the case this guards is an `@Override`'d method written
+ * before issue #25 that still wraps its `query` param manually.
+ */
+export class WireQueryPipe implements PipeTransform<unknown, WireQuery> {
+  transform(value: unknown): WireQuery {
+    return new WireQuery(flattenQuery((value ?? {}) as Readonly<Record<string, unknown>>));
+  }
+}

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -49,17 +49,6 @@ function server(): Parameters<typeof request>[0] {
   return app.getHttpServer() as Parameters<typeof request>[0];
 }
 
-/**
- * What an `@Override`'d read method must do to Nest's raw `@Query()`
- * object before handing it to `DefaultCrudService` — the same wrapping
- * `crud.decorator.ts`'s generated routes apply internally. Skipping this
- * sends wire-format query strings straight into `normalizeInput` instead
- * of `normalizeWire`, and they 400.
- */
-function wireQuery(query: unknown): WireQuery {
-  return new WireQuery(flattenQuery((query ?? {}) as Readonly<Record<string, unknown>>));
-}
-
 describe("@Crud route generation (Phases 11–12)", () => {
   @Crud(Todo)
   @Controller("todos")
@@ -407,8 +396,8 @@ describe("@Crud @Override — controller-method overrides that keep generated ro
       constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
 
       @Override()
-      async findOne(id: string, query: unknown): Promise<unknown> {
-        const item = await this.base.findOne(id as never, wireQuery(query) as never);
+      async findOne(id: string, query: WireQuery): Promise<unknown> {
+        const item = await this.base.findOne(id as never, query as never);
         return { ...item, viaOverride: true };
       }
     }
@@ -419,9 +408,85 @@ describe("@Crud @Override — controller-method overrides that keep generated ro
     expect(response.body).toMatchObject({ id: 1, title: "x", viaOverride: true });
 
     // Regression: a wire-format query string must reach the override
-    // normalized, not passed through raw — this is what wireQuery() buys.
+    // normalized, not passed through raw — this is what auto-wiring buys
+    // (issue #25). The override never calls flattenQuery/WireQuery itself.
     const narrowed = await request(server()).get("/todos/1").query("fields=id,title").expect(200);
     expect(Object.keys(narrowed.body).sort()).toEqual(["id", "title", "viaOverride"]);
+  });
+
+  it("passes an overridden findOne a WireQuery instance, not a raw query object (issue #25)", async () => {
+    let received: unknown;
+
+    @Crud(Todo)
+    @Controller("todos")
+    class OverrideFindOneQueryShapeController {
+      constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
+
+      @Override()
+      async findOne(id: string, query: WireQuery): Promise<unknown> {
+        received = query;
+        return this.base.findOne(id as never, query as never);
+      }
+    }
+
+    await bootstrap(OverrideFindOneQueryShapeController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    await request(server()).get("/todos/1").query("fields=id,title").expect(200);
+
+    expect(received).toBeInstanceOf(WireQuery);
+    expect((received as WireQuery).params).toMatchObject({ fields: "id,title" });
+  });
+
+  it("passes an overridden findMany a WireQuery instance, not a raw query object (issue #25)", async () => {
+    let received: unknown;
+
+    @Crud(Todo)
+    @Controller("todos")
+    class OverrideFindManyQueryShapeController {
+      constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
+
+      @Override()
+      async findMany(query: WireQuery): Promise<unknown> {
+        received = query;
+        return this.base.findMany(query as never);
+      }
+    }
+
+    await bootstrap(OverrideFindManyQueryShapeController);
+    await request(server()).get("/todos").query("limit=2&offset=1").expect(200);
+
+    expect(received).toBeInstanceOf(WireQuery);
+    expect((received as WireQuery).params).toMatchObject({ limit: "2", offset: "1" });
+  });
+
+  it("keeps filtering intact when a stale override still manually double-wraps its already-wired query (issue #25 regression)", async () => {
+    @Crud(Todo)
+    @Controller("todos")
+    class StaleDoubleWrapController {
+      constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
+
+      // Pre-#25 pattern: `query` is already a WireQuery (via WireQueryPipe),
+      // but this override still calls flattenQuery/WireQuery on it itself.
+      // Without flattenQuery's idempotency guard, this would silently mangle
+      // every key one bracket level too deep and drop the filter entirely.
+      @Override()
+      async findMany(query: WireQuery): Promise<unknown> {
+        const rewrapped = new WireQuery(flattenQuery(query as unknown as Record<string, unknown>));
+        return this.base.findMany(rewrapped as never);
+      }
+    }
+
+    await bootstrap(StaleDoubleWrapController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    // The fake adapter doesn't evaluate filters — it only records the
+    // normalized query (filter evaluation is @kavo/typeorm's concern) — so
+    // assert on the normalized AST itself: without flattenQuery's idempotency
+    // guard, the mangled `params[filter[...]]` keys would vanish, leaving an
+    // empty filter/sort with no error raised, rather than the AST below.
+    await request(server()).get("/todos?filter[title][eq]=x&sort=-priority").expect(200);
+    expect(adapter.lastQuery?.filter.root).toMatchObject({ kind: "condition", field: "title", operator: "EQ" });
+    expect(adapter.lastQuery?.sort).toEqual([{ field: "priority", direction: "desc" }]);
   });
 
   it("keeps createOne's generated route/param wiring (body alone, 201, no :id)", async () => {
@@ -498,8 +563,8 @@ describe("@Crud @Override — controller-method overrides that keep generated ro
       constructor(@Inject(getCrudServiceToken(Todo)) private readonly base: DefaultCrudService<Todo>) {}
 
       @Override()
-      async findOne(id: string, query: unknown): Promise<unknown> {
-        return this.base.findOne(id as never, wireQuery(query) as never);
+      async findOne(id: string, query: WireQuery): Promise<unknown> {
+        return this.base.findOne(id as never, query as never);
       }
     }
 

--- a/packages/frameworks/nest/tests/flatten-query.spec.ts
+++ b/packages/frameworks/nest/tests/flatten-query.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { WireQuery } from "@kavo/core";
 import { flattenQuery } from "@kavo/nest";
 
 /**
@@ -155,5 +156,25 @@ describe("flattenQuery — nesting depth and empty values (Phase 5)", () => {
       limit: 20,
       "filter[done][eq]": true,
     });
+  });
+});
+
+describe("flattenQuery — idempotent against an already-wrapped WireQuery (issue #25)", () => {
+  it("returns a WireQuery's own params unchanged instead of flattening them one level too deep", () => {
+    const params = { "filter[status][eq]": "active", fields: "id,title" };
+    const wired = new WireQuery(params);
+
+    // A stale @Override written before issue #25 that still manually wraps
+    // its (now already-wired) query param must not have its filter/fields
+    // silently mangled into `params[filter[status][eq]]` etc.
+    expect(flattenQuery(wired as unknown as Record<string, unknown>)).toEqual(params);
+  });
+
+  it("does not mutate or alias the WireQuery's params object", () => {
+    const params = { fields: "id,title" };
+    const wired = new WireQuery(params);
+    const flattened = flattenQuery(wired as unknown as Record<string, unknown>);
+    expect(flattened).not.toBe(params);
+    expect(flattened).toEqual(params);
   });
 });


### PR DESCRIPTION
## What & why

Generated read routes (`findOne`, `findMany`, custom `kind: "read"` operations) wrap Nest's raw `@Query()` object in `WireQuery` via the internal `wire()` helper before calling into `DefaultCrudService`. `@Override`'d methods bypassed that wiring entirely, so every read override had to reproduce it by hand (`new WireQuery(flattenQuery(query))`) — a documented footgun with a silent-400 failure mode if forgotten.

This moves the wrapping into a Nest pipe (`WireQueryPipe`, applied via `Query(new WireQueryPipe())` in `applyParamDecorators`), which is the single call site used for both generated routes and `@Override`'d methods. Overrides of read-kind operations now receive an already-wired `WireQuery` automatically; write-kind overrides are unaffected. `flattenQuery` gained an idempotency guard (`instanceof WireQuery` short-circuit) so a stale pre-#25 override that still manually wires its query doesn't get double-flattened. `AddressController.findOne` drops its manual wiring as the reference example, and `10-nestjs-integration.md` documents the new behavior.

## Public API impact

None. `WireQueryPipe` is internal (not exported from `@kavo/nest`'s barrel). `flattenQuery`/`WireQuery` remain exported for manual use in the rare case it's still needed. No barrel changes.

## Testing

Added/updated coverage in `packages/frameworks/nest/tests/binding.e2e.spec.ts` (override receives a genuine `WireQuery` instance with filter/sort/select intact, plus the double-wrap idempotency case) and `flatten-query.spec.ts` (idempotency guard at the unit level). `packages/examples/tests/app.e2e.spec.ts` updated for the simplified `AddressController`.

`pnpm check`: green — build, typecheck, depcruise (150 modules/550 deps, no violations), 495 tests passed across 23 files.

Reviewed via the full `/verify` fan-out (kavo-reviewer, kavo-boundary-guard, kavo-test-auditor, kavo-docs-auditor, kavo-security-auditor) — all clean, no blocking findings.

## Review notes

One non-blocking gap flagged by the test auditor: no test pins that a non-read `@Override` (e.g. `updateOne`) does *not* get `WireQueryPipe` applied, and `WireQueryPipe.transform()` has no direct unit test independent of the e2e binding tests. Both are low-risk (the `kind === "read"` gate is straightforward and covered indirectly) — left for a follow-up if desired.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)