### PR TITLE
feat: GraphQL protocol binding (@kavo/graphql) with a Nest zero-config route

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -42,12 +42,27 @@ module.exports = {
       name: "nest-only-imports-core",
       severity: "error",
       comment:
-        "@kavo/nest may depend on @kavo/core and the @nestjs/* peers — " +
-        "never on an ORM adapter (ADR-0002). Adapters reach Nest's container " +
-        "via DI, not via imports. Package-specifier form matched too, per the " +
-        "note on typeorm-only-imports-core.",
+        "@kavo/nest may depend on @kavo/core, the @nestjs/* peers, and " +
+        "@kavo/graphql (its optional GraphQL glue, `BaseCrudGraphQLController`)" +
+        " — never on an ORM adapter (ADR-0002). Adapters reach Nest's " +
+        "container via DI, not via imports. The graphql-only-imports-core " +
+        "rule keeps this one-directional: @kavo/graphql never imports " +
+        "@kavo/nest back (ADR-0016). Package-specifier form matched too, " +
+        "per the note on typeorm-only-imports-core.",
       from: { path: "^packages/frameworks/nest/src" },
       to: { path: "^(packages/orms|@kavo/typeorm)" },
+    },
+    {
+      name: "graphql-only-imports-core",
+      severity: "error",
+      comment:
+        "@kavo/graphql may depend on @kavo/core and the graphql peer — " +
+        "never on an ORM adapter or a framework binding (ADR-0016, which " +
+        "makes @kavo/graphql a protocols/* package: host-framework-agnostic, " +
+        "same constraint as an ORM adapter). Package-specifier form matched " +
+        "too, per the note on typeorm-only-imports-core.",
+      from: { path: "^packages/protocols/graphql/src" },
+      to: { path: "^(packages/orms|packages/frameworks|@kavo/(typeorm|nest))" },
     },
     {
       name: "no-cross-package-deep-imports-core",
@@ -58,15 +73,15 @@ module.exports = {
         "another package's src are not API — matched as a relative path and " +
         "as a `@kavo/core/...` subpath. `packages/examples` is in scope: it " +
         "is the reference app, so an illegal import there teaches one.",
-      from: { path: "^packages/(orms|frameworks|examples)" },
+      from: { path: "^packages/(orms|frameworks|protocols|examples)" },
       to: { path: "^(packages/core/src/.+|@kavo/core/.+)" },
     },
     {
       name: "no-cross-package-deep-imports-adapters",
       severity: "error",
-      comment: "Same rule for adapter/framework package internals.",
+      comment: "Same rule for adapter/framework/protocol package internals.",
       from: { path: "^packages/core" },
-      to: { path: "^packages/(orms|frameworks)/[^/]+/src/.+" },
+      to: { path: "^packages/(orms|frameworks|protocols)/[^/]+/src/.+" },
     },
     {
       name: "tests-no-other-package-internals",
@@ -80,9 +95,11 @@ module.exports = {
         "`tests/` used to be excluded from cruising entirely. The `$1` " +
         "back-reference is the package root captured from `from`, so " +
         "same-package imports stay legal.",
-      from: { path: "^(packages/core|packages/examples|packages/orms/[^/]+|packages/frameworks/[^/]+)/tests/" },
+      from: {
+        path: "^(packages/core|packages/examples|packages/orms/[^/]+|packages/frameworks/[^/]+|packages/protocols/[^/]+)/tests/",
+      },
       to: {
-        path: "^(packages/core|packages/examples|packages/orms/[^/]+|packages/frameworks/[^/]+)/(src|tests)/",
+        path: "^(packages/core|packages/examples|packages/orms/[^/]+|packages/frameworks/[^/]+|packages/protocols/[^/]+)/(src|tests)/",
         pathNot: "^$1/",
       },
     },
@@ -96,7 +113,7 @@ module.exports = {
         "core's tests may use the barrel and vitest; this keeps the part that " +
         "still matters — no adapter, no framework — enforced for them too.",
       from: { path: "^packages/core/tests" },
-      to: { path: "^(@kavo/(typeorm|nest)|packages/(orms|frameworks))" },
+      to: { path: "^(@kavo/(typeorm|nest|graphql)|packages/(orms|frameworks|protocols))" },
     },
     {
       name: "no-circular",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "tsc -b --clean",
     "depcruise": "depcruise packages --config .dependency-cruiser.cjs",
     "test": "vitest run",
-    "typecheck": "tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/examples/tsconfig.tests.json",
+    "typecheck": "tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/examples/tsconfig.tests.json",
     "lint": "oxlint packages",
     "prettify": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/docs/adr/0016-graphql-protocols-package.md
+++ b/packages/docs/adr/0016-graphql-protocols-package.md
@@ -1,0 +1,74 @@
+# ADR-0016 — GraphQL is a `protocols/` package, one-directional from `frameworks/`
+
+**Status:** accepted
+
+## Context
+
+ADR-0002 established two parent folders — `orms/` (adapters) and
+`frameworks/` (framework bindings) — and said no speculative packages get
+created beyond what a real feature needs. Adding GraphQL support raised a
+question ADR-0002 never had to answer: GraphQL is not an ORM adapter, and
+it is not quite a "framework binding" in the sense `@kavo/nest` is one.
+`@kavo/nest` bundles two things together — a host framework (Nest's DI,
+routing, decorators) and a wire protocol (REST, via decoration-time route
+generation). GraphQL is only the second thing: a wire protocol/API
+paradigm that could sit atop any host framework — Nest today, a future
+Express/Fastify/Next.js binding later — the same way REST does. Treating
+`@kavo/graphql` as a third `frameworks/*` sibling would conflate protocol
+with host framework and give it no natural way to reach `@kavo/nest`'s
+discovery internals (`getCrudEntities()`, `ModuleRef`) without either
+package importing the other in both directions — exactly the
+`frameworks/* <-> frameworks/*` edge ADR-0002's boundary rules exist to
+prevent between adapter and framework.
+
+## Decision
+
+A new parent folder, `packages/protocols/`, holds wire-protocol bindings
+that are host-framework-agnostic: `@kavo/graphql` is the first. These
+packages depend on `@kavo/core` only (dependency-cruiser:
+`graphql-only-imports-core`) — exactly like an ORM adapter's constraint,
+never a host framework package.
+
+Host framework packages (`packages/frameworks/*`) may depend on a
+protocol package to build framework-specific glue — `@kavo/nest` depends
+on `@kavo/graphql` to provide `BaseCrudGraphQLController` and
+`createDefaultGraphQLController` — but never the reverse.
+`graphql-only-imports-core` enforces the reverse direction by blocking
+`@kavo/graphql` from importing `packages/frameworks` or `@kavo/nest`. The
+resulting dependency direction is `frameworks/* → protocols/*`, mirroring
+`frameworks/* → core` and `orms/* → core`: protocols and ORMs are both
+leaves adapting one concern; framework packages are the only ones allowed
+to depend sideways, and only toward protocols — adapters still meet
+frameworks only through Nest's DI container, unchanged from ADR-0002.
+
+Cases:
+
+- `@kavo/graphql` may depend on `@kavo/core` and the `graphql` peer only.
+- `@kavo/nest` may depend on `@kavo/core`, its `@nestjs/*` peers, and
+  `@kavo/graphql` — never an ORM adapter (`nest-only-imports-core`
+  unchanged).
+- A future `@kavo/grpc` follows the `protocols/` shape above. A future
+  `@kavo/express`/`@kavo/fastify`/`@kavo/nextjs` follows the `frameworks/`
+  shape and may depend on whichever `protocols/*` package(s) it wants to
+  offer glue for.
+
+An entity opts into GraphQL exposure separately from its `@Crud` config —
+`registerCrudGraphQLTypes(Entity, {...})`, not a `@Crud(Entity, { graphql:
+{...} })` option — because `@kavo/graphql` cannot know `@Crud` exists
+(same reasoning ADR-0002 already gives for adapters never being reachable
+from framework config directly).
+
+## Consequences
+
+- `@kavo/graphql`'s host-agnostic discovery helper
+  (`resolveCrudGraphQLSchema`) is reusable verbatim by any future host
+  framework binding — only "how to enumerate entities" and "how to
+  resolve a bound service" differ per host, and both are supplied by the
+  caller, never by `@kavo/graphql` itself.
+- Two framework bindings for the same protocol (e.g. a future Nest and
+  Express GraphQL glue) share code only through `@kavo/graphql`, never
+  with each other directly — the `frameworks/* <-> frameworks/*` edge
+  stays forbidden.
+- ADR-0002's "no speculative packages" still holds: `protocols/graphql` is
+  real, built, tested code, not a stub — a future `protocols/grpc` gets
+  created when there is real work to put in it, not preemptively.

--- a/packages/docs/architecture/02-monorepo-and-packages.md
+++ b/packages/docs/architecture/02-monorepo-and-packages.md
@@ -20,13 +20,17 @@ kavo/
    ├─ frameworks/
    │  └─ nest/                # @kavo/nest
    │     └─ src/index.ts
+   ├─ protocols/
+   │  └─ graphql/             # @kavo/graphql
+   │     └─ src/index.ts
    ├─ examples/               # reference application
    └─ docs/                   # this documentation
 ```
 
-The `orms/` and `frameworks/` parent folders keep the door open for future
-adapters (Prisma, Express, …) without implying any get built — v6 ships
-exactly three packages.
+The `orms/`, `frameworks/`, and `protocols/` parent folders keep the door
+open for future adapters (Prisma, …), host framework bindings
+(Express, Fastify, Next.js, …), and wire protocols (gRPC, …) without
+implying any get built ahead of real work landing (ADR-0002, ADR-0016).
 
 ## 2. Responsibility statements
 
@@ -41,10 +45,18 @@ exactly three packages.
 - **`@kavo/nest`** exists to bind Kavo to NestJS (module, decorator,
   route generation, exception filter, Swagger). It can't depend on TypeORM
   or `@kavo/typeorm` — it sees persistence only as an injected
-  `RepositoryAdapter`.
+  `RepositoryAdapter`. It may depend on a `protocols/*` package
+  (`@kavo/graphql`) to offer that protocol's glue as an add-on — see
+  ADR-0016 — but never another `frameworks/*` package.
+- **`@kavo/graphql`** (`packages/protocols/graphql`, ADR-0016) exists to
+  build a `GraphQLSchema` over a `createCrud` service — host-framework-
+  agnostic, same constraint as an ORM adapter: it depends on `@kavo/core`
+  and the `graphql` peer only, never `@kavo/nest` or any other framework
+  package. See `packages/docs/architecture/13-graphql-binding.md`.
 
-Every package earns its place: core is the hub, and the two edges each
-adapt exactly one external technology. Nothing else qualifies in v6.
+Every package earns its place: core is the hub, and every other package
+adapts exactly one external technology or protocol — an ORM, a host
+framework, or a wire protocol.
 
 ## 3. Dependency rules — mechanically enforced
 
@@ -57,7 +69,10 @@ Two independent enforcement layers:
    forbids: core importing anything, adapter↔framework imports in either
    direction, cross-package deep imports past a barrel, and runtime import
    cycles (type-only cycles are exempt — core's contracts are mutually
-   referential by design and erase at compile time).
+   referential by design and erase at compile time). One exception to
+   "no cross-edge imports": a `frameworks/*` package may depend on a
+   `protocols/*` package (`@kavo/nest` → `@kavo/graphql`), never the
+   reverse — ADR-0016.
 
    Two properties of that rule set are load-bearing and easy to lose:
 
@@ -123,11 +138,12 @@ publish order) are future work.
 
 ## 8. Dependency classification (decided now, executed later)
 
-| Package         | `dependencies` | `peerDependencies`                                              |
-| --------------- | -------------- | --------------------------------------------------------------- |
-| `@kavo/core`    | — (none, ever) | —                                                               |
-| `@kavo/typeorm` | `@kavo/core`   | `typeorm`                                                       |
-| `@kavo/nest`    | `@kavo/core`   | `@nestjs/common`, `@nestjs/core` (+ `@nestjs/swagger` optional) |
+| Package         | `dependencies`                | `peerDependencies`                                                         |
+| --------------- | ----------------------------- | -------------------------------------------------------------------------- |
+| `@kavo/core`    | — (none, ever)                | —                                                                          |
+| `@kavo/typeorm` | `@kavo/core`                  | `typeorm`                                                                  |
+| `@kavo/graphql` | `@kavo/core`                  | `graphql`                                                                  |
+| `@kavo/nest`    | `@kavo/core`, `@kavo/graphql` | `@nestjs/common`, `@nestjs/core`, `graphql` (+ `@nestjs/swagger` optional) |
 
 Peers, not dependencies, because the consumer's app owns the TypeORM/Nest
 instance — a second copy via a nested dependency would fracture

--- a/packages/docs/architecture/13-graphql-binding.md
+++ b/packages/docs/architecture/13-graphql-binding.md
@@ -1,0 +1,196 @@
+# 13 — GraphQL Binding
+
+`@kavo/graphql` (`packages/protocols/graphql`) builds a `GraphQLSchema`
+over an existing `createCrud` service. Every resolver is a direct call
+into the same `DefaultCrudService`/engine pipeline REST binds to — there
+is no parallel request path, no second copy of filter/sort/pagination
+validation, and no separate error handling. `@kavo/nest` (`packages/frameworks/nest`)
+depends on `@kavo/graphql` to provide a ready-made Nest controller; the
+package topology and the one-directional dependency this implies are
+ADR-0016's subject — this doc covers what the binding actually does.
+
+## 1. Package boundary
+
+`@kavo/graphql` is host-framework-agnostic: it imports `@kavo/core` and
+the `graphql` peer only, never `@kavo/nest` or any other framework
+package (`graphql-only-imports-core` in `.dependency-cruiser.cjs`). It has
+no idea Nest, Express, or any other host exists. This is what makes its
+discovery helper (§4) reusable by a future host binding with zero changes
+to `@kavo/graphql` itself.
+
+## 2. Building one entity's schema
+
+```ts
+import { createCrudGraphQLSchema } from "@kavo/graphql";
+
+const schema = createCrudGraphQLSchema({
+  name: "Owner",
+  service: ownerService, // whatever createCrud(Owner, ...) returned
+  itemType: OwnerType, // hand-written GraphQLObjectType
+  createInputType: CreateOwnerInput, // optional — omit to skip the mutation
+  updateInputType: UpdateOwnerInput,
+  patchInputType: PatchOwnerInput,
+  deleteOne: true,
+  restoreOne: true, // meaningful only if Owner declared soft delete
+  purgeOne: true,
+});
+```
+
+Every field this produces:
+
+| Field                                       | Enabled by         |
+| ------------------------------------------- | ------------------ |
+| `Query.owner(id)`                           | always             |
+| `Query.owners(limit, offset, sort, filter)` | always             |
+| `Mutation.createOwner`                      | `createInputType`  |
+| `Mutation.updateOwner`                      | `updateInputType`  |
+| `Mutation.patchOwner`                       | `patchInputType`   |
+| `Mutation.deleteOwner: Boolean`             | `deleteOne: true`  |
+| `Mutation.restoreOwner: Owner`              | `restoreOne: true` |
+| `Mutation.purgeOwner: Boolean`              | `purgeOne: true`   |
+
+Each mutation is opt-in per entity — omit the option and the field never
+reaches the schema. This does **not** read the entity's `OperationRegistry`
+to check what REST actually has enabled: setting `restoreOne: true` here
+for an entity whose `@Crud` config disables `restoreOne` still puts the
+field in the schema, and it throws `OperationDisabledException` at resolve
+time, the same way calling the REST route would. Keeping the two in sync
+is the caller's job today — reading the registry directly is real,
+scoped follow-up work (tracked as a GraphQL issue), not implemented here.
+
+**Filter and sort** (`Query.<entity>s` args, always present):
+
+- `sort: [String!]` — REST's own `-field` convention (`["-createdAt",
+"name"]`), translated into `Sort[]` objects locally; this binding calls
+  the programmatic `QueryContext` surface, which takes `Sort[]` directly,
+  never REST's wire-string form.
+- `filter: JSON` — a custom scalar (`GraphQLJSON`, built on graphql-js's
+  own `valueFromASTUntyped`) carrying Kavo's raw filter AST directly:
+  `{ kind: "condition", field, operator, value }` for a leaf, or `{ kind:
+"group", operator: "AND"|"OR"|"NOT", children: [...] }` to combine.
+  Operators are the AST's own `SCREAMING_SNAKE` spelling (`EQ`, `GTE`,
+  `IN`, ...), not REST's camelCase wire tokens (`eq`, `gte`, `in`). This is
+  the pragmatic version: a generated `<Entity>FilterInput` type per entity
+  (real introspection, no raw AST in the schema) is schema-derivation work,
+  scoped out for the same reason `itemType`/`createInputType` are still
+  hand-written rather than derived from `EntityMetadata`.
+
+## 3. Multiple entities on one schema
+
+```ts
+import { mergeCrudGraphQLSchemas } from "@kavo/graphql";
+
+const schema = mergeCrudGraphQLSchemas([
+  { name: "Owner", service: ownerService, itemType: OwnerType, createInputType: CreateOwnerInput },
+  { name: "Cat", service: catService, itemType: CatType, createInputType: CreateCatInput },
+]);
+```
+
+Field names are namespaced by each entity's own `name`, so entries never
+collide. `mergeCrudGraphQLSchemas` throws `ConfigurationException` if the
+result would have zero `Query` fields (an empty binding list) — an empty
+`Query` type is invalid GraphQL, and graphql-js would otherwise only
+report that on the first request, deep inside `graphql()`'s own schema
+validation; this fails at schema-build time instead, with a message that
+names the actual fix.
+
+## 4. Registering types once, discovering everywhere
+
+Hand-listing every entity at the call site (as in §3) works, but doesn't
+scale past a couple of entities and needs updating every time one is
+added. `registerCrudGraphQLTypes`/`getCrudGraphQLTypes` is a small,
+process-wide registry — the GraphQL counterpart of `@kavo/nest`'s `@Crud`
+registry — so an entity declares its GraphQL types once, next to its
+DTOs:
+
+```ts
+// owner.graphql-types.ts
+registerCrudGraphQLTypes(Owner, { itemType: OwnerType, createInputType: CreateOwnerInput });
+```
+
+`resolveCrudGraphQLSchema` (`discovery.ts`) is the host-agnostic pipeline
+that ties this together: given a list of `{ entity }` refs and a
+`resolveService(entity)` callback, it looks up each entity's registered
+types, skips any entity with none (opt-in, not implied by `@Crud` alone),
+and merges the rest. Two things are deliberately left to the caller,
+supplied per host:
+
+- **How to enumerate `@Crud` entities** — `@kavo/nest`'s
+  `getCrudEntities()`, a plain array a future Express/Fastify/Next.js app
+  builds by hand, or any other host's own registry.
+- **How to resolve one entity's bound service** — `@kavo/nest`'s
+  `ModuleRef` + `getCrudServiceToken`, a plain `Map`, or whatever DI
+  container that host uses.
+
+This is what makes the exact same `resolveCrudGraphQLSchema` call work
+from `@kavo/nest`'s `BaseCrudGraphQLController` today and from a future
+host binding without either package importing the other (ADR-0016).
+
+## 5. The Nest binding
+
+`@kavo/nest` (`packages/frameworks/nest/src/graphql/`) supplies the two
+Nest-specific pieces `resolveCrudGraphQLSchema` needs and nothing else:
+
+- **`BaseCrudGraphQLController`** (abstract): `onModuleInit` calls
+  `resolveCrudGraphQLSchema(getCrudEntities(), (entity) =>
+this.moduleRef.get(getCrudServiceToken(entity), { strict: false }))`
+  and stores the result; `execute(query, variables)` runs one operation
+  against it. A concrete controller adds `@Controller`/`@Post` and calls
+  `execute`:
+
+  ```ts
+  @Controller("graphql")
+  export class GraphQLController extends BaseCrudGraphQLController {
+    // Nest reads constructor-injection metadata off the concrete class,
+    // not an inherited one — this constructor must be declared even
+    // though it only forwards to `super`.
+    constructor(moduleRef: ModuleRef) {
+      super(moduleRef);
+    }
+
+    @Post()
+    @HttpCode(200) // GraphQL-over-HTTP convention: 200 even for a mutation
+    handle(@Body() body: { query: string; variables?: Record<string, unknown> }) {
+      return this.execute(body.query, body.variables);
+    }
+  }
+  ```
+
+- **`createDefaultGraphQLController(path)`** + `KavoModule`'s `graphql`
+  option: the zero-code path. `KavoModule.forRoot({ infrastructure,
+graphql: true })` mounts `POST /graphql`; `{ graphql: { path: "api/graphql"
+} }` mounts it there instead. Setting `graphql` implies `provideServices`
+  (the merged schema's resolvers need every entity's service as a DI
+  provider to look up via `ModuleRef`), even if `provideServices` itself is
+  left unset. A concrete controller (previous bullet) and this flag are
+  alternatives — pick one per app, never both at the same path.
+
+  `createDefaultGraphQLController` builds a **fresh class per call**, with
+  real `@Controller`/`@Post`/`@HttpCode` decorator syntax closing over
+  `path` — not a shared singleton, and not decorators applied as plain
+  function calls after the class body. Both alternatives matter:
+  a shared singleton would make two independently-configured `KavoModule`
+  calls in one process (two apps, or two test files sharing a module
+  cache) fight over one `@Controller` path metadata; and TypeScript's
+  `emitDecoratorMetadata` only emits `design:paramtypes` for a class it
+  sees an actual `@decorator` applied to at compile time — calling the
+  same decorator function afterward compiles fine but silently drops the
+  constructor's `ModuleRef` injection.
+
+## 6. What's out of scope (by design, for now)
+
+- Schema derivation from `EntityMetadata` — `itemType`/`createInputType`/etc.
+  are hand-written per entity, the same status core's DTOs were before
+  derivation existed for those.
+- Registry-driven mutation exposure (§2) — this binding trusts the caller's
+  `restoreOne: true`/etc. flags rather than cross-checking `OperationRegistry`.
+- Relations/includes as GraphQL fields — only scalar `itemType` fields exist
+  today; a relation would need to be hand-added to `itemType` with its own
+  resolver.
+- A typed `<Entity>FilterInput` per entity, instead of the raw-AST `JSON`
+  scalar (§2).
+- Bulk operations and subscriptions.
+
+Each of these is real, valuable follow-up work, not an oversight — the
+proof-of-concept status this package started at is still visible in what
+it does _not_ attempt.

--- a/packages/frameworks/nest/package.json
+++ b/packages/frameworks/nest/package.json
@@ -27,17 +27,22 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@kavo/core": "workspace:^"
+    "@kavo/core": "workspace:^",
+    "@kavo/graphql": "workspace:^"
   },
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "@nestjs/swagger": "^8.0.0 || ^11.0.0",
+    "graphql": "^16.0.0",
     "reflect-metadata": "^0.1.13 || ^0.2.0",
     "rxjs": "^7.8.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/swagger": {
+      "optional": true
+    },
+    "graphql": {
       "optional": true
     }
   },
@@ -48,6 +53,7 @@
     "@nestjs/swagger": "^11.0.0",
     "@nestjs/testing": "^11.0.0",
     "@types/supertest": "^7.2.1",
+    "graphql": "^16.11.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "supertest": "^7.0.0"

--- a/packages/frameworks/nest/src/crud.decorator.ts
+++ b/packages/frameworks/nest/src/crud.decorator.ts
@@ -43,6 +43,21 @@ export function getRegisteredCrudControllers(): ReadonlyMap<Function, CrudContro
 }
 
 /**
+ * Every `@Crud`-decorated entity the process has seen, in decoration
+ * order — the public, read-only counterpart of the registry above. Meant
+ * for a second binding (e.g. a GraphQL schema) that wants to mirror
+ * whatever entities are already exposed over REST without a hand-kept
+ * list of its own. Same process-wide scope and caveats as
+ * `KavoModule.forFeature()`'s no-arg form: if two controllers register the
+ * same entity, both appear here — this function does not dedupe or throw,
+ * since unlike `forFeature` it never has to pick one config to bind a DI
+ * token to.
+ */
+export function getCrudEntities(): readonly CrudControllerMetadata[] {
+  return Array.from(registeredCrudControllers.values());
+}
+
+/**
  * The default route shape of each standard operation. `Partial`
  * because the disabled batch operations have no route yet; keyed by the
  * union so a misspelled id cannot sit here unread.

--- a/packages/frameworks/nest/src/graphql/base-crud-graphql.controller.ts
+++ b/packages/frameworks/nest/src/graphql/base-crud-graphql.controller.ts
@@ -1,0 +1,63 @@
+import type { OnModuleInit } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import { resolveCrudGraphQLSchema } from "@kavo/graphql";
+import { graphql, type ExecutionResult, type GraphQLSchema } from "graphql";
+import { getCrudEntities } from "../crud.decorator.js";
+import { getCrudServiceToken } from "../tokens.js";
+
+/**
+ * Nest-side half of the `@kavo/graphql` glue: discovers every `@Crud`
+ * entity that also called `registerCrudGraphQLTypes` and merges them onto
+ * one schema, the same moment `KavoCrudBinder` does its own discovery pass
+ * (`onModuleInit`, after every controller file has been imported). All the
+ * actual schema-building is `@kavo/graphql`'s `resolveCrudGraphQLSchema` —
+ * this class only supplies the two Nest-specific pieces that function
+ * deliberately doesn't know about: how to enumerate `@Crud` entities
+ * (`getCrudEntities()`) and how to resolve one's bound service (`ModuleRef`
+ * + `getCrudServiceToken`). A future `@kavo/express`/`@kavo/fastify` binding
+ * would supply its own version of just those two things and reuse the same
+ * `resolveCrudGraphQLSchema` call.
+ *
+ * `@kavo/graphql` itself stays framework-agnostic — it never imports
+ * `@kavo/nest` (`graphql-only-imports-core` in `.dependency-cruiser.cjs`,
+ * ADR-0016) — so this controller is the only place the two meet. A
+ * concrete controller just adds the `@Controller` decorator and a route:
+ *
+ * ```ts
+ * @Controller("graphql")
+ * export class GraphQLController extends BaseCrudGraphQLController {
+ *   // Nest reads constructor-injection metadata off the concrete class, not
+ *   // an inherited one — the subclass must declare this constructor (just
+ *   // forwarding to `super`) even though it does nothing else.
+ *   constructor(moduleRef: ModuleRef) {
+ *     super(moduleRef);
+ *   }
+ *
+ *   @Post()
+ *   @HttpCode(200) // GraphQL-over-HTTP convention: 200 even for a mutation
+ *   handle(@Body() body: { query: string; variables?: Record<string, unknown> }) {
+ *     return this.execute(body.query, body.variables);
+ *   }
+ * }
+ * ```
+ *
+ * An entity with no `registerCrudGraphQLTypes` call simply has no GraphQL
+ * surface — opt-in per entity, same as the REST side is opt-in per
+ * `@Crud` controller.
+ */
+export abstract class BaseCrudGraphQLController implements OnModuleInit {
+  private schema!: GraphQLSchema;
+
+  constructor(protected readonly moduleRef: ModuleRef) {}
+
+  onModuleInit(): void {
+    this.schema = resolveCrudGraphQLSchema(getCrudEntities(), (entity) =>
+      this.moduleRef.get(getCrudServiceToken(entity), { strict: false }),
+    );
+  }
+
+  /** Runs one query/mutation against the merged schema — call this from the concrete controller's route. */
+  protected execute(source: string, variableValues?: Record<string, unknown>): Promise<ExecutionResult> {
+    return graphql({ schema: this.schema, source, variableValues });
+  }
+}

--- a/packages/frameworks/nest/src/graphql/default-graphql.controller.ts
+++ b/packages/frameworks/nest/src/graphql/default-graphql.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, HttpCode, Post, type Type } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import { BaseCrudGraphQLController } from "./base-crud-graphql.controller.js";
+
+/** `KavoModule.forRoot`/`forRootAsync({ graphql: true })`'s default mount path when no `path` override is given. */
+export const DEFAULT_GRAPHQL_PATH = "graphql";
+
+/**
+ * Builds the zero-config GraphQL controller at `path` — one `POST <path>`,
+ * mounted by `KavoModule.forRoot`/`forRootAsync` when `graphql` is set,
+ * with no hand-written controller needed. A fresh class per call (never a
+ * shared singleton) so two independently-configured Kavo modules in the
+ * same process — two apps, or two test files sharing a module cache —
+ * never fight over one `@Controller` path.
+ *
+ * The class is declared with real `@Controller`/`@Post`/`@HttpCode`
+ * decorator syntax (closing over `path`), not built by calling those
+ * decorators as plain functions afterward: `emitDecoratorMetadata` only
+ * emits `design:paramtypes` for a class tsc sees an actual decorator
+ * applied to, so the constructor's `ModuleRef` injection silently breaks
+ * without it.
+ *
+ * A consumer wanting a different method, auth guard, or transport
+ * (subscriptions, batched requests) writes their own controller extending
+ * `BaseCrudGraphQLController` instead and leaves `graphql` unset — this
+ * factory and a custom controller are alternatives, never both at once.
+ */
+export function createDefaultGraphQLController(path: string = DEFAULT_GRAPHQL_PATH): Type<BaseCrudGraphQLController> {
+  @Controller(path)
+  class DefaultGraphQLController extends BaseCrudGraphQLController {
+    constructor(moduleRef: ModuleRef) {
+      super(moduleRef);
+    }
+
+    @Post()
+    @HttpCode(200)
+    handle(@Body() body: { query: string; variables?: Record<string, unknown> }) {
+      return this.execute(body.query, body.variables);
+    }
+  }
+
+  return DefaultGraphQLController;
+}

--- a/packages/frameworks/nest/src/index.ts
+++ b/packages/frameworks/nest/src/index.ts
@@ -12,12 +12,13 @@
  * augments core's `OperationMetadata` with its `routes` key (ADR-0007).
  * `@nestjs/*` are peerDependencies; `@nestjs/swagger` is optional.
  */
-export { Crud, type CrudControllerMetadata } from "./crud.decorator.js";
+export { Crud, getCrudEntities, type CrudControllerMetadata } from "./crud.decorator.js";
 export { Override, type OverrideMetadata } from "./override.decorator.js";
-export { KavoModule, type KavoModuleAsyncOptions } from "./kavo.module.js";
+export { KavoModule, type KavoModuleAsyncOptions, type KavoGraphQLOption } from "./kavo.module.js";
 export type { KavoModuleOptions } from "./kavo-options.js";
 export { KavoExceptionFilter } from "./kavo-exception.filter.js";
 export { flattenQuery } from "./flatten-query.js";
 export { enumProp, oneOfArray, type SchemaHint } from "./schema-hints.js";
 export { KAVO_INSTANCE, KAVO_MODULE_OPTIONS, getCrudServiceToken, boundCrudService } from "./tokens.js";
+export { BaseCrudGraphQLController } from "./graphql/base-crud-graphql.controller.js";
 export type { CrudHttpMethod, CrudRouteOptions } from "./operation-metadata.js";

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -7,6 +7,7 @@ import type { KavoModuleOptions } from "./kavo-options.js";
 import type { CrudControllerMetadata } from "./crud.decorator.js";
 import { getRegisteredCrudControllers } from "./crud.decorator.js";
 import { KavoExceptionFilter } from "./kavo-exception.filter.js";
+import { createDefaultGraphQLController, DEFAULT_GRAPHQL_PATH } from "./graphql/default-graphql.controller.js";
 import {
   KAVO_INSTANCE,
   KAVO_MODULE_OPTIONS,
@@ -14,6 +15,15 @@ import {
   CRUD_SERVICE_PROPERTY,
   getCrudServiceToken,
 } from "./tokens.js";
+
+/** `graphql: true` mounts the default controller at `POST /graphql`; `{ path }` mounts it at `POST <path>` instead. */
+export type KavoGraphQLOption = boolean | { readonly path?: string };
+
+function graphqlPathFrom(option: KavoGraphQLOption | undefined): string | undefined {
+  if (option === undefined || option === false) return undefined;
+  if (option === true) return DEFAULT_GRAPHQL_PATH;
+  return option.path ?? DEFAULT_GRAPHQL_PATH;
+}
 
 export interface KavoModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> {
   useFactory: (...args: never[]) => KavoModuleOptions | Promise<KavoModuleOptions>;
@@ -28,6 +38,17 @@ export interface KavoModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> 
    * in one file.
    */
   provideServices?: boolean;
+  /**
+   * Mounts a default GraphQL controller — every `@Crud` entity that also
+   * called `registerCrudGraphQLTypes` (`@kavo/graphql`), merged onto one
+   * schema, with no controller of your own to write. `true` mounts it at
+   * `POST /graphql`; `{ path: "api/graphql" }` mounts it there instead.
+   * Implies `provideServices` (the merged schema's resolvers need every
+   * entity's service as a DI provider to look up via `ModuleRef`, the same
+   * requirement `BaseCrudGraphQLController` always has) even if
+   * `provideServices` itself is left unset.
+   */
+  graphql?: KavoGraphQLOption;
 }
 
 /**
@@ -66,13 +87,17 @@ export interface KavoModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> 
  */
 @Module({})
 export class KavoModule {
-  static forRoot(options: KavoModuleOptions & { provideServices?: boolean } = {}): DynamicModule {
-    const { provideServices, ...kavoOptions } = options;
-    const serviceProviders = provideServices === true ? providersFromRegistry() : [];
+  static forRoot(
+    options: KavoModuleOptions & { provideServices?: boolean; graphql?: KavoGraphQLOption } = {},
+  ): DynamicModule {
+    const { provideServices, graphql, ...kavoOptions } = options;
+    const graphqlPath = graphqlPathFrom(graphql);
+    const serviceProviders = provideServices === true || graphqlPath !== undefined ? providersFromRegistry() : [];
     return {
       module: KavoModule,
       global: true,
       imports: [DiscoveryModule],
+      controllers: graphqlPath !== undefined ? [createDefaultGraphQLController(graphqlPath)] : [],
       providers: [
         { provide: KAVO_MODULE_OPTIONS, useValue: kavoOptions },
         {
@@ -89,11 +114,14 @@ export class KavoModule {
   }
 
   static forRootAsync(options: KavoModuleAsyncOptions): DynamicModule {
-    const serviceProviders = options.provideServices === true ? providersFromRegistry() : [];
+    const graphqlPath = graphqlPathFrom(options.graphql);
+    const serviceProviders =
+      options.provideServices === true || graphqlPath !== undefined ? providersFromRegistry() : [];
     return {
       module: KavoModule,
       global: true,
       imports: [DiscoveryModule, ...(options.imports ?? [])],
+      controllers: graphqlPath !== undefined ? [createDefaultGraphQLController(graphqlPath)] : [],
       providers: [
         {
           provide: KAVO_MODULE_OPTIONS,

--- a/packages/frameworks/nest/tests/base-crud-graphql.controller.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/base-crud-graphql.controller.e2e.spec.ts
@@ -1,0 +1,93 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Body, Controller, HttpCode, Post } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import { Test } from "@nestjs/testing";
+import type { INestApplication } from "@nestjs/common";
+import { Crud, KavoModule, BaseCrudGraphQLController } from "@kavo/nest";
+import { registerCrudGraphQLTypes } from "@kavo/graphql";
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+
+/**
+ * Proves `BaseCrudGraphQLController` end to end: a concrete controller
+ * that only adds `@Controller`/`@Post` discovers `Todo` through
+ * `getCrudEntities()` + `registerCrudGraphQLTypes`, merges it onto one
+ * schema at `onModuleInit`, and resolves through the exact
+ * `DefaultCrudService` REST binds to. Vitest isolates modules per file, so
+ * this is a safe place for a single `@Crud(Todo)` registration (same
+ * reasoning as `for-feature-registry.e2e.spec.ts`).
+ */
+const TodoType = new GraphQLObjectType({
+  name: "Todo",
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLInt) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    done: { type: new GraphQLNonNull(GraphQLBoolean) },
+  },
+});
+const CreateTodoInput = new GraphQLInputObjectType({
+  name: "CreateTodoInput",
+  fields: {
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    done: { type: GraphQLBoolean },
+  },
+});
+registerCrudGraphQLTypes(Todo, { itemType: TodoType, createInputType: CreateTodoInput });
+
+@Crud(Todo)
+@Controller("todos")
+class TodoController {}
+
+@Controller("graphql")
+class GraphQLController extends BaseCrudGraphQLController {
+  constructor(moduleRef: ModuleRef) {
+    super(moduleRef);
+  }
+
+  @Post()
+  @HttpCode(200)
+  handle(@Body() body: { query: string; variables?: Record<string, unknown> }) {
+    return this.execute(body.query, body.variables);
+  }
+}
+
+let app: INestApplication;
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe("BaseCrudGraphQLController", () => {
+  it("discovers @Crud(Todo) and resolves a mutation + query against the merged schema", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), provideServices: true })],
+      controllers: [TodoController, GraphQLController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const created = await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/graphql")
+      .send({ query: `mutation { createTodo(input: { title: "from graphql", done: false }) { id title } }` })
+      .expect(200);
+    expect(created.body.errors).toBeUndefined();
+    expect(created.body.data.createTodo).toEqual({ id: 1, title: "from graphql" });
+
+    const fetched = await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/graphql")
+      .send({ query: `query { todo(id: 1) { title done } }` })
+      .expect(200);
+    expect(fetched.body.errors).toBeUndefined();
+    expect(fetched.body.data.todo).toEqual({ title: "from graphql", done: false });
+  });
+});

--- a/packages/frameworks/nest/tests/default-graphql-controller.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/default-graphql-controller.e2e.spec.ts
@@ -1,0 +1,114 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Controller } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import type { INestApplication } from "@nestjs/common";
+import { Crud, KavoModule } from "@kavo/nest";
+import { registerCrudGraphQLTypes } from "@kavo/graphql";
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+
+/**
+ * Proves the zero-controller path: `KavoModule.forRoot({ graphql: true })`
+ * mounts `POST /graphql` on its own — no `GraphQLController` anywhere in
+ * this file, unlike `base-crud-graphql.controller.e2e.spec.ts`, which
+ * covers the opt-out (a hand-written controller extending
+ * `BaseCrudGraphQLController`). Vitest isolates modules per file, so a
+ * single `@Crud(Todo)` registration here is safe, same reasoning as the
+ * other GraphQL e2e specs.
+ */
+const TodoType = new GraphQLObjectType({
+  name: "Todo",
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLInt) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    done: { type: new GraphQLNonNull(GraphQLBoolean) },
+  },
+});
+const CreateTodoInput = new GraphQLInputObjectType({
+  name: "CreateTodoInput",
+  fields: {
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    done: { type: GraphQLBoolean },
+  },
+});
+registerCrudGraphQLTypes(Todo, { itemType: TodoType, createInputType: CreateTodoInput });
+
+@Crud(Todo)
+@Controller("todos")
+class TodoController {}
+
+let app: INestApplication;
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe("KavoModule.forRoot({ graphql: true })", () => {
+  it("mounts POST /graphql with no controller of its own", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), graphql: true })],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const created = await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/graphql")
+      .send({ query: `mutation { createTodo(input: { title: "zero controller", done: false }) { id title } }` })
+      .expect(200);
+    expect(created.body.errors).toBeUndefined();
+    expect(created.body.data.createTodo).toEqual({ id: 1, title: "zero controller" });
+
+    const fetched = await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/graphql")
+      .send({ query: `query { todo(id: 1) { title } }` })
+      .expect(200);
+    expect(fetched.body.errors).toBeUndefined();
+    expect(fetched.body.data.todo).toEqual({ title: "zero controller" });
+  });
+
+  it("mounts at a custom path when { path } is given instead of true", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), graphql: { path: "api/graphql" } })],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/graphql")
+      .expect(404);
+
+    const created = await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/api/graphql")
+      .send({ query: `mutation { createTodo(input: { title: "custom path", done: false }) { id title } }` })
+      .expect(200);
+    expect(created.body.errors).toBeUndefined();
+    expect(created.body.data.createTodo).toEqual({ id: 1, title: "custom path" });
+  });
+
+  it("mounts no controller at all when graphql is left unset", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter) })],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    await request(app.getHttpServer() as Parameters<typeof request>[0])
+      .post("/graphql")
+      .expect(404);
+  });
+});

--- a/packages/frameworks/nest/tests/get-crud-entities.spec.ts
+++ b/packages/frameworks/nest/tests/get-crud-entities.spec.ts
@@ -1,0 +1,26 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { Controller } from "@nestjs/common";
+import { Crud, getCrudEntities } from "@kavo/nest";
+import { Todo } from "./support/fake-infrastructure.js";
+
+/**
+ * `getCrudEntities()` is the public, read-only counterpart of the
+ * `forFeature()`-internal registry — a second binding's way to discover
+ * every `@Crud` entity without a hand-kept list. Vitest isolates modules
+ * per file (see `for-feature-registry.e2e.spec.ts`), so this file is the
+ * only place a single `@Crud(Todo)` class is guaranteed to be the sole
+ * registrant.
+ */
+@Crud(Todo)
+@Controller("only-todos")
+class OnlyTodoController {}
+
+describe("getCrudEntities", () => {
+  it("lists every @Crud-decorated entity registered so far", () => {
+    expect(OnlyTodoController).toBeDefined();
+    const entities = getCrudEntities();
+    expect(entities).toHaveLength(1);
+    expect(entities[0]?.entity).toBe(Todo);
+  });
+});

--- a/packages/frameworks/nest/tsconfig.json
+++ b/packages/frameworks/nest/tsconfig.json
@@ -9,5 +9,5 @@
     "useDefineForClassFields": false
   },
   "include": ["src"],
-  "references": [{ "path": "../../core" }]
+  "references": [{ "path": "../../core" }, { "path": "../../protocols/graphql" }]
 }

--- a/packages/frameworks/nest/tsconfig.tests.json
+++ b/packages/frameworks/nest/tsconfig.tests.json
@@ -11,6 +11,7 @@
     "types": ["node"],
     "paths": {
       "@kavo/core": ["../../core/src/index.ts"],
+      "@kavo/graphql": ["../../protocols/graphql/src/index.ts"],
       "@kavo/nest": ["./src/index.ts"]
     }
   },

--- a/packages/protocols/graphql/package.json
+++ b/packages/protocols/graphql/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@kavo/graphql",
+  "version": "0.1.0",
+  "description": "Kavo GraphQL binding — builds a GraphQL schema over a createCrud service, delegating every resolver to the same engine REST uses.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kavo-labs/kavo.git",
+    "directory": "packages/protocols/graphql"
+  },
+  "homepage": "https://github.com/kavo-labs/kavo/tree/main/packages/protocols/graphql#readme",
+  "type": "module",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@kavo/core": "workspace:^"
+  },
+  "peerDependencies": {
+    "graphql": "^16.0.0"
+  },
+  "devDependencies": {
+    "graphql": "^16.11.0"
+  }
+}

--- a/packages/protocols/graphql/src/discovery.ts
+++ b/packages/protocols/graphql/src/discovery.ts
@@ -1,0 +1,45 @@
+import type { ClassRef, EntityId } from "@kavo/core";
+import type { GraphQLSchema } from "graphql";
+import type { BoundCrudService, CrudGraphQLOptions } from "./schema.js";
+import { mergeCrudGraphQLSchemas } from "./schema.js";
+import { getCrudGraphQLTypes } from "./registry.js";
+
+/** The minimum a host framework needs to hand this package about one `@Crud` entity. */
+export interface CrudEntityRef {
+  readonly entity: ClassRef;
+}
+
+/**
+ * The host-agnostic half of "discover every entity that registered
+ * GraphQL types and put them all on one schema." Two things stay
+ * deliberately outside this package, supplied by the caller instead:
+ *
+ * - **How to enumerate `@Crud` entities** — `@kavo/nest`'s `getCrudEntities()`,
+ *   a plain array an Express/Fastify/Next.js app builds by hand, or any
+ *   other host's own registry.
+ * - **How to resolve a bound service for one entity** — `@kavo/nest`'s
+ *   `ModuleRef` + `getCrudServiceToken`, a plain `Map`, or whatever DI
+ *   container that host uses.
+ *
+ * This function only ever touches `@kavo/core` shapes and this package's
+ * own type registry — never a host framework — so the same call works
+ * from `@kavo/nest`'s `BaseCrudGraphQLController` today and from a future
+ * `@kavo/express`/`@kavo/fastify`/`@kavo/nextjs` binding without either
+ * package importing the other (ADR-0016).
+ */
+export function resolveCrudGraphQLSchema(
+  entities: readonly CrudEntityRef[],
+  resolveService: (entity: ClassRef) => BoundCrudService<object, EntityId, unknown, unknown, unknown, unknown, unknown>,
+): GraphQLSchema {
+  const bindings: CrudGraphQLOptions<object, EntityId, unknown, unknown, unknown, unknown, unknown>[] = [];
+
+  for (const { entity } of entities) {
+    const types = getCrudGraphQLTypes(entity);
+    if (types === undefined) {
+      continue;
+    }
+    bindings.push({ name: entity.name, service: resolveService(entity), ...types });
+  }
+
+  return mergeCrudGraphQLSchemas(bindings);
+}

--- a/packages/protocols/graphql/src/index.ts
+++ b/packages/protocols/graphql/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  createCrudGraphQLSchema,
+  mergeCrudGraphQLSchemas,
+  type CrudGraphQLOptions,
+  type BoundCrudService,
+} from "./schema.js";
+export { registerCrudGraphQLTypes, getCrudGraphQLTypes, type CrudGraphQLTypes } from "./registry.js";
+export { resolveCrudGraphQLSchema, type CrudEntityRef } from "./discovery.js";
+export { GraphQLJSON } from "./json-scalar.js";

--- a/packages/protocols/graphql/src/json-scalar.ts
+++ b/packages/protocols/graphql/src/json-scalar.ts
@@ -1,0 +1,18 @@
+import { GraphQLScalarType, Kind, valueFromASTUntyped } from "graphql";
+
+/**
+ * Arbitrary JSON, used for `filter` args until schema-derived
+ * `<Entity>FilterInput` types exist (tracked separately — that's the
+ * "derive types from entity metadata" work this package's proof-of-concept
+ * status has always deferred). The value that reaches a resolver is the
+ * raw filter AST (`FilterExpression` from `@kavo/core`) — the same shape
+ * any other programmatic caller of `QueryContext.filter` already hands
+ * core directly; there is no wire-string grammar to parse here.
+ */
+export const GraphQLJSON = new GraphQLScalarType({
+  name: "JSON",
+  description: "Arbitrary JSON value — used here for a raw Kavo filter expression.",
+  serialize: (value: unknown) => value,
+  parseValue: (value: unknown) => value,
+  parseLiteral: (ast) => (ast.kind === Kind.NULL ? null : valueFromASTUntyped(ast)),
+});

--- a/packages/protocols/graphql/src/registry.ts
+++ b/packages/protocols/graphql/src/registry.ts
@@ -1,0 +1,46 @@
+import type { ClassRef } from "@kavo/core";
+import type { GraphQLInputObjectType, GraphQLObjectType } from "graphql";
+
+/**
+ * GraphQL object/input types (and which mutations to expose) for one
+ * entity — the hand-written part `registerCrudGraphQLTypes` attaches to a
+ * class. Each mutation flag/input mirrors `CrudGraphQLOptions` in
+ * `schema.ts` one for one — omit any of them to leave that mutation off
+ * the schema for this entity, same opt-in shape `@Crud`'s own `operations`
+ * config uses on the REST side.
+ */
+export interface CrudGraphQLTypes {
+  readonly itemType: GraphQLObjectType;
+  /** Omit to leave the `create<Name>` mutation off the schema for this entity. */
+  readonly createInputType?: GraphQLInputObjectType;
+  /** Omit to leave the `update<Name>` mutation off the schema for this entity. */
+  readonly updateInputType?: GraphQLInputObjectType;
+  /** Omit to leave the `patch<Name>` mutation off the schema for this entity. */
+  readonly patchInputType?: GraphQLInputObjectType;
+  /** Adds `delete<Name>(id): Boolean`. */
+  readonly deleteOne?: boolean;
+  /** Adds `restore<Name>(id): <Name>` — meaningful only for a soft-deletable entity. */
+  readonly restoreOne?: boolean;
+  /** Adds `purge<Name>(id): Boolean` — meaningful only for a soft-deletable entity. */
+  readonly purgeOne?: boolean;
+}
+
+const typeRegistry = new Map<ClassRef, CrudGraphQLTypes>();
+
+/**
+ * Attaches GraphQL types to an entity once, next to its DTOs — the
+ * counterpart of `@kavo/nest`'s `getCrudEntities()`: a consumer can walk
+ * every `@Crud` entity and look up its GraphQL types here, wiring a merged
+ * schema with no per-entity list of its own (see `resolveCrudGraphQLSchema`
+ * in `discovery.ts`, which does exactly that). An entity with no
+ * registration here simply has no GraphQL surface — opt-in, not implied by
+ * `@Crud` alone. Process-wide, same scope as `@kavo/nest`'s own registry.
+ */
+export function registerCrudGraphQLTypes(entity: ClassRef, types: CrudGraphQLTypes): void {
+  typeRegistry.set(entity, types);
+}
+
+/** The types `registerCrudGraphQLTypes` attached to `entity`, or `undefined` if it never registered any. */
+export function getCrudGraphQLTypes(entity: ClassRef): CrudGraphQLTypes | undefined {
+  return typeRegistry.get(entity);
+}

--- a/packages/protocols/graphql/src/schema.ts
+++ b/packages/protocols/graphql/src/schema.ts
@@ -1,0 +1,289 @@
+import {
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  type GraphQLFieldConfig,
+  type GraphQLInputObjectType,
+} from "graphql";
+import type { DefaultCrudService, EntityId } from "@kavo/core";
+import { ConfigurationException } from "@kavo/core";
+import { GraphQLJSON } from "./json-scalar.js";
+
+/**
+ * `sort: ["-createdAt", "name"]` → `[{ field: "createdAt", direction: "desc" }, { field: "name", direction: "asc" }]`
+ * — the same leading-`-` convention REST's `?sort=` wire param uses, translated here instead of through core's
+ * wire-string parser (this binding calls the programmatic `QueryContext` surface, which takes `Sort[]` objects
+ * directly, never wire strings).
+ */
+function parseSortArg(tokens: readonly string[] | undefined): { field: string; direction: "asc" | "desc" }[] {
+  if (tokens === undefined) return [];
+  return tokens.map((token) =>
+    token.startsWith("-")
+      ? { field: token.slice(1), direction: "desc" as const }
+      : { field: token, direction: "asc" as const },
+  );
+}
+
+/**
+ * What a query/mutation resolver in this binding actually calls — the
+ * transport-agnostic programmatic surface `createCrud` returns. Kept as a
+ * structural type (not `DefaultCrudService` itself) so a caller only has to
+ * satisfy the handful of methods a schema actually wires up, the same way
+ * `@kavo/nest`'s standard-operation routes bind to it. Exported (not just
+ * internal) so `discovery.ts`'s host-agnostic resolver callback can name it.
+ *
+ * Every standard operation is picked unconditionally — whether a given
+ * field actually reaches the schema is decided per entity by which
+ * `*InputType`/`include*` options `crudFields` receives, mirroring how
+ * `@Crud`'s own `operations` config opts entities in or out on the REST
+ * side. Calling `restoreOne`/`purgeOne` against an entity that never
+ * declared soft delete still raises `OperationDisabledException` from the
+ * engine itself — this binding does not re-check that, same as REST.
+ */
+export type BoundCrudService<
+  Entity extends object,
+  Id extends EntityId,
+  CreateDto,
+  UpdateDto,
+  PatchDto,
+  ItemDto,
+  ListDto,
+> = Pick<
+  DefaultCrudService<Entity, Id, CreateDto, UpdateDto, PatchDto, unknown, ItemDto, ListDto>,
+  "findOne" | "findMany" | "createOne" | "updateOne" | "patchOne" | "deleteOne" | "restoreOne" | "purgeOne"
+>;
+
+/**
+ * One entity's GraphQL binding: a query root (`<name>`/`<name>s`) plus
+ * whichever mutations its options ask for — every resolver a direct call
+ * into the same engine REST routes use, no parallel request pipeline.
+ * Each mutation is opt-in per entity: omit the corresponding option and
+ * that field never reaches the schema, the same "declare what you want"
+ * shape `createInputType` already had.
+ */
+export interface CrudGraphQLOptions<
+  Entity extends object,
+  Id extends EntityId,
+  CreateDto,
+  UpdateDto,
+  PatchDto,
+  ItemDto,
+  ListDto,
+> {
+  /** Singular, capitalized entity name — becomes `Query.<lowerName>` / `<Name>List` / `createName` / etc. */
+  readonly name: string;
+  readonly service: BoundCrudService<Entity, Id, CreateDto, UpdateDto, PatchDto, ItemDto, ListDto>;
+  readonly itemType: GraphQLObjectType;
+  /** Omit to leave the `create<Name>` mutation off the schema. */
+  readonly createInputType?: GraphQLInputObjectType;
+  /** Omit to leave the `update<Name>` mutation off the schema. */
+  readonly updateInputType?: GraphQLInputObjectType;
+  /** Omit to leave the `patch<Name>` mutation off the schema. */
+  readonly patchInputType?: GraphQLInputObjectType;
+  /** Adds `delete<Name>(id): Boolean`. */
+  readonly deleteOne?: boolean;
+  /** Adds `restore<Name>(id): <Name>` — meaningful only for a soft-deletable entity. */
+  readonly restoreOne?: boolean;
+  /** Adds `purge<Name>(id): Boolean` — meaningful only for a soft-deletable entity. */
+  readonly purgeOne?: boolean;
+}
+
+function lowerFirst(value: string): string {
+  return value.charAt(0).toLowerCase() + value.slice(1);
+}
+
+/**
+ * Field maps for one entity's binding — the unit `createCrudGraphQLSchema`
+ * wraps and `mergeCrudGraphQLSchemas`/`resolveCrudGraphQLSchema` combine.
+ * Not exported from the barrel: an internal building block, same status as
+ * `lowerFirst`.
+ */
+export function crudFields<
+  Entity extends object,
+  Id extends EntityId,
+  CreateDto,
+  UpdateDto,
+  PatchDto,
+  ItemDto,
+  ListDto,
+>(
+  options: CrudGraphQLOptions<Entity, Id, CreateDto, UpdateDto, PatchDto, ItemDto, ListDto>,
+): {
+  query: Record<string, GraphQLFieldConfig<unknown, unknown>>;
+  mutation: Record<string, GraphQLFieldConfig<unknown, unknown>>;
+} {
+  const { name, service, itemType, createInputType, updateInputType, patchInputType, deleteOne, restoreOne, purgeOne } =
+    options;
+  const fieldName = lowerFirst(name);
+  const idArgs = { id: { type: new GraphQLNonNull(GraphQLInt) } };
+
+  const listType = new GraphQLObjectType({
+    name: `${name}List`,
+    fields: {
+      items: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(itemType))) },
+      total: { type: GraphQLInt },
+      limit: { type: new GraphQLNonNull(GraphQLInt) },
+      offset: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+  });
+
+  const query: Record<string, GraphQLFieldConfig<unknown, unknown>> = {
+    [fieldName]: {
+      type: itemType,
+      args: idArgs,
+      resolve: (_root: unknown, args: { id: number }) => service.findOne(args.id as Id),
+    },
+    [`${fieldName}s`]: {
+      type: new GraphQLNonNull(listType),
+      args: {
+        limit: { type: GraphQLInt },
+        offset: { type: GraphQLInt },
+        sort: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+        filter: { type: GraphQLJSON },
+      },
+      resolve: (
+        _root: unknown,
+        args: { limit?: number; offset?: number; sort?: readonly string[]; filter?: unknown },
+      ) =>
+        service.findMany({
+          limit: args.limit,
+          offset: args.offset,
+          sort: parseSortArg(args.sort),
+          filter: args.filter ?? null,
+        } as never),
+    },
+  };
+
+  const mutation: Record<string, GraphQLFieldConfig<unknown, unknown>> = {};
+
+  if (createInputType !== undefined) {
+    mutation[`create${name}`] = {
+      type: new GraphQLNonNull(itemType),
+      args: { input: { type: new GraphQLNonNull(createInputType) } },
+      resolve: (_root: unknown, args: { input: CreateDto }) => service.createOne(args.input),
+    };
+  }
+
+  if (updateInputType !== undefined) {
+    mutation[`update${name}`] = {
+      type: new GraphQLNonNull(itemType),
+      args: { ...idArgs, input: { type: new GraphQLNonNull(updateInputType) } },
+      resolve: (_root: unknown, args: { id: number; input: UpdateDto }) => service.updateOne(args.id as Id, args.input),
+    };
+  }
+
+  if (patchInputType !== undefined) {
+    mutation[`patch${name}`] = {
+      type: new GraphQLNonNull(itemType),
+      args: { ...idArgs, input: { type: new GraphQLNonNull(patchInputType) } },
+      resolve: (_root: unknown, args: { id: number; input: PatchDto }) => service.patchOne(args.id as Id, args.input),
+    };
+  }
+
+  if (deleteOne === true) {
+    mutation[`delete${name}`] = {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      args: idArgs,
+      resolve: async (_root: unknown, args: { id: number }) => {
+        await service.deleteOne(args.id as Id);
+        return true;
+      },
+    };
+  }
+
+  if (restoreOne === true) {
+    mutation[`restore${name}`] = {
+      type: new GraphQLNonNull(itemType),
+      args: idArgs,
+      resolve: (_root: unknown, args: { id: number }) => service.restoreOne(args.id as Id),
+    };
+  }
+
+  if (purgeOne === true) {
+    mutation[`purge${name}`] = {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      args: idArgs,
+      resolve: async (_root: unknown, args: { id: number }) => {
+        await service.purgeOne(args.id as Id);
+        return true;
+      },
+    };
+  }
+
+  return { query, mutation };
+}
+
+/**
+ * Builds a one-entity `GraphQLSchema` over an existing `createCrud`
+ * service. Schema derivation from entity metadata, relations, and
+ * filtering is still out of scope (ADR-worthy work, tracked separately):
+ * the caller supplies the GraphQL object/input types by hand, and every
+ * resolver delegates straight to the bound service, which itself is sugar
+ * over `engine.execute` — the identical pipeline REST runs.
+ *
+ * For an app with more than one entity, prefer `mergeCrudGraphQLSchemas` (or
+ * `resolveCrudGraphQLSchema` for a framework-driven registry) — they put
+ * every entity's fields on one `Query`/`Mutation` root instead of one
+ * schema (and one mounted endpoint) per entity.
+ */
+export function createCrudGraphQLSchema<
+  Entity extends object,
+  Id extends EntityId,
+  CreateDto,
+  UpdateDto,
+  PatchDto,
+  ItemDto,
+  ListDto,
+>(options: CrudGraphQLOptions<Entity, Id, CreateDto, UpdateDto, PatchDto, ItemDto, ListDto>): GraphQLSchema {
+  const { query, mutation } = crudFields(options);
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({ name: "Query", fields: query }),
+    mutation:
+      Object.keys(mutation).length > 0 ? new GraphQLObjectType({ name: "Mutation", fields: mutation }) : undefined,
+  });
+}
+
+/**
+ * Combines several entities' bindings onto one `Query`/`Mutation` root —
+ * the shape an app actually wants: one `/graphql` endpoint for every
+ * `@Crud` entity, not one per entity. Each entry is the same options shape
+ * `createCrudGraphQLSchema` takes; field names are namespaced by each
+ * entity's own `name`, so entries never collide with each other.
+ */
+export function mergeCrudGraphQLSchemas(
+  bindings: readonly CrudGraphQLOptions<object, EntityId, unknown, unknown, unknown, unknown, unknown>[],
+): GraphQLSchema {
+  const query: Record<string, GraphQLFieldConfig<unknown, unknown>> = {};
+  const mutation: Record<string, GraphQLFieldConfig<unknown, unknown>> = {};
+
+  for (const binding of bindings) {
+    const fields = crudFields(binding);
+    Object.assign(query, fields.query);
+    Object.assign(mutation, fields.mutation);
+  }
+
+  if (Object.keys(query).length === 0) {
+    // An empty `Query` type is invalid GraphQL (`Type Query must define one
+    // or more fields.`) — graphql-js would only report that cryptically, on
+    // the first request, deep inside `graphql()`'s own schema validation.
+    // Failing fast here, at schema-build time, with a message that names the
+    // actual fix, is what `resolveCrudGraphQLSchema` (zero entities
+    // discovered) relies on to fail at boot instead of at request time.
+    throw new ConfigurationException(
+      "GraphQLSchema",
+      "bindings",
+      "no entity registered any GraphQL types — call registerCrudGraphQLTypes(Entity, {...}) " +
+        "for at least one @Crud entity before enabling a GraphQL endpoint",
+    );
+  }
+
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({ name: "Query", fields: query }),
+    mutation:
+      Object.keys(mutation).length > 0 ? new GraphQLObjectType({ name: "Mutation", fields: mutation }) : undefined,
+  });
+}

--- a/packages/protocols/graphql/tests/discovery.spec.ts
+++ b/packages/protocols/graphql/tests/discovery.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { ConfigurationException, createKavo } from "@kavo/core";
+import { graphql, GraphQLInt, GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql";
+import { registerCrudGraphQLTypes, resolveCrudGraphQLSchema } from "@kavo/graphql";
+import { InMemoryTodoAdapter, Todo, todoMetadata } from "./support/todo-fixture.js";
+
+/**
+ * `resolveCrudGraphQLSchema` is the host-agnostic half of the discovery
+ * pipeline `@kavo/nest`'s `BaseCrudGraphQLController` uses — this proves it
+ * directly, with a plain array standing in for a host's own entity
+ * registry and a plain `Map` standing in for a host's DI container, so the
+ * test never has to touch Nest at all.
+ */
+describe("resolveCrudGraphQLSchema", () => {
+  const TodoType = new GraphQLObjectType({
+    name: "Todo",
+    fields: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+      title: { type: new GraphQLNonNull(GraphQLString) },
+    },
+  });
+
+  it("skips entities with no registered GraphQL types and resolves the rest via the caller's callback", async () => {
+    class Unregistered {}
+
+    registerCrudGraphQLTypes(Todo, { itemType: TodoType });
+
+    const adapter = new InMemoryTodoAdapter();
+    adapter.rows.push({ id: 1, title: "discovered", done: false });
+    const todoService = createKavo().createCrud(Todo, undefined, { adapter, metadata: todoMetadata });
+
+    const services = new Map<unknown, unknown>([[Todo, todoService]]);
+    const schema = resolveCrudGraphQLSchema(
+      [{ entity: Unregistered }, { entity: Todo }],
+      (entity) => services.get(entity) as never,
+    );
+
+    expect(schema.getQueryType()?.getFields()["unregistered"]).toBeUndefined();
+
+    const result = await graphql({ schema, source: `query { todo(id: 1) { title } }` });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.todo).toEqual({ title: "discovered" });
+  });
+
+  it("fails fast at schema-build time when no entity registered any GraphQL types", () => {
+    class Unregistered {}
+
+    expect(() => resolveCrudGraphQLSchema([{ entity: Unregistered }], () => ({}) as never)).toThrow(
+      ConfigurationException,
+    );
+  });
+});

--- a/packages/protocols/graphql/tests/graphql-schema.spec.ts
+++ b/packages/protocols/graphql/tests/graphql-schema.spec.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { createKavo } from "@kavo/core";
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  graphql,
+} from "graphql";
+import {
+  createCrudGraphQLSchema,
+  getCrudGraphQLTypes,
+  mergeCrudGraphQLSchemas,
+  registerCrudGraphQLTypes,
+} from "@kavo/graphql";
+import {
+  InMemoryNoteAdapter,
+  InMemoryTagAdapter,
+  InMemoryTodoAdapter,
+  Note,
+  noteMetadata,
+  Tag,
+  tagMetadata,
+  Todo,
+  todoMetadata,
+} from "./support/todo-fixture.js";
+
+/**
+ * Proves the binding end to end: a schema built by `createCrudGraphQLSchema`
+ * resolves queries and mutations by calling straight into the same
+ * `createCrud` service REST would bind to — no parallel pipeline, no
+ * database, just the in-memory adapter core's own tests use.
+ */
+describe("createCrudGraphQLSchema", () => {
+  const TodoType = new GraphQLObjectType({
+    name: "Todo",
+    fields: {
+      id: { type: new GraphQLNonNull(GraphQLInt) },
+      title: { type: new GraphQLNonNull(GraphQLString) },
+      done: { type: new GraphQLNonNull(GraphQLBoolean) },
+    },
+  });
+
+  const CreateTodoInput = new GraphQLInputObjectType({
+    name: "CreateTodoInput",
+    fields: {
+      title: { type: new GraphQLNonNull(GraphQLString) },
+      done: { type: GraphQLBoolean },
+    },
+  });
+
+  function setup() {
+    const adapter = new InMemoryTodoAdapter();
+    const service = createKavo().createCrud(Todo, undefined, { adapter, metadata: todoMetadata });
+    const schema = createCrudGraphQLSchema({
+      name: "Todo",
+      service,
+      itemType: TodoType,
+      createInputType: CreateTodoInput,
+    });
+    return { adapter, schema };
+  }
+
+  it("resolves a mutation and a follow-up query through the same engine", async () => {
+    const { schema } = setup();
+
+    const created = await graphql({
+      schema,
+      source: `mutation { createTodo(input: { title: "write tests", done: false }) { id title done } }`,
+    });
+    expect(created.errors).toBeUndefined();
+    expect(created.data?.createTodo).toEqual({ id: 1, title: "write tests", done: false });
+
+    const fetched = await graphql({ schema, source: `query { todo(id: 1) { id title } }` });
+    expect(fetched.errors).toBeUndefined();
+    expect(fetched.data?.todo).toEqual({ id: 1, title: "write tests" });
+  });
+
+  it("resolves the list query with pagination envelope fields", async () => {
+    const { adapter, schema } = setup();
+    adapter.rows.push({ id: 1, title: "a", done: false }, { id: 2, title: "b", done: true });
+
+    const result = await graphql({
+      schema,
+      source: `query { todos(limit: 1, offset: 1) { items { id title } total limit offset } }`,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.todos).toEqual({
+      items: [{ id: 2, title: "b" }],
+      total: 2,
+      limit: 1,
+      offset: 1,
+    });
+  });
+
+  it("merges multiple entities onto one Query/Mutation root without collisions", async () => {
+    const todoAdapter = new InMemoryTodoAdapter();
+    const todoService = createKavo().createCrud(Todo, undefined, { adapter: todoAdapter, metadata: todoMetadata });
+    const tagAdapter = new InMemoryTagAdapter();
+    const tagService = createKavo().createCrud(Tag, undefined, { adapter: tagAdapter, metadata: tagMetadata });
+
+    const TagType = new GraphQLObjectType({
+      name: "Tag",
+      fields: {
+        id: { type: new GraphQLNonNull(GraphQLInt) },
+        label: { type: new GraphQLNonNull(GraphQLString) },
+      },
+    });
+    const CreateTagInput = new GraphQLInputObjectType({
+      name: "CreateTagInput",
+      fields: { label: { type: new GraphQLNonNull(GraphQLString) } },
+    });
+
+    const schema = mergeCrudGraphQLSchemas([
+      { name: "Todo", service: todoService, itemType: TodoType, createInputType: CreateTodoInput },
+      { name: "Tag", service: tagService, itemType: TagType, createInputType: CreateTagInput },
+    ]);
+
+    const created = await graphql({
+      schema,
+      source: `mutation {
+        createTodo(input: { title: "one endpoint", done: false }) { id title }
+        createTag(input: { label: "urgent" }) { id label }
+      }`,
+    });
+    expect(created.errors).toBeUndefined();
+    expect(created.data).toEqual({
+      createTodo: { id: 1, title: "one endpoint" },
+      createTag: { id: 1, label: "urgent" },
+    });
+
+    const fetched = await graphql({ schema, source: `query { todo(id: 1) { title } tag(id: 1) { label } }` });
+    expect(fetched.errors).toBeUndefined();
+    expect(fetched.data).toEqual({ todo: { title: "one endpoint" }, tag: { label: "urgent" } });
+  });
+
+  it("omits the mutation type when no createInputType is supplied", () => {
+    const service = createKavo().createCrud(Todo, undefined, {
+      adapter: new InMemoryTodoAdapter(),
+      metadata: todoMetadata,
+    });
+    const schema = createCrudGraphQLSchema({ name: "Todo", service, itemType: TodoType });
+    expect(schema.getMutationType()).toBeUndefined();
+  });
+
+  it("registers and retrieves GraphQL types per entity, letting a consumer discover them by class", () => {
+    expect(getCrudGraphQLTypes(Tag)).toBeUndefined();
+
+    registerCrudGraphQLTypes(Tag, { itemType: TodoType });
+    expect(getCrudGraphQLTypes(Tag)).toEqual({ itemType: TodoType });
+  });
+
+  it("resolves update/patch/delete mutations through the same engine", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    adapter.rows.push({ id: 1, title: "before", done: false });
+    const service = createKavo().createCrud(Todo, undefined, { adapter, metadata: todoMetadata });
+
+    const UpdateTodoInput = new GraphQLInputObjectType({
+      name: "UpdateTodoInput",
+      fields: {
+        title: { type: new GraphQLNonNull(GraphQLString) },
+        done: { type: new GraphQLNonNull(GraphQLBoolean) },
+      },
+    });
+    const PatchTodoInput = new GraphQLInputObjectType({
+      name: "PatchTodoInput",
+      fields: { done: { type: GraphQLBoolean } },
+    });
+
+    const schema = createCrudGraphQLSchema({
+      name: "Todo",
+      service,
+      itemType: TodoType,
+      updateInputType: UpdateTodoInput,
+      patchInputType: PatchTodoInput,
+      deleteOne: true,
+    });
+
+    const updated = await graphql({
+      schema,
+      source: `mutation { updateTodo(id: 1, input: { title: "after", done: true }) { title done } }`,
+    });
+    expect(updated.errors).toBeUndefined();
+    expect(updated.data?.updateTodo).toEqual({ title: "after", done: true });
+
+    const patched = await graphql({ schema, source: `mutation { patchTodo(id: 1, input: { done: false }) { done } }` });
+    expect(patched.errors).toBeUndefined();
+    expect(patched.data?.patchTodo).toEqual({ done: false });
+
+    const deleted = await graphql({ schema, source: `mutation { deleteTodo(id: 1) }` });
+    expect(deleted.errors).toBeUndefined();
+    expect(deleted.data?.deleteTodo).toBe(true);
+
+    const afterDelete = await graphql({ schema, source: `query { todo(id: 1) { id } }` });
+    expect(afterDelete.errors?.[0]?.message).toMatch(/not found/i);
+  });
+
+  it("forwards sort and filter args through to the normalized query", async () => {
+    const { adapter, schema } = setup();
+    adapter.rows.push({ id: 1, title: "a", done: false }, { id: 2, title: "b", done: true });
+
+    const result = await graphql({
+      schema,
+      source: `query {
+        todos(sort: ["-title"], filter: { kind: "condition", field: "done", operator: "EQ", value: true }) {
+          items { id }
+        }
+      }`,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(adapter.lastQuery?.sort).toEqual([{ field: "title", direction: "desc" }]);
+    expect(adapter.lastQuery?.filter.root).toEqual({ kind: "condition", field: "done", operator: "EQ", value: true });
+  });
+
+  it("resolves restore/purge mutations against a soft-deletable entity", async () => {
+    const adapter = new InMemoryNoteAdapter();
+    const service = createKavo().createCrud(
+      Note,
+      { softDelete: { strategy: "soft" }, operations: { purgeOne: true } },
+      { adapter, metadata: noteMetadata },
+    );
+    const created = await service.createOne({ text: "keep me" } as never);
+    await service.deleteOne(created.id as never);
+
+    const NoteType = new GraphQLObjectType({
+      name: "Note",
+      fields: {
+        id: { type: new GraphQLNonNull(GraphQLInt) },
+        text: { type: new GraphQLNonNull(GraphQLString) },
+      },
+    });
+
+    const schema = createCrudGraphQLSchema({
+      name: "Note",
+      service,
+      itemType: NoteType,
+      restoreOne: true,
+      purgeOne: true,
+    });
+
+    const restored = await graphql({ schema, source: `mutation { restoreNote(id: ${created.id}) { id text } }` });
+    expect(restored.errors).toBeUndefined();
+    expect(restored.data?.restoreNote).toEqual({ id: created.id, text: "keep me" });
+
+    const purged = await graphql({ schema, source: `mutation { purgeNote(id: ${created.id}) }` });
+    expect(purged.errors).toBeUndefined();
+    expect(purged.data?.purgeNote).toBe(true);
+
+    expect(adapter.rows).toHaveLength(0);
+  });
+});

--- a/packages/protocols/graphql/tests/json-scalar.spec.ts
+++ b/packages/protocols/graphql/tests/json-scalar.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parse, valueFromASTUntyped, type ValueNode } from "graphql";
+import { GraphQLJSON } from "@kavo/graphql";
+
+/** Parses a GraphQL value literal (the part after `filter:`) the same way the executor would when calling `parseLiteral`. */
+function literalOf(source: string): ValueNode {
+  const document = parse(`{ f(x: ${source}) }`);
+  const field = document.definitions[0] as {
+    selectionSet: { selections: readonly { arguments: readonly { value: ValueNode }[] }[] };
+  };
+  return field.selectionSet.selections[0]!.arguments[0]!.value;
+}
+
+describe("GraphQLJSON", () => {
+  it("serializes and parses values pass-through", () => {
+    const value = { kind: "condition", field: "age", operator: "GTE", value: 18 };
+    expect(GraphQLJSON.serialize(value)).toBe(value);
+    expect(GraphQLJSON.parseValue!(value)).toBe(value);
+  });
+
+  it("parses a null literal as null, not the string 'null'", () => {
+    expect(GraphQLJSON.parseLiteral!(literalOf("null"), {})).toBeNull();
+  });
+
+  it("parses object/list literals into the equivalent plain JS value", () => {
+    const parsed = GraphQLJSON.parseLiteral!(
+      literalOf(
+        `{ kind: "group", operator: "AND", children: [{ kind: "condition", field: "done", operator: "EQ", value: true }] }`,
+      ),
+      {},
+    );
+    expect(parsed).toEqual({
+      kind: "group",
+      operator: "AND",
+      children: [{ kind: "condition", field: "done", operator: "EQ", value: true }],
+    });
+  });
+
+  it("round-trips through valueFromASTUntyped for a scalar literal", () => {
+    expect(GraphQLJSON.parseLiteral!(literalOf("42"), {})).toBe(valueFromASTUntyped(literalOf("42")));
+  });
+
+  it("is registered under the name JSON", () => {
+    expect(GraphQLJSON.name).toBe("JSON");
+  });
+});

--- a/packages/protocols/graphql/tests/support/todo-fixture.ts
+++ b/packages/protocols/graphql/tests/support/todo-fixture.ts
@@ -1,0 +1,254 @@
+import type { CrudContext, EntityId, EntityMetadata, NormalizedQueryContext, RepositoryAdapter } from "@kavo/core";
+import { NotFoundException } from "@kavo/core";
+
+/** Third entity — the only one that's soft-deletable, so `restoreOne`/`purgeOne` have something real to exercise. */
+export class Note {
+  id = 0;
+  text = "";
+  deletedAt: Date | null = null;
+}
+
+export const noteMetadata: EntityMetadata<Note> = {
+  entity: Note,
+  name: "Note",
+  idField: "id",
+  fields: [
+    { name: "id", kind: "number", nullable: false, generated: true },
+    { name: "text", kind: "string", nullable: false, generated: false },
+    { name: "deletedAt", kind: "date", nullable: true, generated: true },
+  ],
+  relations: [],
+  softDeleteField: "deletedAt",
+};
+
+export class InMemoryNoteAdapter implements RepositoryAdapter<Note> {
+  rows: Note[] = [];
+  private nextId = 1;
+
+  async findOneById(id: EntityId): Promise<Note | null> {
+    return this.rows.find((row) => row.id === Number(id) && row.deletedAt === null) ?? null;
+  }
+
+  async findOne(): Promise<Note | null> {
+    return this.rows.find((row) => row.deletedAt === null) ?? null;
+  }
+
+  async findMany(query: NormalizedQueryContext<Note>): Promise<readonly Note[]> {
+    const { offset, limit } = query.pagination;
+    return this.rows.filter((row) => row.deletedAt === null).slice(offset, offset + limit);
+  }
+
+  async count(): Promise<number> {
+    return this.rows.filter((row) => row.deletedAt === null).length;
+  }
+
+  async create(data: Partial<Note>): Promise<Note> {
+    const row = { ...new Note(), ...data, id: this.nextId++ };
+    this.rows.push(row);
+    return row;
+  }
+
+  async update(id: EntityId, data: Partial<Note>): Promise<Note> {
+    const row = await this.requireLive(id);
+    Object.assign(row, data);
+    return row;
+  }
+
+  async patch(id: EntityId, data: Partial<Note>): Promise<Note> {
+    return this.update(id, data);
+  }
+
+  async delete(id: EntityId): Promise<void> {
+    const row = await this.requireLive(id);
+    row.deletedAt = new Date();
+  }
+
+  async restore(id: EntityId): Promise<Note> {
+    const row = await this.requireAny(id);
+    row.deletedAt = null;
+    return row;
+  }
+
+  async purge(id: EntityId): Promise<void> {
+    await this.requireAny(id);
+    this.rows = this.rows.filter((candidate) => candidate.id !== Number(id));
+  }
+
+  private async requireLive(id: EntityId): Promise<Note> {
+    const row = this.rows.find((candidate) => candidate.id === Number(id) && candidate.deletedAt === null) ?? null;
+    if (row === null) {
+      throw new NotFoundException({ messageParams: { entity: "Note", id: String(id) } });
+    }
+    return row;
+  }
+
+  private async requireAny(id: EntityId): Promise<Note> {
+    const row = this.rows.find((candidate) => candidate.id === Number(id)) ?? null;
+    if (row === null) {
+      throw new NotFoundException({ messageParams: { entity: "Note", id: String(id) } });
+    }
+    return row;
+  }
+}
+
+/** Test entity for the GraphQL binding — no ORM, no Nest anywhere near this package. */
+export class Todo {
+  id = 0;
+  title = "";
+  done = false;
+}
+
+/** Second entity — exists only to prove `mergeCrudGraphQLSchemas` puts two entities on one root without colliding. */
+export class Tag {
+  id = 0;
+  label = "";
+}
+
+export const tagMetadata: EntityMetadata<Tag> = {
+  entity: Tag,
+  name: "Tag",
+  idField: "id",
+  fields: [
+    { name: "id", kind: "number", nullable: false, generated: true },
+    { name: "label", kind: "string", nullable: false, generated: false },
+  ],
+  relations: [],
+};
+
+export class InMemoryTagAdapter implements RepositoryAdapter<Tag> {
+  rows: Tag[] = [];
+  private nextId = 1;
+
+  async findOneById(id: EntityId): Promise<Tag | null> {
+    return this.rows.find((row) => row.id === Number(id)) ?? null;
+  }
+
+  async findOne(): Promise<Tag | null> {
+    return this.rows[0] ?? null;
+  }
+
+  async findMany(query: NormalizedQueryContext<Tag>): Promise<readonly Tag[]> {
+    const { offset, limit } = query.pagination;
+    return this.rows.slice(offset, offset + limit);
+  }
+
+  async count(): Promise<number> {
+    return this.rows.length;
+  }
+
+  async create(data: Partial<Tag>): Promise<Tag> {
+    const row = { ...new Tag(), ...data, id: this.nextId++ };
+    this.rows.push(row);
+    return row;
+  }
+
+  async update(id: EntityId, data: Partial<Tag>): Promise<Tag> {
+    const row = await this.require(id);
+    Object.assign(row, data);
+    return row;
+  }
+
+  async patch(id: EntityId, data: Partial<Tag>): Promise<Tag> {
+    return this.update(id, data);
+  }
+
+  async delete(id: EntityId): Promise<void> {
+    await this.require(id);
+    this.rows = this.rows.filter((row) => row.id !== Number(id));
+  }
+
+  async restore(): Promise<Tag> {
+    throw new Error("Tag is not soft-deletable");
+  }
+
+  async purge(id: EntityId): Promise<void> {
+    await this.delete(id);
+  }
+
+  private async require(id: EntityId): Promise<Tag> {
+    const row = await this.findOneById(id);
+    if (row === null) {
+      throw new NotFoundException({ messageParams: { entity: "Tag", id: String(id) } });
+    }
+    return row;
+  }
+}
+
+export const todoMetadata: EntityMetadata<Todo> = {
+  entity: Todo,
+  name: "Todo",
+  idField: "id",
+  fields: [
+    { name: "id", kind: "number", nullable: false, generated: true },
+    { name: "title", kind: "string", nullable: false, generated: false },
+    { name: "done", kind: "boolean", nullable: false, generated: false },
+  ],
+  relations: [],
+};
+
+/** In-memory adapter, same shape as core's own test fixtures — no database needed to prove the binding. */
+export class InMemoryTodoAdapter implements RepositoryAdapter<Todo> {
+  rows: Todo[] = [];
+  /** Records the normalized query `findMany` last received — filter/sort *evaluation* is a real adapter's job (@kavo/typeorm's), not re-implemented here; this just proves the GraphQL binding wired them through. */
+  lastQuery: NormalizedQueryContext<Todo> | null = null;
+  private nextId = 1;
+
+  async findOneById(id: EntityId): Promise<Todo | null> {
+    return this.rows.find((row) => row.id === Number(id)) ?? null;
+  }
+
+  async findOne(): Promise<Todo | null> {
+    return this.rows[0] ?? null;
+  }
+
+  async findMany(query: NormalizedQueryContext<Todo>): Promise<readonly Todo[]> {
+    this.lastQuery = query;
+    const { offset, limit } = query.pagination;
+    return this.rows.slice(offset, offset + limit);
+  }
+
+  async count(): Promise<number> {
+    return this.rows.length;
+  }
+
+  async create(data: Partial<Todo>): Promise<Todo> {
+    const row = { ...new Todo(), ...data, id: this.nextId++ };
+    this.rows.push(row);
+    return row;
+  }
+
+  async update(id: EntityId, data: Partial<Todo>): Promise<Todo> {
+    const row = await this.require(id);
+    Object.assign(row, data);
+    return row;
+  }
+
+  async patch(id: EntityId, data: Partial<Todo>): Promise<Todo> {
+    return this.update(id, data);
+  }
+
+  async delete(id: EntityId): Promise<void> {
+    await this.require(id);
+    this.rows = this.rows.filter((row) => row.id !== Number(id));
+  }
+
+  async restore(): Promise<Todo> {
+    throw new Error("Todo is not soft-deletable");
+  }
+
+  async purge(id: EntityId): Promise<void> {
+    await this.delete(id);
+  }
+
+  private async require(id: EntityId): Promise<Todo> {
+    const row = await this.findOneById(id);
+    if (row === null) {
+      throw new NotFoundException({ messageParams: { entity: "Todo", id: String(id) } });
+    }
+    return row;
+  }
+}
+
+export function contextStub(): CrudContext<Todo> {
+  return {} as CrudContext<Todo>;
+}

--- a/packages/protocols/graphql/tsconfig.json
+++ b/packages/protocols/graphql/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/protocols/graphql/tsconfig.tests.json
+++ b/packages/protocols/graphql/tsconfig.tests.json
@@ -1,0 +1,15 @@
+{
+  // Typecheck-only project for `tests/` — see packages/core/tsconfig.tests.json.
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["node"],
+    "paths": {
+      "@kavo/core": ["../../core/src/index.ts"],
+      "@kavo/graphql": ["./src/index.ts"]
+    }
+  },
+  "include": ["tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@kavo/core':
         specifier: workspace:^
         version: link:../../core
+      '@kavo/graphql':
+        specifier: workspace:^
+        version: link:../../protocols/graphql
     devDependencies:
       '@nestjs/common':
         specifier: ^11.0.0
@@ -111,6 +114,9 @@ importers:
       '@types/supertest':
         specifier: ^7.2.1
         version: 7.2.1
+      graphql:
+        specifier: ^16.11.0
+        version: 16.14.2
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -136,6 +142,16 @@ importers:
       typeorm:
         specifier: ^1.1.0
         version: 1.1.0(better-sqlite3@13.0.2)(pg@8.22.0)
+
+  packages/protocols/graphql:
+    dependencies:
+      '@kavo/core':
+        specifier: workspace:^
+        version: link:../../core
+    devDependencies:
+      graphql:
+        specifier: ^16.11.0
+        version: 16.14.2
 
 packages:
 
@@ -1404,6 +1420,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3434,6 +3454,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql@16.14.2: {}
 
   has-flag@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ packages:
   - packages/core
   - packages/orms/*
   - packages/frameworks/*
+  - packages/protocols/*
   - packages/examples

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     { "path": "packages/core" },
     { "path": "packages/orms/typeorm" },
     { "path": "packages/frameworks/nest" },
+    { "path": "packages/protocols/graphql" },
     { "path": "packages/examples" }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       "@kavo/core": new URL("./packages/core/src/index.ts", import.meta.url).pathname,
       "@kavo/typeorm": new URL("./packages/orms/typeorm/src/index.ts", import.meta.url).pathname,
       "@kavo/nest": new URL("./packages/frameworks/nest/src/index.ts", import.meta.url).pathname,
+      "@kavo/graphql": new URL("./packages/protocols/graphql/src/index.ts", import.meta.url).pathname,
     },
   },
   test: {


### PR DESCRIPTION
## What

Adds `@kavo/graphql`, a new host-framework-agnostic package (`packages/protocols/graphql`) that builds a `GraphQLSchema` over an existing `createCrud` service — every resolver calls straight into the same engine pipeline REST uses, no parallel request path. `@kavo/nest` then wires it up: a `BaseCrudGraphQLController` for hand-written overrides, and a `graphql: true | { path }` option on `KavoModule.forRoot`/`forRootAsync` for a zero-code `POST /graphql` (or a custom path).

## Why

REST is Kavo's only wire protocol today. This is the first step toward supporting others (GraphQL now, gRPC/other host frameworks later) without compromising the existing hub-and-spoke topology — see ADR-0016 for why GraphQL lives under a new `packages/protocols/` category rather than `packages/frameworks/`, and why the dependency between the two is strictly one-directional (`@kavo/nest → @kavo/graphql`, never the reverse).

Feature surface:
- All standard operations: `findOne`/`findMany` (with `sort`/`filter` args), `createOne`/`updateOne`/`patchOne`/`deleteOne`, and `restoreOne`/`purgeOne` for soft-deletable entities — each opt-in per entity.
- `mergeCrudGraphQLSchemas`/`resolveCrudGraphQLSchema`: combine many entities onto one `Query`/`Mutation` root, with a process-wide type registry (`registerCrudGraphQLTypes`) so an app doesn't hand-list entities at the wiring site.
- `@kavo/nest`'s `getCrudEntities()`: a new public, read-only projection of the `@Crud` registry — the enumeration half a second protocol binding needs.
- `KavoModule`'s `graphql` option: `true` mounts `POST /graphql`; `{ path: "api/graphql" }` mounts it there instead; a hand-written controller extending `BaseCrudGraphQLController` is the alternative for custom auth/paths/behavior.

## Public API impact

Additive only, no breaking changes:
- New package `@kavo/graphql` (`packages/protocols/graphql`).
- `@kavo/nest` barrel gains `getCrudEntities`, `BaseCrudGraphQLController`, `KavoGraphQLOption`, and `KavoModule.forRoot`/`forRootAsync`'s new optional `graphql` field.
- `@kavo/nest` gains a new real dependency on `@kavo/graphql` (previously depended only on `@kavo/core`).

## Testing

`pnpm check` passes: build, typecheck, `depcruise` (new `graphql-only-imports-core` boundary rule + the one-directional exception), lint, and **607 tests** (33 files) — up from 590 on `main`. New coverage://
- `@kavo/graphql`: schema building for every operation, sort/filter forwarding, multi-entity merging, the type registry, the empty-schema guard (`ConfigurationException` instead of a silent invalid `GraphQLSchema`), and the `GraphQLJSON` scalar directly.
- `@kavo/nest`: `getCrudEntities()` discovery, the hand-written `BaseCrudGraphQLController` override path (real HTTP round trip via `supertest`), and the zero-config `graphql: true` / custom-path / left-unset paths.

## Review notes

- `filter` is currently a raw-AST `JSON` scalar (`{ kind: "condition", field, operator, value }`), not a generated, type-safe `<Entity>FilterInput` — a deliberate scope cut, documented in `packages/docs/architecture/13-graphql-binding.md` §6, same status `itemType`/DTOs had before schema derivation.
- The binding does not cross-check `OperationRegistry`: setting e.g. `restoreOne: true` in the GraphQL options for an entity whose `@Crud` config disables `restoreOne` still puts the field in the schema (it throws `OperationDisabledException` at resolve time, same as REST would). Making this registry-driven is scoped as real follow-up work.
- Worth a close look: `createDefaultGraphQLController` (`packages/frameworks/nest/src/graphql/default-graphql.controller.ts`) builds a class with real `@Controller`/`@Post`/`@HttpCode` decorator syntax inside a factory function (closing over `path`) rather than applying those decorators as plain function calls afterward — the latter compiles but silently drops `emitDecoratorMetadata`'s `design:paramtypes`, breaking `ModuleRef` constructor injection. Worth double-checking this holds across the Nest/TS versions in the peer range.