### PR TITLE
refactor(mcp): rename tool ids to dotted <entity>.<op> form

### DIFF
--- a/docs/internals/architecture/14-mcp-binding.md
+++ b/docs/internals/architecture/14-mcp-binding.md
@@ -36,19 +36,19 @@ the full standard set, unconditionally:
 
 | Tool               | Args                                              |
 | ------------------ | ------------------------------------------------- |
-| `owner_findOne`    | `{ id }`                                          |
-| `owner_findMany`   | `{ limit?, offset?, sort?, filter? }`             |
-| `owner_createOne`  | any fields (forwarded straight to the create DTO) |
-| `owner_updateOne`  | `{ id, ...anyFields }`                            |
-| `owner_patchOne`   | `{ id, ...anyFields }`                            |
-| `owner_deleteOne`  | `{ id }`                                          |
-| `owner_restoreOne` | `{ id }`                                          |
-| `owner_purgeOne`   | `{ id }`                                          |
+| `owner.findOne`    | `{ id }`                                          |
+| `owner.findMany`   | `{ limit?, offset?, sort?, filter? }`             |
+| `owner.createOne`  | any fields (forwarded straight to the create DTO) |
+| `owner.updateOne`  | `{ id, ...anyFields }`                            |
+| `owner.patchOne`   | `{ id, ...anyFields }`                            |
+| `owner.deleteOne`  | `{ id }`                                          |
+| `owner.restoreOne` | `{ id }`                                          |
+| `owner.purgeOne`   | `{ id }`                                          |
 
 This mirrors how `@Kavo` itself enables every standard operation by
 default: no hand-authored per-entity JSON Schema to keep in sync, and no
 `OperationRegistry` cross-check either — an entity that never declared
-soft delete still gets `owner_restoreOne`/`owner_purgeOne` tools, and
+soft delete still gets `owner.restoreOne`/`owner.purgeOne` tools, and
 calling either surfaces `OperationDisabledException` as a normal `isError`
 result (§3), exactly like calling the equivalent disabled REST route
 would. `createOne`/`updateOne`/`patchOne`'s `inputSchema` is deliberately
@@ -81,7 +81,7 @@ programmatic `QueryContext` surface, not REST's wire-string/camelCase form.
 
 **Update/patch args are flat, not wrapped.** GraphQL's mutations take `(id,
 input)` as two separate arguments because GraphQL has native argument
-lists; an MCP tool call takes one JSON object, so `owner_updateOne`'s
+lists; an MCP tool call takes one JSON object, so `owner.updateOne`'s
 `inputSchema` merges `id` directly into the DTO schema's own `properties`/
 `required` instead of nesting the DTO under an `input` key — one flat
 object a caller fills in once.

--- a/packages/frameworks/nest/tests/base-kavo-mcp.controller.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/base-kavo-mcp.controller.e2e.spec.ts
@@ -58,22 +58,22 @@ describe("BaseKavoMcpController", () => {
         .sort(),
     ).toEqual(
       [
-        "todo_createOne",
-        "todo_deleteOne",
-        "todo_findMany",
-        "todo_findOne",
-        "todo_patchOne",
-        "todo_purgeOne",
-        "todo_restoreOne",
-        "todo_updateOne",
+        "todo.createOne",
+        "todo.deleteOne",
+        "todo.findMany",
+        "todo.findOne",
+        "todo.patchOne",
+        "todo.purgeOne",
+        "todo.restoreOne",
+        "todo.updateOne",
       ].sort(),
     );
 
-    const created = await toolset.run("todo_createOne", { title: "from mcp", done: false });
+    const created = await toolset.run("todo.createOne", { title: "from mcp", done: false });
     expect(created.isError).toBeUndefined();
     expect(JSON.parse((created.content[0] as { text: string }).text)).toMatchObject({ title: "from mcp" });
 
-    const fetched = await toolset.run("todo_findOne", { id: 1 });
+    const fetched = await toolset.run("todo.findOne", { id: 1 });
     expect(JSON.parse((fetched.content[0] as { text: string }).text)).toMatchObject({ title: "from mcp" });
   });
 
@@ -88,7 +88,7 @@ describe("BaseKavoMcpController", () => {
     await app.init();
 
     const toolset = app.get(McpToolset);
-    const result = await toolset.run("todo_findOne", { id: 999 });
+    const result = await toolset.run("todo.findOne", { id: 999 });
     expect(result.isError).toBe(true);
     expect((result.content[0] as { text: string }).text).toContain("KAVO_NOT_FOUND");
   });

--- a/packages/frameworks/nest/tests/default-mcp-controller.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/default-mcp-controller.e2e.spec.ts
@@ -48,14 +48,14 @@ describe("KavoModule.forRoot({ mcp: true })", () => {
     const toolNames = (listed.body.result.tools as { name: string }[]).map((tool) => tool.name).sort();
     expect(toolNames).toEqual(
       [
-        "todo_createOne",
-        "todo_deleteOne",
-        "todo_findMany",
-        "todo_findOne",
-        "todo_patchOne",
-        "todo_purgeOne",
-        "todo_restoreOne",
-        "todo_updateOne",
+        "todo.createOne",
+        "todo.deleteOne",
+        "todo.findMany",
+        "todo.findOne",
+        "todo.patchOne",
+        "todo.purgeOne",
+        "todo.restoreOne",
+        "todo.updateOne",
       ].sort(),
     );
 
@@ -63,7 +63,7 @@ describe("KavoModule.forRoot({ mcp: true })", () => {
       jsonrpc: "2.0",
       id: 2,
       method: "tools/call",
-      params: { name: "todo_createOne", arguments: { title: "from mcp http", done: false } },
+      params: { name: "todo.createOne", arguments: { title: "from mcp http", done: false } },
     });
     expect(called.status).toBe(200);
     expect(called.body.result.isError).toBeUndefined();
@@ -86,14 +86,14 @@ describe("KavoModule.forRoot({ mcp: true })", () => {
     expect(listed.status).toBe(200);
     expect((listed.body.result.tools as { name: string }[]).map((tool) => tool.name).sort()).toEqual(
       [
-        "todo_createOne",
-        "todo_deleteOne",
-        "todo_findMany",
-        "todo_findOne",
-        "todo_patchOne",
-        "todo_purgeOne",
-        "todo_restoreOne",
-        "todo_updateOne",
+        "todo.createOne",
+        "todo.deleteOne",
+        "todo.findMany",
+        "todo.findOne",
+        "todo.patchOne",
+        "todo.purgeOne",
+        "todo.restoreOne",
+        "todo.updateOne",
       ].sort(),
     );
   });
@@ -123,7 +123,7 @@ describe("KavoModule.forRoot({ mcp: true })", () => {
       jsonrpc: "2.0",
       id: 1,
       method: "tools/call",
-      params: { name: "todo_findOne", arguments: { id: 999 } },
+      params: { name: "todo.findOne", arguments: { id: 999 } },
     });
     expect(called.status).toBe(200);
     expect(called.body.result.isError).toBe(true);

--- a/packages/protocols/mcp/src/tools.ts
+++ b/packages/protocols/mcp/src/tools.ts
@@ -36,7 +36,7 @@ export interface KavoMcpToolBinding {
 
 /** One entity's MCP binding options. */
 export interface KavoMcpToolsOptions<Entity extends object, Id extends EntityId, CreateDto, UpdateDto, PatchDto> {
-  /** Singular, capitalized entity name — becomes the `<lowerName>_<operation>` tool name prefix. */
+  /** Singular, capitalized entity name — becomes the `<lowerName>.<operation>` tool name prefix. */
   readonly name: string;
   readonly service: BoundKavoService<Entity, Id, CreateDto, UpdateDto, PatchDto>;
 }
@@ -116,12 +116,12 @@ export function crudTools<Entity extends object, Id extends EntityId, CreateDto,
 
   return [
     {
-      tool: { name: `${prefix}_findOne`, description: `Find one ${name} by id.`, inputSchema: idOnlySchema },
+      tool: { name: `${prefix}.findOne`, description: `Find one ${name} by id.`, inputSchema: idOnlySchema },
       handler: (args) => guarded(() => service.findOne(args["id"] as Id)),
     },
     {
       tool: {
-        name: `${prefix}_findMany`,
+        name: `${prefix}.findMany`,
         description: `List ${name} records, with optional pagination, sort, and filter.`,
         inputSchema: objectSchema(
           {
@@ -144,12 +144,12 @@ export function crudTools<Entity extends object, Id extends EntityId, CreateDto,
         ),
     },
     {
-      tool: { name: `${prefix}_createOne`, description: `Create a new ${name}.`, inputSchema: freeformObjectSchema },
+      tool: { name: `${prefix}.createOne`, description: `Create a new ${name}.`, inputSchema: freeformObjectSchema },
       handler: (args) => guarded(() => service.createOne(args as CreateDto)),
     },
     {
       tool: {
-        name: `${prefix}_updateOne`,
+        name: `${prefix}.updateOne`,
         description: `Replace an existing ${name} by id.`,
         inputSchema: idAndFreeformSchema,
       },
@@ -160,7 +160,7 @@ export function crudTools<Entity extends object, Id extends EntityId, CreateDto,
     },
     {
       tool: {
-        name: `${prefix}_patchOne`,
+        name: `${prefix}.patchOne`,
         description: `Partially update an existing ${name} by id.`,
         inputSchema: idAndFreeformSchema,
       },
@@ -170,7 +170,7 @@ export function crudTools<Entity extends object, Id extends EntityId, CreateDto,
       },
     },
     {
-      tool: { name: `${prefix}_deleteOne`, description: `Delete a ${name} by id.`, inputSchema: idOnlySchema },
+      tool: { name: `${prefix}.deleteOne`, description: `Delete a ${name} by id.`, inputSchema: idOnlySchema },
       handler: (args) =>
         guarded(async () => {
           await service.deleteOne(args["id"] as Id);
@@ -179,7 +179,7 @@ export function crudTools<Entity extends object, Id extends EntityId, CreateDto,
     },
     {
       tool: {
-        name: `${prefix}_restoreOne`,
+        name: `${prefix}.restoreOne`,
         description: `Restore a soft-deleted ${name} by id.`,
         inputSchema: idOnlySchema,
       },
@@ -187,7 +187,7 @@ export function crudTools<Entity extends object, Id extends EntityId, CreateDto,
     },
     {
       tool: {
-        name: `${prefix}_purgeOne`,
+        name: `${prefix}.purgeOne`,
         description: `Permanently delete a soft-deleted ${name} by id.`,
         inputSchema: idOnlySchema,
       },

--- a/packages/protocols/mcp/tests/discovery.spec.ts
+++ b/packages/protocols/mcp/tests/discovery.spec.ts
@@ -19,10 +19,10 @@ describe("resolveKavoMcpTools", () => {
     const services = new Map<unknown, unknown>([[Todo, todoService]]);
     const bindings = resolveKavoMcpTools([{ entity: Todo }], (entity) => services.get(entity) as never);
 
-    expect(bindings.map((binding) => binding.tool.name)).toContain("todo_findOne");
+    expect(bindings.map((binding) => binding.tool.name)).toContain("todo.findOne");
     expect(bindings.map((binding) => binding.tool.name)).toHaveLength(8);
 
-    const findOne = bindings.find((binding) => binding.tool.name === "todo_findOne");
+    const findOne = bindings.find((binding) => binding.tool.name === "todo.findOne");
     const result = await findOne!.handler({ id: 1 });
     expect(JSON.parse((result.content[0] as { text: string }).text)).toMatchObject({ title: "discovered" });
   });

--- a/packages/protocols/mcp/tests/mcp-tools.spec.ts
+++ b/packages/protocols/mcp/tests/mcp-tools.spec.ts
@@ -35,14 +35,14 @@ describe("crudTools", () => {
     const { bindings } = setup();
     expect(bindings.map((binding) => binding.tool.name).sort()).toEqual(
       [
-        "todo_createOne",
-        "todo_deleteOne",
-        "todo_findMany",
-        "todo_findOne",
-        "todo_patchOne",
-        "todo_purgeOne",
-        "todo_restoreOne",
-        "todo_updateOne",
+        "todo.createOne",
+        "todo.deleteOne",
+        "todo.findMany",
+        "todo.findOne",
+        "todo.patchOne",
+        "todo.purgeOne",
+        "todo.restoreOne",
+        "todo.updateOne",
       ].sort(),
     );
   });
@@ -50,7 +50,7 @@ describe("crudTools", () => {
   it("runs createOne then findOne through the same engine, returning JSON text content", async () => {
     const { bindings } = setup();
 
-    const created = await find(bindings, "todo_createOne").handler({ title: "write tests", done: false });
+    const created = await find(bindings, "todo.createOne").handler({ title: "write tests", done: false });
     expect(created.isError).toBeUndefined();
     expect(JSON.parse((created.content[0] as { text: string }).text)).toEqual({
       id: 1,
@@ -58,7 +58,7 @@ describe("crudTools", () => {
       done: false,
     });
 
-    const fetched = await find(bindings, "todo_findOne").handler({ id: 1 });
+    const fetched = await find(bindings, "todo.findOne").handler({ id: 1 });
     expect(JSON.parse((fetched.content[0] as { text: string }).text)).toMatchObject({ id: 1, title: "write tests" });
   });
 
@@ -66,7 +66,7 @@ describe("crudTools", () => {
     const { adapter, bindings } = setup();
     adapter.rows.push({ id: 1, title: "a", done: false }, { id: 2, title: "b", done: true });
 
-    const result = await find(bindings, "todo_findMany").handler({
+    const result = await find(bindings, "todo.findMany").handler({
       limit: 1,
       offset: 1,
       sort: ["-title"],
@@ -84,13 +84,13 @@ describe("crudTools", () => {
     const { adapter, bindings } = setup();
     adapter.rows.push({ id: 1, title: "before", done: false });
 
-    const updated = await find(bindings, "todo_updateOne").handler({ id: 1, title: "after", done: true });
+    const updated = await find(bindings, "todo.updateOne").handler({ id: 1, title: "after", done: true });
     expect(JSON.parse((updated.content[0] as { text: string }).text)).toMatchObject({ title: "after", done: true });
 
-    const patched = await find(bindings, "todo_patchOne").handler({ id: 1, done: false });
+    const patched = await find(bindings, "todo.patchOne").handler({ id: 1, done: false });
     expect(JSON.parse((patched.content[0] as { text: string }).text)).toMatchObject({ done: false });
 
-    const deleted = await find(bindings, "todo_deleteOne").handler({ id: 1 });
+    const deleted = await find(bindings, "todo.deleteOne").handler({ id: 1 });
     expect(JSON.parse((deleted.content[0] as { text: string }).text)).toEqual({ deleted: true });
     expect(adapter.rows).toHaveLength(0);
   });
@@ -98,7 +98,7 @@ describe("crudTools", () => {
   it("maps a KavoException (not found) to an isError tool result instead of throwing", async () => {
     const { bindings } = setup();
 
-    const result = await find(bindings, "todo_findOne").handler({ id: 999 });
+    const result = await find(bindings, "todo.findOne").handler({ id: 999 });
 
     expect(result.isError).toBe(true);
     expect((result.content[0] as { text: string }).text).toContain("KAVO_NOT_FOUND");
@@ -108,7 +108,7 @@ describe("crudTools", () => {
     const { adapter, bindings } = setup();
     adapter.rows.push({ id: 1, title: "a", done: false });
 
-    const restored = await find(bindings, "todo_restoreOne").handler({ id: 1 });
+    const restored = await find(bindings, "todo.restoreOne").handler({ id: 1 });
     expect(restored.isError).toBe(true);
   });
 
@@ -124,13 +124,13 @@ describe("crudTools", () => {
 
     const bindings = crudTools({ name: "Note", service });
 
-    const restored = await find(bindings, "note_restoreOne").handler({ id: created.id });
+    const restored = await find(bindings, "note.restoreOne").handler({ id: created.id });
     expect(JSON.parse((restored.content[0] as { text: string }).text)).toMatchObject({
       id: created.id,
       text: "keep me",
     });
 
-    const purged = await find(bindings, "note_purgeOne").handler({ id: created.id });
+    const purged = await find(bindings, "note.purgeOne").handler({ id: created.id });
     expect(JSON.parse((purged.content[0] as { text: string }).text)).toEqual({ purged: true });
     expect(adapter.rows).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- MCP tool names change from `<entity>_<operation>` to `<entity>.<operation>` (e.g. `book_findOne` → `book.findOne`).
- Updates `crudTools` in `packages/protocols/mcp/src/tools.ts`, its doc comment, `docs/internals/architecture/14-mcp-binding.md`, and all affected test expectations in `packages/protocols/mcp/tests` and `packages/frameworks/nest/tests`.

## Test plan
- [x] `pnpm check` passes (build, typecheck, depcruise, lint, test — 896 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)