### PR TITLE
feat(core): add global operations defaults

### DIFF
--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -33,4 +33,8 @@ export const BUILT_IN_DEFAULTS: KavoSettings = Object.freeze({
     field: "deletedAt",
     strategy: "auto" as const,
   }),
+  // Unset: today's `STANDARD_OPERATIONS` enabled-by-default behavior (and
+  // ADR-0013's soft-delete-driven `restoreOne` auto-enable) is unchanged
+  // for apps that don't set a global default.
+  operations: Object.freeze({}),
 });

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -25,7 +25,7 @@ export interface QueryAllowlists<Entity = unknown> {
  * Settings keys override entity scope for this operation only; `false` in
  * the parent `operations` record disables the operation outright.
  */
-export interface OperationConfig<Entity = unknown> extends DeepPartial<KavoSettings> {
+export interface OperationConfig<Entity = unknown> extends Omit<DeepPartial<KavoSettings>, "operations"> {
   /**
    * Turn the operation on or off explicitly, overriding its default. The
    * long form of the `false` / `true` shorthands in the parent
@@ -52,7 +52,7 @@ export interface EntityConfig<
   QueryDto = QueryContext<Entity>,
   ItemDto = Entity,
   ListDto = ItemDto,
-> extends DeepPartial<KavoSettings> {
+> extends Omit<DeepPartial<KavoSettings>, "operations"> {
   readonly dto?: OperationDtoMap<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>;
   readonly allowlists?: QueryAllowlists<Entity>;
   /**

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -12,7 +12,19 @@ import { DefaultDtoResolver } from "../dto/default-dto-resolver.js";
 import { DefaultRelationRegistry } from "../relations/default-relation-registry.js";
 import { resolveSoftDelete } from "../persistence/soft-delete.js";
 
-/** Top-level settings keys — the subset of an `EntityConfig` that merges. */
+/**
+ * Top-level settings keys — the subset of an `EntityConfig` that merges.
+ * `operations` is deliberately excluded: `EntityConfig.operations` is a
+ * structurally different (richer, per-entity-typed) shape than
+ * `KavoSettings.operations`'s global boolean map, so picking it here would
+ * feed entity-scope `handler`/`meta` entries through the boolean-shaped
+ * merge. `createOperationRegistry` resolves entity/operation-scope
+ * `operations` directly from `EntityConfig`; the global boolean default
+ * still reaches `entitySettings.operations` for free below, via
+ * `mergeSettings(BUILT_IN_DEFAULTS, globalDefaults, …)` — `globalDefaults`
+ * is a `KavoSettings`-shaped `DeepPartial`, so its `operations` key merges
+ * normally even though `pickSettings` never reads it off `entityConfig`.
+ */
 const SETTINGS_KEYS = [
   "pagination",
   "query",

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -1,4 +1,5 @@
 import type { RelationLoadStrategy } from "../relations/relation-descriptor.js";
+import type { StandardOperationId } from "../operations/operation.js";
 
 /**
  * The complete, canonical settings schema — one schema for every scope.
@@ -82,4 +83,12 @@ export interface KavoSettings {
   readonly errors: ErrorSettings;
   readonly relations: RelationSettings;
   readonly softDelete: SoftDeleteSettings | false;
+  /**
+   * Global operation enablement, keyed by standard operation id — booleans
+   * only, unlike the richer per-entity `EntityConfig.operations` (which also
+   * carries `handler`/`meta` and is entity-typed). An id absent here defers
+   * to the built-in default (and, for `restoreOne`, ADR-0013's soft-delete
+   * auto-enable); an entity's own `operations.<id>` always wins over this.
+   */
+  readonly operations: Readonly<Partial<Record<StandardOperationId, boolean>>>;
 }

--- a/packages/core/src/config/validate-settings.ts
+++ b/packages/core/src/config/validate-settings.ts
@@ -1,5 +1,6 @@
 import type { KavoSettings } from "./settings.js";
 import { ConfigurationException } from "../errors/exceptions.js";
+import { STANDARD_OPERATIONS } from "../operations/default-operation-registry.js";
 
 /**
  * Bootstrap validation (Phase 8). Fails fast with an error naming the
@@ -88,5 +89,17 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
         `expected "auto", "soft", or "hard", got ${JSON.stringify(strategy)}`,
       );
     }
+  }
+
+  for (const [id, value] of Object.entries(settings.operations)) {
+    const path = `operations.${id}`;
+    if (!(id in STANDARD_OPERATIONS)) {
+      throw new ConfigurationException(
+        entityName,
+        path,
+        `unknown operation id ${JSON.stringify(id)} — expected one of ${Object.keys(STANDARD_OPERATIONS).join(", ")}`,
+      );
+    }
+    bool(path, value);
   }
 }

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -110,6 +110,7 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
       const registry = createOperationRegistry<Entity>(
         config as EntityConfig<Entity> | undefined,
         builtInHandlers(adapter as unknown as RepositoryAdapter<Entity>),
+        resolved.settings.operations,
       );
       requireSoftDeletable(resolved, registry);
 

--- a/packages/core/src/operations/default-operation-registry.ts
+++ b/packages/core/src/operations/default-operation-registry.ts
@@ -115,10 +115,17 @@ const unboundHandler = (id: OperationId): OperationHandler<unknown> => ({
  * `handlers` binds the built-in behaviors; when omitted the entries carry
  * throwing placeholders — that mode exists for consumers that only need
  * the table (`@kavo/nest` route generation), never for execution.
+ *
+ * `globalOperations` is the resolved `KavoSettings.operations` boolean map
+ * (issue #38's global default): it fills `byDefault` for an id the entity
+ * config doesn't mention at all, sitting between the unconditional/soft-delete
+ * default and the entity's own `operations.<id>` — which always wins when
+ * present, boolean shorthand or long form alike.
  */
 export function createOperationRegistry<Entity extends object>(
   config: EntityConfig<Entity> | undefined,
   handlers?: StandardHandlerFactory<Entity>,
+  globalOperations?: Readonly<Partial<Record<StandardOperationId, boolean>>>,
 ): OperationRegistry<Entity> {
   const registry = new DefaultOperationRegistry<Entity>();
   const operations = config?.operations ?? {};
@@ -128,11 +135,12 @@ export function createOperationRegistry<Entity extends object>(
     const operationConfig = operations[id];
     const settings = typeof operationConfig === "object" ? operationConfig : undefined;
     const byDefault = shape.enabled || (id === "restoreOne" && softDeleteDeclared);
+    const defaultForEntity = globalOperations?.[id] ?? byDefault;
     registry.register({
       id,
       kind: shape.kind,
       cardinality: shape.cardinality,
-      enabled: typeof operationConfig === "boolean" ? operationConfig : (settings?.enabled ?? byDefault),
+      enabled: typeof operationConfig === "boolean" ? operationConfig : (settings?.enabled ?? defaultForEntity),
       handler: settings?.handler ?? handlers?.(id) ?? (unboundHandler(id) as unknown as OperationHandler<Entity>),
       input: null,
       output: null,

--- a/packages/core/tests/config-validation.spec.ts
+++ b/packages/core/tests/config-validation.spec.ts
@@ -205,6 +205,28 @@ describe("validateSettings — soft delete (Phase 14 keys, Phase 8 rules)", () =
   });
 });
 
+describe("validateSettings — global operations default (issue #38)", () => {
+  it("rejects an unknown operation id", () => {
+    const error = rejectionOf({ operations: { notAnOperation: false } });
+    expect(error.code).toBe("KAVO_CONFIG_INVALID");
+    expect(error.messageParams).toMatchObject({ entity: "User", path: "operations.notAnOperation" });
+  });
+
+  it("rejects a non-boolean value for a known operation id", () => {
+    for (const value of ["off", 1, null]) {
+      expectRejected({ operations: { deleteOne: value } }, "operations.deleteOne", value);
+    }
+  });
+
+  it("accepts a boolean map over known operation ids", () => {
+    expect(() => accept({ operations: { deleteOne: false, patchOne: false, restoreOne: true } })).not.toThrow();
+  });
+
+  it("accepts an empty map — the zero-config default", () => {
+    expect(() => accept({ operations: {} })).not.toThrow();
+  });
+});
+
 describe("validateSettings — the base of the precedence chain", () => {
   it("accepts the built-in defaults unchanged", () => {
     // Everything merges onto these, so a schema change that leaves them

--- a/packages/core/tests/global-operations-defaults.spec.ts
+++ b/packages/core/tests/global-operations-defaults.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { ConfigurationException, OperationDisabledException, createKavo } from "@kavo/core";
+import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
+
+/**
+ * End-to-end coverage for `KavoSettings.operations` (issue #38): a global
+ * default set via `createKavo({ defaults: { operations } })` reaches the
+ * engine through `resolveEntityConfig` → `createOperationRegistry`, with
+ * entity-level `operations` still winning where it's set.
+ */
+function makeCrud(globalOperations: Record<string, boolean>, entityConfig?: Record<string, unknown>) {
+  const adapter = new InMemoryUserAdapter();
+  const crud = createKavo({ defaults: { operations: globalOperations } }).createCrud(User, entityConfig as never, {
+    adapter,
+    metadata: userMetadata,
+  });
+  return { crud, adapter };
+}
+
+describe("global operations default — end to end (issue #38)", () => {
+  it("disables an operation for every entity that doesn't override it", async () => {
+    const { crud } = makeCrud({ deleteOne: false });
+    await expect(crud.deleteOne(1)).rejects.toBeInstanceOf(OperationDisabledException);
+  });
+
+  it("still allows an entity that explicitly re-enables it", async () => {
+    const { crud, adapter } = makeCrud({ deleteOne: false }, { operations: { deleteOne: true } });
+    adapter.rows.push(Object.assign(new User(), { id: 1 }));
+    await expect(crud.deleteOne(1)).resolves.toBeUndefined();
+  });
+
+  it("does not silently force-enable restoreOne on a hard-delete entity", () => {
+    // User's fixture metadata carries no delete-marker field, so it
+    // resolves to hard delete — a global force-enable must fail loudly at
+    // bootstrap, not silently no-op or succeed (ADR-0013).
+    expect(() => makeCrud({ restoreOne: true })).toThrow(ConfigurationException);
+  });
+
+  it("leaves an operation the global default didn't mention at its built-in default", async () => {
+    const { crud } = makeCrud({ deleteOne: false });
+    const created = await crud.createOne({
+      name: "Ada",
+      email: "ada@example.com",
+      age: 30,
+      status: "active",
+    } as never);
+    expect(created).toMatchObject({ name: "Ada" });
+  });
+});

--- a/packages/core/tests/operation-registry.spec.ts
+++ b/packages/core/tests/operation-registry.spec.ts
@@ -235,3 +235,60 @@ describe("createOperationRegistry — Phase 13 control surface", () => {
     expect(registry.get("findMany")?.meta).toBe(meta);
   });
 });
+
+describe("createOperationRegistry — global operations default (issue #38)", () => {
+  it("disables an always-on operation globally when the entity doesn't override it", () => {
+    const registry = createOperationRegistry<User>(undefined, standardHandlers, { deleteOne: false, patchOne: false });
+    expect(registry.get("deleteOne")?.enabled).toBe(false);
+    expect(registry.get("patchOne")?.enabled).toBe(false);
+    // Everything the global default didn't mention keeps its own default.
+    expect(registry.get("createOne")?.enabled).toBe(true);
+  });
+
+  it("lets an entity boolean shorthand override a global disable", () => {
+    const registry = createOperationRegistry<User>(
+      { operations: { deleteOne: true } } as UserConfig,
+      standardHandlers,
+      { deleteOne: false },
+    );
+    expect(registry.get("deleteOne")?.enabled).toBe(true);
+  });
+
+  it("lets an entity long-form `{ enabled }` override a global disable", () => {
+    const registry = createOperationRegistry<User>(
+      { operations: { deleteOne: { enabled: true } } } as UserConfig,
+      standardHandlers,
+      { deleteOne: false },
+    );
+    expect(registry.get("deleteOne")?.enabled).toBe(true);
+  });
+
+  it("global enable composes with an entity that already declares soft delete", () => {
+    const registry = createOperationRegistry<User>(
+      { softDelete: { strategy: "soft", field: "deletedAt" } } as UserConfig,
+      standardHandlers,
+      { restoreOne: true },
+    );
+    expect(registry.get("restoreOne")?.enabled).toBe(true);
+  });
+
+  it("global disable wins over the soft-delete auto-enable of restoreOne", () => {
+    const registry = createOperationRegistry<User>(
+      { softDelete: { strategy: "soft", field: "deletedAt" } } as UserConfig,
+      standardHandlers,
+      { restoreOne: false },
+    );
+    expect(registry.get("restoreOne")?.enabled).toBe(false);
+  });
+
+  it("reproduces today's STANDARD_OPERATIONS behavior byte-for-byte when unset", () => {
+    const withUndefined = createOperationRegistry<User>(undefined, standardHandlers, undefined);
+    const withEmpty = createOperationRegistry<User>(undefined, standardHandlers, {});
+    const withoutArg = createOperationRegistry<User>(undefined, standardHandlers);
+    expect(ids(withUndefined)).toEqual(Object.keys(STANDARD_OPERATIONS));
+    for (const id of Object.keys(STANDARD_OPERATIONS) as StandardOperationId[]) {
+      expect(withUndefined.get(id)?.enabled).toBe(withoutArg.get(id)?.enabled);
+      expect(withEmpty.get(id)?.enabled).toBe(withoutArg.get(id)?.enabled);
+    }
+  });
+});

--- a/packages/core/tests/types/usage-full.test-d.ts
+++ b/packages/core/tests/types/usage-full.test-d.ts
@@ -91,3 +91,15 @@ void kavo.createCrud(Author, { allowlists: { filterable: ["nmae"] } });
 
 // Overridden and default operations dispatch through the engine, one pipeline either way.
 void authors.engine.execute({ operation: "findMany", id: null, body: null, query: null, options: null });
+
+// A global default may set the (boolean-only) operations map...
+createKavo({ defaults: { operations: { deleteOne: false, restoreOne: true } } });
+
+// @ts-expect-error — but not the richer per-entity shape (handler/meta):
+// `KavoSettings.operations` is boolean-only global state (issue #38).
+createKavo({ defaults: { operations: { deleteOne: { handler: promote } } } });
+
+// @ts-expect-error — nesting `operations` inside an `OperationConfig` is a
+// type error now that `OperationConfig` no longer inherits `operations`
+// from `DeepPartial<KavoSettings>` (issue #38).
+kavo.createCrud(Author, { operations: { findMany: { operations: {} } } });

--- a/packages/docs/adr/0015-global-operation-defaults-are-engine-only.md
+++ b/packages/docs/adr/0015-global-operation-defaults-are-engine-only.md
@@ -1,0 +1,72 @@
+# ADR-0015 — Global operation defaults are enforced by the engine, not decoration-time routing
+
+**Status:** accepted (issue #38)
+
+## Context
+
+Disabling an operation was, until now, only an entity-scope decision
+(`operations: { deleteOne: false }` in each `createCrud`/`@Crud` config).
+Apps that want a conservative default — read-mostly APIs, admin-only
+writes — had to repeat the same block on every entity. This adds a
+global `KavoSettings.operations` boolean map, resolved through the
+existing `built-in → global → entity → operation` precedence chain
+(`resolveEntityConfig`) and fed into `createOperationRegistry`'s
+existing `enabled` resolution as one more fallback rung, ahead of the
+unconditional/soft-delete default and behind the entity's own
+`operations.<id>`.
+
+The complication is the same one ADR-0012 already names: `@kavo/nest`
+generates routes at **class-decoration time** (import time), strictly
+before `KavoModule.forRootAsync`'s (sync or async) factory ever runs —
+decoration is the only moment Nest's router scan can see the generated
+methods, and there is no bootstrap-time value to read yet. A global
+operations default therefore cannot reach the router the way an
+entity-level `operations.<id>: false` already does (no route generated
+at all): the value that would disable the route simply does not exist
+when the route is generated.
+
+The alternative — deferring `@kavo/nest` route generation to a
+bootstrap-time phase that has seen `forRootAsync`'s options — is the
+"Phase 16 DX option" ADR-0012 already reserves as a possible future
+change. Chasing it here would turn a config-schema addition into a
+routing-architecture rewrite for a case (global operation-enablement
+defaults) that doesn't need the route removed, only the request refused.
+
+## Decision
+
+A global `defaults.operations.<id>` reaches **only** the engine/service
+side of the split: `createKavo`'s `createCrud` resolves it through
+`resolveEntityConfig` and passes it to `createOperationRegistry`, which
+every `DefaultCrudService` call and every `engine.execute(...)` custom
+dispatch goes through. `@kavo/nest`'s route generation
+(`crud.decorator.ts`) calls `createOperationRegistry` the same way it
+always has — two arguments, entity config only, no global value — so it
+keeps computing `enabled` from exactly what it could see before this
+change.
+
+The result is a deliberate split: an entity that doesn't override a
+globally-disabled operation still gets the route (decoration couldn't
+know to skip it), but calling that route always resolves through the
+bound service, which does know the global default, and throws
+`OperationDisabledException` (`KAVO_OPERATION_DISABLED`, HTTP 405) via
+the existing problem-details path — never a silent 2xx, and never a
+bare 404 that would suggest the route was never there.
+
+An entity that wants the route itself to disappear still states so in
+its own `operations.<id>: false`, exactly as before this change —
+nothing about entity-level disabling changes.
+
+## Consequences
+
+- A global default is a _behavioral_ switch, not a _routing_ switch. Apps
+  that need the route to vanish (e.g. to keep it out of generated
+  OpenAPI docs) must still say so per entity; the global default only
+  guarantees the operation cannot execute.
+- The two registry builds (engine, router) stay independently correct
+  for what each can see, the same discipline ADR-0013 established for
+  soft-delete operations — this ADR generalizes that pattern to an
+  arbitrary global boolean rather than adding a second special case.
+- If a future phase moves `@kavo/nest` route generation behind a
+  bootstrap-time registration (ADR-0012's reserved option), this gap
+  closes for free — nothing about the config shape here needs to change,
+  only where `createOperationRegistry` is called from.

--- a/packages/docs/architecture/01-system-architecture.md
+++ b/packages/docs/architecture/01-system-architecture.md
@@ -239,22 +239,23 @@ Kavo is **not**:
 
 ## 9. ADR index
 
-| ADR                                                           | Decision                                                  |
-| ------------------------------------------------------------- | --------------------------------------------------------- |
-| [0001](../adr/0001-clean-architecture-core-owns-contracts.md) | Clean architecture: core owns all contracts               |
-| [0002](../adr/0002-package-topology.md)                       | Three packages under `orms/` / `frameworks/` parents      |
-| [0003](../adr/0003-pnpm-plain-scripts-tsc-build.md)           | pnpm workspaces, plain scripts, `tsc -b` — no task runner |
-| [0004](../adr/0004-lockstep-versioning.md)                    | Lockstep versioning                                       |
-| [0005](../adr/0005-core-zero-runtime-dependencies.md)         | Zero runtime dependencies in `@kavo/core`                 |
-| [0006](../adr/0006-registry-driven-operations.md)             | Registry-driven operation dispatch                        |
-| [0007](../adr/0007-module-augmentable-operation-metadata.md)  | Module-augmentable `OperationMetadata`                    |
-| [0008](../adr/0008-field-path-recursion-cap.md)               | `FieldPath` recursion cap (default 3, max 5)              |
-| [0009](../adr/0009-problem-details-error-shape.md)            | RFC 9457 problem details as the wire error shape          |
-| [0010](../adr/0010-explicit-named-barrel.md)                  | Explicit named barrel in core                             |
-| [0011](../adr/0011-entity-metadata-infrastructure-seam.md)    | Entity-metadata & infrastructure seam                     |
-| [0012](../adr/0012-decoration-time-route-generation.md)       | Decoration-time route generation in `@kavo/nest`          |
-| [0013](../adr/0013-config-declared-soft-delete-operations.md) | Soft-delete operations enabled from config, not metadata  |
-| [0014](../adr/0014-associate-by-id-not-deep-writes.md)        | Write-side relations: associate by id, no deep writes     |
+| ADR                                                              | Decision                                                  |
+| ---------------------------------------------------------------- | --------------------------------------------------------- |
+| [0001](../adr/0001-clean-architecture-core-owns-contracts.md)    | Clean architecture: core owns all contracts               |
+| [0002](../adr/0002-package-topology.md)                          | Three packages under `orms/` / `frameworks/` parents      |
+| [0003](../adr/0003-pnpm-plain-scripts-tsc-build.md)              | pnpm workspaces, plain scripts, `tsc -b` — no task runner |
+| [0004](../adr/0004-lockstep-versioning.md)                       | Lockstep versioning                                       |
+| [0005](../adr/0005-core-zero-runtime-dependencies.md)            | Zero runtime dependencies in `@kavo/core`                 |
+| [0006](../adr/0006-registry-driven-operations.md)                | Registry-driven operation dispatch                        |
+| [0007](../adr/0007-module-augmentable-operation-metadata.md)     | Module-augmentable `OperationMetadata`                    |
+| [0008](../adr/0008-field-path-recursion-cap.md)                  | `FieldPath` recursion cap (default 3, max 5)              |
+| [0009](../adr/0009-problem-details-error-shape.md)               | RFC 9457 problem details as the wire error shape          |
+| [0010](../adr/0010-explicit-named-barrel.md)                     | Explicit named barrel in core                             |
+| [0011](../adr/0011-entity-metadata-infrastructure-seam.md)       | Entity-metadata & infrastructure seam                     |
+| [0012](../adr/0012-decoration-time-route-generation.md)          | Decoration-time route generation in `@kavo/nest`          |
+| [0013](../adr/0013-config-declared-soft-delete-operations.md)    | Soft-delete operations enabled from config, not metadata  |
+| [0014](../adr/0014-associate-by-id-not-deep-writes.md)           | Write-side relations: associate by id, no deep writes     |
+| [0015](../adr/0015-global-operation-defaults-are-engine-only.md) | Global operation defaults are engine-only, not routing    |
 
 ## 10. Tradeoff analysis
 

--- a/packages/docs/architecture/08-configuration.md
+++ b/packages/docs/architecture/08-configuration.md
@@ -21,6 +21,7 @@ built-in defaults → global (createKavo) → entity (createCrud)
 | `relations.maxIncludeDepth` / `maxIncludedNodes` | 2 / 10                   | include depth budget and total node cap (Phase 15)                             |
 | `relations.edges.<name>`                         | `{}`                     | per-relation `includable` / `defaultInclude` / `maxDepth` / `strategy`         |
 | `softDelete.field` / `strategy`                  | `"deletedAt"` / `"auto"` | Phase 14; `auto` = soft when the entity has the marker field, `false` disables |
+| `operations.<id>`                                | `{}` (unset)             | global operation-enablement default (issue #38); see below                     |
 | `bulk.mode` / `maxBatchSize`                     | `"atomic"` / 500         | reserved (bulk is not built)                                                   |
 
 **Schema extensibility rule:** feature phases add keys to this schema —
@@ -41,6 +42,24 @@ Implemented in `mergeSettings` (`merge-settings.ts`):
 An `EntityConfig` mixes settings keys with structural keys (`dto`,
 `allowlists`, `operations`); only the settings subset participates in
 the merge.
+
+**`operations` is a special case, at two different scopes.** At _global_
+scope, `KavoSettings.operations` is a plain boolean map
+(`Partial<Record<StandardOperationId, boolean>>`) and merges through
+`mergeSettings` exactly like any other key — `createKavo({ defaults:
+{ operations: { deleteOne: false } } })` sets an app-wide default. At
+_entity/operation_ scope, `EntityConfig.operations`/`OperationConfig` is
+a structurally richer, per-entity-typed shape (it also carries
+`handler`/`meta`), so it is deliberately **excluded** from the generic
+`SETTINGS_KEYS` merge (`resolve-entity-config.ts`) — folding it in would
+feed a `handler` function through the boolean-shaped global merge.
+Instead, `createOperationRegistry` resolves `enabled` for each operation
+directly, in one precedence chain: the unconditional/soft-delete-declared
+default, then the global `operations.<id>` boolean (if the entity didn't
+say anything), then the entity's own `operations.<id>` (boolean
+shorthand or `{ enabled }` long form) — which always wins. See
+ADR-0015 for what this global default can and cannot reach in
+`@kavo/nest`.
 
 ## 3. Resolution timing and immutability
 

--- a/packages/docs/architecture/10-nestjs-integration.md
+++ b/packages/docs/architecture/10-nestjs-integration.md
@@ -91,6 +91,20 @@ decoration time has no ORM metadata (ADR-0013): `softDelete: { strategy:
 "soft" }` adds the restore route, `operations: { purgeOne: true }` the
 purge route.
 
+**Global `defaults.operations.<id>` (issue #38, ADR-0015) is not seen
+here.** `KavoModule.forRootAsync`'s `defaults` resolves only once its
+factory runs, which is always _after_ `@Crud` has already decorated
+every controller and generated its routes (ADR-0012) — there is no
+value to read yet at the moment this table's decision is made. A route
+an entity doesn't disable itself therefore still generates, even under
+a global `operations.<id>: false`. The bound service _does_ see the
+global default (it's resolved through `createKavo`'s `createCrud`,
+which runs at `onModuleInit`), so calling that route always answers
+`405` with `code: "KAVO_OPERATION_DISABLED"` — never a silent success,
+and never a bare `404` that would suggest the route was never mapped.
+An app that wants the route itself gone still states so per entity,
+exactly as before.
+
 **Manual-method-wins:** a hand-written controller method whose name
 matches an operation id suppresses that generated route — detected via
 `hasOwnProperty` on the prototype, no config needed.

--- a/packages/examples/src/app.module.ts
+++ b/packages/examples/src/app.module.ts
@@ -37,6 +37,10 @@ export class AppModule {
             defaults: {
               pagination: { defaultLimit: 20, maxLimit: 100 },
               errors: { exposeInternals: false },
+              // App-wide default (issue #38): off unless an entity opts back
+              // in via its own `operations.restoreOne`. `OwnerController`
+              // does exactly that.
+              operations: { restoreOne: false },
             },
           }),
         }),

--- a/packages/examples/src/owner/owner.controller.ts
+++ b/packages/examples/src/owner/owner.controller.ts
@@ -14,7 +14,11 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
  * `PATCH /owners/:id/restore` on the router — route generation runs before
  * any ORM metadata exists, so the config, not the entity, is what it can
  * read (ADR-0013). `purgeOne` is off by default everywhere; asked for by
- * name it adds `DELETE /owners/:id/purge`.
+ * name it adds `DELETE /owners/:id/purge`. `restoreOne: true` here is
+ * explicit rather than relying on the soft-delete auto-enable, because
+ * `AppModule` sets a global `defaults.operations.restoreOne: false`
+ * (issue #38) — this entity opts back in, which is the whole point of the
+ * precedence chain: entity config always wins over the global default.
  */
 @Crud(Owner, {
   dto: {
@@ -31,6 +35,7 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
   relations: { edges: { pets: { includable: true }, address: { includable: true } } },
   operations: {
     purgeOne: true,
+    restoreOne: true,
   },
 })
 @Controller("owners")

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -260,6 +260,35 @@ describe("@Crud operation control surface", () => {
     await request(server()).delete("/todos/1").expect(404);
   });
 
+  it("a global operations default guards the route rather than removing it (issue #38, ADR-0015)", async () => {
+    // Decoration runs before KavoModule.forRoot(Async)'s options are known
+    // (ADR-0012), so a global `defaults.operations.deleteOne: false` can't
+    // retract the already-generated DELETE route. It reaches the bound
+    // service instead: the route still exists, but calling it always
+    // answers with a 405 problem-details document, never a 2xx or a bare 404.
+    @Crud(Todo)
+    @Controller("todos")
+    class GloballyGuardedController {}
+
+    await bootstrap(GloballyGuardedController, { defaults: { operations: { deleteOne: false } } });
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    const response = await request(server())
+      .delete("/todos/1")
+      .expect(405)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body).toMatchObject({ code: "KAVO_OPERATION_DISABLED" });
+  });
+
+  it("an entity-level override still wins over a global operations default", async () => {
+    @Crud(Todo, { operations: { deleteOne: true } })
+    @Controller("todos")
+    class ReenabledController {}
+
+    await bootstrap(ReenabledController, { defaults: { operations: { deleteOne: false } } });
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    await request(server()).delete("/todos/1").expect(204);
+  });
+
   it("manual-method-wins: a hand-written method suppresses generation", async () => {
     @Crud(Todo)
     @Controller("todos")


### PR DESCRIPTION
## What & why

Adds a global `operations` key to `KavoSettings` so `KavoModule.forRootAsync`/`createKavo`'s `defaults` can disable (or enable) standard operations app-wide — e.g. a conservative `{ deleteOne: false, patchOne: false, restoreOne: false }` default for a read-mostly or admin-only-writes API — instead of repeating the same `operations` block on every entity.

The global shape is a boolean-only map (`Partial<Record<StandardOperationId, boolean>>`), not the richer per-entity `EntityConfig.operations` shape the issue's literal wording suggested. That richer shape is generic over `Entity` (carries `handler`/`meta`) and doesn't typecheck against an entity-erased global schema; the issue's own "out of scope" section excludes a global handler/meta override anyway, so the boolean map covers the actual use case with no loss.

The new default resolves through the existing `built-in → global → entity → operation` precedence chain (`resolveEntityConfig`) and feeds `createOperationRegistry` as one more fallback rung, ahead of the unconditional/soft-delete default and behind the entity's own `operations.<id>` — which always wins.

**Known, deliberate gap (ADR-0015):** `@kavo/nest` generates routes at class-decoration time, strictly before `KavoModule.forRootAsync`'s options are known (ADR-0012), so a global disable cannot retract an already-generated route. The route stays; calling it always throws `OperationDisabledException` (405 `KAVO_OPERATION_DISABLED`) via the bound service, which does see the global default. An app that wants the route itself gone still states so per entity, same as before. This mirrors ADR-0013's existing "two registry builds, each correct for what it can see" discipline.

## Public API impact

- `KavoSettings` gains a new **required** field `operations` (default `{}`) — additive but technically breaking for any external consumer building a `KavoSettings` object literal by hand (not via `DeepPartial`). No such literal exists in this repo (verified via grep); `pnpm check`'s `tsc` step would catch any consumer-side occurrence.
- `EntityConfig`/`OperationConfig` value-level shape is unchanged for callers; only their internal `extends` clause moved to `Omit<DeepPartial<KavoSettings>, "operations">` so their own richer `operations` field no longer collides with the new global boolean map.
- `createOperationRegistry` gains an optional third parameter (`globalOperations`) — non-breaking for all existing callers.
- Nothing removed from the barrel.

## Testing

- Registry-level: global disable respected when unset by the entity; entity boolean/long-form override always wins; global enable/disable composing correctly with the soft-delete auto-enable of `restoreOne`; full regression guard that an unset global default reproduces today's `STANDARD_OPERATIONS` behavior byte-for-byte.
- Validation: unknown operation id and non-boolean value in the global map both throw `ConfigurationException`.
- Integration (`createKavo` end to end): global disable blocks the operation; entity override re-enables it; a global force-enable of `restoreOne` on a hard-delete entity fails loudly at bootstrap (never silent), per ADR-0013.
- Nest e2e: a global disable leaves the route generated but every call to it answers 405 `KAVO_OPERATION_DISABLED`; an entity-level override still wins end to end over HTTP.
- Type-level: nesting `operations` inside an `OperationConfig` is now a compile error; the global `defaults.operations` map rejects the richer per-entity shape.
- `packages/examples` updated to demonstrate the feature (`AppModule` sets `operations.restoreOne: false` globally; `OwnerController` opts back in) and is exercised by the existing example e2e suites.
- `pnpm check` (build + typecheck + depcruise + full test suite): **green** — 556 tests passing across 25 files.

## Review notes

- The decoration-time gap (ADR-0015) is the main thing worth a close look — it's a deliberate scope boundary, not an oversight, but worth confirming the documentation (doc 08 §2, doc 10, ADR-0015) explains it clearly enough for a future reader.
- `validateSettings` now imports `STANDARD_OPERATIONS` from `../operations/default-operation-registry.js` to validate operation ids against the canonical table rather than duplicating the list — confirmed this doesn't introduce a runtime import cycle (`depcruise`'s `no-circular` rule passed).

Closes #38