### PR TITLE
chore(agents): drop boundary-guard's redundant docs-debt check

### DIFF
--- a/.claude/agents/kavo-boundary-guard.md
+++ b/.claude/agents/kavo-boundary-guard.md
@@ -46,16 +46,14 @@ violations in a change. You do not fix them and you do not edit files.
 4. Diff the barrel specifically: `git diff main...HEAD -- packages/core/src/index.ts`.
    For each added export, ask whether it is meant to be public. For each removed
    or renamed one, flag it as breaking.
-5. Check the docs debt: if the change alters behavior governed by an ADR in
-   `packages/docs/adr/`, the ADR or the matching document in
-   `packages/docs/architecture/` should have been updated. A silent divergence
-   is a finding.
+
+ADR/architecture-doc sync is `kavo-docs-auditor`'s job now — don't duplicate it.
 
 ## Output
 
 For each finding: the file and line, the rule broken, why it is a real problem
 rather than a style preference, and the smallest fix. Rank by severity —
-boundary violations and breaking barrel changes first, docs drift last.
+boundary violations first, breaking barrel changes last.
 
 If the change is clean, say so plainly and state what you checked. Do not
 manufacture findings to look useful.

--- a/.claude/skills/add-exception/SKILL.md
+++ b/.claude/skills/add-exception/SKILL.md
@@ -13,7 +13,7 @@ code, or a second serialization path.
 ## Decide it's actually new
 
 Check `ERROR_CATALOG` (`packages/core/src/errors/error-catalog.ts`) and the
-hierarchy first — a new failure mode for an *existing* code (e.g. another
+hierarchy first — a new failure mode for an _existing_ code (e.g. another
 reason a request is malformed) is usually a `QueryValidationException` issue,
 not a new class. Only add a leaf when the failure needs its own HTTP status,
 its own payload shape, or callers need to `instanceof`/catch it distinctly.
@@ -41,7 +41,7 @@ its own payload shape, or callers need to `instanceof`/catch it distinctly.
    backfills whatever's missing. Don't hand-roll that at the throw site.
 5. **Adapter mapping, if it originates from `@kavo/typeorm`** — add the
    translation in the adapter's own table (`mapDriverError`, doc 09 §5)
-   *inside the adapter package*. Core never gains ORM-specific knowledge to
+   _inside the adapter package_. Core never gains ORM-specific knowledge to
    recognize a driver error; whatever the adapter doesn't recognize already
    falls through to `PersistenceException` with the original as `cause`.
 6. **`exposeInternals`** — if the new exception can carry adapter/driver

--- a/.claude/skills/conventions/SKILL.md
+++ b/.claude/skills/conventions/SKILL.md
@@ -10,15 +10,15 @@ issue's label, its branch prefix, and the Conventional Commit prefix used for
 work on it:
 
 | Type       | Meaning                                | Issue label     |
-| ---------- | --------------------------------------- | ---------------- |
-| `feat`     | New capability                          | `type:feat`      |
-| `fix`      | Bug fix                                 | `type:fix`       |
-| `chore`    | Tooling, deps, housekeeping             | `type:chore`     |
-| `test`     | Test coverage work                      | `type:test`      |
-| `docs`     | Documentation                           | `type:docs`      |
-| `refactor` | Code restructuring, no behavior change  | `type:refactor`  |
-| `perf`     | Performance improvements                | `type:perf`      |
-| `ci`       | CI/build pipeline changes               | `type:ci`        |
+| ---------- | -------------------------------------- | --------------- |
+| `feat`     | New capability                         | `type:feat`     |
+| `fix`      | Bug fix                                | `type:fix`      |
+| `chore`    | Tooling, deps, housekeeping            | `type:chore`    |
+| `test`     | Test coverage work                     | `type:test`     |
+| `docs`     | Documentation                          | `type:docs`     |
+| `refactor` | Code restructuring, no behavior change | `type:refactor` |
+| `perf`     | Performance improvements               | `type:perf`     |
+| `ci`       | CI/build pipeline changes              | `type:ci`       |
 
 ## Creating a branch from an issue
 


### PR DESCRIPTION
## Summary
- Audited all seven `.claude/agents/*.md` files against the current codebase — every cited file path, ADR, and config field checked out accurately (no stale references, no unused agents).
- Found one real overlap: `kavo-boundary-guard` had a leftover "check docs debt against ADRs" step that fully duplicates `kavo-docs-auditor` (added specifically to own ADR/architecture-doc sync). Removed that step and its ranking mention, replaced with an explicit deferral to `kavo-docs-auditor`.
- Fixed pre-existing Prettier formatting drift in `.claude/skills/add-exception/SKILL.md` and `.claude/skills/conventions/SKILL.md` (italics using `*` instead of `_`) — this was failing CI's `format` check on `main` independent of this branch.

## Test plan
- [x] Verified every file/path referenced across the seven agent definitions exists in the current source tree
- [x] `pnpm check` — 495 tests passing
- [x] `pnpm prettier --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)