### PR TITLE
docs(homepage): add a box around the ORM equation on the homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -783,9 +783,11 @@ GET /books
 .equation-frame {
   max-width: 940px;
   margin: 0 auto;
-  padding: 24px;
+  padding: 28px;
   border: 1px solid var(--vp-c-divider);
-  border-radius: 16px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, var(--vp-c-bg-soft) 0%, var(--vp-c-bg) 100%);
+  box-shadow: 0 8px 24px -18px rgba(0, 0, 0, 0.3);
 }
 
 .equation {
@@ -814,7 +816,7 @@ GET /books
   padding: 18px 20px;
   border: 1px solid var(--vp-c-divider);
   border-radius: 12px;
-  background: var(--vp-c-bg-soft);
+  background: var(--vp-c-bg);
   text-align: left;
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -739,20 +739,22 @@ GET /books
 <div class="layer-section">
   <p class="layer-title">Not a replacement for your ORM</p>
   <p class="layer-subtitle">Kavo doesn't own your data model — it sits on top of the entity you already defined.</p>
-  <div class="equation">
-    <div class="eq-card">
-      <span class="eq-label">Your ORM</span>
-      <span class="eq-desc">Entity, migrations, and relations — unchanged.</span>
-    </div>
-    <span class="eq-op">+</span>
-    <div class="eq-card eq-card--kavo">
-      <span class="eq-label eq-label--kavo">Kavo</span>
-      <span class="eq-desc">Reads the entity's metadata, generates the CRUD surface.</span>
-    </div>
-    <span class="eq-op eq-op--equals">=</span>
-    <div class="eq-card">
-      <span class="eq-label">REST + GraphQL API</span>
-      <span class="eq-desc">Filtering, sorting, pagination, includes, DTOs, errors.</span>
+  <div class="equation-frame">
+    <div class="equation">
+      <div class="eq-card">
+        <span class="eq-label">Your ORM</span>
+        <span class="eq-desc">Entity, migrations, and relations — unchanged.</span>
+      </div>
+      <span class="eq-op">+</span>
+      <div class="eq-card eq-card--kavo">
+        <span class="eq-label eq-label--kavo">Kavo</span>
+        <span class="eq-desc">Reads the entity's metadata, generates the CRUD surface.</span>
+      </div>
+      <span class="eq-op eq-op--equals">=</span>
+      <div class="eq-card">
+        <span class="eq-label">REST + GraphQL API</span>
+        <span class="eq-desc">Filtering, sorting, pagination, includes, DTOs, errors.</span>
+      </div>
     </div>
   </div>
   <p class="layer-note">Swap ORMs later and the API surface doesn't move — <code>RepositoryAdapter</code> is the only seam that changes.</p>
@@ -776,6 +778,14 @@ GET /books
   margin: 0 0 36px;
   font-size: 14.5px;
   color: var(--vp-c-text-2);
+}
+
+.equation-frame {
+  max-width: 940px;
+  margin: 0 auto;
+  padding: 24px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
 }
 
 .equation {


### PR DESCRIPTION
## Summary
- Wraps the three "Not a replacement for your ORM" cards (Your ORM + Kavo = REST/GraphQL API) in a bordered `.equation-frame` container, so the trio reads as one visual group on the homepage.

## Test plan
- [ ] Visually confirm the frame renders correctly in light/dark mode via `pnpm docs:dev`