### PR TITLE
Support { exclude } shape in query allowlists; demonstrate it on Owner and Cat

### DIFF
--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -8,6 +8,17 @@ import type { OperationHandler, OperationMetadata } from "../operations/operatio
 import type { StandardOperationId } from "../operations/operation.js";
 
 /**
+ * One allowlist key's raw configuration: either the explicit set of paths
+ * to allow, or `{ exclude }` — every own column except the ones named.
+ * `exclude` is resolved against the entity's own columns at bootstrap
+ * (`resolveAllowlists`), never evaluated eagerly here — the `@Crud(...)`
+ * config object is built at class-decoration time, before any ORM metadata
+ * exists (ADR-0013), so there is nothing to resolve `exclude` against yet.
+ */
+export type QueryFieldSelector<Entity> =
+  readonly FieldPath<Entity>[] | { readonly exclude: readonly FieldPath<Entity>[] };
+
+/**
  * Security allowlists: what a request may filter, sort, and
  * select on — including relation paths. Anything outside an allowlist is
  * rejected with a 400 (`QueryValidationException`), never silently
@@ -15,9 +26,9 @@ import type { StandardOperationId } from "../operations/operation.js";
  * entity metadata at bootstrap.
  */
 export interface QueryAllowlists<Entity = unknown> {
-  readonly filterable?: readonly FieldPath<Entity>[];
-  readonly sortable?: readonly FieldPath<Entity>[];
-  readonly selectable?: readonly FieldPath<Entity>[];
+  readonly filterable?: QueryFieldSelector<Entity>;
+  readonly sortable?: QueryFieldSelector<Entity>;
+  readonly selectable?: QueryFieldSelector<Entity>;
 }
 
 /**

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -1,6 +1,6 @@
 import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
-import type { EntityConfig, OperationConfig } from "./entity-config.js";
+import type { EntityConfig, OperationConfig, QueryFieldSelector } from "./entity-config.js";
 import type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./resolved-entity-config.js";
 import type { EntityMetadata } from "../metadata/entity-metadata.js";
 import type { FieldPath } from "../types/field-path.js";
@@ -119,10 +119,26 @@ function resolveAllowlists<Entity extends object>(
   const ownColumns = metadata.fields.map((field) => field.name) as unknown as readonly FieldPath<Entity>[];
   const configured = entityConfig?.allowlists;
   return deepFreeze({
-    filterable: configured?.filterable ?? ownColumns,
-    sortable: configured?.sortable ?? ownColumns,
-    selectable: configured?.selectable ?? ownColumns,
+    filterable: resolveFieldSelector(ownColumns, configured?.filterable),
+    sortable: resolveFieldSelector(ownColumns, configured?.sortable),
+    selectable: resolveFieldSelector(ownColumns, configured?.selectable),
   });
+}
+
+/**
+ * Resolves one allowlist key's raw selector against the entity's own
+ * columns: an explicit array is used as-is; `{ exclude }` resolves to
+ * `ownColumns` minus the named paths, so a column outside `ownColumns` can
+ * never appear via `exclude` and stays fail-closed like the plain default.
+ */
+function resolveFieldSelector<Entity>(
+  ownColumns: readonly FieldPath<Entity>[],
+  selector: QueryFieldSelector<Entity> | undefined,
+): readonly FieldPath<Entity>[] {
+  if (selector === undefined) return ownColumns;
+  if (!("exclude" in selector)) return selector;
+  const excluded = new Set(selector.exclude);
+  return ownColumns.filter((column) => !excluded.has(column));
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,7 +52,7 @@ export type {
   PaginationStrategyName,
 } from "./config/settings.js";
 export type { GlobalConfig } from "./config/global-config.js";
-export type { EntityConfig, OperationConfig, QueryAllowlists } from "./config/entity-config.js";
+export type { EntityConfig, OperationConfig, QueryAllowlists, QueryFieldSelector } from "./config/entity-config.js";
 export type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./config/resolved-entity-config.js";
 
 // ── Operations ────────────────────────────────────────────────────────

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -132,6 +132,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "ProblemDetailsOptions",
   "QueryAllowlists",
   "QueryContext",
+  "QueryFieldSelector",
   "QueryIssueDto",
   "QueryNormalizer",
   "QuerySettings",

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -88,6 +88,42 @@ describe("resolveEntityConfig — bootstrap", () => {
     // Unconfigured lists still derive.
     expect(config.allowlists.sortable).toContain("email");
   });
+
+  it("resolves { exclude } to every own column except the ones named", () => {
+    const config = resolveEntityConfig(userMetadata, { allowlists: { filterable: { exclude: ["email"] } } }, undefined);
+    expect(config.allowlists.filterable).toEqual(["id", "name", "age", "status", "createdAt"]);
+    // Unconfigured lists still derive in full.
+    expect(config.allowlists.sortable).toContain("email");
+  });
+
+  it("never lets { exclude } surface a column outside own columns", () => {
+    // A name that isn't an own column is a no-op to exclude — the result
+    // stays a subset of own columns, never an arbitrary string added in.
+    const notAColumn = "notAColumn" as unknown as keyof User;
+    const config = resolveEntityConfig(
+      userMetadata,
+      { allowlists: { filterable: { exclude: [notAColumn] } } },
+      undefined,
+    );
+    expect(config.allowlists.filterable).toEqual(["id", "name", "email", "age", "status", "createdAt"]);
+  });
+
+  it("resolves { exclude } independently for sortable and selectable too", () => {
+    const config = resolveEntityConfig(
+      userMetadata,
+      {
+        allowlists: {
+          sortable: { exclude: ["status"] },
+          selectable: { exclude: ["age", "status"] },
+        },
+      },
+      undefined,
+    );
+    expect(config.allowlists.sortable).toEqual(["id", "name", "email", "age", "createdAt"]);
+    expect(config.allowlists.selectable).toEqual(["id", "name", "email", "createdAt"]);
+    // Unconfigured filterable still derives in full.
+    expect(config.allowlists.filterable).toContain("status");
+  });
 });
 
 describe("User fixture sanity", () => {

--- a/packages/core/tests/types/usage-full.test-d.ts
+++ b/packages/core/tests/types/usage-full.test-d.ts
@@ -89,6 +89,19 @@ void authors.createOne({ name: "Ada", bio: "x" });
 // @ts-expect-error — an allowlist entry has to name a real field.
 void kavo.createCrud(Author, { allowlists: { filterable: ["nmae"] } });
 
+// `{ exclude }` is accepted wherever an explicit array is, and still
+// type-checks each excluded path against the entity.
+void kavo.createCrud(Author, { allowlists: { filterable: { exclude: ["name"] } } });
+
+// @ts-expect-error — `{ exclude }` names have to be real fields too.
+void kavo.createCrud(Author, { allowlists: { sortable: { exclude: ["nmae"] } } });
+
+// `{ exclude }` on `selectable` type-checks the same way.
+void kavo.createCrud(Author, { allowlists: { selectable: { exclude: ["name"] } } });
+
+// @ts-expect-error — including `selectable`.
+void kavo.createCrud(Author, { allowlists: { selectable: { exclude: ["nmae"] } } });
+
 // Overridden and default operations dispatch through the engine, one pipeline either way.
 void authors.engine.execute({ operation: "findMany", id: null, body: null, query: null, options: null });
 

--- a/packages/docs/architecture/05-query-grammar.md
+++ b/packages/docs/architecture/05-query-grammar.md
@@ -112,6 +112,12 @@ fields:     root: [id, name, email]
   (`KAVO_QUERY_INVALID_FIELD`), never a silent drop. Programmatic
   callers (`findMany({ filter })`) pass through the **same** allowlist
   and limit checks — typed input skips coercion, not security.
+- **Excluding instead of enumerating:** each allowlist key also accepts
+  `{ exclude: [...] }` instead of an explicit array — resolved at
+  bootstrap to every own column except the ones named, so hiding one
+  column (e.g. a soft-delete marker) doesn't require re-listing every
+  other one. Resolution still starts from the same own-columns default,
+  so the result stays fail-closed like the plain array form.
 - **Limits** (configurable per scope, doc 8): `query.maxFilterDepth`
   (default 3) on the built AST, `query.maxInValues` (default 100) on
   `in`/`notIn` arrays, `pagination.maxLimit` (default 100) on page size.

--- a/packages/examples/src/cat/cat.controller.ts
+++ b/packages/examples/src/cat/cat.controller.ts
@@ -21,6 +21,16 @@ import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.j
     list: CatListDto,
   },
   pagination: { defaultLimit: 10, maxLimit: 50 },
+  // Explicit include-lists (the plain form, contrast Owner's `{ exclude }`
+  // in owner.controller.ts): `indoor`, `livesLeft`, and `createdAt` are
+  // still returned in every response (`CatItemDto` includes them), just
+  // not queryable — narrower than "every own column" without excluding
+  // anything by name.
+  allowlists: {
+    filterable: ["id", "name", "age", "size"],
+    sortable: ["id", "name", "age"],
+    selectable: ["id", "name", "age", "size"],
+  },
   // The to-one side of the owner edge joins; `tags` is a to-many (many-to-
   // many) and batches. `fields[owner]=id,name` / `fields[tags]=id,name`
   // narrow each embedded relation.

--- a/packages/examples/src/owner/owner.controller.ts
+++ b/packages/examples/src/owner/owner.controller.ts
@@ -28,6 +28,14 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
     list: OwnerListDto,
   },
   softDelete: { strategy: "soft" },
+  // `deletedAt` is soft-delete plumbing (`@DeleteDateColumn`), not data a
+  // client should ever filter, sort, or select on — `{ exclude }` resolves
+  // to every own column except this one, without hand-enumerating the rest.
+  allowlists: {
+    filterable: { exclude: ["deletedAt"] },
+    sortable: { exclude: ["deletedAt"] },
+    selectable: { exclude: ["deletedAt"] },
+  },
   // `include=pets` — opt-in per relation. Pets are a to-many,
   // so they batch-load: one extra query per page of owners, never a joined
   // row explosion under pagination. `address` is the to-one counterpart —

--- a/packages/examples/tests/crud-e2e.suite.ts
+++ b/packages/examples/tests/crud-e2e.suite.ts
@@ -107,6 +107,26 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       expect(Object.keys(response.body.items[0])).toEqual(["id", "name"]);
     });
 
+    it("restricts filterable, sortable, and selectable to an explicit list (issue #45)", async () => {
+      // `indoor`/`livesLeft`/`createdAt` are still in every response
+      // (`CatItemDto` includes them) but are not on the explicit
+      // filterable/sortable/selectable lists in `cat.controller.ts`.
+      const filtered = await request(server()).get("/cats").query("filter[indoor][eq]=true").expect(400);
+      expect(filtered.body.errors).toEqual([
+        expect.objectContaining({ field: "indoor", code: "KAVO_QUERY_INVALID_FIELD" }),
+      ]);
+
+      const sorted = await request(server()).get("/cats").query("sort=livesLeft").expect(400);
+      expect(sorted.body.errors).toEqual([
+        expect.objectContaining({ field: "livesLeft", code: "KAVO_QUERY_INVALID_FIELD" }),
+      ]);
+
+      const selected = await request(server()).get("/cats").query("fields=id,createdAt").expect(400);
+      expect(selected.body.errors).toEqual([
+        expect.objectContaining({ field: "createdAt", code: "KAVO_QUERY_INVALID_FIELD" }),
+      ]);
+    });
+
     it("honors the entity-scope pagination override (defaultLimit 10, max 50)", async () => {
       const defaulted = await request(server()).get("/cats").expect(200);
       expect(defaulted.body.limit).toBe(10);
@@ -209,6 +229,25 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       await request(server()).delete(`/owners/${id}`).expect(204);
       await request(server()).delete(`/owners/${id}/purge`).expect(204);
       await request(server()).patch(`/owners/${id}/restore`).expect(404);
+    });
+
+    it("keeps deletedAt out of the filterable, sortable, and selectable allowlists (issue #45)", async () => {
+      // `deletedAt` is soft-delete plumbing, not client-queryable data —
+      // Owner's `@Crud` config excludes it explicitly via `{ exclude }`.
+      const filtered = await request(server()).get("/owners").query("filter[deletedAt][eq]=x").expect(400);
+      expect(filtered.body.errors).toEqual([
+        expect.objectContaining({ field: "deletedAt", code: "KAVO_QUERY_INVALID_FIELD" }),
+      ]);
+
+      const sorted = await request(server()).get("/owners").query("sort=deletedAt").expect(400);
+      expect(sorted.body.errors).toEqual([
+        expect.objectContaining({ field: "deletedAt", code: "KAVO_QUERY_INVALID_FIELD" }),
+      ]);
+
+      const selected = await request(server()).get("/owners").query("fields=id,deletedAt").expect(400);
+      expect(selected.body.errors).toEqual([
+        expect.objectContaining({ field: "deletedAt", code: "KAVO_QUERY_INVALID_FIELD" }),
+      ]);
     });
 
     it("leaves hard-delete entities without restore or purge routes", async () => {


### PR DESCRIPTION
## What & why

`QueryAllowlists`'s `filterable`/`sortable`/`selectable` keys previously only accepted an explicit include-list, so hiding one column (e.g. a soft-delete marker) meant hand-enumerating every other own column — tedious and prone to going stale as columns are added. Each key now also accepts `{ exclude: [...] }`, resolved against the entity's own columns inside `resolveAllowlists` at bootstrap (the only point after ORM metadata exists — the `@Crud` config itself is built at decoration time, before it, per ADR-0013). Resolution still starts from the same own-columns default, so the result stays fail-closed identically to the plain array form.

`Owner`'s `@Crud` config now uses `{ exclude: ["deletedAt"] }` on all three keys — `deletedAt` is soft-delete plumbing, not client-queryable data. `Cat`'s config demonstrates the plain explicit-array form for contrast, restricting to `["id","name","age","size"]` (filterable/selectable) and `["id","name","age"]` (sortable), leaving `indoor`/`livesLeft`/`createdAt` out of what's queryable while still returning them in every response.

## Public API impact

`@kavo/core` barrel: adds `QueryFieldSelector<Entity>` as a new named export, and widens `QueryAllowlists`'s member types from `readonly FieldPath<Entity>[]` to `QueryFieldSelector<Entity>` (a union that includes the old array type). Non-breaking — every existing explicit-array config continues to type-check and behave identically; only new `{ exclude }` configs are new syntax. `ResolvedQueryAllowlists` (the post-bootstrap shape) is unchanged.

## Testing

- `packages/core/tests/config.spec.ts`: `resolveEntityConfig` resolves `{ exclude }` to own-columns-minus-excluded for `filterable`, `sortable`, and `selectable`; never lets `exclude` surface a column outside own columns.
- `packages/core/tests/types/usage-full.test-d.ts`: `{ exclude }` type-checks against `FieldPath<Entity>` for all three keys, and a bad field name still `@ts-expect-error`s, matching the explicit-array case.
- `packages/core/tests/barrel.spec.ts`: manifest updated for the new `QueryFieldSelector` export.
- `packages/examples/tests/crud-e2e.suite.ts`: HTTP-level tests on `/owners` (excluded `deletedAt` 400s on filter/sort/fields) and `/cats` (non-listed `indoor`/`livesLeft`/`createdAt` 400 on filter/sort/fields, `KAVO_QUERY_INVALID_FIELD`).
- `pnpm check` (build + typecheck + depcruise + lint + test): green, 563 tests passing.

## Review notes

- `resolveFieldSelector` (in `resolve-entity-config.ts`) narrows the union via `"exclude" in selector` rather than `Array.isArray` — the latter doesn't narrow a generic array-vs-object union reliably under `tsc -b`'s project-reference build; worth double-checking that reasoning holds.
- No global-scope (`KavoSettings`) allowlist default was added — `allowlists` remains entity-scoped only, out of scope for this issue.

Closes #45