### PR TITLE
test(examples): add a Testcontainers MongoDB e2e suite to nest-mongoose

### DIFF
--- a/examples/nest-mongoose/README.md
+++ b/examples/nest-mongoose/README.md
@@ -19,11 +19,40 @@ pnpm build && MONGO_URL=mongodb://127.0.0.1:27017/kavo pnpm --filter @kavo/examp
 
 `MONGO_URL` defaults to `mongodb://127.0.0.1:27017/kavo`.
 
-The e2e suite (`tests/app.e2e.spec.ts`) needs none of this set up by hand — it
-provisions an in-memory MongoDB via `mongodb-memory-server`, so `pnpm check`
-exercises the full Nest → engine → Mongoose → MongoDB path with no manual
-step. (The first run downloads a `mongod` binary and caches it, so it needs
-network access once.)
+## The e2e suites
+
+Neither suite needs any of the above set up by hand, and both run the same
+assertions — `tests/crud-e2e.suite.ts` holds them, and each spec only differs
+in how it gets a `mongod` to point the default `mongoose` instance at. One
+behavioral spec, two servers, no forked assertions (the same split
+`nest-typeorm` uses for SQLite/Postgres/MariaDB).
+
+| Spec                          | Server                                                |
+| ----------------------------- | ----------------------------------------------------- |
+| `tests/app.e2e.spec.ts`       | `mongodb-memory-server` — standalone, no Docker       |
+| `tests/app-mongo.e2e.spec.ts` | Testcontainers `mongo:8` — a real, pinned replica set |
+
+The default suite keeps `pnpm check` runnable with no daemon: it downloads a
+`mongod` binary once and caches it, then runs it against an ephemeral data
+directory. What it cannot pin down is the server the app is actually deployed
+onto — it is a standalone of whatever version the tool fetches for the current
+platform.
+
+So `tests/app-mongo.e2e.spec.ts` self-provisions a pinned `mongo:8` container
+via Testcontainers and runs the identical suite against it, exactly the way
+`nest-typeorm`'s Postgres and MariaDB suites do. That needs a running Docker
+daemon wherever `pnpm check`/`pnpm test` runs. Two details are specific to
+MongoDB:
+
+- `MongoDBContainer` always starts a **single-node replica set**, and
+  `rs.initiate()` advertises that member under the container's own hostname.
+  The test connects with `directConnection: true` so the driver keeps talking
+  to the mapped port instead of chasing that unroutable address —
+  `getConnectionString()` does not set it.
+- Unique indexes are only enforced once they exist, and Mongoose builds them
+  in the background after connecting. The shared suite awaits `Model.init()`
+  before asserting that a duplicate `Author.email` is a 409, so the assertion
+  cannot race the index into existence on a cold database.
 
 ## What's different from the TypeORM app
 
@@ -52,10 +81,10 @@ keyed by `_id` rather than a numeric `id`. Filtering _across_ a relation
 (`filter[author.name]`) is refused with a 400 rather than silently matching
 nothing — MongoDB resolves dotted paths inside a document, not across a `ref`.
 
-The e2e suite deliberately does not reuse `nest-typeorm`'s
-`crud-e2e.suite.ts`: that suite is written against a numeric `id` and
-single-table inheritance, and forking its assertions would hide exactly the
-difference this app exists to show.
+This app's `crud-e2e.suite.ts` deliberately does not reuse `nest-typeorm`'s
+same-named suite: that one is written against a numeric `id` and single-table
+inheritance, and forking its assertions would hide exactly the difference this
+app exists to show.
 
 The app consumes only public package APIs — if it ever needs a deep import,
 that is an API-surface bug in the package, not the app.

--- a/examples/nest-mongoose/package.json
+++ b/examples/nest-mongoose/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^11.0.0",
+    "@testcontainers/mongodb": "^12.0.4",
     "@types/supertest": "^7.2.1",
     "mongodb-memory-server": "^10.1.4",
     "supertest": "^7.0.0"

--- a/examples/nest-mongoose/tests/app-mongo.e2e.spec.ts
+++ b/examples/nest-mongoose/tests/app-mongo.e2e.spec.ts
@@ -1,0 +1,51 @@
+import "reflect-metadata";
+import { afterAll, beforeAll } from "vitest";
+import mongoose from "mongoose";
+import { MongoDBContainer, type StartedMongoDBContainer } from "@testcontainers/mongodb";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { AppModule } from "../src/app.module.js";
+import { registerCrudE2eSuite } from "./crud-e2e.suite.js";
+
+/**
+ * Same suite as `app.e2e.spec.ts`, run against a real, pinned MongoDB
+ * instead of `mongodb-memory-server`'s standalone `mongod` — the document
+ * counterpart to `nest-typeorm`'s Testcontainers Postgres and MariaDB
+ * suites. No manual MongoDB setup is needed to run `pnpm check`, since this
+ * test provisions the server itself; it does need a running Docker daemon.
+ *
+ * `AppModule.forRoot()` takes no connection options, unlike its TypeORM
+ * counterpart: `mongoose.connection` *is* the model registry the app hands
+ * to `createInfrastructure` (ADR-0018), so pointing the app at this
+ * container is just connecting the default `mongoose` instance to it.
+ */
+let container: StartedMongoDBContainer;
+let app: INestApplication;
+
+beforeAll(async () => {
+  container = await new MongoDBContainer("mongo:8").start();
+
+  // `MongoDBContainer` always starts a single-node replica set, and
+  // `rs.initiate()` advertises that member under the *container's* own
+  // hostname. `directConnection` keeps the driver talking to the mapped
+  // port it was given rather than chasing that unroutable address —
+  // `getConnectionString()` does not set it.
+  await mongoose.connect(container.getConnectionString(), {
+    dbName: "kavo-examples",
+    directConnection: true,
+  });
+
+  const moduleRef = await Test.createTestingModule({
+    imports: [AppModule.forRoot()],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  await app.init();
+}, 240_000);
+
+afterAll(async () => {
+  if (app !== undefined) await app.close();
+  await mongoose.disconnect();
+  if (container !== undefined) await container.stop();
+}, 30_000);
+
+registerCrudE2eSuite(() => app);

--- a/examples/nest-mongoose/tests/app.e2e.spec.ts
+++ b/examples/nest-mongoose/tests/app.e2e.spec.ts
@@ -1,24 +1,20 @@
 import "reflect-metadata";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import request from "supertest";
+import { afterAll, beforeAll } from "vitest";
 import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import type { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import { AppModule } from "../src/app.module.js";
+import { registerCrudE2eSuite } from "./crud-e2e.suite.js";
 
 /**
- * The Blog example served by the real stack — `@Kavo`-generated NestJS
- * routes → CRUD engine → `@kavo/mongoose` → a real MongoDB.
+ * The default suite: `mongodb-memory-server` runs a `mongod` against an
+ * ephemeral data directory, so `pnpm check` gets the full Nest → engine →
+ * Mongoose → MongoDB path with no Docker daemon and no manual setup.
  *
- * This is the only place all three packages are exercised together: the
- * adapter's own suites drive the engine directly, so nothing else proves
- * that route generation, DTO projection, the exception filter, and the
- * Mongoose adapter compose. It deliberately does *not* reuse
- * `nest-typeorm`'s `crud-e2e.suite.ts`, which is written against that
- * app's numeric `id` and single-table inheritance; a document store's
- * `_id` string is a different contract, and forking those assertions
- * would hide exactly the difference worth showing.
+ * It is a standalone `mongod` of whatever version the tool downloads, which
+ * is not what the app is deployed onto — `app-mongo.e2e.spec.ts` runs the
+ * same assertions against a pinned, containerized MongoDB replica set.
  */
 let server: MongoMemoryServer;
 let app: INestApplication;
@@ -40,131 +36,4 @@ afterAll(async () => {
   if (server !== undefined) await server.stop();
 });
 
-beforeEach(async () => {
-  await Promise.all(Object.values(mongoose.connection.models).map((model) => model.deleteMany({})));
-});
-
-function http(): Parameters<typeof request>[0] {
-  return app.getHttpServer() as Parameters<typeof request>[0];
-}
-
-async function newAuthor(email = "ada@x.io"): Promise<string> {
-  const created = await request(http()).post("/authors").send({ name: "Ada", email }).expect(201);
-  return created.body._id as string;
-}
-
-describe("Blog example app (Mongoose)", () => {
-  it("runs the full CRUD lifecycle over HTTP", async () => {
-    const created = await request(http())
-      .post("/articles")
-      .send({ title: "First", body: "hello", tags: ["intro"] })
-      .expect(201);
-    // Response is the ArticleItemDto projection, keyed by `_id`.
-    expect(created.body).toMatchObject({ title: "First", body: "hello", status: "draft", tags: ["intro"] });
-    expect(created.body._id).toMatch(/^[0-9a-f]{24}$/);
-    const id = created.body._id as string;
-
-    const fetched = await request(http()).get(`/articles/${id}`).expect(200);
-    expect(Object.keys(fetched.body).sort()).toEqual(["_id", "body", "createdAt", "status", "tags", "title"]);
-
-    await request(http()).put(`/articles/${id}`).send({ title: "Renamed", status: "published" }).expect(200);
-    const patched = await request(http()).patch(`/articles/${id}`).send({ body: "edited" }).expect(200);
-    expect(patched.body).toMatchObject({ title: "Renamed", status: "published", body: "edited" });
-
-    await request(http()).delete(`/articles/${id}`).expect(204);
-    await request(http()).get(`/articles/${id}`).expect(404);
-  });
-
-  it("serves the leaner list projection with the pagination envelope", async () => {
-    for (const title of ["A", "B", "C"]) {
-      await request(http()).post("/articles").send({ title, body: "x" }).expect(201);
-    }
-    const list = await request(http()).get("/articles?limit=2&offset=0&sort=title").expect(200);
-
-    expect(list.body).toMatchObject({ limit: 2, offset: 0, total: 3 });
-    expect(list.body.items.map((item: { title: string }) => item.title)).toEqual(["A", "B"]);
-    // ArticleListDto omits `body` and `createdAt`, which `item` carries.
-    expect(Object.keys(list.body.items[0]).sort()).toEqual(["_id", "status", "tags", "title"]);
-  });
-
-  it("filters and sorts through the wire grammar", async () => {
-    await request(http()).post("/articles").send({ title: "Draft one", status: "draft" }).expect(201);
-    await request(http()).post("/articles").send({ title: "Published one", status: "published" }).expect(201);
-
-    const filtered = await request(http()).get("/articles?filter[status][eq]=published").expect(200);
-    expect(filtered.body.items).toHaveLength(1);
-    expect(filtered.body.items[0].title).toBe("Published one");
-
-    // LIKE is translated to an anchored, fully escaped $regex.
-    const liked = await request(http()).get("/articles?filter[title][like]=Draft%25").expect(200);
-    expect(liked.body.items.map((item: { title: string }) => item.title)).toEqual(["Draft one"]);
-  });
-
-  it("embeds a relation with include, and filters by the reference id", async () => {
-    const authorId = await newAuthor();
-    await request(http()).post("/articles").send({ title: "Owned", author: authorId }).expect(201);
-    await request(http()).post("/articles").send({ title: "Orphan" }).expect(201);
-
-    const included = await request(http()).get("/articles?include=author&filter[title][eq]=Owned").expect(200);
-    expect(included.body.items[0].author).toMatchObject({ _id: authorId, name: "Ada" });
-
-    // A Mongoose `ref` path is the foreign key too, so it is filterable.
-    const byAuthor = await request(http()).get(`/articles?filter[author][eq]=${authorId}`).expect(200);
-    expect(byAuthor.body.items.map((item: { title: string }) => item.title)).toEqual(["Owned"]);
-  });
-
-  it("soft-deletes, hides, restores, and purges", async () => {
-    const created = await request(http()).post("/articles").send({ title: "Temporary" }).expect(201);
-    const id = created.body._id as string;
-
-    await request(http()).delete(`/articles/${id}`).expect(204);
-    expect((await request(http()).get("/articles").expect(200)).body.total).toBe(0);
-    expect((await request(http()).get("/articles?withDeleted=true").expect(200)).body.total).toBe(1);
-    // Deleting twice is a state conflict, not a missing document.
-    await request(http()).delete(`/articles/${id}`).expect(409);
-
-    // `restoreOne` exists because the controller *declares* soft delete.
-    const restored = await request(http()).patch(`/articles/${id}/restore`).expect(200);
-    expect(restored.body).toMatchObject({ _id: id, title: "Temporary" });
-    expect((await request(http()).get("/articles").expect(200)).body.total).toBe(1);
-
-    // Purge only ever removes an already-deleted document.
-    await request(http()).delete(`/articles/${id}/purge`).expect(409);
-    await request(http()).delete(`/articles/${id}`).expect(204);
-    await request(http()).delete(`/articles/${id}/purge`).expect(204);
-    expect((await request(http()).get("/articles?withDeleted=true").expect(200)).body.total).toBe(0);
-    await request(http()).patch(`/articles/${id}/restore`).expect(404);
-  });
-
-  it("answers a malformed id with 404 and a bad query with problem details", async () => {
-    const missing = await request(http()).get("/articles/not-an-objectid").expect(404);
-    expect(missing.body).toMatchObject({ code: "KAVO_NOT_FOUND", status: 404 });
-
-    // A filter on a field that is not allowlisted is a 400 with issues[].
-    const invalid = await request(http()).get("/articles?filter[body][eq]=x").expect(400);
-    expect(invalid.body).toMatchObject({ code: "KAVO_QUERY_INVALID", status: 400 });
-    expect(invalid.body.errors[0]).toMatchObject({ field: "body" });
-  });
-
-  it("refuses a relation-path filter instead of silently matching nothing", async () => {
-    // MongoDB resolves a dotted path inside a document, never across a
-    // `ref`, so this is refused rather than quietly returning [].
-    const refused = await request(http()).get("/articles?filter[author.name][eq]=Ada").expect(400);
-    expect(refused.body).toMatchObject({ code: "KAVO_QUERY_INVALID" });
-  });
-
-  it("serves the zero-config Author routes with derived defaults", async () => {
-    const authorId = await newAuthor("grace@x.io");
-    const fetched = await request(http()).get(`/authors/${authorId}`).expect(200);
-    expect(fetched.body).toMatchObject({ _id: authorId, name: "Ada", email: "grace@x.io" });
-    // Mongoose's `__v` bookkeeping never reaches the wire.
-    expect(fetched.body).not.toHaveProperty("__v");
-
-    // `_id`/`createdAt`/`updatedAt` are generated, so they are not writable.
-    const created = await request(http())
-      .post("/authors")
-      .send({ _id: "507f1f77bcf86cd799439011", name: "Alan", email: "alan@x.io" })
-      .expect(201);
-    expect(created.body._id).not.toBe("507f1f77bcf86cd799439011");
-  });
-});
+registerCrudE2eSuite(() => app);

--- a/examples/nest-mongoose/tests/crud-e2e.suite.ts
+++ b/examples/nest-mongoose/tests/crud-e2e.suite.ts
@@ -1,0 +1,179 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import mongoose from "mongoose";
+import type { INestApplication } from "@nestjs/common";
+
+/**
+ * The Blog example served by the real stack — `@Kavo`-generated NestJS
+ * routes → CRUD engine → `@kavo/mongoose` → a real MongoDB.
+ *
+ * This is the only place all three packages are exercised together: the
+ * adapter's own suites drive the engine directly, so nothing else proves
+ * that route generation, DTO projection, the exception filter, and the
+ * Mongoose adapter compose. It deliberately does *not* reuse
+ * `nest-typeorm`'s `crud-e2e.suite.ts`, which is written against that
+ * app's numeric `id` and single-table inheritance; a document store's
+ * `_id` string is a different contract, and forking those assertions
+ * would hide exactly the difference worth showing.
+ *
+ * Parameterized by `getApp` so the same suite runs, unchanged, against both
+ * the `mongodb-memory-server` app (`app.e2e.spec.ts`) and the
+ * Testcontainers-provisioned MongoDB app (`app-mongo.e2e.spec.ts`) — one
+ * behavioral spec, two ways of getting a `mongod`, no forked assertions.
+ * Both connect the *default* `mongoose` instance, which is the model
+ * registry `AppModule` hands to `createInfrastructure` (ADR-0018), so the
+ * suite reaches the connection through `mongoose` rather than through
+ * `getApp()`.
+ */
+export function registerCrudE2eSuite(getApp: () => INestApplication): void {
+  function server(): Parameters<typeof request>[0] {
+    return getApp().getHttpServer() as Parameters<typeof request>[0];
+  }
+
+  async function newAuthor(email = "ada@x.io"): Promise<string> {
+    const created = await request(server()).post("/authors").send({ name: "Ada", email }).expect(201);
+    return created.body._id as string;
+  }
+
+  describe("Blog example app (Mongoose)", () => {
+    beforeAll(async () => {
+      // A unique index is only enforced once it actually exists. Mongoose's
+      // `autoIndex` builds them in the background after connecting, so
+      // awaiting `init()` is what keeps the duplicate-key assertion below
+      // from racing the index into existence on a cold database.
+      await Promise.all(Object.values(mongoose.connection.models).map((model) => model.init()));
+    });
+
+    beforeEach(async () => {
+      await Promise.all(Object.values(mongoose.connection.models).map((model) => model.deleteMany({})));
+    });
+
+    it("runs the full CRUD lifecycle over HTTP", async () => {
+      const created = await request(server())
+        .post("/articles")
+        .send({ title: "First", body: "hello", tags: ["intro"] })
+        .expect(201);
+      // Response is the ArticleItemDto projection, keyed by `_id`.
+      expect(created.body).toMatchObject({ title: "First", body: "hello", status: "draft", tags: ["intro"] });
+      expect(created.body._id).toMatch(/^[0-9a-f]{24}$/);
+      const id = created.body._id as string;
+
+      const fetched = await request(server()).get(`/articles/${id}`).expect(200);
+      expect(Object.keys(fetched.body).sort()).toEqual(["_id", "body", "createdAt", "status", "tags", "title"]);
+
+      await request(server()).put(`/articles/${id}`).send({ title: "Renamed", status: "published" }).expect(200);
+      const patched = await request(server()).patch(`/articles/${id}`).send({ body: "edited" }).expect(200);
+      expect(patched.body).toMatchObject({ title: "Renamed", status: "published", body: "edited" });
+
+      await request(server()).delete(`/articles/${id}`).expect(204);
+      await request(server()).get(`/articles/${id}`).expect(404);
+    });
+
+    it("serves the leaner list projection with the pagination envelope", async () => {
+      for (const title of ["A", "B", "C"]) {
+        await request(server()).post("/articles").send({ title, body: "x" }).expect(201);
+      }
+      const list = await request(server()).get("/articles?limit=2&offset=0&sort=title").expect(200);
+
+      expect(list.body).toMatchObject({ limit: 2, offset: 0, total: 3 });
+      expect(list.body.items.map((item: { title: string }) => item.title)).toEqual(["A", "B"]);
+      // ArticleListDto omits `body` and `createdAt`, which `item` carries.
+      expect(Object.keys(list.body.items[0]).sort()).toEqual(["_id", "status", "tags", "title"]);
+    });
+
+    it("filters and sorts through the wire grammar", async () => {
+      await request(server()).post("/articles").send({ title: "Draft one", status: "draft" }).expect(201);
+      await request(server()).post("/articles").send({ title: "Published one", status: "published" }).expect(201);
+
+      const filtered = await request(server()).get("/articles?filter[status][eq]=published").expect(200);
+      expect(filtered.body.items).toHaveLength(1);
+      expect(filtered.body.items[0].title).toBe("Published one");
+
+      // LIKE is translated to an anchored, fully escaped $regex.
+      const liked = await request(server()).get("/articles?filter[title][like]=Draft%25").expect(200);
+      expect(liked.body.items.map((item: { title: string }) => item.title)).toEqual(["Draft one"]);
+    });
+
+    it("embeds a relation with include, and filters by the reference id", async () => {
+      const authorId = await newAuthor();
+      await request(server()).post("/articles").send({ title: "Owned", author: authorId }).expect(201);
+      await request(server()).post("/articles").send({ title: "Orphan" }).expect(201);
+
+      const included = await request(server()).get("/articles?include=author&filter[title][eq]=Owned").expect(200);
+      expect(included.body.items[0].author).toMatchObject({ _id: authorId, name: "Ada" });
+
+      // A Mongoose `ref` path is the foreign key too, so it is filterable.
+      const byAuthor = await request(server()).get(`/articles?filter[author][eq]=${authorId}`).expect(200);
+      expect(byAuthor.body.items.map((item: { title: string }) => item.title)).toEqual(["Owned"]);
+    });
+
+    it("soft-deletes, hides, restores, and purges", async () => {
+      const created = await request(server()).post("/articles").send({ title: "Temporary" }).expect(201);
+      const id = created.body._id as string;
+
+      await request(server()).delete(`/articles/${id}`).expect(204);
+      expect((await request(server()).get("/articles").expect(200)).body.total).toBe(0);
+      expect((await request(server()).get("/articles?withDeleted=true").expect(200)).body.total).toBe(1);
+      // Deleting twice is a state conflict, not a missing document.
+      await request(server()).delete(`/articles/${id}`).expect(409);
+
+      // `restoreOne` exists because the controller *declares* soft delete.
+      const restored = await request(server()).patch(`/articles/${id}/restore`).expect(200);
+      expect(restored.body).toMatchObject({ _id: id, title: "Temporary" });
+      expect((await request(server()).get("/articles").expect(200)).body.total).toBe(1);
+
+      // Purge only ever removes an already-deleted document.
+      await request(server()).delete(`/articles/${id}/purge`).expect(409);
+      await request(server()).delete(`/articles/${id}`).expect(204);
+      await request(server()).delete(`/articles/${id}/purge`).expect(204);
+      expect((await request(server()).get("/articles?withDeleted=true").expect(200)).body.total).toBe(0);
+      await request(server()).patch(`/articles/${id}/restore`).expect(404);
+    });
+
+    it("answers a malformed id with 404 and a bad query with problem details", async () => {
+      const missing = await request(server()).get("/articles/not-an-objectid").expect(404);
+      expect(missing.body).toMatchObject({ code: "KAVO_NOT_FOUND", status: 404 });
+
+      // A filter on a field that is not allowlisted is a 400 with issues[].
+      const invalid = await request(server()).get("/articles?filter[body][eq]=x").expect(400);
+      expect(invalid.body).toMatchObject({ code: "KAVO_QUERY_INVALID", status: 400 });
+      expect(invalid.body.errors[0]).toMatchObject({ field: "body" });
+    });
+
+    it("refuses a relation-path filter instead of silently matching nothing", async () => {
+      // MongoDB resolves a dotted path inside a document, never across a
+      // `ref`, so this is refused rather than quietly returning [].
+      const refused = await request(server()).get("/articles?filter[author.name][eq]=Ada").expect(400);
+      expect(refused.body).toMatchObject({ code: "KAVO_QUERY_INVALID" });
+    });
+
+    it("serves the zero-config Author routes with derived defaults", async () => {
+      const authorId = await newAuthor("grace@x.io");
+      const fetched = await request(server()).get(`/authors/${authorId}`).expect(200);
+      expect(fetched.body).toMatchObject({ _id: authorId, name: "Ada", email: "grace@x.io" });
+      // Mongoose's `__v` bookkeeping never reaches the wire.
+      expect(fetched.body).not.toHaveProperty("__v");
+
+      // `_id`/`createdAt`/`updatedAt` are generated, so they are not writable.
+      const created = await request(server())
+        .post("/authors")
+        .send({ _id: "507f1f77bcf86cd799439011", name: "Alan", email: "alan@x.io" })
+        .expect(201);
+      expect(created.body._id).not.toBe("507f1f77bcf86cd799439011");
+    });
+
+    it("maps a duplicate email to a 409 conflict problem details", async () => {
+      // `Author.email` is `unique: true`, so the second insert is refused by
+      // the server's own index, surfacing as duplicate key 11000 — the one
+      // adapter error path that only a real `mongod` enforcing a real index
+      // can produce.
+      await newAuthor("ada@x.io");
+      const conflict = await request(server())
+        .post("/authors")
+        .send({ name: "Ada again", email: "ada@x.io" })
+        .expect(409)
+        .expect("Content-Type", /application\/problem\+json/);
+      expect(conflict.body).toMatchObject({ code: "KAVO_CONFLICT", status: 409 });
+    });
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@nestjs/testing':
         specifier: ^11.0.0
         version: 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.28)
+      '@testcontainers/mongodb':
+        specifier: ^12.0.4
+        version: 12.0.4
       '@types/supertest':
         specifier: ^7.2.1
         version: 7.2.1
@@ -1230,6 +1233,9 @@ packages:
   '@testcontainers/mariadb@12.0.4':
     resolution: {integrity: sha512-AdMFF4VfzBq2brV5Ol9OAx4CSrK5u0kRromNv0pSsp6LTK0JEBGyj5JysRo9CMHnsbG5X4I2jkfhAZsonUoBWw==}
 
+  '@testcontainers/mongodb@12.0.4':
+    resolution: {integrity: sha512-lVz3pCHJntsJYOyhDaWLakDCcG3CnFP9ijZ2JOFPKg8p1ysZLoU/NqNzPQdKAD4X4BeWW8h+dabW2e8XvEVmGQ==}
+
   '@testcontainers/postgresql@12.0.4':
     resolution: {integrity: sha512-a/pLU6j5lpKKAlUTPwqweqMGhOSjgTSb6HBX69TOrXn32ifU37nnQDmNFTj8ddOAw+BQL9oTRkeOxVbZkqhgZA==}
 
@@ -1718,6 +1724,9 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
@@ -4149,6 +4158,16 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  '@testcontainers/mongodb@12.0.4':
+    dependencies:
+      compare-versions: 6.1.1
+      testcontainers: 12.0.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@testcontainers/postgresql@12.0.4':
     dependencies:
       testcontainers: 12.0.4
@@ -4679,6 +4698,8 @@ snapshots:
   commander@15.0.0: {}
 
   commondir@1.0.1: {}
+
+  compare-versions@6.1.1: {}
 
   component-emitter@1.3.1: {}
 


### PR DESCRIPTION
## What

Gives `examples/nest-mongoose` a second e2e suite that runs against a real, pinned MongoDB provisioned by Testcontainers — the document-store counterpart to `nest-typeorm`'s Postgres and MariaDB suites.

- `tests/crud-e2e.suite.ts` (new) — the assertions that were inline in `app.e2e.spec.ts`, parameterized by `getApp`, following `nest-typeorm`'s precedent.
- `tests/app-mongo.e2e.spec.ts` (new) — starts a `mongo:8` `MongoDBContainer`, connects the default `mongoose` instance to it, boots `AppModule.forRoot()`, registers the shared suite.
- `tests/app.e2e.spec.ts` — unchanged behavior, now a thin `mongodb-memory-server` bootstrapper over the shared suite. Still the fast, Docker-free default.
- `@testcontainers/mongodb` added as a devDependency; `README.md` documents both paths.

## Why

`@kavo/mongoose` only ever ran its e2e against whatever `mongod` binary `mongodb-memory-server` fetches for the host — a standalone, of an unpinned version, provisioned by a downloader rather than the container runtime the rest of the repo's e2e suites use. This closes that gap the same way `nest-typeorm` already does.

Note the issue's original framing called `mongodb-memory-server` "an embedded fake, not the real `mongod` binary". That's wrong — it runs a genuine `mongod`. I corrected the issue description; the narrower real gaps (version/platform drift, standalone vs. replica set) still justify the change.

## Two MongoDB-specific gotchas, both documented in-code

- `MongoDBContainer` **always** starts a single-node replica set, and `rs.initiate()` advertises that member under the container's own hostname. `getConnectionString()` does **not** set `directConnection`, so without it the driver takes the seed as a discovery hint and then chases an unroutable address. The spec connects with `directConnection: true`.
- A unique index is only enforced once it exists, and Mongoose builds them in the background after connecting. The shared suite awaits `Model.init()` first.

## Public API impact

None. `examples/*` only; no `@kavo/*` package source changed, and `@kavo/mongoose` is untouched (ADR-0018 boundary respected).

## Testing

`pnpm check` green: **50 test files, 880 tests passed**, exit 0 — build, typecheck, depcruise, lint, test.

Adds one assertion beyond a pure port: duplicate `Author.email` → 409. `email` is `unique: true` and `@kavo/mongoose` maps duplicate key 11000 to a `ConflictException`, but nothing exercised it; `nest-typeorm`'s shared suite has the equivalent test and this one did not.

## Review notes — pre-existing flakiness, worth a separate issue

While verifying this I measured the full suite's stability. **Unmodified `main` fails 2 of 6 consecutive `pnpm vitest run` invocations**, e.g.:

- `examples/nest-typeorm/tests/app.e2e.spec.ts` — "associates tags by id and embeds them via a batched many-to-many include"
- `packages/frameworks/nest/tests/binding.e2e.spec.ts` — "reports the occurrence as a correlation URN"
- one run failed 17 tests in `app-mariadb.e2e.spec.ts`

The symptoms are always a supertest HTTP call getting the wrong response (a `POST` returning 400, a `GET` returning 404) — including in `packages/frameworks/nest`, which uses no database and no Docker. Consistent with supertest closing and rebinding an ephemeral port per request across ~50 parallel worker processes, not with anything in this PR.

This PR does not cause it and does not fix it, but by adding a 50th test file holding another container it likely nudges the rate up slightly. Suggest filing it separately.
