### PR TITLE
test(examples): add a MariaDB e2e suite to nest-typeorm, alongside Postgres

### DIFF
--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -66,9 +66,14 @@ fields:     root: [id, name, email]
   spellings mean what they read as.
 - **`like` / `ilike`:** never auto-wrap wildcards — callers pass `%`
   explicitly. Literal `%` and `_` are escaped with a backslash (`\%`,
-  `\_`); the adapter emits the matching `ESCAPE '\'` clause. `ilike` is
-  translated portably (`LOWER(col) LIKE LOWER(:v)`), identical on every
-  driver. Both operators apply to string columns only.
+  `\_`); the adapter emits the matching `ESCAPE` clause, with the
+  backslash bound as a query parameter rather than inlined as a `'\'`
+  string literal (drivers disagree on how backslash is escaped inside a
+  literal — MySQL's default `sql_mode` treats it as its own in-string
+  escape character, Postgres does not — so a parameter is the portable
+  spelling). `ilike` is translated portably (`LOWER(col) LIKE
+LOWER(:v)`), identical on every driver. Both operators apply to string
+  columns only.
 - **Relation-path filtering:** dot notation
   (`filter[profile.city][eq]=Helsinki`), permitted only for paths on the
   filterable allowlist. Relation-path filters **restrict root rows** (a

--- a/docs/internals/architecture/09-typeorm-adapter.md
+++ b/docs/internals/architecture/09-typeorm-adapter.md
@@ -25,9 +25,12 @@ zero-config sugar.
 is explicit parentheses, never operator-order luck; parameters are
 numbered globally per query. Notable translations: `EQ null` → `IS NULL`;
 empty `IN` → `1 = 0` (empty `NOT IN` → `1 = 1`) since SQL `IN ()` is
-invalid; `LIKE` carries `ESCAPE '\'` (the grammar's literal-escape);
-`ILIKE` → `LOWER(col) LIKE LOWER(:v)` — portable across every driver, one
-spelling instead of a per-driver fork.
+invalid; `LIKE` carries an `ESCAPE` clause with the backslash (the
+grammar's literal-escape) bound as a parameter rather than inlined as a
+`'\'` string literal, since drivers disagree on how backslash is escaped
+inside a literal (MySQL vs. Postgres); `ILIKE` → `LOWER(col) LIKE
+LOWER(:v)` — portable across every driver, one spelling instead of a
+per-driver fork.
 
 **Relation-path conditions** (`author.name`) add one **non-selecting**
 left join per path segment with deterministic aliases (`Book__author`),

--- a/examples/nest-typeorm/README.md
+++ b/examples/nest-typeorm/README.md
@@ -9,8 +9,8 @@ subtypes of `Pet`; `Owner` is the relation side, and is soft-deletable.
 
 The entities, DTOs, and controllers are entirely database-agnostic through
 `@kavo/typeorm` — only `DatabaseModule`/`AppModule` (both dynamic modules,
-via `.forRoot(...)`) pick a driver, so the same app runs against either
-database below unchanged.
+via `.forRoot(...)`) pick a driver, so the same app runs against any of the
+databases below unchanged.
 
 ## SQLite (default)
 
@@ -35,9 +35,24 @@ pnpm build && pnpm --filter @kavo/example-nest-typeorm start:postgres
 The e2e suite (`tests/app-postgres.e2e.spec.ts`) needs none of this set up
 by hand — it self-provisions a Postgres container via Testcontainers and
 passes that container's connection options straight to
-`AppModule.forRoot(...)`, so `pnpm check`/`pnpm test` exercises both
+`AppModule.forRoot(...)`, so `pnpm check`/`pnpm test` exercises all three
 databases with no manual step. This does require a running Docker daemon
 wherever those commands run.
+
+## MySQL
+
+`main-mysql.ts` boots the same app against a real MySQL instance, with
+connection settings hardcoded to match a single local container:
+
+```bash
+docker run --rm -e MYSQL_ROOT_PASSWORD=kavo -e MYSQL_DATABASE=kavo -p 3306:3306 mysql:8
+pnpm build && pnpm --filter @kavo/example-nest-typeorm start:mysql
+# → http://localhost:3000/cats   (Swagger at /docs)
+```
+
+The e2e suite (`tests/app-mysql.e2e.spec.ts`) self-provisions a MySQL
+container via Testcontainers the same way the Postgres suite does — no
+manual setup, just a running Docker daemon.
 
 Try it:
 
@@ -59,11 +74,11 @@ POST   /cats                     {"name":"Kit","age":1,"owner":1}   # associate 
 ```
 
 The e2e suite in `tests/` is the executable form of the behavior spec.
-`crud-e2e.suite.ts` holds the shared assertions; `app.e2e.spec.ts`
-and `app-postgres.e2e.spec.ts` each boot the app against their own database
-and run the same suite against it — one behavioral spec, two drivers. This
-app grows into a fuller reference application (`User`, `Project`, `Task`,
-`Comment`, `Tag`).
+`crud-e2e.suite.ts` holds the shared assertions; `app.e2e.spec.ts`,
+`app-postgres.e2e.spec.ts`, and `app-mysql.e2e.spec.ts` each boot the app
+against their own database and run the same suite against it — one
+behavioral spec, three drivers. This app grows into a fuller reference
+application (`User`, `Project`, `Task`, `Comment`, `Tag`).
 
 The app consumes only public package APIs — if it ever needs a deep
 import, that is an API-surface bug in the package, not the app.

--- a/examples/nest-typeorm/README.md
+++ b/examples/nest-typeorm/README.md
@@ -39,18 +39,18 @@ passes that container's connection options straight to
 databases with no manual step. This does require a running Docker daemon
 wherever those commands run.
 
-## MySQL
+## MariaDB
 
-`main-mysql.ts` boots the same app against a real MySQL instance, with
+`main-mariadb.ts` boots the same app against a real MariaDB instance, with
 connection settings hardcoded to match a single local container:
 
 ```bash
-docker run --rm -e MYSQL_ROOT_PASSWORD=kavo -e MYSQL_DATABASE=kavo -p 3306:3306 mysql:8
-pnpm build && pnpm --filter @kavo/example-nest-typeorm start:mysql
+docker run --rm -e MARIADB_ROOT_PASSWORD=kavo -e MARIADB_DATABASE=kavo -p 3306:3306 mariadb:12
+pnpm build && pnpm --filter @kavo/example-nest-typeorm start:mariadb
 # → http://localhost:3000/cats   (Swagger at /docs)
 ```
 
-The e2e suite (`tests/app-mysql.e2e.spec.ts`) self-provisions a MySQL
+The e2e suite (`tests/app-mariadb.e2e.spec.ts`) self-provisions a MariaDB
 container via Testcontainers the same way the Postgres suite does — no
 manual setup, just a running Docker daemon.
 
@@ -75,7 +75,7 @@ POST   /cats                     {"name":"Kit","age":1,"owner":1}   # associate 
 
 The e2e suite in `tests/` is the executable form of the behavior spec.
 `crud-e2e.suite.ts` holds the shared assertions; `app.e2e.spec.ts`,
-`app-postgres.e2e.spec.ts`, and `app-mysql.e2e.spec.ts` each boot the app
+`app-postgres.e2e.spec.ts`, and `app-mariadb.e2e.spec.ts` each boot the app
 against their own database and run the same suite against it — one
 behavioral spec, three drivers. This app grows into a fuller reference
 application (`User`, `Project`, `Task`, `Comment`, `Tag`).

--- a/examples/nest-typeorm/package.json
+++ b/examples/nest-typeorm/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc -b",
     "start": "node dist/main.js",
-    "start:postgres": "node dist/main-postgres.js"
+    "start:postgres": "node dist/main-postgres.js",
+    "start:mysql": "node dist/main-mysql.js"
   },
   "dependencies": {
     "@kavo/core": "workspace:*",
@@ -19,6 +20,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/swagger": "^11.0.0",
     "better-sqlite3": "^13.0.2",
+    "mysql2": "^3.11.0",
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
@@ -26,6 +28,7 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^11.0.0",
+    "@testcontainers/mysql": "^12.0.4",
     "@testcontainers/postgresql": "^12.0.4",
     "@types/supertest": "^7.2.1",
     "supertest": "^7.0.0"

--- a/examples/nest-typeorm/package.json
+++ b/examples/nest-typeorm/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -b",
     "start": "node dist/main.js",
     "start:postgres": "node dist/main-postgres.js",
-    "start:mysql": "node dist/main-mysql.js"
+    "start:mariadb": "node dist/main-mariadb.js"
   },
   "dependencies": {
     "@kavo/core": "workspace:*",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^11.0.0",
-    "@testcontainers/mysql": "^12.0.4",
+    "@testcontainers/mariadb": "^12.0.4",
     "@testcontainers/postgresql": "^12.0.4",
     "@types/supertest": "^7.2.1",
     "supertest": "^7.0.0"

--- a/examples/nest-typeorm/src/app.module.ts
+++ b/examples/nest-typeorm/src/app.module.ts
@@ -16,7 +16,7 @@ import { AddressController } from "./address/address.controller.js";
  *
  * `forRoot()` defaults to the in-memory SQLite `DatabaseModule`;
  * `forRoot(sql)` threads the same options through to a real Postgres or
- * MySQL instance instead, picked by `sql.type` (see `DatabaseModule`).
+ * MariaDB instance instead, picked by `sql.type` (see `DatabaseModule`).
  */
 @Module({})
 export class AppModule {

--- a/examples/nest-typeorm/src/app.module.ts
+++ b/examples/nest-typeorm/src/app.module.ts
@@ -2,7 +2,7 @@ import { Module, type DynamicModule } from "@nestjs/common";
 import { KavoModule } from "@kavo/nest";
 import { createInfrastructure } from "@kavo/typeorm";
 import type { DataSource } from "typeorm";
-import { DATA_SOURCE, DatabaseModule, type PostgresOptions } from "./database.module.js";
+import { DATA_SOURCE, DatabaseModule, type SqlOptions } from "./database.module.js";
 import { OwnerController } from "./owner/owner.controller.js";
 import { CatController } from "./cat/cat.controller.js";
 import { DogController } from "./dog/dog.controller.js";
@@ -15,17 +15,17 @@ import { AddressController } from "./address/address.controller.js";
  * adapters meet the framework in the DI container).
  *
  * `forRoot()` defaults to the in-memory SQLite `DatabaseModule`;
- * `forRoot(postgres)` threads the same options through to a real Postgres
- * instance instead (see `DatabaseModule`).
+ * `forRoot(sql)` threads the same options through to a real Postgres or
+ * MySQL instance instead, picked by `sql.type` (see `DatabaseModule`).
  */
 @Module({})
 export class AppModule {
-  static forRoot(postgres?: PostgresOptions): DynamicModule {
+  static forRoot(sql?: SqlOptions): DynamicModule {
     return {
       module: AppModule,
       imports: [
         KavoModule.forRootAsync({
-          imports: [DatabaseModule.forRoot(postgres)],
+          imports: [DatabaseModule.forRoot(sql)],
           inject: [DATA_SOURCE] as never[],
           // AddressController constructor-injects its own service
           // (getKavoServiceToken), which needs a real DI provider —

--- a/examples/nest-typeorm/src/database.module.ts
+++ b/examples/nest-typeorm/src/database.module.ts
@@ -11,7 +11,7 @@ export const DATA_SOURCE = Symbol("DATA_SOURCE");
 
 const entities = [Owner, Pet, Cat, Dog, Tag, Address];
 
-export interface PostgresOptions {
+interface ConnectionOptions {
   host: string;
   port: number;
   username: string;
@@ -19,13 +19,25 @@ export interface PostgresOptions {
   database: string;
 }
 
+export interface PostgresOptions extends ConnectionOptions {
+  type: "postgres";
+}
+
+export interface MySqlOptions extends ConnectionOptions {
+  type: "mysql";
+}
+
+/** The driver a real (non-SQLite) `forRoot(...)` call picks. */
+export type SqlOptions = PostgresOptions | MySqlOptions;
+
 /**
  * One `DataSource` for the whole app. `forRoot()` (no argument) defaults to
  * an in-memory SQLite database, keeping the demo (and its e2e suite)
- * dependency-free; `forRoot(postgres)` switches the same app to a real
- * Postgres instance instead — see `examples/nest-typeorm/README.md` for the
- * `docker run` used locally, and `tests/app-postgres.e2e.spec.ts` for how
- * the e2e suite self-provisions one via Testcontainers.
+ * dependency-free; `forRoot(sql)` switches the same app to a real Postgres
+ * or MySQL instance instead, picked by `sql.type` — see
+ * `examples/nest-typeorm/README.md` for the `docker run` used locally for
+ * each, and `tests/app-postgres.e2e.spec.ts` / `tests/app-mysql.e2e.spec.ts`
+ * for how the e2e suite self-provisions one via Testcontainers.
  *
  * Global so `DATA_SOURCE` is injectable straight into any `@Kavo`
  * controller (e.g. `AddressController`'s `@Override`'d methods), not just
@@ -35,17 +47,16 @@ export interface PostgresOptions {
 @Global()
 @Module({})
 export class DatabaseModule {
-  static forRoot(postgres?: PostgresOptions): DynamicModule {
+  static forRoot(sql?: SqlOptions): DynamicModule {
     return {
       module: DatabaseModule,
       providers: [
         {
           provide: DATA_SOURCE,
           useFactory: async (): Promise<DataSource> => {
-            const dataSource = postgres
+            const dataSource = sql
               ? new DataSource({
-                  type: "postgres",
-                  ...postgres,
+                  ...sql,
                   entities,
                   synchronize: true,
                 })

--- a/examples/nest-typeorm/src/database.module.ts
+++ b/examples/nest-typeorm/src/database.module.ts
@@ -23,20 +23,20 @@ export interface PostgresOptions extends ConnectionOptions {
   type: "postgres";
 }
 
-export interface MySqlOptions extends ConnectionOptions {
-  type: "mysql";
+export interface MariaDbOptions extends ConnectionOptions {
+  type: "mariadb";
 }
 
 /** The driver a real (non-SQLite) `forRoot(...)` call picks. */
-export type SqlOptions = PostgresOptions | MySqlOptions;
+export type SqlOptions = PostgresOptions | MariaDbOptions;
 
 /**
  * One `DataSource` for the whole app. `forRoot()` (no argument) defaults to
  * an in-memory SQLite database, keeping the demo (and its e2e suite)
  * dependency-free; `forRoot(sql)` switches the same app to a real Postgres
- * or MySQL instance instead, picked by `sql.type` — see
+ * or MariaDB instance instead, picked by `sql.type` — see
  * `examples/nest-typeorm/README.md` for the `docker run` used locally for
- * each, and `tests/app-postgres.e2e.spec.ts` / `tests/app-mysql.e2e.spec.ts`
+ * each, and `tests/app-postgres.e2e.spec.ts` / `tests/app-mariadb.e2e.spec.ts`
  * for how the e2e suite self-provisions one via Testcontainers.
  *
  * Global so `DATA_SOURCE` is injectable straight into any `@Kavo`

--- a/examples/nest-typeorm/src/main-mariadb.ts
+++ b/examples/nest-typeorm/src/main-mariadb.ts
@@ -4,8 +4,8 @@ import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { AppModule } from "./app.module.js";
 
 // Matches the `docker run` command in examples/nest-typeorm/README.md.
-const MYSQL_OPTIONS = {
-  type: "mysql",
+const MARIADB_OPTIONS = {
+  type: "mariadb",
   host: "localhost",
   port: 3306,
   username: "root",
@@ -14,12 +14,12 @@ const MYSQL_OPTIONS = {
 } as const;
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule.forRoot(MYSQL_OPTIONS));
+  const app = await NestFactory.create(AppModule.forRoot(MARIADB_OPTIONS));
 
   const document = SwaggerModule.createDocument(
     app,
     new DocumentBuilder()
-      .setTitle("Kavo — Pet example (MySQL)")
+      .setTitle("Kavo — Pet example (MariaDB)")
       .setDescription(
         "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
           "sorting, pagination, layered config, and RFC 9457 problem-details " +

--- a/examples/nest-typeorm/src/main-mysql.ts
+++ b/examples/nest-typeorm/src/main-mysql.ts
@@ -4,22 +4,22 @@ import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { AppModule } from "./app.module.js";
 
 // Matches the `docker run` command in examples/nest-typeorm/README.md.
-const POSTGRES_OPTIONS = {
-  type: "postgres",
+const MYSQL_OPTIONS = {
+  type: "mysql",
   host: "localhost",
-  port: 5432,
-  username: "postgres",
+  port: 3306,
+  username: "root",
   password: "kavo",
   database: "kavo",
 } as const;
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule.forRoot(POSTGRES_OPTIONS));
+  const app = await NestFactory.create(AppModule.forRoot(MYSQL_OPTIONS));
 
   const document = SwaggerModule.createDocument(
     app,
     new DocumentBuilder()
-      .setTitle("Kavo — Pet example (Postgres)")
+      .setTitle("Kavo — Pet example (MySQL)")
       .setDescription(
         "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
           "sorting, pagination, layered config, and RFC 9457 problem-details " +

--- a/examples/nest-typeorm/tests/app-mariadb.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/app-mariadb.e2e.spec.ts
@@ -2,26 +2,26 @@ import "reflect-metadata";
 import { afterAll, beforeAll } from "vitest";
 import type { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
-import { MySqlContainer, type StartedMySqlContainer } from "@testcontainers/mysql";
+import { MariaDbContainer, type StartedMariaDbContainer } from "@testcontainers/mariadb";
 import { AppModule } from "../src/app.module.js";
 import { registerCrudE2eSuite } from "./crud-e2e.suite.js";
 
 /**
- * Same suite as `app.e2e.spec.ts`, run against a real MySQL instead of
- * in-memory SQLite. `AppModule.forRoot(mysql)` takes the connection options
- * directly — no manual MySQL setup needed to run `pnpm check`, since the
- * options come from a container this test provisions itself.
+ * Same suite as `app.e2e.spec.ts`, run against a real MariaDB instead of
+ * in-memory SQLite. `AppModule.forRoot(mariadb)` takes the connection
+ * options directly — no manual MariaDB setup needed to run `pnpm check`,
+ * since the options come from a container this test provisions itself.
  */
-let container: StartedMySqlContainer;
+let container: StartedMariaDbContainer;
 let app: INestApplication;
 
 beforeAll(async () => {
-  container = await new MySqlContainer("mysql:8").start();
+  container = await new MariaDbContainer("mariadb:12").start();
 
   const moduleRef = await Test.createTestingModule({
     imports: [
       AppModule.forRoot({
-        type: "mysql",
+        type: "mariadb",
         host: container.getHost(),
         port: container.getPort(),
         username: container.getUsername(),

--- a/examples/nest-typeorm/tests/app-mysql.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/app-mysql.e2e.spec.ts
@@ -2,37 +2,37 @@ import "reflect-metadata";
 import { afterAll, beforeAll } from "vitest";
 import type { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { MySqlContainer, type StartedMySqlContainer } from "@testcontainers/mysql";
 import { AppModule } from "../src/app.module.js";
 import { registerCrudE2eSuite } from "./crud-e2e.suite.js";
 
 /**
- * Same suite as `app.e2e.spec.ts`, run against a real Postgres instead of
- * in-memory SQLite. `AppModule.forRoot(postgres)` takes the connection
- * options directly — no manual Postgres setup needed to run `pnpm check`,
- * since the options come from a container this test provisions itself.
+ * Same suite as `app.e2e.spec.ts`, run against a real MySQL instead of
+ * in-memory SQLite. `AppModule.forRoot(mysql)` takes the connection options
+ * directly — no manual MySQL setup needed to run `pnpm check`, since the
+ * options come from a container this test provisions itself.
  */
-let container: StartedPostgreSqlContainer;
+let container: StartedMySqlContainer;
 let app: INestApplication;
 
 beforeAll(async () => {
-  container = await new PostgreSqlContainer("postgres:18-alpine").start();
+  container = await new MySqlContainer("mysql:8").start();
 
   const moduleRef = await Test.createTestingModule({
     imports: [
       AppModule.forRoot({
-        type: "postgres",
+        type: "mysql",
         host: container.getHost(),
         port: container.getPort(),
         username: container.getUsername(),
-        password: container.getPassword(),
+        password: container.getUserPassword(),
         database: container.getDatabase(),
       }),
     ],
   }).compile();
   app = moduleRef.createNestApplication();
   await app.init();
-}, 120_000);
+}, 240_000);
 
 afterAll(async () => {
   if (app !== undefined) await app.close();

--- a/packages/orms/typeorm/src/filter-translator.ts
+++ b/packages/orms/typeorm/src/filter-translator.ts
@@ -122,17 +122,24 @@ export class FilterTranslator<Entity extends ObjectLiteral> implements FilterBui
         return;
       }
       case "LIKE":
-        // `\` is the documented literal-escape for `%`/`_`.
-        where.where(`${column} LIKE :${parameter} ESCAPE '\\'`, {
+        // `\` is the documented literal-escape for `%`/`_`. Bound as a
+        // parameter rather than inlined as a `'\'` string literal: MySQL's
+        // default `sql_mode` treats backslash as its own in-string escape
+        // character, so a literal `'\'` there is an unterminated string
+        // (syntax error), while Postgres takes it literally. A bound
+        // parameter sidesteps each driver's own string-literal escaping.
+        where.where(`${column} LIKE :${parameter} ESCAPE :${parameter}Escape`, {
           [parameter]: value,
+          [`${parameter}Escape`]: "\\",
         });
         return;
       case "ILIKE":
         // Portable case-insensitive match. Postgres has native ILIKE, but
         // LOWER() LIKE LOWER() behaves identically across every TypeORM
         // driver; one spelling beats a per-driver fork.
-        where.where(`LOWER(${column}) LIKE LOWER(:${parameter}) ESCAPE '\\'`, {
+        where.where(`LOWER(${column}) LIKE LOWER(:${parameter}) ESCAPE :${parameter}Escape`, {
           [parameter]: value,
+          [`${parameter}Escape`]: "\\",
         });
         return;
       case "BETWEEN": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       better-sqlite3:
         specifier: ^13.0.2
         version: 13.0.2
+      mysql2:
+        specifier: ^3.11.0
+        version: 3.23.2(@types/node@22.20.1)
       pg:
         specifier: ^8.13.0
         version: 8.22.0
@@ -122,11 +125,14 @@ importers:
         version: 7.8.2
       typeorm:
         specifier: ^1.1.0
-        version: 1.1.0(better-sqlite3@13.0.2)(pg@8.22.0)
+        version: 1.1.0(better-sqlite3@13.0.2)(mysql2@3.23.2(@types/node@22.20.1))(pg@8.22.0)
     devDependencies:
       '@nestjs/testing':
         specifier: ^11.0.0
         version: 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.28)
+      '@testcontainers/mysql':
+        specifier: ^12.0.4
+        version: 12.0.4
       '@testcontainers/postgresql':
         specifier: ^12.0.4
         version: 12.0.4
@@ -219,7 +225,7 @@ importers:
         version: 0.2.2
       typeorm:
         specifier: ^1.1.0
-        version: 1.1.0(better-sqlite3@13.0.2)(pg@8.22.0)
+        version: 1.1.0(better-sqlite3@13.0.2)(mysql2@3.23.2(@types/node@22.20.1))(pg@8.22.0)
 
   packages/protocols/graphql:
     dependencies:
@@ -1221,6 +1227,9 @@ packages:
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
+  '@testcontainers/mysql@12.0.4':
+    resolution: {integrity: sha512-XZWh/L6EN8XQa5lsBdESDolDmyUA56bDgYh5SicLzzC2b4jho4lc0yA0GOOVX/bd0zK6VQK6hmDDJE+T3rFrdA==}
+
   '@testcontainers/postgresql@12.0.4':
     resolution: {integrity: sha512-a/pLU6j5lpKKAlUTPwqweqMGhOSjgTSb6HBX69TOrXn32ifU37nnQDmNFTj8ddOAw+BQL9oTRkeOxVbZkqhgZA==}
 
@@ -1523,6 +1532,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
@@ -1812,6 +1825,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2040,6 +2057,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2165,6 +2185,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -2234,6 +2257,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2419,6 +2446,16 @@ packages:
   multer@2.2.0:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
+
+  mysql2@3.23.2:
+    resolution: {integrity: sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
@@ -2845,6 +2882,10 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   sql-highlight@6.1.0:
     resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
@@ -4099,6 +4140,15 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@testcontainers/mysql@12.0.4':
+    dependencies:
+      testcontainers: 12.0.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@testcontainers/postgresql@12.0.4':
     dependencies:
       testcontainers: 12.0.4
@@ -4452,6 +4502,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  aws-ssl-profiles@1.1.2: {}
+
   b4a@1.8.1: {}
 
   balanced-match@1.0.2: {}
@@ -4708,6 +4760,8 @@ snapshots:
   defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -5021,6 +5075,10 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
@@ -5153,6 +5211,8 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-property@1.0.2: {}
+
   is-stream@2.0.1: {}
 
   is-what@5.5.0: {}
@@ -5200,6 +5260,8 @@ snapshots:
   long@5.3.2: {}
 
   lru-cache@10.4.3: {}
+
+  lru.min@1.1.4: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -5382,6 +5444,22 @@ snapshots:
       busboy: 1.6.0
       concat-stream: 2.0.0
       type-is: 1.6.18
+
+  mysql2@3.23.2(@types/node@22.20.1):
+    dependencies:
+      '@types/node': 22.20.1
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.3
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.5.1
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
 
   nan@2.28.0:
     optional: true
@@ -5852,6 +5930,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sql-escaper@1.5.1: {}
+
   sql-highlight@6.1.0: {}
 
   ssh-remote-port-forward@1.0.4:
@@ -6105,7 +6185,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typeorm@1.1.0(better-sqlite3@13.0.2)(pg@8.22.0):
+  typeorm@1.1.0(better-sqlite3@13.0.2)(mysql2@3.23.2(@types/node@22.20.1))(pg@8.22.0):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.3.1
@@ -6119,6 +6199,7 @@ snapshots:
       yargs: 18.1.0
     optionalDependencies:
       better-sqlite3: 13.0.2
+      mysql2: 3.23.2(@types/node@22.20.1)
       pg: 8.22.0
     transitivePeerDependencies:
       - babel-plugin-macros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
       '@nestjs/testing':
         specifier: ^11.0.0
         version: 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.28)
-      '@testcontainers/mysql':
+      '@testcontainers/mariadb':
         specifier: ^12.0.4
         version: 12.0.4
       '@testcontainers/postgresql':
@@ -1227,8 +1227,8 @@ packages:
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
-  '@testcontainers/mysql@12.0.4':
-    resolution: {integrity: sha512-XZWh/L6EN8XQa5lsBdESDolDmyUA56bDgYh5SicLzzC2b4jho4lc0yA0GOOVX/bd0zK6VQK6hmDDJE+T3rFrdA==}
+  '@testcontainers/mariadb@12.0.4':
+    resolution: {integrity: sha512-AdMFF4VfzBq2brV5Ol9OAx4CSrK5u0kRromNv0pSsp6LTK0JEBGyj5JysRo9CMHnsbG5X4I2jkfhAZsonUoBWw==}
 
   '@testcontainers/postgresql@12.0.4':
     resolution: {integrity: sha512-a/pLU6j5lpKKAlUTPwqweqMGhOSjgTSb6HBX69TOrXn32ifU37nnQDmNFTj8ddOAw+BQL9oTRkeOxVbZkqhgZA==}
@@ -4140,7 +4140,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@testcontainers/mysql@12.0.4':
+  '@testcontainers/mariadb@12.0.4':
     dependencies:
       testcontainers: 12.0.4
     transitivePeerDependencies:


### PR DESCRIPTION
## What & why

`examples/nest-typeorm` already ran its shared behavior spec (`crud-e2e.suite.ts`) against in-memory SQLite and a Testcontainers-provisioned Postgres. This adds MariaDB as a third driver, following the exact same shape: `DatabaseModule`/`AppModule.forRoot(...)` widens `PostgresOptions` into a `SqlOptions` union (`{ type: "postgres" | "mariadb" } & ConnectionOptions`), `main-mariadb.ts` + `start:mariadb` mirror the Postgres entry point, and `tests/app-mariadb.e2e.spec.ts` self-provisions a MariaDB container via `@testcontainers/mariadb` and runs the same `registerCrudE2eSuite`.

Note: TypeORM's `type: "mariadb"` reuses `MysqlDriver` internally and always loads the `mysql2` npm package (not the separate `mariadb` package), so `mysql2` stays the runtime dependency. The official `mariadb` Docker Hub image has no `alpine` variant (only jammy/noble/ubi bases exist across all versions), so the container image is `mariadb:12`.

Getting the suite green surfaced a real cross-driver bug in `@kavo/typeorm`'s `FilterTranslator`: `LIKE`/`ILIKE` conditions inlined their `ESCAPE '\'` clause as a raw SQL string literal. Postgres treats `\` as a plain character there, but MySQL/MariaDB's default `sql_mode` treats backslash as its own in-string escape character, so `'\'` is an unterminated string literal and every `like`/`ilike` filter 500'd. Fixed by binding the escape character as a query parameter instead of inlining it — portable across all drivers, no other behavior change. Updated `docs/internals/architecture/05-query-grammar.md` and `09-typeorm-adapter.md`, which documented the old (buggy) inline-literal form.

## Public API impact

None. The `filter-translator.ts` change is an internal SQL-generation detail (same operators, same semantics, no public surface change). The example app's `DatabaseModule`/`AppModule.forRoot(...)` signature widened from `PostgresOptions` to a `SqlOptions` union, but `examples/nest-typeorm` is not a published package.

## Testing

- New `tests/app-mariadb.e2e.spec.ts`, self-provisioning MariaDB via `@testcontainers/mariadb`, running the full shared CRUD e2e suite (50 tests).
- `pnpm check` (build + typecheck + depcruise + lint + full test suite) is green: 870 tests / 49 files passing, including SQLite, Postgres, and MariaDB e2e suites side by side.

## Review notes

- The `filter-translator.ts` fix is in scope creep territory relative to issue #70 (which scoped changes to `examples/nest-typeorm` only) — it was required to satisfy the issue's own "pnpm check passes with all three drivers" acceptance criterion, so I fixed it rather than leaving `like`/`ilike` broken on the new driver. Worth a close look since it touches shared query-translation code.
- MariaDB's container is heavier to cold-start than Postgres's, so the `beforeAll` hook timeout in `app-mariadb.e2e.spec.ts` is 240s (vs. 120s for Postgres) to give it headroom on a cold image cache.

Closes #70