### PR TITLE
fix(nest): lazy-load @kavo/graphql so it stays a truly optional peer

### DIFF
--- a/packages/docs/architecture/13-graphql-binding.md
+++ b/packages/docs/architecture/13-graphql-binding.md
@@ -177,7 +177,58 @@ graphql: true })` mounts `POST /graphql`; `{ graphql: { path: "api/graphql"
   same decorator function afterward compiles fine but silently drops the
   constructor's `ModuleRef` injection.
 
-## 6. What's out of scope (by design, for now)
+## 6. Lazy-loading an optional protocol dependency
+
+`graphql` is an _optional_ peer of `@kavo/nest` (`peerDependenciesMeta.graphql.optional: true`)
+— an app that never touches GraphQL shouldn't need it installed. That
+guarantee only holds if nothing `@kavo/nest`'s always-loaded module graph
+(`index.ts`, `kavo.module.ts`) reaches at import time ever statically
+imports `@kavo/graphql` or `graphql`. A static top-level `import` is
+resolved eagerly, so a single one anywhere in that graph — even several
+files deep — makes `import { Crud } from "@kavo/nest"` itself crash with
+a raw `ERR_MODULE_NOT_FOUND` whenever `graphql` isn't installed, for
+every app, whether or not it ever sets `KavoModule`'s `graphql` option.
+This was a real bug in this package's first version, caught by asking
+"what error shows if graphql isn't installed" rather than by a test —
+`load-graphql.spec.ts`'s first test (`import("@kavo/nest")` must not
+throw even when `@kavo/graphql` is mocked to explode) is what pins the
+fix now.
+
+`@kavo/nest/src/graphql/load-graphql.ts` is the fix, and the pattern to
+copy for any future optional dependency (a future `@kavo/grpc` glue
+package, or a second protocol binding for `@kavo/express`/`@kavo/fastify`):
+
+- `loadGraphQL()` dynamically `import()`s the optional package(s) inside
+  a function body — never a top-level `import` — caches the result
+  (`null` on failure, so a second call doesn't retry), and throws a clear
+  `ConfigurationException` on failure instead of leaking the raw
+  module-resolution error.
+- Only `import type { ... } from "graphql"` appears at the top of
+  `base-crud-graphql.controller.ts` — type-only imports are fully erased
+  by `tsc` (`isolatedModules`/`verbatimModuleSyntax`, `tsconfig.base.json`),
+  so they cost nothing at runtime and never require the package to be
+  installed, only present at _compile_ time (always true for a workspace
+  package like `@kavo/graphql`).
+- `loadGraphQL()` is only ever called from code a consumer reaches by
+  opting in — `BaseCrudGraphQLController.onModuleInit`/`execute` — never
+  from `index.ts` or `kavo.module.ts` directly. Those two files only
+  reference the _types_ and the plain functions/classes around GraphQL
+  (`createDefaultGraphQLController`, `DEFAULT_GRAPHQL_PATH`), none of
+  which themselves import `@kavo/graphql` or `graphql` at the top level.
+
+One wrinkle worth remembering if a future binding copies this: `@kavo/nest`
+already had exactly this problem solved once, for `@nestjs/swagger`
+(`swagger.ts`'s `loadSwagger()`) — but that one uses a **synchronous**
+`createRequire(...).require(...)`, because `@nestjs/swagger` ships as
+CommonJS. `@kavo/graphql` is Kavo's own package, built as ESM
+(`tsconfig.base.json`'s `"module": "Node16"` + `"type": "module"`), and
+Node cannot `require()` an ES module synchronously — only a dynamic
+`import()` (necessarily async) works for lazily loading an ESM package.
+`BaseCrudGraphQLController.onModuleInit`/`execute` are `async` for
+exactly this reason; a future binding lazily loading another first-party
+ESM package should expect the same.
+
+## 7. What's out of scope (by design, for now)
 
 - Schema derivation from `EntityMetadata` — `itemType`/`createInputType`/etc.
   are hand-written per entity, the same status core's DTOs were before

--- a/packages/frameworks/nest/src/graphql/base-crud-graphql.controller.ts
+++ b/packages/frameworks/nest/src/graphql/base-crud-graphql.controller.ts
@@ -1,9 +1,9 @@
 import type { OnModuleInit } from "@nestjs/common";
 import { ModuleRef } from "@nestjs/core";
-import { resolveCrudGraphQLSchema } from "@kavo/graphql";
-import { graphql, type ExecutionResult, type GraphQLSchema } from "graphql";
+import type { ExecutionResult, GraphQLSchema } from "graphql";
 import { getCrudEntities } from "../crud.decorator.js";
 import { getCrudServiceToken } from "../tokens.js";
+import { loadGraphQL } from "./load-graphql.js";
 
 /**
  * Nest-side half of the `@kavo/graphql` glue: discovers every `@Crud`
@@ -17,6 +17,15 @@ import { getCrudServiceToken } from "../tokens.js";
  * + `getCrudServiceToken`). A future `@kavo/express`/`@kavo/fastify` binding
  * would supply its own version of just those two things and reuse the same
  * `resolveCrudGraphQLSchema` call.
+ *
+ * `@kavo/graphql` and `graphql` are both loaded lazily, via `loadGraphQL()`
+ * — not imported at the top of this file — so that `@kavo/nest`'s
+ * always-loaded module graph never requires either to be installed. Only
+ * `import type` appears above (erased at compile time, ADR-n/a but see
+ * `load-graphql.ts`'s own doc comment for the full reasoning); the runtime
+ * import happens the first time `onModuleInit`/`execute` actually runs,
+ * which only happens for an app that opted in by extending this class or
+ * setting `KavoModule`'s `graphql` option.
  *
  * `@kavo/graphql` itself stays framework-agnostic — it never imports
  * `@kavo/nest` (`graphql-only-imports-core` in `.dependency-cruiser.cjs`,
@@ -50,14 +59,16 @@ export abstract class BaseCrudGraphQLController implements OnModuleInit {
 
   constructor(protected readonly moduleRef: ModuleRef) {}
 
-  onModuleInit(): void {
+  async onModuleInit(): Promise<void> {
+    const { resolveCrudGraphQLSchema } = await loadGraphQL();
     this.schema = resolveCrudGraphQLSchema(getCrudEntities(), (entity) =>
       this.moduleRef.get(getCrudServiceToken(entity), { strict: false }),
     );
   }
 
   /** Runs one query/mutation against the merged schema — call this from the concrete controller's route. */
-  protected execute(source: string, variableValues?: Record<string, unknown>): Promise<ExecutionResult> {
+  protected async execute(source: string, variableValues?: Record<string, unknown>): Promise<ExecutionResult> {
+    const { graphql } = await loadGraphQL();
     return graphql({ schema: this.schema, source, variableValues });
   }
 }

--- a/packages/frameworks/nest/src/graphql/load-graphql.ts
+++ b/packages/frameworks/nest/src/graphql/load-graphql.ts
@@ -1,0 +1,48 @@
+import { ConfigurationException } from "@kavo/core";
+
+interface LazyGraphQL {
+  readonly resolveCrudGraphQLSchema: typeof import("@kavo/graphql").resolveCrudGraphQLSchema;
+  readonly graphql: typeof import("graphql").graphql;
+}
+
+let cached: LazyGraphQL | null | undefined;
+
+/**
+ * Lazily loads `@kavo/graphql` and the `graphql` peer — mirrors
+ * `swagger.ts`'s `loadSwagger()` for the same reason: `graphql` is an
+ * *optional* peer (`package.json`'s `peerDependenciesMeta`), so nothing in
+ * `@kavo/nest`'s always-loaded module graph (`index.ts`, `kavo.module.ts`)
+ * may import it eagerly — doing so would make `import { Crud } from
+ * "@kavo/nest"` itself crash for every app that never touches GraphQL,
+ * whenever `graphql` happens not to be installed.
+ *
+ * Unlike `@nestjs/swagger` (published as CommonJS, loadable via
+ * `loadSwagger()`'s synchronous `require`), `@kavo/graphql` is Kavo's own
+ * ESM package — Node cannot `require()` an ES module synchronously, so a
+ * dynamic `import()` is the only correct lazy-load here, which is why this
+ * (and `BaseCrudGraphQLController.onModuleInit`/`execute`) is async.
+ *
+ * Called only from code a consumer reaches by opting in — extending
+ * `BaseCrudGraphQLController`, or setting `KavoModule`'s `graphql` option
+ * — never from `index.ts` or `kavo.module.ts` directly.
+ */
+export async function loadGraphQL(): Promise<LazyGraphQL> {
+  if (cached === undefined) {
+    try {
+      const [kavoGraphql, graphqlJs] = await Promise.all([import("@kavo/graphql"), import("graphql")]);
+      cached = { resolveCrudGraphQLSchema: kavoGraphql.resolveCrudGraphQLSchema, graphql: graphqlJs.graphql };
+    } catch {
+      cached = null;
+    }
+  }
+  if (cached === null) {
+    throw new ConfigurationException(
+      "GraphQL",
+      "graphql",
+      "GraphQL support requires the `graphql` package to be installed " +
+        "(an optional peer of @kavo/nest) — install it, or don't extend " +
+        "BaseCrudGraphQLController / set `graphql` on KavoModule.",
+    );
+  }
+  return cached;
+}

--- a/packages/frameworks/nest/tests/load-graphql.spec.ts
+++ b/packages/frameworks/nest/tests/load-graphql.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConfigurationException } from "@kavo/core";
+
+/**
+ * Proves the actual bug this file exists to fix: before `loadGraphQL()`,
+ * `@kavo/nest`'s always-loaded module graph (`index.ts`, `kavo.module.ts`)
+ * statically imported `@kavo/graphql`, which statically imports the
+ * `graphql` peer — meaning `import { Crud } from "@kavo/nest"` itself
+ * crashed with a raw `ERR_MODULE_NOT_FOUND` whenever `graphql` (an
+ * *optional* peer) wasn't installed, for every app, whether or not it
+ * ever touched GraphQL. `vi.mock` stands in for "`graphql` isn't
+ * installed": the dynamic `import("@kavo/graphql")` inside `loadGraphQL`
+ * fails, and it must turn into a catchable `ConfigurationException` with
+ * an actionable message, not an unhandled module-resolution error.
+ */
+vi.mock("@kavo/graphql", () => {
+  throw new Error("Cannot find package 'graphql'");
+});
+
+describe("loadGraphQL", () => {
+  it("importing @kavo/nest's barrel never touches @kavo/graphql, even when it would throw", async () => {
+    // The regression this whole file guards against: this import must not
+    // throw, despite the mock above making @kavo/graphql itself explode —
+    // proof that no module reachable from the barrel imports it eagerly.
+    await expect(import("@kavo/nest")).resolves.toBeDefined();
+  });
+
+  it("wraps a failed dynamic import in a ConfigurationException", async () => {
+    const { loadGraphQL } = await import("../src/graphql/load-graphql.js");
+    await expect(loadGraphQL()).rejects.toThrow(ConfigurationException);
+    await expect(loadGraphQL()).rejects.toThrow(/graphql.*package.*installed/i);
+  });
+});


### PR DESCRIPTION
## What

`graphql` is declared as an optional peer of `@kavo/nest` (from #49), but `BaseCrudGraphQLController` imported `@kavo/graphql` (and transitively `graphql`) with a static top-level `import`. Since ES module imports resolve eagerly, `import { Crud } from "@kavo/nest"` itself crashed with a raw `ERR_MODULE_NOT_FOUND` whenever `graphql` wasn't installed — for every app, not just ones that set `KavoModule`'s `graphql` option.

## Why

Caught by asking "what error shows if a user enables `graphql` but doesn't install it" rather than by a test. The answer turned out to be worse than a bad error message: the crash wasn't gated behind the feature at all. `@kavo/nest` already solves exactly this shape of problem for `@nestjs/swagger` (`swagger.ts`'s `loadSwagger()`), and this PR follows the same pattern for `@kavo/graphql`.

## Changes

- `packages/frameworks/nest/src/graphql/load-graphql.ts`: a lazy loader, called only from `BaseCrudGraphQLController.onModuleInit`/`execute` — i.e. only once an app opts in by extending that class or setting `KavoModule`'s `graphql` option. Wraps a failed load in `ConfigurationException` with an actionable message instead of leaking the raw module-resolution error.
- Unlike `loadSwagger`'s synchronous `require` (valid because `@nestjs/swagger` ships CommonJS), `@kavo/graphql` is Kavo's own ESM package, which Node cannot `require()` synchronously — this loader uses a dynamic `import()` instead, which is why `onModuleInit`/`execute` are now `async`.
- `packages/docs/architecture/13-graphql-binding.md` gets a new §6 documenting this as the pattern any future optional protocol/framework dependency (a future `@kavo/grpc`, `@kavo/express`, etc.) should follow.

## Public API impact

None breaking. `BaseCrudGraphQLController.onModuleInit`/`execute` change from sync to `async`-returning — both were already only ever awaited by Nest's lifecycle/router, not called synchronously by any consumer.

## Testing

`pnpm check` green: build, typecheck, depcruise, lint, and **609 tests** (34 files, up from 607 pre-fix — the previous count already included this session's other GraphQL work, merged in #49).

New: `load-graphql.spec.ts`, including the regression proof — with `@kavo/graphql` mocked to throw, `import("@kavo/nest")` must still not throw. All existing GraphQL e2e suites (from #49) still pass unchanged, proving the async conversion is transparent to callers.

## Review notes

Worth double-checking: the dynamic-`import()`-of-an-ESM-package approach is the only correct one here (vs. `loadSwagger`'s sync `require`), since `@kavo/graphql` is built as ESM and Node forbids synchronous `require()` of ES modules. Flagging in case there's a compatibility angle (older bundlers, CJS consumers of `@kavo/nest`) worth a closer look.