### PR TITLE
test(nest, examples): cover @Crud settings not yet exercised over HTTP

### DIFF
--- a/packages/examples/tests/crud-e2e.suite.ts
+++ b/packages/examples/tests/crud-e2e.suite.ts
@@ -161,6 +161,29 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       ]);
     });
 
+    it("rejects a filter nested deeper than the default maxFilterDepth over a real query", async () => {
+      // Built-in default is 3; four nested logical wrappers exceeds it
+      // regardless of exactly where the count starts.
+      const response = await request(server())
+        .get("/cats")
+        .query("filter[or][0][and][0][or][0][and][0][name][eq]=x")
+        .expect(400);
+      expect(response.body).toMatchObject({ code: "KAVO_QUERY_INVALID" });
+      expect(response.body.errors).toEqual([
+        expect.objectContaining({ field: "filter", code: "KAVO_QUERY_LIMIT_EXCEEDED" }),
+      ]);
+    });
+
+    it("rejects an `in` value list past the default maxInValues over a real query", async () => {
+      // Built-in default is 100; 101 values trips it.
+      const query = Array.from({ length: 101 }, (_, i) => `filter[age][in][]=${i}`).join("&");
+      const response = await request(server()).get("/cats").query(query).expect(400);
+      expect(response.body).toMatchObject({ code: "KAVO_QUERY_INVALID" });
+      expect(response.body.errors).toEqual([
+        expect.objectContaining({ field: "age", code: "KAVO_QUERY_LIMIT_EXCEEDED" }),
+      ]);
+    });
+
     it("embeds relations both ways: a joined owner and batched pets", async () => {
       const owner = await request(server()).post("/owners").send({ name: "Rae", email: "rae@x.io" }).expect(201);
       const ownerId = owner.body.id as number;
@@ -186,6 +209,29 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       expect(owners.body.items[0].pets).toEqual([expect.objectContaining({ name: "Kit" })]);
       const one = await request(server()).get(`/owners/${ownerId}?include=pets`).expect(200);
       expect(one.body.pets).toHaveLength(1);
+    });
+
+    it("embeds a two-level include (cat -> owner -> pets) within the default relation budget", async () => {
+      // Built-in defaults (maxIncludeDepth: 2, maxIncludedNodes: 10) are
+      // exactly enough for this real, two-level joined-then-batched tree —
+      // never exercised together elsewhere in this suite. `owner.pets`
+      // itself cannot be the second level here: `Pet` is the abstract STI
+      // base `owner.pets` targets, and only the concrete `Cat`/`Dog`
+      // subtypes carry a registered @Crud config, so nothing below
+      // `owner.pets` is includable (a real, separate limitation from the
+      // relation budgets this test is actually about).
+      const owner = await request(server()).post("/owners").send({ name: "Nia", email: "nia@x.io" }).expect(201);
+      const ownerId = owner.body.id as number;
+      const cat = await request(server())
+        .post("/cats")
+        .send({ name: "Momo", age: 2, size: "small", indoor: true, livesLeft: 9, owner: ownerId })
+        .expect(201);
+
+      const response = await request(server()).get(`/cats/${cat.body.id}?include=owner.pets`).expect(200);
+      expect(response.body.owner).toMatchObject({
+        name: "Nia",
+        pets: [expect.objectContaining({ name: "Momo" })],
+      });
     });
 
     it("keeps a relation out of the response until it is included", async () => {

--- a/packages/frameworks/nest/tests/for-feature-registry.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/for-feature-registry.e2e.spec.ts
@@ -1,0 +1,52 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Controller, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import type { DefaultCrudService } from "@kavo/core";
+import { Crud, KavoModule, getCrudServiceToken } from "@kavo/nest";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+
+/**
+ * `KavoModule.forFeature()` called with no arguments provides every
+ * `@Crud`-decorated class the *process* has seen — the registry in
+ * `crud.decorator.ts` is a module-level singleton. Vitest isolates modules
+ * per test file, so this file is the only place a single `@Crud(Todo, ...)`
+ * class is guaranteed to be the sole registrant; every other suite in this
+ * package (`binding.e2e.spec.ts`, `settings.e2e.spec.ts`) declares many
+ * differently-configured `@Crud(Todo, ...)` classes and always passes
+ * `forFeature` an explicit array for exactly that reason.
+ */
+
+let app: INestApplication;
+
+afterEach(async () => {
+  await app.close();
+});
+
+@Crud(Todo)
+@Controller("todos")
+class OnlyTodoController {}
+
+describe("KavoModule.forFeature() — no-arg, discovery-driven registry", () => {
+  it("binds the controller via discovery and provides the token from the process-wide registry", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter) }), KavoModule.forFeature()],
+      controllers: [OnlyTodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const created = await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/todos")
+      .send({ title: "x" })
+      .expect(201);
+    expect(created.body).toMatchObject({ title: "x" });
+
+    const service = app.get<DefaultCrudService<Todo>>(getCrudServiceToken(Todo));
+    expect(service).toBeDefined();
+    const found = await service.findOne(created.body.id as number);
+    expect(found).toMatchObject({ title: "x" });
+  });
+});

--- a/packages/frameworks/nest/tests/settings.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/settings.e2e.spec.ts
@@ -1,0 +1,261 @@
+import "reflect-metadata";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Controller, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import type { KavoModuleOptions } from "@kavo/nest";
+import { Crud, KavoModule } from "@kavo/nest";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+
+/**
+ * End-to-end coverage for `@Crud`/`KavoSettings` knobs that
+ * `binding.e2e.spec.ts` never drives over HTTP (issue #47) — allowlists,
+ * relation include budgets, filter limits, pagination `count`/limits, a
+ * per-operation settings override, custom `meta.routes` on a
+ * non-`@Override`'d standard operation, and `forRootAsync`. The no-arg
+ * `KavoModule.forFeature()` path gets its own file (its registry is
+ * process-wide, and this file — like `binding.e2e.spec.ts` — declares many
+ * `@Crud(Todo, ...)` classes for the same entity).
+ */
+
+let app: INestApplication;
+let adapter: InMemoryTodoAdapter;
+
+interface BootstrapOptions {
+  readonly defaults?: KavoModuleOptions["defaults"];
+  readonly async?: boolean;
+}
+
+async function bootstrap(controller: unknown, options: BootstrapOptions = {}): Promise<void> {
+  adapter = new InMemoryTodoAdapter();
+  const infrastructure = fakeInfrastructure(adapter);
+  const rootModule =
+    options.async === true
+      ? KavoModule.forRootAsync({ useFactory: () => ({ infrastructure, defaults: options.defaults }) })
+      : KavoModule.forRoot({ infrastructure, defaults: options.defaults });
+  const moduleRef = await Test.createTestingModule({
+    imports: [rootModule, KavoModule.forFeature([controller as never])],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  await app.init();
+}
+
+afterEach(async () => {
+  await app.close();
+});
+
+function server(): Parameters<typeof request>[0] {
+  return app.getHttpServer() as Parameters<typeof request>[0];
+}
+
+describe("@Crud allowlists — filterable/sortable/selectable enforced over HTTP", () => {
+  @Crud(Todo, { allowlists: { filterable: ["done"], sortable: ["priority"], selectable: ["id", "title"] } })
+  @Controller("todos")
+  class AllowlistedController {}
+
+  beforeEach(async () => {
+    await bootstrap(AllowlistedController);
+  });
+
+  it("400s a filter field outside the allowlist", async () => {
+    const response = await request(server()).get("/todos?filter[title][eq]=x").expect(400);
+    expect(response.body).toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "title", code: "KAVO_QUERY_INVALID_FIELD" }],
+    });
+  });
+
+  it("400s a sort field outside the allowlist", async () => {
+    const response = await request(server()).get("/todos?sort=title").expect(400);
+    expect(response.body).toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "title", code: "KAVO_QUERY_INVALID_FIELD" }],
+    });
+  });
+
+  it("400s a select field outside the allowlist", async () => {
+    const response = await request(server()).get("/todos?fields=priority").expect(400);
+    expect(response.body).toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "priority", code: "KAVO_QUERY_INVALID_FIELD" }],
+    });
+  });
+
+  it("allows a filter/sort/select field that is on the allowlist", async () => {
+    await request(server()).get("/todos?filter[done][eq]=true&sort=priority&fields=id,title").expect(200);
+  });
+});
+
+describe("@Crud relation include budgets (maxIncludeDepth/maxIncludedNodes)", () => {
+  // `Todo.list` and `TodoList.list` deliberately share the relation name,
+  // so one global `edges.list` entry opts both levels in at once (see
+  // `fake-infrastructure.ts`) — an `include=list.list` request is a
+  // genuine two-level tree, which a single relation can never produce
+  // once a positive integer is the smallest legal budget.
+  @Crud(Todo)
+  @Controller("todos")
+  class NestedIncludeController {}
+
+  it("rejects an include deeper than the configured maxIncludeDepth", async () => {
+    await bootstrap(NestedIncludeController, {
+      defaults: { relations: { maxIncludeDepth: 1, edges: { list: { includable: true } } } },
+    });
+
+    const response = await request(server()).get("/todos?include=list.list").expect(400);
+    expect(response.body).toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "list.list", code: "KAVO_QUERY_LIMIT_EXCEEDED" }],
+    });
+  });
+
+  it("rejects an include tree exceeding the configured maxIncludedNodes", async () => {
+    await bootstrap(NestedIncludeController, {
+      defaults: { relations: { maxIncludedNodes: 1, edges: { list: { includable: true } } } },
+    });
+
+    const response = await request(server()).get("/todos?include=list.list").expect(400);
+    expect(response.body).toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "list.list", code: "KAVO_QUERY_LIMIT_EXCEEDED" }],
+    });
+  });
+
+  it("accepts an include within both budgets", async () => {
+    @Crud(Todo, {
+      relations: { maxIncludeDepth: 1, maxIncludedNodes: 1, edges: { list: { includable: true } } },
+    })
+    @Controller("todos")
+    class RoomyController {}
+    await bootstrap(RoomyController);
+
+    await request(server()).get("/todos?include=list").expect(200);
+  });
+});
+
+describe("@Crud query limits (maxFilterDepth/maxInValues) enforced over HTTP", () => {
+  it("rejects a filter tree deeper than the configured maxFilterDepth", async () => {
+    @Crud(Todo, { query: { maxFilterDepth: 1 } })
+    @Controller("todos")
+    class ShallowFilterController {}
+    await bootstrap(ShallowFilterController);
+
+    const response = await request(server()).get("/todos?filter[or][0][done][eq]=true").expect(400);
+    expect(response.body).toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "filter", code: "KAVO_QUERY_LIMIT_EXCEEDED" }],
+    });
+  });
+
+  it("rejects an `in` value list longer than the configured maxInValues", async () => {
+    @Crud(Todo, { query: { maxInValues: 1 } })
+    @Controller("todos")
+    class NarrowInController {}
+    await bootstrap(NarrowInController);
+
+    const response = await request(server()).get("/todos?filter[title][in][]=a&filter[title][in][]=b").expect(400);
+    expect(response.body).toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      errors: [{ field: "title", code: "KAVO_QUERY_LIMIT_EXCEEDED" }],
+    });
+  });
+});
+
+describe("@Crud pagination — count and limit overrides over HTTP", () => {
+  @Crud(Todo, { pagination: { count: false, defaultLimit: 1, maxLimit: 2 } })
+  @Controller("todos")
+  class NoCountController {}
+
+  it("suppresses `total` in the envelope when pagination.count is false", async () => {
+    await bootstrap(NoCountController);
+    await request(server()).post("/todos").send({ title: "a" }).expect(201);
+    await request(server()).post("/todos").send({ title: "b" }).expect(201);
+
+    const response = await request(server()).get("/todos").expect(200);
+    expect(response.body.total).toBeNull();
+  });
+
+  it("applies a custom defaultLimit with no limit param on the wire", async () => {
+    await bootstrap(NoCountController);
+    for (let i = 0; i < 3; i++) {
+      await request(server())
+        .post("/todos")
+        .send({ title: `t${i}` })
+        .expect(201);
+    }
+    const response = await request(server()).get("/todos").expect(200);
+    expect(response.body.limit).toBe(1);
+    expect(response.body.items).toHaveLength(1);
+  });
+
+  it("clamps a requested limit to a custom maxLimit", async () => {
+    await bootstrap(NoCountController);
+    const response = await request(server()).get("/todos?limit=50").expect(200);
+    expect(response.body.limit).toBe(2);
+  });
+});
+
+describe("@Crud per-operation settings override — scoped to that operation only", () => {
+  @Crud(Todo, {
+    pagination: { maxLimit: 100 },
+    operations: { findMany: { pagination: { defaultLimit: 1, maxLimit: 1 } } },
+  })
+  @Controller("todos")
+  class PerOperationController {}
+
+  it("clamps findMany to the operation-level maxLimit rather than the entity default", async () => {
+    await bootstrap(PerOperationController);
+    const response = await request(server()).get("/todos?limit=50").expect(200);
+    expect(response.body.limit).toBe(1);
+  });
+});
+
+describe("@Crud custom meta.routes on a standard, non-@Override'd operation", () => {
+  @Crud(Todo, {
+    operations: { deleteOne: { meta: { routes: { path: ":id/remove", successStatus: 200 } } } },
+  })
+  @Controller("todos")
+  class ReshapedDeleteController {}
+
+  it("serves the reshaped route at the configured path and status", async () => {
+    await bootstrap(ReshapedDeleteController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    await request(server()).delete("/todos/1/remove").expect(200);
+  });
+
+  it("no longer serves the default `DELETE /:id` route", async () => {
+    await bootstrap(ReshapedDeleteController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    await request(server()).delete("/todos/1").expect(404);
+  });
+});
+
+describe("KavoModule.forRootAsync — same route surface as forRoot", () => {
+  @Crud(Todo)
+  @Controller("todos")
+  class AsyncController {}
+
+  it("boots and serves the standard CRUD routes", async () => {
+    await bootstrap(AsyncController, { async: true });
+
+    const created = await request(server()).post("/todos").send({ title: "async" }).expect(201);
+    expect(created.body).toMatchObject({ title: "async" });
+    await request(server())
+      .get(`/todos/${created.body.id as number}`)
+      .expect(200);
+  });
+
+  it("still merges global defaults supplied through the async factory", async () => {
+    await bootstrap(AsyncController, { async: true, defaults: { pagination: { defaultLimit: 1 } } });
+    for (let i = 0; i < 2; i++) {
+      await request(server())
+        .post("/todos")
+        .send({ title: `t${i}` })
+        .expect(201);
+    }
+    const response = await request(server()).get("/todos").expect(200);
+    expect(response.body.limit).toBe(1);
+    expect(response.body.items).toHaveLength(1);
+  });
+});

--- a/packages/frameworks/nest/tests/support/fake-infrastructure.ts
+++ b/packages/frameworks/nest/tests/support/fake-infrastructure.ts
@@ -24,8 +24,22 @@ export class Todo {
   list: TodoList | null = null;
 }
 
-/** The other side of the relation — never routed, only included. */
+/**
+ * The other side of the relation — never routed, only included. Its own
+ * `list` relation (deliberately reusing the name `Todo.list` uses) reaches
+ * a third entity, so tests can exercise a two-level include tree — e.g.
+ * `relations.maxIncludeDepth`/`maxIncludedNodes` budgets, which a
+ * single-level relation can never exceed once a positive integer is the
+ * smallest legal setting.
+ */
 export class TodoList {
+  id = 0;
+  name = "";
+  list: TodoTag | null = null;
+}
+
+/** Third entity in the relation chain — never routed, only included. */
+export class TodoTag {
   id = 0;
   name = "";
 }
@@ -56,6 +70,25 @@ export const todoMetadata: EntityMetadata<Todo> = {
 export const todoListMetadata: EntityMetadata<TodoList> = {
   entity: TodoList,
   name: "TodoList",
+  idField: "id",
+  fields: [
+    { name: "id", kind: "number", nullable: false, generated: true },
+    { name: "name", kind: "string", nullable: false, generated: false },
+  ],
+  relations: [
+    {
+      name: "list",
+      target: () => TodoTag,
+      cardinality: "one",
+      includable: false,
+      strategy: "auto",
+    },
+  ],
+};
+
+export const todoTagMetadata: EntityMetadata<TodoTag> = {
+  entity: TodoTag,
+  name: "TodoTag",
   idField: "id",
   fields: [
     { name: "id", kind: "number", nullable: false, generated: true },
@@ -185,6 +218,9 @@ export function fakeInfrastructure(adapter: InMemoryTodoAdapter): CrudInfrastruc
     metadataFor<Entity extends object>(entity: ClassRef<Entity>) {
       if ((entity as ClassRef) === TodoList) {
         return todoListMetadata as unknown as EntityMetadata<Entity>;
+      }
+      if ((entity as ClassRef) === TodoTag) {
+        return todoTagMetadata as unknown as EntityMetadata<Entity>;
       }
       if ((entity as ClassRef) !== Todo) {
         throw new Error(`no metadata for ${entity.name}`);


### PR DESCRIPTION
## What & why

`@kavo/nest`'s e2e suite exercised operation enable/disable, overrides, soft delete, and includes, but several `KavoSettings`/`EntityConfig` knobs were only validated at the core unit level (`config-validation.spec.ts`) and never driven through a live route. This adds that missing wire-level coverage, plus a follow-up pass over `packages/examples` covering the same categories against a **real** TypeORM datasource instead of the fake adapter.

**`packages/frameworks/nest/tests/`** (new: `settings.e2e.spec.ts`, `for-feature-registry.e2e.spec.ts`; extended: `support/fake-infrastructure.ts`):
- allowlist enforcement (`filterable`/`sortable`/`selectable`) over HTTP
- `relations.maxIncludeDepth`/`maxIncludedNodes` budgets — required extending the shared `Todo` fixture with a genuine two-level relation chain (`TodoList.list -> TodoTag`, reusing the name `Todo.list` uses), since a single relation can never exceed a budget once the minimum legal value is 1
- `query.maxFilterDepth`/`maxInValues` over a live query string
- `pagination.count: false` and custom `defaultLimit`/`maxLimit`
- a per-operation settings override, scoped to that operation only
- a custom `meta.routes` shape on a standard (non-`@Override`'d) operation
- `KavoModule.forRootAsync`
- the no-arg, discovery-driven `KavoModule.forFeature()` — isolated in its own file since its registry is process-wide

**`packages/examples/tests/crud-e2e.suite.ts`** (run against both SQLite and Postgres):
- a filter tree deeper than the built-in `maxFilterDepth` default, rejected over a live query
- an `in` value list past the built-in `maxInValues` default, rejected over a live query
- a genuine two-level include (`Cat -> owner -> pets`) landing inside the built-in `maxIncludeDepth`/`maxIncludedNodes` budget — `Owner.pets -> Pet.tags` was tried first but doesn't work: `Pet` is the abstract single-table-inheritance base `owner.pets` targets, and only the concrete `Cat`/`Dog` subtypes carry a registered `@Crud` config, so nothing below `owner.pets` is includable. That's a real, separate finding, left as a comment in the test rather than "fixed" here since it's out of scope for a test-only PR.

No production code changes.

Closes #47

## Public API impact

None — test files only, plus one test-support fixture (`fake-infrastructure.ts`) gaining a third entity/relation for depth-budget coverage.

## Testing

`pnpm check` (build + typecheck + depcruise + lint + `vitest run`): **green**, 587/587 tests passing, 27 files. Verified end-to-end, unsandboxed, immediately before pushing.

## Review notes

- The `Owner.pets -> Pet.tags` STI limitation noted above (abstract base entity has no registered config, so nothing under it is includable) is real production behavior, not a test bug — worth a look, but I'd treat it as its own issue rather than something this PR should fix.
- `for-feature-registry.e2e.spec.ts` is deliberately its own file (not folded into `settings.e2e.spec.ts`) because `KavoModule.forFeature()`'s no-arg registry is a process-wide, module-level singleton — every other file in this package declares multiple `@Crud(Todo, ...)` classes and would break it.