### PR TITLE
Document eager-loading pattern for detail views

### DIFF
--- a/packages/core/src/relations/relation-descriptor.ts
+++ b/packages/core/src/relations/relation-descriptor.ts
@@ -4,7 +4,9 @@ export type RelationCardinality = "one" | "many";
 
 /**
  * How an included relation is loaded (Phase 15):
- * - `join`  — single query with joins; correct default for to-one.
+ * - `join`  — single query with joins; correct default for to-one. Forcing
+ *   it onto a to-many edge is also the eager-loading pattern for detail
+ *   views (`findOne`/`findOneById`) — see architecture doc 12, section 3.
  * - `batch` — per-level `WHERE parentId IN (…)` queries stitched in
  *   memory; correct default for to-many (avoids row explosion and the
  *   joined-pagination trap).

--- a/packages/docs/architecture/12-relations-and-includes.md
+++ b/packages/docs/architecture/12-relations-and-includes.md
@@ -83,6 +83,31 @@ and share `FilterTranslator`'s scheme, so `filter[blog.name][eq]=…`
 alongside `include=blog` reuses the one selecting join instead of adding a
 second, non-selecting one under a duplicate alias.
 
+**Eager loading for detail views.** `strategy: "join"` is not restricted to
+to-one edges — forcing it onto a to-many edge folds that relation into the
+main query too, so `findOne`/`findOneById` resolves in a single round trip
+instead of the main query plus one batch query per relation level. This is
+the pattern for a detail endpoint over a relation with modest cardinality
+(an owner's pets, a blog's articles), where the extra joined rows are cheap
+and a second query is pure overhead:
+
+```ts
+joinedBlogs = kavo.createCrud(Blog, {
+  relations: { edges: { articles: { includable: true, strategy: "join" } } },
+});
+```
+
+It is opt-in per edge, never the default — `auto` still resolves a to-many
+to `batch`, and a list endpoint over the same relation should keep it that
+way: joining a large to-many into a paginated main query is correct (the
+skip/take-on-distinct-roots fallback above holds) but wastes bandwidth on
+rows the batch strategy would fetch once per page instead of once per root.
+Because `strategy` is entity-wide config, not per-operation, giving a detail
+route eager loading while a list route keeps batching means two `createCrud`
+registrations of the same entity — one per route, each with its own
+strategy — exactly as `blogs` and `joinedBlogs` do in
+`packages/orms/typeorm/tests/includes.spec.ts`.
+
 A many-to-many edge is nothing special here: metadata maps
 `isManyToMany` to cardinality `"many"` exactly like `isOneToMany`, so it
 gets the same `batch` default and the same distinct-roots pagination

--- a/packages/orms/typeorm/tests/includes.spec.ts
+++ b/packages/orms/typeorm/tests/includes.spec.ts
@@ -1,8 +1,22 @@
 import "reflect-metadata";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Column, DataSource, DeleteDateColumn, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import type { Logger } from "typeorm";
 import type { KavoInstance, DefaultCrudService } from "@kavo/core";
 import { createTypeOrmKavo } from "@kavo/typeorm";
+
+/** Counts SELECT statements so a test can assert "exactly one query fired". */
+class QueryCountingLogger implements Logger {
+  count = 0;
+  logQuery(): void {
+    this.count += 1;
+  }
+  logQueryError(): void {}
+  logQuerySlow(): void {}
+  logSchemaBuild(): void {}
+  logMigration(): void {}
+  log(): void {}
+}
 
 @Entity()
 class Blog {
@@ -51,6 +65,7 @@ let kavo: KavoInstance;
 let blogs: DefaultCrudService<Blog>;
 let joinedBlogs: DefaultCrudService<Blog>;
 let articles: DefaultCrudService<Article>;
+const queryLogger = new QueryCountingLogger();
 
 beforeAll(async () => {
   dataSource = new DataSource({
@@ -58,6 +73,8 @@ beforeAll(async () => {
     database: ":memory:",
     entities: [Blog, Article, Note],
     synchronize: true,
+    logging: "all",
+    logger: queryLogger,
   });
   await dataSource.initialize();
   kavo = createTypeOrmKavo(dataSource);
@@ -169,6 +186,22 @@ describe("Pagination correctness with a joined to-many (Phase 15, normative)", (
     expect(page.items).toHaveLength(1);
     expect(page.total).toBe(2);
     expect((page.items[0] as { articles: unknown[] }).articles).toHaveLength(2);
+  });
+});
+
+describe("Single-query eager loading for detail views (Phase 15)", () => {
+  it("findOne with a joined to-many fires exactly one query", async () => {
+    const { blogId } = await seed();
+    const before = queryLogger.count;
+    await joinedBlogs.findOne(blogId, { include: ["articles"] } as never);
+    expect(queryLogger.count - before).toBe(1);
+  });
+
+  it("findOne with the same to-many left batched fires more than one query", async () => {
+    const { blogId } = await seed();
+    const before = queryLogger.count;
+    await blogs.findOne(blogId, { include: ["articles"] } as never);
+    expect(queryLogger.count - before).toBeGreaterThan(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Document the existing `strategy: "join"` mechanism as the single-query eager-loading pattern for detail views (`findOne`/`findOneById`), clarifying when to use it (modest-cardinality relations on detail endpoints) and when not to (large to-many on paginated list endpoints). The capability already existed in the code; this PR makes it discoverable and regression-tested.

Closes #34

## Public API impact

None. No new exported types, no barrel changes, no behavior change.

## Testing

Added query-count assertions to `packages/orms/typeorm/tests/includes.spec.ts`:
- `findOne` with a joined to-many fires exactly 1 query
- `findOne` with the same to-many left at batch default fires >1 query

This provides a real regression guard for single-query execution, replacing the existing test's result-shape assertion.

Verified: `pnpm check` (build + typecheck + depcruise + 495 tests) — all green.

## Review notes

The architect agent (`kavo-architect`) found that the issue's acceptance criteria were already met by existing code. This PR closes the gap by documenting the pattern and adding the query-count test the AC asked for. No adapter/engine behavior changed, which is correct — the pattern was always there, just undocumented.