### PR TITLE
Add configurable default sort order to getMany/list queries

### DIFF
--- a/docs/architecture/05-query-grammar.md
+++ b/docs/architecture/05-query-grammar.md
@@ -81,6 +81,11 @@ fields:     root: [id, name, email]
   appear, they AND together.
 - **Sort:** `sort=-createdAt,name` — comma-separated, `-` prefix =
   descending, list order is priority order. Sortable-allowlist enforced.
+  A request that supplies no `sort` falls back to the resolved
+  `query.defaultSort` setting (doc 08) if one is configured; a client- or
+  caller-supplied `sort` always wins outright over the default rather than
+  merging with it. With neither, there is no `ORDER BY` at all — row order
+  is DB-dependent.
 - **Pagination:** pluggable `PaginationStrategy`. Default `offset`: flat
   `limit`/`offset` (0-based) — the same field names the response envelope
   reports, so request and response mirror each other. Built-in

--- a/docs/architecture/08-configuration.md
+++ b/docs/architecture/08-configuration.md
@@ -90,9 +90,12 @@ merge. Each entry is `{ field, direction }` (the same shape as a parsed
 `Sort`), resolved through the full precedence chain like every other
 setting, so it can be set globally, per entity, per operation, or per call.
 Fields are checked against the same sortable allowlist client-supplied
-`sort` fields are checked against, but at **bootstrap** (`resolveEntityConfig`)
-rather than request time, so a typo in a default fails fast instead of
-producing a broken `ORDER BY` on the first request. Doc 05 covers the
+`sort` fields are checked against, but as soon as the value is set rather
+than when a request uses it: at **bootstrap** (`resolveEntityConfig`) for
+global/entity/operation scope, and when a per-call override is merged
+(`KavoEngine.configViewFor`) for per-call scope — so a bad default fails
+fast at the scope that introduced it instead of producing a broken
+`ORDER BY` on the first request that hits it. Doc 05 covers the
 request-time semantics (client `sort` vs. this fallback).
 
 ## 5. Root factory and framework skin

--- a/docs/architecture/08-configuration.md
+++ b/docs/architecture/08-configuration.md
@@ -17,6 +17,7 @@ built-in defaults → global (createKavo) → entity (createCrud)
 | `pagination.strategy`                            | `"offset"`               | `"page"` built in; custom via `paginationStrategies`                   |
 | `pagination.count`                               | `true`                   | `false` skips the count query; envelope reports `total: null`          |
 | `query.maxFilterDepth` / `maxInValues`           | 3 / 100                  |                                                                        |
+| `query.defaultSort`                              | `[]` (unset)             | order applied when a request supplies no `sort` (issue #56); see below |
 | `errors.exposeInternals`                         | `false`                  | leak driver detail into responses                                      |
 | `relations.maxIncludeDepth` / `maxIncludedNodes` | 2 / 10                   | include depth budget and total node cap                                |
 | `relations.edges.<name>`                         | `{}`                     | per-relation `includable` / `defaultInclude` / `maxDepth` / `strategy` |
@@ -80,6 +81,19 @@ request.
 expected a positive integer, got -1`). The same bar applies to unknown
 pagination strategies, missing infrastructure, non-`@Kavo` controllers in
 `forFeature`, and custom-operation id collisions.
+
+### `query.defaultSort`
+
+Order applied when a request supplies no `sort` at all — a client- or
+caller-supplied `sort`, when present, always wins outright; the two never
+merge. Each entry is `{ field, direction }` (the same shape as a parsed
+`Sort`), resolved through the full precedence chain like every other
+setting, so it can be set globally, per entity, per operation, or per call.
+Fields are checked against the same sortable allowlist client-supplied
+`sort` fields are checked against, but at **bootstrap** (`resolveEntityConfig`)
+rather than request time, so a typo in a default fails fast instead of
+producing a broken `ORDER BY` on the first request. Doc 05 covers the
+request-time semantics (client `sort` vs. this fallback).
 
 ## 5. Root factory and framework skin
 

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -15,6 +15,9 @@ export const BUILT_IN_DEFAULTS: KavoSettings = Object.freeze({
   query: Object.freeze({
     maxFilterDepth: 3,
     maxInValues: 100,
+    // Unset: today's no-`sort`-means-no-`ORDER BY` behavior is unchanged
+    // for apps that don't declare a default.
+    defaultSort: Object.freeze([]),
   }),
   errors: Object.freeze({
     exposeInternals: false,

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -11,6 +11,7 @@ import { validateSettings } from "./validate-settings.js";
 import { DefaultDtoResolver } from "../dto/default-dto-resolver.js";
 import { DefaultRelationRegistry } from "../relations/default-relation-registry.js";
 import { resolveSoftDelete } from "../persistence/soft-delete.js";
+import { ConfigurationException } from "../errors/exceptions.js";
 
 /**
  * Top-level settings keys — the subset of an `EntityConfig` that merges.
@@ -59,12 +60,14 @@ export function resolveEntityConfig<Entity extends object>(
   globalDefaults: DeepPartial<KavoSettings> | undefined,
 ): ResolvedEntityConfig<Entity> {
   const entityName = metadata.name;
+  const allowlists = resolveAllowlists(metadata, entityConfig);
   const entitySettings = mergeSettings(
     BUILT_IN_DEFAULTS,
     globalDefaults,
     pickSettings(entityConfig as Readonly<Record<string, unknown>> | undefined),
   );
   validateSettings(entityName, entitySettings);
+  validateDefaultSort(entityName, entitySettings, allowlists);
 
   // Per-operation settings views, precomputed for every operation that
   // declares overrides. `false` (disabled) contributes no settings — the
@@ -81,6 +84,7 @@ export function resolveEntityConfig<Entity extends object>(
     const merged = mergeSettings(entitySettings, settings);
     const scope = `${entityName}.operations.${operation}`;
     validateSettings(scope, merged);
+    validateDefaultSort(scope, merged, allowlists);
     // Resolve for its validation side effect: a per-operation scope that
     // demands soft delete on an entity without a marker field must fail at
     // bootstrap, not on the first request (the engine recomputes the
@@ -88,8 +92,6 @@ export function resolveEntityConfig<Entity extends object>(
     resolveSoftDelete(metadata, merged, scope);
     perOperation.set(operation, deepFreeze(merged));
   }
-
-  const allowlists = resolveAllowlists(metadata, entityConfig);
 
   const resolved: ResolvedEntityConfig<Entity> = {
     entityName,
@@ -123,6 +125,29 @@ function resolveAllowlists<Entity extends object>(
     sortable: resolveFieldSelector(ownColumns, configured?.sortable),
     selectable: resolveFieldSelector(ownColumns, configured?.selectable),
   });
+}
+
+/**
+ * `query.defaultSort` fields are checked against the same sortable
+ * allowlist client-supplied `sort` fields are checked against at request
+ * time — but here, at bootstrap, so a misconfigured default fails fast
+ * instead of surfacing as a broken `ORDER BY` on the first request.
+ */
+function validateDefaultSort<Entity>(
+  scope: string,
+  settings: KavoSettings,
+  allowlists: ResolvedQueryAllowlists<Entity>,
+): void {
+  const sortable = allowlists.sortable as readonly string[];
+  for (const entry of settings.query.defaultSort) {
+    if (!sortable.includes(entry.field)) {
+      throw new ConfigurationException(
+        scope,
+        "query.defaultSort",
+        `field '${entry.field}' is not in the sortable allowlist`,
+      );
+    }
+  }
 }
 
 /**

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -133,7 +133,7 @@ function resolveAllowlists<Entity extends object>(
  * time — but here, at bootstrap, so a misconfigured default fails fast
  * instead of surfacing as a broken `ORDER BY` on the first request.
  */
-function validateDefaultSort<Entity>(
+export function validateDefaultSort<Entity>(
   scope: string,
   settings: KavoSettings,
   allowlists: ResolvedQueryAllowlists<Entity>,

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -1,5 +1,6 @@
 import type { RelationLoadStrategy } from "../relations/relation-descriptor.js";
 import type { StandardOperationId } from "../operations/operation.js";
+import type { Sort } from "../query/sort.js";
 
 /**
  * The complete, canonical settings schema — one schema for every scope.
@@ -27,6 +28,13 @@ export interface QuerySettings {
   readonly maxFilterDepth: number;
   /** Max array length for `IN`/`NOT_IN`/`BETWEEN` values. */
   readonly maxInValues: number;
+  /**
+   * Order applied when a request supplies no `sort` — a client-supplied
+   * `sort` always wins outright, never merges with this. Fields are
+   * validated against the sortable allowlist at bootstrap, the same as
+   * client-supplied sort fields are at request time.
+   */
+  readonly defaultSort: readonly Sort[];
 }
 
 export interface ErrorSettings {

--- a/packages/core/src/config/validate-settings.ts
+++ b/packages/core/src/config/validate-settings.ts
@@ -40,6 +40,31 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
   positiveInt("query.maxFilterDepth", settings.query.maxFilterDepth);
   positiveInt("query.maxInValues", settings.query.maxInValues);
 
+  if (!Array.isArray(settings.query.defaultSort)) {
+    throw new ConfigurationException(
+      entityName,
+      "query.defaultSort",
+      `expected an array, got ${JSON.stringify(settings.query.defaultSort)}`,
+    );
+  }
+  for (const [index, entry] of settings.query.defaultSort.entries()) {
+    const path = `query.defaultSort[${index}]`;
+    if (typeof entry !== "object" || entry === null || typeof entry.field !== "string" || entry.field.length === 0) {
+      throw new ConfigurationException(
+        entityName,
+        path,
+        `expected { field: string, direction: "asc" | "desc" }, got ${JSON.stringify(entry)}`,
+      );
+    }
+    if (entry.direction !== "asc" && entry.direction !== "desc") {
+      throw new ConfigurationException(
+        entityName,
+        `${path}.direction`,
+        `expected "asc" or "desc", got ${JSON.stringify(entry.direction)}`,
+      );
+    }
+  }
+
   bool("errors.exposeInternals", settings.errors.exposeInternals);
 
   positiveInt("relations.maxIncludeDepth", settings.relations.maxIncludeDepth);

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -16,6 +16,7 @@ import { QueryNormalizer } from "../query/query-normalizer.js";
 import { createKavoContext, randomUuid } from "../context/default-kavo-context.js";
 import { mergeSettings } from "../config/merge-settings.js";
 import { validateSettings } from "../config/validate-settings.js";
+import { validateDefaultSort } from "../config/resolve-entity-config.js";
 import { resolveSoftDelete } from "../persistence/soft-delete.js";
 import type { FindManyResult } from "./built-in-handlers.js";
 
@@ -137,7 +138,9 @@ export class KavoEngine<Entity extends object> {
     let settings: KavoSettings = base;
     if (overrides !== undefined) {
       settings = mergeSettings(base, overrides);
-      validateSettings(`${config.entityName} (per-call)`, settings);
+      const scope = `${config.entityName} (per-call)`;
+      validateSettings(scope, settings);
+      validateDefaultSort(scope, settings, config.allowlists);
     }
     if (settings === config.settings) return config;
     return {

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -61,7 +61,8 @@ export class QueryNormalizer<Entity = unknown> {
       collectIssues(error, issues);
     }
 
-    const sort = parseSort(rawParams["sort"], config, issues);
+    const clientSort = parseSort(rawParams["sort"], config, issues);
+    const sort = clientSort.length > 0 ? clientSort : defaultSortOf(config);
     const fields = parseFields(rawParams, config, issues);
     const include = this.resolveIncludes(parseIncludePaths(rawParams["include"], issues), fields, config, issues);
 
@@ -110,10 +111,11 @@ export class QueryNormalizer<Entity = unknown> {
       validateExpression(root, config, issues);
     }
 
-    const sort = input.sort ?? [];
-    for (const entry of sort) {
+    const clientSort = input.sort ?? [];
+    for (const entry of clientSort) {
       requireAllowlisted(entry.field as string, config.allowlists.sortable, "sorting", issues);
     }
+    const sort = clientSort.length > 0 ? clientSort : defaultSortOf(config);
 
     const { root: rootFields, relations: relationFields } = collapseFieldSelection<Entity>(input.fields, issues);
     if (rootFields != null) {
@@ -263,6 +265,15 @@ function parseWithDeleted<Entity>(
     return false;
   }
   return true;
+}
+
+/**
+ * `config.settings.query.defaultSort` — bootstrap-validated against the
+ * sortable allowlist (`resolve-entity-config.ts`), so it's applied here
+ * as-is rather than re-checked per request.
+ */
+function defaultSortOf<Entity>(config: ResolvedEntityConfig<Entity>): readonly Sort<Entity>[] {
+  return config.settings.query.defaultSort as unknown as readonly Sort<Entity>[];
 }
 
 function parseSort<Entity>(

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -268,9 +268,10 @@ function parseWithDeleted<Entity>(
 }
 
 /**
- * `config.settings.query.defaultSort` — bootstrap-validated against the
- * sortable allowlist (`resolve-entity-config.ts`), so it's applied here
- * as-is rather than re-checked per request.
+ * `config.settings.query.defaultSort` — validated against the sortable
+ * allowlist wherever it's set (`resolveEntityConfig` at bootstrap for
+ * entity/operation scope, `KavoEngine.configViewFor` for per-call scope),
+ * so it's applied here as-is rather than re-checked per request.
  */
 function defaultSortOf<Entity>(config: ResolvedEntityConfig<Entity>): readonly Sort<Entity>[] {
   return config.settings.query.defaultSort as unknown as readonly Sort<Entity>[];

--- a/packages/core/tests/config-validation.spec.ts
+++ b/packages/core/tests/config-validation.spec.ts
@@ -84,6 +84,39 @@ describe("validateSettings — query limits", () => {
   it("accepts a depth and a value cap of 1", () => {
     expect(() => accept({ query: { maxFilterDepth: 1, maxInValues: 1 } })).not.toThrow();
   });
+
+  it("rejects a defaultSort that is not an array", () => {
+    for (const value of ["name", null, { field: "name", direction: "asc" }]) {
+      expectRejected({ query: { defaultSort: value } }, "query.defaultSort", value);
+    }
+  });
+
+  it("rejects a defaultSort entry missing a field or with a non-string field", () => {
+    for (const entry of [{}, { field: 1, direction: "asc" }, { direction: "asc" }]) {
+      expectRejected({ query: { defaultSort: [entry] } }, "query.defaultSort[0]", entry);
+    }
+  });
+
+  it("rejects a defaultSort entry with an invalid direction", () => {
+    expectRejected(
+      { query: { defaultSort: [{ field: "name", direction: "up" }] } },
+      "query.defaultSort[0].direction",
+      "up",
+    );
+  });
+
+  it("accepts a well-formed defaultSort", () => {
+    expect(() =>
+      accept({
+        query: {
+          defaultSort: [
+            { field: "createdAt", direction: "desc" },
+            { field: "id", direction: "asc" },
+          ],
+        },
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe("validateSettings — errors", () => {

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -147,8 +147,22 @@ describe("resolveEntityConfig — bootstrap", () => {
     expect(config.settingsFor("findOne").query.defaultSort).toEqual([{ field: "createdAt", direction: "desc" }]);
   });
 
+  it("applies the precedence chain global -> entity for defaultSort", () => {
+    const config = resolveEntityConfig(
+      userMetadata,
+      { query: { defaultSort: [{ field: "name", direction: "asc" }] } },
+      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
+    );
+    expect(config.settings.query.defaultSort).toEqual([{ field: "name", direction: "asc" }]); // entity beats global
+
+    const globalOnly = resolveEntityConfig(userMetadata, undefined, {
+      query: { defaultSort: [{ field: "createdAt", direction: "desc" }] },
+    });
+    expect(globalOnly.settings.query.defaultSort).toEqual([{ field: "createdAt", direction: "desc" }]);
+  });
+
   it("rejects an entity-scope defaultSort field outside the sortable allowlist", () => {
-    expect(() =>
+    try {
       resolveEntityConfig(
         userMetadata,
         {
@@ -156,12 +170,16 @@ describe("resolveEntityConfig — bootstrap", () => {
           query: { defaultSort: [{ field: "email", direction: "asc" }] },
         },
         undefined,
-      ),
-    ).toThrowError(ConfigurationException);
+      );
+      expect.unreachable();
+    } catch (error) {
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).detail).toContain("email");
+    }
   });
 
   it("rejects an operation-scope defaultSort field outside the sortable allowlist", () => {
-    expect(() =>
+    try {
       resolveEntityConfig(
         userMetadata,
         {
@@ -169,8 +187,12 @@ describe("resolveEntityConfig — bootstrap", () => {
           operations: { findMany: { query: { defaultSort: [{ field: "email", direction: "asc" }] } } },
         },
         undefined,
-      ),
-    ).toThrowError(ConfigurationException);
+      );
+      expect.unreachable();
+    } catch (error) {
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).detail).toContain("email");
+    }
   });
 });
 

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -124,6 +124,54 @@ describe("resolveEntityConfig — bootstrap", () => {
     // Unconfigured filterable still derives in full.
     expect(config.allowlists.filterable).toContain("status");
   });
+
+  it("resolves an entity-scope defaultSort", () => {
+    const config = resolveEntityConfig(
+      userMetadata,
+      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
+      undefined,
+    );
+    expect(config.settings.query.defaultSort).toEqual([{ field: "createdAt", direction: "desc" }]);
+  });
+
+  it("lets an operation override the entity-scope defaultSort", () => {
+    const config = resolveEntityConfig(
+      userMetadata,
+      {
+        query: { defaultSort: [{ field: "createdAt", direction: "desc" }] },
+        operations: { findMany: { query: { defaultSort: [{ field: "name", direction: "asc" }] } } },
+      },
+      undefined,
+    );
+    expect(config.settingsFor("findMany").query.defaultSort).toEqual([{ field: "name", direction: "asc" }]);
+    expect(config.settingsFor("findOne").query.defaultSort).toEqual([{ field: "createdAt", direction: "desc" }]);
+  });
+
+  it("rejects an entity-scope defaultSort field outside the sortable allowlist", () => {
+    expect(() =>
+      resolveEntityConfig(
+        userMetadata,
+        {
+          allowlists: { sortable: ["name"] },
+          query: { defaultSort: [{ field: "email", direction: "asc" }] },
+        },
+        undefined,
+      ),
+    ).toThrowError(ConfigurationException);
+  });
+
+  it("rejects an operation-scope defaultSort field outside the sortable allowlist", () => {
+    expect(() =>
+      resolveEntityConfig(
+        userMetadata,
+        {
+          allowlists: { sortable: ["name"] },
+          operations: { findMany: { query: { defaultSort: [{ field: "email", direction: "asc" }] } } },
+        },
+        undefined,
+      ),
+    ).toThrowError(ConfigurationException);
+  });
 });
 
 describe("User fixture sanity", () => {

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -97,6 +97,17 @@ describe("KavoEngine pipeline", () => {
     expect(counted.total).toBe(1);
   });
 
+  it("honors a per-call defaultSort override for one request only", async () => {
+    const { crud, adapter } = makeCrud();
+    await crud.findMany(undefined, {
+      settings: { query: { defaultSort: [{ field: "name", direction: "asc" }] } },
+    });
+    expect(adapter.lastQuery?.sort).toEqual([{ field: "name", direction: "asc" }]);
+
+    await crud.findMany();
+    expect(adapter.lastQuery?.sort).toEqual([]);
+  });
+
   it("raises OperationDisabledException for operations off by default", async () => {
     const { crud } = makeCrud();
     // `restoreOne` stays off until the entity config declares soft delete.

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { NotFoundException, OperationDisabledException, createKavo, toProblemDetails } from "@kavo/core";
+import {
+  ConfigurationException,
+  NotFoundException,
+  OperationDisabledException,
+  createKavo,
+  toProblemDetails,
+} from "@kavo/core";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
 
 function makeCrud(config?: Parameters<ReturnType<typeof createKavo>["createCrud"]>[1]) {
@@ -106,6 +112,15 @@ describe("KavoEngine pipeline", () => {
 
     await crud.findMany();
     expect(adapter.lastQuery?.sort).toEqual([]);
+  });
+
+  it("rejects a per-call defaultSort field outside the sortable allowlist", async () => {
+    const { crud } = makeCrud();
+    await expect(
+      crud.findMany(undefined, {
+        settings: { query: { defaultSort: [{ field: "notAColumn", direction: "asc" }] } },
+      }),
+    ).rejects.toBeInstanceOf(ConfigurationException);
   });
 
   it("raises OperationDisabledException for operations off by default", async () => {

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -37,6 +37,10 @@ describe("QueryNormalizer — wire params", () => {
     expect(clamped.pagination.limit).toBe(100);
   });
 
+  it("issues no sort at all when neither the client nor config supplies one", () => {
+    expect(normalizer.normalizeWire({}, config).sort).toEqual([]);
+  });
+
   it("rejects malformed pagination values", () => {
     const issues = issuesOf(() => normalizer.normalizeWire({ limit: "abc" }, config));
     expect(issues[0]).toMatchObject({
@@ -101,6 +105,25 @@ describe("QueryNormalizer — wire params", () => {
     expect(normalizer.normalizeWire({}, defaulted).sort).toEqual([{ field: "createdAt", direction: "desc" }]);
   });
 
+  it("applies a multi-field defaultSort in priority order", () => {
+    const defaulted = resolveEntityConfig(
+      userMetadata,
+      {
+        query: {
+          defaultSort: [
+            { field: "createdAt", direction: "desc" },
+            { field: "id", direction: "asc" },
+          ],
+        },
+      },
+      undefined,
+    );
+    expect(normalizer.normalizeWire({}, defaulted).sort).toEqual([
+      { field: "createdAt", direction: "desc" },
+      { field: "id", direction: "asc" },
+    ]);
+  });
+
   it("lets a client-supplied sort override the configured defaultSort outright", () => {
     const defaulted = resolveEntityConfig(
       userMetadata,
@@ -123,6 +146,10 @@ describe("QueryNormalizer — programmatic input", () => {
     );
     expect(query.filter.root).toMatchObject({ value: 18 });
     expect(query.pagination).toEqual({ limit: 5, offset: 0 });
+  });
+
+  it("issues no sort at all when neither the caller nor config supplies one", () => {
+    expect(normalizer.normalizeInput({}, config).sort).toEqual([]);
   });
 
   it("enforces allowlists identically to the wire path", () => {

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -91,6 +91,24 @@ describe("QueryNormalizer — wire params", () => {
     const uncounted = resolveEntityConfig(userMetadata, { pagination: { count: false } }, undefined);
     expect(normalizer.normalizeWire({}, uncounted).count).toBe(false);
   });
+
+  it("falls back to the configured defaultSort when the client supplies no sort", () => {
+    const defaulted = resolveEntityConfig(
+      userMetadata,
+      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
+      undefined,
+    );
+    expect(normalizer.normalizeWire({}, defaulted).sort).toEqual([{ field: "createdAt", direction: "desc" }]);
+  });
+
+  it("lets a client-supplied sort override the configured defaultSort outright", () => {
+    const defaulted = resolveEntityConfig(
+      userMetadata,
+      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
+      undefined,
+    );
+    expect(normalizer.normalizeWire({ sort: "name" }, defaulted).sort).toEqual([{ field: "name", direction: "asc" }]);
+  });
 });
 
 describe("QueryNormalizer — programmatic input", () => {
@@ -124,6 +142,25 @@ describe("QueryNormalizer — programmatic input", () => {
       ),
     );
     expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_FIELD");
+  });
+
+  it("falls back to the configured defaultSort when no sort is given", () => {
+    const defaulted = resolveEntityConfig(
+      userMetadata,
+      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
+      undefined,
+    );
+    expect(normalizer.normalizeInput({}, defaulted).sort).toEqual([{ field: "createdAt", direction: "desc" }]);
+  });
+
+  it("lets a caller-supplied sort override the configured defaultSort outright", () => {
+    const defaulted = resolveEntityConfig(
+      userMetadata,
+      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
+      undefined,
+    );
+    const query = normalizer.normalizeInput({ sort: [{ field: "name", direction: "asc" }] }, defaulted);
+    expect(query.sort).toEqual([{ field: "name", direction: "asc" }]);
   });
 });
 

--- a/packages/orms/prisma/tests/adapter.spec.ts
+++ b/packages/orms/prisma/tests/adapter.spec.ts
@@ -196,6 +196,24 @@ describe("PrismaRepositoryAdapter — query translation", () => {
     expect(list.items).toHaveLength(0);
   });
 
+  it("applies the configured defaultSort when the caller supplies no sort", async () => {
+    await seed();
+    const withDefault = kavo.createCrud(Author, {
+      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+    }) as DefaultKavoService<Author>;
+    const list = await withDefault.findMany();
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Joan", "Ada", "Alan", "Grace"]);
+  });
+
+  it("lets a caller-supplied sort override the configured defaultSort", async () => {
+    await seed();
+    const withDefault = kavo.createCrud(Author, {
+      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+    }) as DefaultKavoService<Author>;
+    const list = await withDefault.findMany({ sort: [{ field: "age", direction: "desc" }] });
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Grace", "Alan", "Ada", "Joan"]);
+  });
+
   it("skips the count query when counting is disabled", async () => {
     await seed();
     const list = await authors.findMany(undefined, { settings: { pagination: { count: false } } });

--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -238,6 +238,24 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
     expect(list.items).toHaveLength(0);
   });
 
+  it("applies the configured defaultSort when the caller supplies no sort", async () => {
+    await seed();
+    const withDefault = kavo.createCrud(Author, {
+      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+    }) as DefaultKavoService<Author>;
+    const list = await withDefault.findMany();
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Joan", "Ada", "Alan", "Grace"]);
+  });
+
+  it("lets a caller-supplied sort override the configured defaultSort", async () => {
+    await seed();
+    const withDefault = kavo.createCrud(Author, {
+      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+    }) as DefaultKavoService<Author>;
+    const list = await withDefault.findMany({ sort: [{ field: "age", direction: "desc" }] });
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Grace", "Alan", "Ada", "Joan"]);
+  });
+
   it("skips the count query when counting is disabled", async () => {
     await seed();
     const list = await authors.findMany(undefined, {

--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -256,6 +256,36 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
     expect(list.items.map((a) => (a as Author).name)).toEqual(["Grace", "Alan", "Ada", "Joan"]);
   });
 
+  it("breaks ties on the second field of a multi-field defaultSort", async () => {
+    const withDefault = kavo.createCrud(Author, {
+      query: {
+        defaultSort: [
+          { field: "status", direction: "asc" },
+          { field: "name", direction: "asc" },
+        ],
+      },
+    }) as DefaultKavoService<Author>;
+    await withDefault.createOne({ email: "b@x.io", name: "Bea", age: 30, status: "active" } as never);
+    await withDefault.createOne({ email: "c@x.io", name: "Cy", age: 31, status: "active" } as never);
+    await withDefault.createOne({ email: "a@x.io", name: "Amy", age: 29, status: "active" } as never);
+    const list = await withDefault.findMany();
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Amy", "Bea", "Cy"]);
+  });
+
+  it("keeps defaultSort-ordered pages disjoint and stable across offsets", async () => {
+    await seed();
+    const withDefault = kavo.createCrud(Author, {
+      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+    }) as DefaultKavoService<Author>;
+    const page1 = await withDefault.findMany({ limit: 2, offset: 0 });
+    const page2 = await withDefault.findMany({ limit: 2, offset: 2 });
+    const names1 = page1.items.map((a) => (a as Author).name);
+    const names2 = page2.items.map((a) => (a as Author).name);
+    expect(names1).toEqual(["Joan", "Ada"]);
+    expect(names2).toEqual(["Alan", "Grace"]);
+    expect(new Set([...names1, ...names2]).size).toBe(4); // disjoint, no repeats/skips
+  });
+
   it("skips the count query when counting is disabled", async () => {
     await seed();
     const list = await authors.findMany(undefined, {


### PR DESCRIPTION
## What & why

`getMany`/list queries issued no `ORDER BY` at all when the caller supplied no `sort`, making row order (and page contents, combined with limit/offset pagination) DB-dependent. This adds `query.defaultSort` to `KavoSettings`: an ordered `{ field, direction }[]` resolved through the full precedence chain (global → entity → operation → per-call), applied by `QueryNormalizer` only when the caller supplies no `sort` — a client- or caller-supplied `sort` always wins outright, never merges with the default.

`defaultSort` fields are checked against the same sortable allowlist client-supplied `sort` fields are checked against, at the scope that introduces the value: bootstrap (`resolveEntityConfig`) for global/entity/operation scope, and when a per-call override is merged (`KavoEngine.configViewFor`) for per-call scope — so a bad default fails fast instead of reaching the database.

`@kavo/typeorm` and `@kavo/prisma` needed **no adapter changes** — both already consume `query.sort` as-is, so a populated default flows through for free (verified with new adapter tests in both packages, including a multi-field tiebreak test and a paginated-pages-stay-disjoint test).

## Public API impact

Additive only: new `defaultSort` key on `QuerySettings` (already exported via the `@kavo/core` barrel as part of `KavoSettings`/`QuerySettings`), plus a newly-exported `validateDefaultSort` helper from `@kavo/core`'s internal config module (not barrel-exported; used by the engine). Default is `[]`, so existing behavior (no `ORDER BY` when nothing is configured) is unchanged. Not breaking.

## Testing

- `packages/core/tests/config-validation.spec.ts` — shape validation (array, well-formed entries, valid direction)
- `packages/core/tests/config.spec.ts` — bootstrap resolution, global/entity/operation precedence, allowlist rejection at bootstrap (asserting `.code`/`.detail`)
- `packages/core/tests/query-normalizer.spec.ts` — wire and programmatic fallback, client/caller override, multi-field priority order, and the unset-defaultSort/no-sort-at-all case
- `packages/core/tests/engine.spec.ts` — per-call override applies for one request only and doesn't leak, **and is rejected when it names a field outside the sortable allowlist**
- `packages/orms/typeorm/tests/adapter.spec.ts`, `packages/orms/prisma/tests/adapter.spec.ts` — real DB ordering via `defaultSort`, override by explicit `sort`, multi-field tiebreak, and pages staying disjoint/stable under `defaultSort` + `limit`/`offset`

`pnpm check`: build, typecheck, depcruise, and lint all green. Test suite: 640 passed, 50 skipped. The only failing suite is `packages/examples/tests/app-postgres.e2e.spec.ts`, which requires a Docker container runtime unavailable in this sandbox — pre-existing and unrelated to this change.

## Review notes

`/review` (kavo-reviewer + kavo-test-auditor + kavo-security-auditor, run in parallel) independently converged on one real blocking finding, now fixed in this branch: the per-call scope (`KavoCallOptions.settings`) was the one place `defaultSort` skipped the sortable-allowlist check — `KavoEngine.configViewFor` only ran generic shape validation before merging a per-call override, so a caller could name a field outside the allowlist and have it reach the adapter's `ORDER BY` unchecked. Fixed by exporting `validateDefaultSort` from `resolve-entity-config.ts` and calling it in `configViewFor` after the per-call merge, using the allowlist already in scope there; added a regression test (`engine.spec.ts`) and corrected a misleading trust-boundary comment in `query-normalizer.ts`. The test-auditor also flagged real coverage gaps (multi-field ordering/tiebreak, global-scope precedence, pagination interaction, no-sort-at-all) — all closed in the same follow-up commit.

Closes #56