### PR TITLE
feat: add onlyDeleted query param to filter reads to only soft-deleted records

### DIFF
--- a/docs/internals/architecture/06-error-handling.md
+++ b/docs/internals/architecture/06-error-handling.md
@@ -31,23 +31,24 @@ Codes are API surface — renaming one is a breaking change (semver
 policy). Source of truth: `ERROR_CATALOG` in
 `core/src/errors/error-catalog.ts`.
 
-| Code                           | HTTP | Fires when                                                                         | Payload extensions                |
-| ------------------------------ | ---- | ---------------------------------------------------------------------------------- | --------------------------------- |
-| `KAVO_QUERY_INVALID`           | 400  | Any query grammar/allowlist/limit violation (aggregate)                            | `errors[]` of the sub-codes below |
-| `KAVO_QUERY_INVALID_FIELD`     | 400  | Field not on the filter/sort/select allowlist                                      | issue-level                       |
-| `KAVO_QUERY_INVALID_OPERATOR`  | 400  | Unknown or misspelled wire operator                                                | issue-level                       |
-| `KAVO_QUERY_INVALID_VALUE`     | 400  | Coercion failure, malformed bounds, bad pagination value                           | issue-level                       |
-| `KAVO_QUERY_LIMIT_EXCEEDED`    | 400  | maxFilterDepth / maxInValues exceeded                                              | issue-level                       |
-| `KAVO_QUERY_UNSUPPORTED_PARAM` | 400  | `withDeleted` on a hard-delete entity; `include` when no include resolver is wired | issue-level                       |
-| `KAVO_NOT_FOUND`               | 404  | Target row missing on findOne/update/patch/delete                                  | —                                 |
-| `KAVO_CONFLICT`                | 409  | Unique/FK violation mapped by the adapter                                          | —                                 |
-| `KAVO_ALREADY_DELETED`         | 409  | Soft-deleting an already-deleted row                                               | —                                 |
-| `KAVO_NOT_DELETED`             | 409  | Restoring or purging a row that is not deleted                                     | —                                 |
-| `KAVO_OPERATION_DISABLED`      | 405  | Programmatic call to a disabled registry entry (no route exists over HTTP)         | —                                 |
-| `KAVO_BULK_FAILED`             | 422  | Atomic bulk failure (reserved — bulk is not built)                                 | `items[]` per-index issues        |
-| `KAVO_PERSISTENCE_FAILED`      | 500  | Unrecognized adapter/driver error                                                  | `cause` kept internally           |
-| `KAVO_TRANSACTION_FAILED`      | 500  | Deadlock/serialization failure                                                     | `retryable` flag                  |
-| `KAVO_CONFIG_INVALID`          | 500  | Bootstrap config error (fails startup, not a response)                             | —                                 |
+| Code                            | HTTP | Fires when                                                                                       | Payload extensions                |
+| ------------------------------- | ---- | ------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `KAVO_QUERY_INVALID`            | 400  | Any query grammar/allowlist/limit violation (aggregate)                                          | `errors[]` of the sub-codes below |
+| `KAVO_QUERY_INVALID_FIELD`      | 400  | Field not on the filter/sort/select allowlist                                                    | issue-level                       |
+| `KAVO_QUERY_INVALID_OPERATOR`   | 400  | Unknown or misspelled wire operator                                                              | issue-level                       |
+| `KAVO_QUERY_INVALID_VALUE`      | 400  | Coercion failure, malformed bounds, bad pagination value                                         | issue-level                       |
+| `KAVO_QUERY_LIMIT_EXCEEDED`     | 400  | maxFilterDepth / maxInValues exceeded                                                            | issue-level                       |
+| `KAVO_QUERY_UNSUPPORTED_PARAM`  | 400  | `withDeleted`/`onlyDeleted` on a hard-delete entity; `include` when no include resolver is wired | issue-level                       |
+| `KAVO_QUERY_CONFLICTING_PARAMS` | 400  | `withDeleted=true` and `onlyDeleted=true` set together                                           | issue-level                       |
+| `KAVO_NOT_FOUND`                | 404  | Target row missing on findOne/update/patch/delete                                                | —                                 |
+| `KAVO_CONFLICT`                 | 409  | Unique/FK violation mapped by the adapter                                                        | —                                 |
+| `KAVO_ALREADY_DELETED`          | 409  | Soft-deleting an already-deleted row                                                             | —                                 |
+| `KAVO_NOT_DELETED`              | 409  | Restoring or purging a row that is not deleted                                                   | —                                 |
+| `KAVO_OPERATION_DISABLED`       | 405  | Programmatic call to a disabled registry entry (no route exists over HTTP)                       | —                                 |
+| `KAVO_BULK_FAILED`              | 422  | Atomic bulk failure (reserved — bulk is not built)                                               | `items[]` per-index issues        |
+| `KAVO_PERSISTENCE_FAILED`       | 500  | Unrecognized adapter/driver error                                                                | `cause` kept internally           |
+| `KAVO_TRANSACTION_FAILED`       | 500  | Deadlock/serialization failure                                                                   | `retryable` flag                  |
+| `KAVO_CONFIG_INVALID`           | 500  | Bootstrap config error (fails startup, not a response)                                           | —                                 |
 
 ## 3. Error context & message strategy
 

--- a/docs/internals/architecture/11-soft-delete.md
+++ b/docs/internals/architecture/11-soft-delete.md
@@ -74,11 +74,25 @@ an entity that is not soft-deletable the parameter is **rejected**
 (`KAVO_QUERY_UNSUPPORTED_PARAM`) rather than ignored: a client that
 believes it is seeing deleted rows should be told it is not.
 
-In `@kavo/typeorm` the flag translates two ways, because a marker column
+`onlyDeleted=true` is the third state: instead of widening the default
+exclusion, it narrows a read to _only_ soft-deleted rows (a "trash" view).
+It is parsed and validated the same way as `withDeleted` — rejected with
+`KAVO_QUERY_UNSUPPORTED_PARAM` on an entity that isn't soft-deletable — and
+`findMany`/`count` honor it identically on both wire and programmatic
+paths. Setting `withDeleted=true` and `onlyDeleted=true` together is a
+contradiction ("everything" vs. "only the deleted") and is rejected with
+`KAVO_QUERY_CONFLICTING_PARAMS` rather than one silently winning.
+
+In `@kavo/typeorm` both flags translate two ways, because a marker column
 is not always the ORM's own: for a `@DeleteDateColumn`, TypeORM already
-excludes deleted rows and the adapter opts in with `.withDeleted()`; for
-an ordinary column named through config, the adapter adds
-`<alias>.<field> IS NULL` itself.
+excludes deleted rows, so the adapter opts in with `.withDeleted()` for
+`withDeleted`, or with `.withDeleted()` plus `<alias>.<field> IS NOT NULL`
+for `onlyDeleted`; for an ordinary column named through config, the
+adapter adds `<alias>.<field> IS NULL` (default) or
+`<alias>.<field> IS NOT NULL` (`onlyDeleted`) itself. `@kavo/prisma` and
+`@kavo/mongoose` have no ORM-declared marker column at all (ADR-0017,
+ADR-0018), so both flags are always the same plain field-predicate over
+the configured `softDelete.field`.
 
 ## 4. Edges
 

--- a/docs/using-the-api.md
+++ b/docs/using-the-api.md
@@ -82,7 +82,7 @@ Comma-separated dot-paths, merged into one tree. Only relations the entity marks
 GET /books?withDeleted=true
 ```
 
-Opts back into seeing soft-deleted rows on a read that would otherwise exclude them. Rejected outright on an entity that isn't soft-deletable, rather than silently ignored — see [Getting started's soft delete section](/getting-started#soft-delete).
+Opts back into seeing soft-deleted rows on a read that would otherwise exclude them. `?onlyDeleted=true` narrows the other way — only soft-deleted rows, for a "trash" view. Both are rejected outright on an entity that isn't soft-deletable, and setting both together is rejected as a conflicting combination, rather than either being silently ignored — see [Getting started's soft delete section](/getting-started#soft-delete).
 
 ## The response envelope
 

--- a/packages/core/src/errors/error-catalog.ts
+++ b/packages/core/src/errors/error-catalog.ts
@@ -56,6 +56,11 @@ export const ERROR_CATALOG = {
     title: "Unsupported query parameter",
     message: "Query parameter '{param}' is not supported: {reason}",
   },
+  KAVO_QUERY_CONFLICTING_PARAMS: {
+    status: 400,
+    title: "Conflicting query parameters",
+    message: "Query parameters '{param}' and '{other}' cannot be used together: {reason}",
+  },
   KAVO_NOT_FOUND: {
     status: 404,
     title: "Not found",

--- a/packages/core/src/query/query-context.ts
+++ b/packages/core/src/query/query-context.ts
@@ -32,6 +32,8 @@ export interface QueryContext<Entity = unknown> {
   readonly include?: readonly IncludePath<Entity>[];
   /** Include soft-deleted rows. */
   readonly withDeleted?: boolean;
+  /** Only soft-deleted rows. Mutually exclusive with `withDeleted`. */
+  readonly onlyDeleted?: boolean;
 }
 
 /**
@@ -47,6 +49,8 @@ export interface NormalizedQueryContext<Entity = unknown> {
   /** Validated include tree; empty object when nothing is included. */
   readonly include: IncludeTree;
   readonly withDeleted: boolean;
+  /** Restrict the read to only soft-deleted rows. Mutually exclusive with `withDeleted`. */
+  readonly onlyDeleted: boolean;
   /**
    * Whether the adapter should compute `ListResultDto.total`. `false`
    * skips the count query entirely and the envelope reports `total: null`.

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -52,7 +52,9 @@ export class QueryNormalizer<Entity = unknown> {
   ): NormalizedQueryContext<Entity> {
     const issues: QueryIssueDto[] = [];
 
-    const withDeleted = parseWithDeleted(rawParams["withDeleted"], config, issues);
+    const withDeleted = parseSoftDeleteFlag("withDeleted", rawParams["withDeleted"], config, issues);
+    const onlyDeleted = parseSoftDeleteFlag("onlyDeleted", rawParams["onlyDeleted"], config, issues);
+    if (withDeleted && onlyDeleted) issues.push(conflictingSoftDeleteFlagsIssue());
 
     let filter: Filter<Entity> = { root: null };
     try {
@@ -88,6 +90,7 @@ export class QueryNormalizer<Entity = unknown> {
       fields,
       include,
       withDeleted,
+      onlyDeleted,
       count: config.settings.pagination.count,
     };
   }
@@ -104,7 +107,9 @@ export class QueryNormalizer<Entity = unknown> {
   ): NormalizedQueryContext<Entity> {
     const issues: QueryIssueDto[] = [];
     const input = query ?? {};
-    const withDeleted = parseWithDeleted(input.withDeleted, config, issues);
+    const withDeleted = parseSoftDeleteFlag("withDeleted", input.withDeleted, config, issues);
+    const onlyDeleted = parseSoftDeleteFlag("onlyDeleted", input.onlyDeleted, config, issues);
+    if (withDeleted && onlyDeleted) issues.push(conflictingSoftDeleteFlagsIssue());
 
     const root = input.filter ?? null;
     if (root !== null) {
@@ -152,6 +157,7 @@ export class QueryNormalizer<Entity = unknown> {
       fields,
       include,
       withDeleted,
+      onlyDeleted,
       count: config.settings.pagination.count,
     };
   }
@@ -233,12 +239,16 @@ function parseIncludePaths(raw: unknown, issues: QueryIssueDto[]): readonly stri
 }
 
 /**
- * `withDeleted`: opt out of the default exclusion of
- * soft-deleted rows. Asking for it on an entity that resolves to a hard
- * delete strategy is rejected rather than silently ignored — a client
- * that thinks it is seeing deleted rows should be told it is not.
+ * `withDeleted` / `onlyDeleted`: opt out of the default exclusion of
+ * soft-deleted rows, or narrow a read to only them. Asking for either on an
+ * entity that resolves to a hard delete strategy is rejected rather than
+ * silently ignored — a client that thinks it is seeing deleted rows should
+ * be told it is not. Setting both together is a separate conflict check
+ * (see {@link conflictingSoftDeleteFlagsIssue}), since each is individually
+ * valid on a soft-deletable entity.
  */
-function parseWithDeleted<Entity>(
+function parseSoftDeleteFlag<Entity>(
+  field: "withDeleted" | "onlyDeleted",
   raw: unknown,
   config: ResolvedEntityConfig<Entity>,
   issues: QueryIssueDto[],
@@ -248,23 +258,34 @@ function parseWithDeleted<Entity>(
   }
   if (raw !== true && raw !== "true" && raw !== "1") {
     issues.push({
-      field: "withDeleted",
+      field,
       code: "KAVO_QUERY_INVALID_VALUE",
-      detail: `Value '${String(raw)}' for field 'withDeleted' is not a valid boolean.`,
+      detail: `Value '${String(raw)}' for field '${field}' is not a valid boolean.`,
     });
     return false;
   }
   if (config.softDelete.strategy !== "soft") {
     issues.push({
-      field: "withDeleted",
+      field,
       code: "KAVO_QUERY_UNSUPPORTED_PARAM",
       detail:
-        `Query parameter 'withDeleted' is not supported: ` +
+        `Query parameter '${field}' is not supported: ` +
         `${config.entityName} is not soft-deletable, so no rows are excluded.`,
     });
     return false;
   }
   return true;
+}
+
+/** `withDeleted=true` and `onlyDeleted=true` together is a contradiction: "everything" vs. "only the deleted". */
+function conflictingSoftDeleteFlagsIssue(): QueryIssueDto {
+  return {
+    field: "onlyDeleted",
+    code: "KAVO_QUERY_CONFLICTING_PARAMS",
+    detail:
+      "Query parameters 'withDeleted' and 'onlyDeleted' cannot be used together: " +
+      "'withDeleted' includes both live and deleted rows, while 'onlyDeleted' restricts to deleted rows only.",
+  };
 }
 
 /**

--- a/packages/core/tests/errors.spec.ts
+++ b/packages/core/tests/errors.spec.ts
@@ -33,6 +33,7 @@ const CATALOG: Readonly<Record<CatalogedErrorCode, { status: number; title: stri
   KAVO_QUERY_INVALID_VALUE: { status: 400, title: "Invalid query value" },
   KAVO_QUERY_LIMIT_EXCEEDED: { status: 400, title: "Query limit exceeded" },
   KAVO_QUERY_UNSUPPORTED_PARAM: { status: 400, title: "Unsupported query parameter" },
+  KAVO_QUERY_CONFLICTING_PARAMS: { status: 400, title: "Conflicting query parameters" },
   KAVO_NOT_FOUND: { status: 404, title: "Not found" },
   KAVO_CONFLICT: { status: 409, title: "Conflict" },
   KAVO_ALREADY_DELETED: { status: 409, title: "Already deleted" },

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { QueryNormalizer, resolveEntityConfig } from "@kavo/core";
 import { userMetadata } from "./support/user-fixture.js";
+import { accountMetadata } from "./support/account-fixture.js";
 import { issuesOf } from "./support/query-issues.js";
 
 const config = resolveEntityConfig(userMetadata, undefined, undefined);
 const normalizer = new QueryNormalizer(userMetadata);
+
+const softDeletableConfig = resolveEntityConfig(accountMetadata, undefined, undefined);
+const softDeletableNormalizer = new QueryNormalizer(accountMetadata);
 
 describe("QueryNormalizer — wire params", () => {
   it("normalizes the full reference query", () => {
@@ -131,6 +135,53 @@ describe("QueryNormalizer — wire params", () => {
       undefined,
     );
     expect(normalizer.normalizeWire({ sort: "name" }, defaulted).sort).toEqual([{ field: "name", direction: "asc" }]);
+  });
+});
+
+describe("QueryNormalizer — onlyDeleted", () => {
+  it("rejects onlyDeleted=true when the entity is not soft-deletable (wire)", () => {
+    const issues = issuesOf(() => normalizer.normalizeWire({ onlyDeleted: "true" }, config));
+    expect(issues[0]).toMatchObject({ field: "onlyDeleted", code: "KAVO_QUERY_UNSUPPORTED_PARAM" });
+  });
+
+  it("rejects onlyDeleted=true when the entity is not soft-deletable (programmatic)", () => {
+    const issues = issuesOf(() => normalizer.normalizeInput({ onlyDeleted: true }, config));
+    expect(issues[0]).toMatchObject({ field: "onlyDeleted", code: "KAVO_QUERY_UNSUPPORTED_PARAM" });
+  });
+
+  it("accepts onlyDeleted=true on a soft-deletable entity (wire)", () => {
+    const query = softDeletableNormalizer.normalizeWire({ onlyDeleted: "true" }, softDeletableConfig);
+    expect(query.onlyDeleted).toBe(true);
+    expect(query.withDeleted).toBe(false);
+  });
+
+  it("accepts onlyDeleted=true on a soft-deletable entity (programmatic)", () => {
+    const query = softDeletableNormalizer.normalizeInput({ onlyDeleted: true }, softDeletableConfig);
+    expect(query.onlyDeleted).toBe(true);
+    expect(query.withDeleted).toBe(false);
+  });
+
+  it("rejects withDeleted and onlyDeleted set together (wire)", () => {
+    const issues = issuesOf(() =>
+      softDeletableNormalizer.normalizeWire({ withDeleted: "true", onlyDeleted: "true" }, softDeletableConfig),
+    );
+    expect(issues).toContainEqual(
+      expect.objectContaining({ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }),
+    );
+  });
+
+  it("rejects withDeleted and onlyDeleted set together (programmatic)", () => {
+    const issues = issuesOf(() =>
+      softDeletableNormalizer.normalizeInput({ withDeleted: true, onlyDeleted: true }, softDeletableConfig),
+    );
+    expect(issues).toContainEqual(
+      expect.objectContaining({ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }),
+    );
+  });
+
+  it("rejects a non-boolean onlyDeleted value", () => {
+    const issues = issuesOf(() => softDeletableNormalizer.normalizeWire({ onlyDeleted: "yes" }, softDeletableConfig));
+    expect(issues[0]).toMatchObject({ field: "onlyDeleted", code: "KAVO_QUERY_INVALID_VALUE" });
   });
 });
 

--- a/packages/core/tests/serializer.spec.ts
+++ b/packages/core/tests/serializer.spec.ts
@@ -20,6 +20,7 @@ const EMPTY_QUERY = {
   fields: { root: null, relations: {} },
   include: {},
   withDeleted: false,
+  onlyDeleted: false,
   count: true,
 };
 

--- a/packages/core/tests/soft-delete.spec.ts
+++ b/packages/core/tests/soft-delete.spec.ts
@@ -103,6 +103,36 @@ describe("soft delete lifecycle", () => {
     });
   });
 
+  it("shows only deleted rows under onlyDeleted, and neither live nor deleted otherwise mixed in", async () => {
+    const { crud } = makeAccountCrud();
+    await crud.createOne({ name: "acme" } as never);
+    await crud.createOne({ name: "globex" } as never);
+    await crud.deleteOne(1);
+
+    const list = await crud.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ id: 1 }]);
+    expect(await crud.findOne(1, { onlyDeleted: true } as never)).toMatchObject({ id: 1 });
+    await expect(crud.findOne(2, { onlyDeleted: true } as never)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("rejects onlyDeleted on an entity that is not soft-deletable", async () => {
+    const crud = createKavo().createCrud(User, undefined, {
+      adapter: new InMemoryUserAdapter(),
+      metadata: userMetadata,
+    });
+    await expect(crud.findMany({ onlyDeleted: true })).rejects.toMatchObject({
+      issues: [{ field: "onlyDeleted", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }],
+    });
+  });
+
+  it("rejects withDeleted and onlyDeleted set together as a conflicting combination", async () => {
+    const { crud } = makeAccountCrud();
+    await crud.createOne({ name: "acme" } as never);
+    await expect(crud.findMany({ withDeleted: true, onlyDeleted: true })).rejects.toMatchObject({
+      issues: [{ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }],
+    });
+  });
+
   it("refuses to delete an already-deleted row", async () => {
     const { crud } = makeAccountCrud();
     await crud.createOne({ name: "acme" } as never);

--- a/packages/core/tests/support/account-fixture.ts
+++ b/packages/core/tests/support/account-fixture.ts
@@ -49,7 +49,7 @@ export class InMemoryAccountAdapter implements RepositoryAdapter<Account> {
   ): Promise<Account | null> {
     const row = this.rows.find((candidate) => candidate.id === Number(id)) ?? null;
     if (row === null) return null;
-    return this.visible(row, context, query?.withDeleted ?? false) ? row : null;
+    return this.visible(row, context, query?.withDeleted ?? false, query?.onlyDeleted ?? false) ? row : null;
   }
 
   async findOne(query: NormalizedQueryContext<Account>, context: KavoContext<Account>): Promise<Account | null> {
@@ -57,13 +57,13 @@ export class InMemoryAccountAdapter implements RepositoryAdapter<Account> {
   }
 
   async findMany(query: NormalizedQueryContext<Account>, context: KavoContext<Account>): Promise<readonly Account[]> {
-    const visible = this.rows.filter((row) => this.visible(row, context, query.withDeleted));
+    const visible = this.rows.filter((row) => this.visible(row, context, query.withDeleted, query.onlyDeleted));
     const { offset, limit } = query.pagination;
     return visible.slice(offset, offset + limit);
   }
 
   async count(query: NormalizedQueryContext<Account>, context: KavoContext<Account>): Promise<number> {
-    return this.rows.filter((row) => this.visible(row, context, query.withDeleted)).length;
+    return this.rows.filter((row) => this.visible(row, context, query.withDeleted, query.onlyDeleted)).length;
   }
 
   async create(data: Partial<Account>): Promise<Account> {
@@ -118,8 +118,9 @@ export class InMemoryAccountAdapter implements RepositoryAdapter<Account> {
     this.rows = this.rows.filter((candidate) => candidate.id !== Number(id));
   }
 
-  private visible(row: Account, context: KavoContext<Account>, withDeleted: boolean): boolean {
+  private visible(row: Account, context: KavoContext<Account>, withDeleted: boolean, onlyDeleted = false): boolean {
     if (context.config.softDelete.strategy !== "soft") return true;
+    if (onlyDeleted) return row.deletedAt !== null;
     return withDeleted || row.deletedAt === null;
   }
 

--- a/packages/orms/mongoose/src/mongoose-repository-adapter.ts
+++ b/packages/orms/mongoose/src/mongoose-repository-adapter.ts
@@ -76,7 +76,12 @@ export class MongooseRepositoryAdapter<Entity extends object> implements Reposit
     context: KavoContext<Entity>,
   ): Promise<Entity | null> {
     try {
-      const where = this.scopeToLive({ [this.idField]: { $eq: id } }, context, query?.withDeleted ?? false);
+      const where = this.scopeToLive(
+        { [this.idField]: { $eq: id } },
+        context,
+        query?.withDeleted ?? false,
+        query?.onlyDeleted ?? false,
+      );
       const row = await this.model.findOne(where, null, this.readOptions(this.buildPopulate(query?.include ?? {})));
       return row === null || row === undefined ? null : (toPlainResult(row) as Entity);
     } catch (error) {
@@ -121,7 +126,12 @@ export class MongooseRepositoryAdapter<Entity extends object> implements Reposit
   }
 
   private buildWhere(query: NormalizedQueryContext<Entity>, context: KavoContext<Entity>): MongoWhere {
-    return this.scopeToLive(translateFilter(query.filter, this.filterOptions), context, query.withDeleted);
+    return this.scopeToLive(
+      translateFilter(query.filter, this.filterOptions),
+      context,
+      query.withDeleted,
+      query.onlyDeleted,
+    );
   }
 
   private readOptions(populate: readonly PopulateSpec[] | undefined, sort?: Record<string, 1 | -1>) {
@@ -172,9 +182,19 @@ export class MongooseRepositoryAdapter<Entity extends object> implements Reposit
 
   // ── Soft delete ──────────────────────────────────────────────────────
 
-  private scopeToLive(where: MongoWhere, context: KavoContext<Entity>, withDeleted: boolean): MongoWhere {
+  private scopeToLive(
+    where: MongoWhere,
+    context: KavoContext<Entity>,
+    withDeleted: boolean,
+    onlyDeleted = false,
+  ): MongoWhere {
     const softDelete = context.config.softDelete;
-    if (softDelete.strategy !== "soft" || withDeleted) return where;
+    if (softDelete.strategy !== "soft") return where;
+    if (onlyDeleted) {
+      const deleted = { [softDelete.field]: { $ne: null } };
+      return Object.keys(where).length === 0 ? deleted : { $and: [where, deleted] };
+    }
+    if (withDeleted) return where;
     const live = { [softDelete.field]: { $eq: null } };
     if (Object.keys(where).length === 0) return live;
     return { $and: [where, live] };

--- a/packages/orms/mongoose/tests/soft-delete.spec.ts
+++ b/packages/orms/mongoose/tests/soft-delete.spec.ts
@@ -114,6 +114,24 @@ describe("MongooseRepositoryAdapter — soft delete", () => {
     expect(await tickets.findOne(id, { withDeleted: true } as never)).toMatchObject({ _id: id });
   });
 
+  it("shows only deleted documents under onlyDeleted, live documents excluded", async () => {
+    const deletedId = await newTicket("T-deleted");
+    await newTicket("T-live");
+    await tickets.deleteOne(deletedId);
+
+    const list = await tickets.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ _id: deletedId }]);
+    expect(list.total).toBe(1);
+    expect(await tickets.findOne(deletedId, { onlyDeleted: true } as never)).toMatchObject({ _id: deletedId });
+  });
+
+  it("rejects withDeleted and onlyDeleted set together", async () => {
+    const error = await rejectionOf(tickets.findMany({ withDeleted: true, onlyDeleted: true }));
+    expect(error).toMatchObject({
+      issues: [{ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }],
+    });
+  });
+
   it("keeps updates away from deleted documents", async () => {
     const id = await newTicket();
     await tickets.deleteOne(id);
@@ -207,5 +225,14 @@ describe("MongooseRepositoryAdapter — configured marker field", () => {
 
     expect(await invoices.restoreOne(created._id)).toMatchObject({ _id: created._id, archivedAt: null });
     expect((await invoices.findMany()).items).toHaveLength(1);
+  });
+
+  it("shows only deleted documents under onlyDeleted over an ordinary field", async () => {
+    const deleted = (await invoices.createOne({ number: "INV-deleted" } as never)) as Invoice;
+    await invoices.createOne({ number: "INV-live" } as never);
+    await invoices.deleteOne(deleted._id);
+
+    const list = await invoices.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ _id: deleted._id }]);
   });
 });

--- a/packages/orms/prisma/src/prisma-repository-adapter.ts
+++ b/packages/orms/prisma/src/prisma-repository-adapter.ts
@@ -57,7 +57,12 @@ export class PrismaRepositoryAdapter<Entity extends object> implements Repositor
     context: KavoContext<Entity>,
   ): Promise<Entity | null> {
     try {
-      const where = this.scopeToLive({ [this.idField]: id }, context, query?.withDeleted ?? false);
+      const where = this.scopeToLive(
+        { [this.idField]: id },
+        context,
+        query?.withDeleted ?? false,
+        query?.onlyDeleted ?? false,
+      );
       const include = this.buildInclude(query?.include ?? {});
       const row = await this.delegate.findFirst({ where, ...(include && { include }) });
       return (row as Entity | null) ?? null;
@@ -92,7 +97,12 @@ export class PrismaRepositoryAdapter<Entity extends object> implements Repositor
     try {
       // A dedicated count — never fetch-then-length: the engine only calls
       // this when `query.count` is true, so `total: null` costs zero queries.
-      const where = this.scopeToLive(translateFilter(query.filter, this.filterOptions), context, query.withDeleted);
+      const where = this.scopeToLive(
+        translateFilter(query.filter, this.filterOptions),
+        context,
+        query.withDeleted,
+        query.onlyDeleted,
+      );
       return await this.delegate.count({ ...(where && { where }) });
     } catch (error) {
       throw mapDriverError(error, errorContext(context));
@@ -100,7 +110,12 @@ export class PrismaRepositoryAdapter<Entity extends object> implements Repositor
   }
 
   private buildFindArgs(query: NormalizedQueryContext<Entity>, context: KavoContext<Entity>): Record<string, unknown> {
-    const where = this.scopeToLive(translateFilter(query.filter, this.filterOptions), context, query.withDeleted);
+    const where = this.scopeToLive(
+      translateFilter(query.filter, this.filterOptions),
+      context,
+      query.withDeleted,
+      query.onlyDeleted,
+    );
     const orderBy = query.sort.map((sort) => nestOrderBy(sort.field as string, sort.direction));
     const include = this.buildInclude(query.include);
     return {
@@ -142,9 +157,15 @@ export class PrismaRepositoryAdapter<Entity extends object> implements Repositor
     where: PrismaWhere | undefined,
     context: KavoContext<Entity>,
     withDeleted: boolean,
+    onlyDeleted = false,
   ): PrismaWhere | undefined {
     const softDelete = context.config.softDelete;
-    if (softDelete.strategy !== "soft" || withDeleted) return where;
+    if (softDelete.strategy !== "soft") return where;
+    if (onlyDeleted) {
+      const deleted = { [softDelete.field]: { not: null } };
+      return where === undefined ? deleted : { AND: [where, deleted] };
+    }
+    if (withDeleted) return where;
     const live = { [softDelete.field]: null };
     if (where === undefined) return live;
     return { AND: [where, live] };

--- a/packages/orms/prisma/tests/soft-delete.spec.ts
+++ b/packages/orms/prisma/tests/soft-delete.spec.ts
@@ -88,6 +88,23 @@ describe("PrismaRepositoryAdapter — soft delete", () => {
     expect(await tickets.findOne(id, { withDeleted: true } as never)).toMatchObject({ id });
   });
 
+  it("shows only deleted rows under onlyDeleted, live rows excluded", async () => {
+    const deletedId = await newTicket("T-deleted");
+    await newTicket("T-live");
+    await tickets.deleteOne(deletedId);
+
+    const list = await tickets.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ id: deletedId }]);
+    expect(list.total).toBe(1);
+    expect(await tickets.findOne(deletedId, { onlyDeleted: true } as never)).toMatchObject({ id: deletedId });
+  });
+
+  it("rejects withDeleted and onlyDeleted set together", async () => {
+    await expect(tickets.findMany({ withDeleted: true, onlyDeleted: true })).rejects.toMatchObject({
+      issues: [{ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }],
+    });
+  });
+
   it("keeps updates away from deleted rows", async () => {
     const id = await newTicket();
     await tickets.deleteOne(id);
@@ -141,5 +158,15 @@ describe("PrismaRepositoryAdapter — configured marker column", () => {
 
     expect(await invoices.restoreOne(id)).toMatchObject({ id, archivedAt: null });
     expect((await invoices.findMany()).items).toHaveLength(1);
+  });
+
+  it("shows only deleted rows under onlyDeleted over an ordinary column", async () => {
+    const deleted = await invoices.createOne({ number: "INV-deleted" } as never);
+    await invoices.createOne({ number: "INV-live" } as never);
+    const deletedId = (deleted as Invoice).id;
+    await invoices.deleteOne(deletedId);
+
+    const list = await invoices.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ id: deletedId }]);
   });
 });

--- a/packages/orms/typeorm/src/typeorm-repository-adapter.ts
+++ b/packages/orms/typeorm/src/typeorm-repository-adapter.ts
@@ -73,7 +73,7 @@ export class TypeOrmRepositoryAdapter<Entity extends ObjectLiteral> implements R
   ): Promise<Entity | null> {
     try {
       const include = query?.include ?? {};
-      const qb = this.byId(id, context, query?.withDeleted ?? false);
+      const qb = this.byId(id, context, query?.withDeleted ?? false, query?.onlyDeleted ?? false);
       this.joinIncludes(qb, include, this.alias);
       const entity = await qb.getOne();
       if (entity !== null) await this.loadBatches([entity], this.entity, include);
@@ -128,7 +128,7 @@ export class TypeOrmRepositoryAdapter<Entity extends ObjectLiteral> implements R
     options: { sorted?: boolean; includes?: boolean } = {},
   ): SelectQueryBuilder<Entity> {
     const qb = this.repository.createQueryBuilder(this.alias);
-    this.scopeToLive(qb, context, query.withDeleted);
+    this.scopeToLive(qb, context, query.withDeleted, query.onlyDeleted);
     const translator = new FilterTranslator(qb, this.alias);
     // Include joins first, then filters: both name joins the same way, so
     // a filter on `owner.name` reuses the selecting join instead of adding
@@ -233,25 +233,45 @@ export class TypeOrmRepositoryAdapter<Entity extends ObjectLiteral> implements R
   // ── Soft delete ──────────────────────────────────────────────────────
 
   /**
-   * Exclude soft-deleted rows unless the caller opted in with
-   * `withDeleted`. Two shapes, one rule: TypeORM already excludes its own
+   * Three-way soft-delete scope: exclude deleted rows by default, include
+   * both live and deleted with `withDeleted`, or restrict to only deleted
+   * with `onlyDeleted` (mutually exclusive — validated upstream). Two
+   * marker shapes, one rule each: TypeORM already excludes its own
    * `@DeleteDateColumn` (so opting *in* is the explicit step), while an
-   * ordinary marker column needs the `IS NULL` predicate spelled out.
-   * Entities that aren't soft-deletable touch neither branch.
+   * ordinary marker column needs the `IS NULL`/`IS NOT NULL` predicate
+   * spelled out. Entities that aren't soft-deletable touch neither branch.
    */
-  private scopeToLive(qb: SelectQueryBuilder<Entity>, context: KavoContext<Entity>, withDeleted: boolean): void {
+  private scopeToLive(
+    qb: SelectQueryBuilder<Entity>,
+    context: KavoContext<Entity>,
+    withDeleted: boolean,
+    onlyDeleted = false,
+  ): void {
     const softDelete = context.config.softDelete;
     if (softDelete.strategy !== "soft") return;
     if (softDelete.field === this.deleteDateColumn) {
+      if (onlyDeleted) {
+        qb.withDeleted().andWhere(`${this.alias}.${softDelete.field} IS NOT NULL`);
+        return;
+      }
       if (withDeleted) qb.withDeleted();
+      return;
+    }
+    if (onlyDeleted) {
+      qb.andWhere(`${this.alias}.${softDelete.field} IS NOT NULL`);
       return;
     }
     if (!withDeleted) qb.andWhere(`${this.alias}.${softDelete.field} IS NULL`);
   }
 
-  private byId(id: EntityId, context: KavoContext<Entity>, withDeleted: boolean): SelectQueryBuilder<Entity> {
+  private byId(
+    id: EntityId,
+    context: KavoContext<Entity>,
+    withDeleted: boolean,
+    onlyDeleted = false,
+  ): SelectQueryBuilder<Entity> {
     const qb = this.repository.createQueryBuilder(this.alias).where(`${this.alias}.${this.idField} = :id`, { id });
-    this.scopeToLive(qb, context, withDeleted);
+    this.scopeToLive(qb, context, withDeleted, onlyDeleted);
     return qb;
   }
 

--- a/packages/orms/typeorm/tests/soft-delete.spec.ts
+++ b/packages/orms/typeorm/tests/soft-delete.spec.ts
@@ -105,6 +105,23 @@ describe("TypeOrmRepositoryAdapter — soft delete", () => {
     expect(await tickets.findOne(id, { withDeleted: true } as never)).toMatchObject({ id });
   });
 
+  it("shows only deleted rows under onlyDeleted, live rows excluded", async () => {
+    const deletedId = await newTicket("T-deleted");
+    await newTicket("T-live");
+    await tickets.deleteOne(deletedId);
+
+    const list = await tickets.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ id: deletedId }]);
+    expect(list.total).toBe(1);
+    expect(await tickets.findOne(deletedId, { onlyDeleted: true } as never)).toMatchObject({ id: deletedId });
+  });
+
+  it("rejects withDeleted and onlyDeleted set together", async () => {
+    await expect(tickets.findMany({ withDeleted: true, onlyDeleted: true })).rejects.toMatchObject({
+      issues: [{ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }],
+    });
+  });
+
   it("keeps updates away from deleted rows", async () => {
     const id = await newTicket();
     await tickets.deleteOne(id);
@@ -160,5 +177,15 @@ describe("TypeOrmRepositoryAdapter — configured marker column", () => {
 
     expect(await invoices.restoreOne(id)).toMatchObject({ id, archivedAt: null });
     expect((await invoices.findMany()).items).toHaveLength(1);
+  });
+
+  it("shows only deleted rows under onlyDeleted over an ordinary column", async () => {
+    const deleted = await invoices.createOne({ number: "INV-deleted" } as never);
+    await invoices.createOne({ number: "INV-live" } as never);
+    const deletedId = (deleted as Invoice).id;
+    await invoices.deleteOne(deletedId);
+
+    const list = await invoices.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ id: deletedId }]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds an `onlyDeleted` boolean query param / programmatic `QueryContext` field, parsed and validated the same way as `withDeleted`: rejected with `KAVO_QUERY_UNSUPPORTED_PARAM` on entities that aren't soft-deletable, and rejected together with `withDeleted=true` as a conflicting combination via a new `KAVO_QUERY_CONFLICTING_PARAMS` catalog code.
- `@kavo/typeorm`'s `scopeToLive` gains a third branch (`IS NOT NULL` on the delete-marker column), covering both the `@DeleteDateColumn` case and the config-named-column case.
- `@kavo/prisma` and `@kavo/mongoose` get the equivalent plain field-predicate over `softDelete.field`, per ADR-0017/ADR-0018 (no ORM-declared marker column there).
- `findMany`/`count` (and `findOne`/`findOneById`, sharing the same seam) honor `onlyDeleted` in all three adapters.
- Docs: doc 11 §3 (soft-delete read semantics), doc 06's error-catalog table, and the adopter-facing `using-the-api.md` guide.

## Why

Soft delete already supports excluding deleted rows by default and opting back in with `withDeleted=true`, but there was no supported way to see *only* the deleted rows (e.g. a "trash" view) without filtering `withDeleted` client-side.

## Public API impact

- New optional `onlyDeleted?: boolean` on `QueryContext` / required `onlyDeleted: boolean` on `NormalizedQueryContext` (`@kavo/core`).
- New error catalog code `KAVO_QUERY_CONFLICTING_PARAMS` (400).
- No `@kavo/nest` changes — wire params flow through the existing generic `WireQuery` path already used for `withDeleted`.

## Testing

- [x] `pnpm check` (build + typecheck + depcruise + lint + full suite — 48 files / 820 tests) green.
- [x] New tests across `@kavo/core`, `@kavo/typeorm`, `@kavo/prisma`, `@kavo/mongoose` covering: normal read, `withDeleted=true`, `onlyDeleted=true`, `onlyDeleted` on a non-soft-deletable entity (rejected), and both flags set together (rejected) — including both TypeORM marker-column shapes.

## Review notes

- Out of scope per the issue: any UI/admin "trash" view, and bulk restore/purge-by-filter workflows.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)