### PR TITLE
test(examples): harden the nest-mongoose e2e teardown, hook timeout, and README

### DIFF
--- a/examples/nest-mongoose/README.md
+++ b/examples/nest-mongoose/README.md
@@ -32,11 +32,14 @@ behavioral spec, two servers, no forked assertions (the same split
 | `tests/app.e2e.spec.ts`       | `mongodb-memory-server` — standalone, no Docker       |
 | `tests/app-mongo.e2e.spec.ts` | Testcontainers `mongo:8` — a real, pinned replica set |
 
-The default suite keeps `pnpm check` runnable with no daemon: it downloads a
-`mongod` binary once and caches it, then runs it against an ephemeral data
-directory. What it cannot pin down is the server the app is actually deployed
-onto — it is a standalone of whatever version the tool fetches for the current
-platform.
+The default suite is the one that runs without Docker: it downloads a `mongod`
+binary once and caches it, then runs it against an ephemeral data directory, so
+`pnpm vitest run examples/nest-mongoose/tests/app.e2e.spec.ts` exercises the
+whole stack on a machine with no daemon. (`pnpm check` as a whole still needs
+one — `nest-typeorm`'s Postgres and MariaDB suites have required it since
+before this app existed.) What the default suite cannot pin down is the server
+the app is actually deployed onto — it is a standalone of whatever version the
+tool fetches for the current platform.
 
 So `tests/app-mongo.e2e.spec.ts` self-provisions a pinned `mongo:8` container
 via Testcontainers and runs the identical suite against it, exactly the way

--- a/examples/nest-mongoose/tests/app-mongo.e2e.spec.ts
+++ b/examples/nest-mongoose/tests/app-mongo.e2e.spec.ts
@@ -43,9 +43,19 @@ beforeAll(async () => {
 }, 240_000);
 
 afterAll(async () => {
-  if (app !== undefined) await app.close();
-  await mongoose.disconnect();
-  if (container !== undefined) await container.stop();
+  // Each step runs even if an earlier one rejects. A half-initialized app
+  // whose `close()` throws would otherwise strand the open socket — keeping
+  // the worker's event loop alive — and leak the container until Ryuk
+  // reaps it, turning one failed test into a hung run.
+  try {
+    if (app !== undefined) await app.close();
+  } finally {
+    try {
+      await mongoose.disconnect();
+    } finally {
+      if (container !== undefined) await container.stop();
+    }
+  }
 }, 30_000);
 
 registerCrudE2eSuite(() => app);

--- a/examples/nest-mongoose/tests/app.e2e.spec.ts
+++ b/examples/nest-mongoose/tests/app.e2e.spec.ts
@@ -31,9 +31,17 @@ beforeAll(async () => {
 }, 60_000);
 
 afterAll(async () => {
-  if (app !== undefined) await app.close();
-  await mongoose.disconnect();
-  if (server !== undefined) await server.stop();
+  // Same reason as the container spec: an `app.close()` rejection must not
+  // strand the connection or the `mongod` process behind it.
+  try {
+    if (app !== undefined) await app.close();
+  } finally {
+    try {
+      await mongoose.disconnect();
+    } finally {
+      if (server !== undefined) await server.stop();
+    }
+  }
 });
 
 registerCrudE2eSuite(() => app);

--- a/examples/nest-mongoose/tests/crud-e2e.suite.ts
+++ b/examples/nest-mongoose/tests/crud-e2e.suite.ts
@@ -41,8 +41,14 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       // `autoIndex` builds them in the background after connecting, so
       // awaiting `init()` is what keeps the duplicate-key assertion below
       // from racing the index into existence on a cold database.
+      //
+      // Explicitly timed out, like every bootstrap hook in the two specs
+      // that call this: `vitest.config.ts` widens `testTimeout` but not
+      // `hookTimeout`, so the default here would be 10s — enough to abort
+      // five index builds on a runner already starting three containers,
+      // and to blame the harness for it.
       await Promise.all(Object.values(mongoose.connection.models).map((model) => model.init()));
-    });
+    }, 60_000);
 
     beforeEach(async () => {
       await Promise.all(Object.values(mongoose.connection.models).map((model) => model.deleteMany({})));


### PR DESCRIPTION
Follow-up to #77 (already merged) — applies the verified findings from a high-effort review of that change. Test-harness and docs only; no `@kavo/*` package source touched.

## 1. Teardown could hang the run and leak a container

Both nest-mongoose specs tore down in three sequential awaits:

```ts
if (app !== undefined) await app.close();
await mongoose.disconnect();
if (container !== undefined) await container.stop();
```

A rejecting `app.close()` — a Nest shutdown hook throwing, or an `app.init()` that failed partway — skips the two steps after it. The mongoose socket stays open, which keeps the vitest worker's event loop alive, and the `mongo:8` container is never stopped. One failed test becomes a run that hangs until CI's global timeout kills it, plus a stray container holding a host port until Ryuk reaps it. Each step now runs under `try/finally`, in both specs.

## 2. The `Model.init()` hook ran on a 10s budget

The shared suite's index-build hook carried no explicit timeout. `vitest.config.ts` sets `testTimeout: 30_000` but not `hookTimeout`, and those are independent — verified empirically with a throwaway spec whose 11s hook aborted with `Hook timed out in 10000ms`. Ten seconds is thin for five index builds across two models on a cold database, on a runner already starting Postgres, MariaDB and MongoDB in parallel; blowing it fails all nine tests in the file with a message that points at the harness rather than the app. Widened to 60s, matching every neighbouring bootstrap hook (60s / 240s / 30s).

## 3. README contradicted itself about Docker

Line 35 claimed the default suite "keeps `pnpm check` runnable with no daemon"; line 43 of the same section said `pnpm check` needs one. The second is correct — `pnpm check` has required Docker since nest-typeorm's Postgres suite, well before this app. Reworded to the narrower true claim: the memory-server spec is the one that runs daemon-free, and the README now names the exact command that does.

## Not applied

The review also flagged (cleanup, plausible) that both specs drive the process-global default `mongoose` connection, and suggested `mongoose.createConnection` per spec as `packages/orms/mongoose/tests/support/database.ts` does. Skipped deliberately: the example app reads `mongoose.connection` in `AppModule.forRoot()` and registers its models on the global instance, because that is the point ADR-0018 makes — a Mongoose model *is* the entity identity and the default connection already is the model registry. Switching the tests would mean rewiring `AppModule` and both model files to thread a connection through, which changes what the example demonstrates. The risk described is also conditional on someone later setting `isolate: false`; the current default (`forks`, isolated per file) is safe.

## Testing

`pnpm check` green: **54 test files, 896 tests**, exit 0 — build, typecheck, depcruise, lint, test.
