### PR TITLE
docs: add CONTRIBUTING.md covering setup, the gate, and PR invariants

### DIFF
--- a/.claude/agents/kavo-test-auditor.md
+++ b/.claude/agents/kavo-test-auditor.md
@@ -19,8 +19,10 @@ enough that someone else can close them.
 - The SWC vitest plugin is required: TypeORM entities and Nest DI need
   decorator metadata that esbuild cannot emit. A test that mysteriously loses
   metadata is usually a transform problem, not a logic problem.
-- Run one file: `pnpm vitest run packages/core/tests/query/filter-parser.spec.ts`.
-  Run by name: `pnpm vitest run -t "coerces numeric ids"`.
+- Run one file: `pnpm vitest run packages/core/tests/filter-parser.spec.ts`.
+  Run by name: `pnpm vitest run -t "coerces JavaScript number syntax"`. A `-t`
+  filter matching nothing skips every test and still exits 0 — check the passed
+  count, not the exit code.
 
 ## Procedure
 

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -20,7 +20,7 @@ description: How to write tests for the Kavo monorepo — file placement, Vitest
 ```bash
 pnpm test                                                    # whole monorepo
 pnpm vitest run packages/core/tests/filter-parser.spec.ts    # one file
-pnpm vitest run -t "coerces numeric ids"                     # one test by name
+pnpm vitest run -t "coerces JavaScript number syntax"        # one test by name
 ```
 
 ## Reuse the fixtures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Run a single test file or test by name:
 
 ```bash
 pnpm vitest run packages/core/tests/filter-parser.spec.ts
-pnpm vitest run -t "coerces numeric ids"
+pnpm vitest run -t "coerces JavaScript number syntax"
 ```
 
 Tests live in each package's `tests/` directory (never in `src/`, so they are not shipped in `dist/`). Vitest aliases `@kavo/*` to package `src/` directly (see `vitest.config.ts`), so tests exercise sources with no stale-`dist` hazard. The SWC vitest plugin is required — TypeORM entities and Nest DI need decorator metadata that esbuild cannot emit.
@@ -48,7 +48,7 @@ Five packages in a strict hub-and-spoke topology (`pnpm-workspace.yaml`):
 - **`@kavo/prisma`** (`packages/orms/prisma`) — the same seams over a Prisma Client delegate, fed from Prisma's DMMF. Needs caller-declared marker classes as entity identities (ADR-0017). `@prisma/client` is a peer dependency.
 - **`@kavo/mongoose`** (`packages/orms/mongoose`) — the same seams over a Mongoose model, fed from `schema.paths`. A Mongoose model _is_ the entity identity, so nothing is declared twice, and `ObjectId` converts to a hex string at the adapter boundary (ADR-0018). `mongoose` is a peer dependency.
 - **`@kavo/nest`** (`packages/frameworks/nest`) — the `@Kavo` decorator and NestJS route generation.
-- **`@kavo/graphql`** (`packages/protocols/graphql`) — host-framework-agnostic GraphQL schema binding: builds a schema over a `createCrud` service, delegating every resolver to the same engine REST uses. Depends only on `@kavo/core` and the `graphql` peer; `@kavo/nest` optionally wires it in (`BaseKavoGraphQLController`) via DI, never via a direct import.
+- **`@kavo/graphql`** (`packages/protocols/graphql`) — host-framework-agnostic GraphQL schema binding: builds a schema over a `createCrud` service, delegating every resolver to the same engine REST uses. Depends only on `@kavo/core` and the `graphql` peer, never on `@kavo/nest` — the `frameworks/* → protocols/*` edge is one-directional (ADR-0016). `@kavo/nest` is the side that imports it, to provide `BaseKavoGraphQLController`; it does so through a lazy `import("@kavo/graphql")` so the peer stays genuinely optional.
 
 These boundaries are **mechanically enforced** by `.dependency-cruiser.cjs`, not just convention: core may import nothing, adapters/protocol bindings/framework bindings import the `@kavo/core` barrel only (no deep imports), and spokes never import each other directly — they meet only through Nest's DI container. An illegal import fails `pnpm depcruise` (part of `pnpm check`), not code review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,296 @@
+# Contributing to Kavo
+
+Thanks for considering a contribution. This document covers getting a working
+checkout, the one gate every change has to pass, and the invariants that will
+get a PR sent back if a change breaks them.
+
+If something here is wrong or out of date, that is a bug — please open an issue.
+
+## Prerequisites
+
+| Requirement | Version            | Notes                                            |
+| ----------- | ------------------ | ------------------------------------------------ |
+| Node        | `>=20`             | Matches `engines` in the root `package.json`     |
+| pnpm        | `9.15.0`           | Pinned by `packageManager`; easiest via Corepack |
+| Docker      | Any recent version | Must be **running** — see below                  |
+
+pnpm is pinned, so let Corepack pick the right version rather than installing it
+globally:
+
+```bash
+corepack enable
+```
+
+Docker is not optional. Three test suites provision a real database with
+[Testcontainers](https://testcontainers.com/) rather than mocking one:
+
+- `examples/nest-typeorm/tests/app-postgres.e2e.spec.ts` — Postgres
+- `examples/nest-typeorm/tests/app-mariadb.e2e.spec.ts` — MariaDB
+- `examples/nest-mongoose/tests/app-mongo.e2e.spec.ts` — MongoDB
+
+They start their own containers and need no manual database setup, but they do
+need a Docker daemon the current user can talk to. Without one, `pnpm check`
+fails in those suites.
+
+## Getting set up
+
+```bash
+pnpm install
+pnpm generate   # generates Prisma Client + pushes the test-fixture schema
+pnpm build
+```
+
+`pnpm generate` builds `@kavo/prisma`'s **test fixtures** — it runs
+`prisma generate` and `prisma db push` against
+`packages/orms/prisma/prisma/schema.prisma`. It needs no configuration: the
+fixture schema is SQLite, and `packages/orms/prisma/prisma/.env` is committed
+with a working `DATABASE_URL`.
+
+Note what it is _not_ for. `@kavo/prisma`'s own `src` never imports
+`@prisma/client` — it models the client structurally in
+`prisma-client-like.ts`, precisely so a library package does not assume the
+consumer has run `prisma generate`. So `pnpm build` works without it; it is
+`pnpm typecheck` and `pnpm test` that need it, because the test fixtures import
+a real generated `PrismaClient` and read the pushed SQLite file. That is why
+`generate` runs first in `pnpm check`.
+
+## The gate
+
+One command decides whether a change is shippable:
+
+```bash
+pnpm check
+```
+
+It runs, in order:
+
+| Step        | Command                         | What it enforces                                    |
+| ----------- | ------------------------------- | --------------------------------------------------- |
+| `generate`  | Prisma client + fixture schema  | `@kavo/prisma`'s test fixtures exist                |
+| `build`     | `tsc -b`                        | Every package's `src` compiles (project references) |
+| `typecheck` | `tsc -p **/tsconfig.tests.json` | Tests compile, including the type-level tests       |
+| `depcruise` | `dependency-cruiser`            | Package boundaries (see [Invariants](#invariants))  |
+| `lint`      | `oxlint`                        | Lint rules over `packages` and `examples`           |
+| `test`      | `vitest run`                    | The whole suite                                     |
+
+**The gate is never worked around.** A red `pnpm check` is not shipped, and a
+test is never weakened, skipped, or narrowed to make it pass. If a change makes
+a test fail, either the change is wrong or the test encoded a behavior that is
+being deliberately changed — and the second case belongs in the PR description.
+
+CI runs the identical gate on three Node versions (`lts/-1`, `lts/*`,
+`current`), plus a separate formatting job. Before pushing:
+
+```bash
+pnpm prettify      # writes formatting fixes
+pnpm format:check  # what CI actually runs
+```
+
+## Running tests
+
+The full suite is `pnpm test`. While iterating, narrow it:
+
+```bash
+pnpm vitest run packages/core/tests/filter-parser.spec.ts   # one file
+pnpm vitest run -t "coerces numeric ids"                    # one test by name
+```
+
+A few things about the test setup that are easy to trip over:
+
+- **Tests live in each package's `tests/` directory, never in `src/`.** The
+  build compiles `src` only, which is what keeps tests out of the published
+  `dist/`.
+- **Tests import package sources, not build output.** `vitest.config.ts` aliases
+  every `@kavo/*` specifier to that package's `src/index.ts`, so there is no
+  stale-`dist` hazard and no need to rebuild between test runs.
+- **The SWC transform is required.** TypeORM entities and Nest DI rely on
+  decorator metadata, which vitest's default esbuild transform cannot emit. That
+  is why `unplugin-swc` is in the vitest config — don't remove it.
+- **`*.test-d.ts` files are type-level tests and never execute.** Vitest does not
+  collect them; `pnpm typecheck` is what verifies them, via each package's
+  `tsconfig.tests.json`. They assert with `expectTypeOf` and `@ts-expect-error`,
+  and because an _unused_ `@ts-expect-error` is itself a compile error, they fail
+  in both directions. Adding one without running `pnpm typecheck` proves nothing.
+
+## How the repo is laid out
+
+Seven published packages in a strict hub-and-spoke topology:
+
+| Package                                       | Path                         | Role                                       |
+| --------------------------------------------- | ---------------------------- | ------------------------------------------ |
+| [`@kavo/core`](packages/core)                 | `packages/core`              | Contracts, type system, request engine     |
+| [`@kavo/typeorm`](packages/orms/typeorm)      | `packages/orms/typeorm`      | TypeORM adapter                            |
+| [`@kavo/prisma`](packages/orms/prisma)        | `packages/orms/prisma`       | Prisma adapter                             |
+| [`@kavo/mongoose`](packages/orms/mongoose)    | `packages/orms/mongoose`     | Mongoose adapter                           |
+| [`@kavo/nest`](packages/frameworks/nest)      | `packages/frameworks/nest`   | NestJS binding — `@Kavo`, route generation |
+| [`@kavo/graphql`](packages/protocols/graphql) | `packages/protocols/graphql` | GraphQL schema binding                     |
+| [`@kavo/mcp`](packages/protocols/mcp)         | `packages/protocols/mcp`     | MCP binding — entities as MCP tools        |
+
+Plus, not published:
+
+- `examples/` — runnable reference apps (`nest-typeorm`, `nest-mongoose`) that
+  double as the e2e suites.
+- `extensions/` — Claude Code skills shipped as a plugin via this repo's own
+  marketplace.
+- `docs/` — the VitePress site, and the internal design docs and ADRs.
+
+`@kavo/core` is the hub. Every spoke depends on core and on nothing else in the
+workspace; spokes never import each other, and meet only through the host
+framework's DI container.
+
+## Invariants
+
+These are enforced, not merely encouraged. Each links to the decision record
+that explains why.
+
+- **Core imports nothing and has zero runtime dependencies** —
+  [ADR-0005](docs/internals/adr/0005-core-zero-runtime-dependencies.md). Core has
+  no knowledge of TypeORM, Prisma, Mongoose, or Nest.
+- **Dependency inversion is strict: spokes depend on core, core never depends on
+  an edge** — [ADR-0001](docs/internals/adr/0001-clean-architecture-core-owns-contracts.md).
+  In practice that means adapters, framework bindings, and protocol bindings
+  import the `@kavo/core` barrel only — no deep imports into another package's
+  internals, and no spoke-to-spoke imports. Spokes meet through the host
+  framework's DI container, never through a direct import. (Where those packages
+  live on disk — `orms/`, `frameworks/`, `protocols/` — is
+  [ADR-0002](docs/internals/adr/0002-package-topology.md).)
+- **The core barrel is an explicit named list** —
+  [ADR-0010](docs/internals/adr/0010-explicit-named-barrel.md).
+  `packages/core/src/index.ts` uses no `export *`, so the public surface changes
+  only on purpose. Adding an export there is a deliberate API decision and
+  belongs in the PR's "Public API impact" section.
+- **Operations are registry-driven** —
+  [ADR-0006](docs/internals/adr/0006-registry-driven-operations.md). The engine
+  loops over registry entries and special-cases no verb. Adding an operation
+  means adding a registry entry, not adding a branch.
+- **Nest routes are generated at decoration time** —
+  [ADR-0012](docs/internals/adr/0012-decoration-time-route-generation.md).
+  Class-definition time is the only moment Nest's router scan can see generated
+  methods.
+
+The first two are checked mechanically by `.dependency-cruiser.cjs` — an illegal
+import fails `pnpm depcruise`, which is part of `pnpm check`. It will name the
+violated rule (`core-imports-nothing`, `nest-only-imports-core`,
+`no-cross-package-deep-imports-core`, and so on).
+
+The others are checked in review. Before changing behavior an ADR governs, read
+that ADR — several are referenced by name from code comments.
+
+## When to write an ADR
+
+Write one when a change makes a load-bearing decision: a new seam, a new
+invariant, a boundary rule, a rule about how packages relate. Do not write one
+for a change that merely implements a decision already on record.
+
+ADRs live in [`docs/internals/adr/`](docs/internals/adr/), numbered sequentially.
+Read a couple of neighbours before writing one — they argue a decision once, so
+it does not get re-argued in every later review.
+
+## Naming conventions
+
+Kavo's naming rules are normative and reviewed. Rather than restate them here in
+a second place that can drift, read them at the source:
+
+- The **Conventions** section of [`CLAUDE.md`](CLAUDE.md) — DTO slots and class
+  names, operation naming (`<verb>One` / `<verb>Many`), envelope fields, factory
+  and data-access naming, exception naming, config keys, and the no-`I`-prefix
+  rule.
+- [`docs/internals/architecture/05-query-grammar.md`](docs/internals/architecture/05-query-grammar.md)
+  — the single source of truth for filter operators, including the mapping
+  between the `SCREAMING_SNAKE` AST enum and the camelCase wire tokens.
+
+## Branches and commits
+
+One `type` vocabulary is shared across an issue's label, its branch prefix, and
+its commit messages:
+
+| Type       | Meaning                                | Issue label     |
+| ---------- | -------------------------------------- | --------------- |
+| `feat`     | New capability                         | `type:feat`     |
+| `fix`      | Bug fix                                | `type:fix`      |
+| `chore`    | Tooling, deps, housekeeping            | `type:chore`    |
+| `test`     | Test coverage work                     | `type:test`     |
+| `docs`     | Documentation                          | `type:docs`     |
+| `refactor` | Code restructuring, no behavior change | `type:refactor` |
+| `perf`     | Performance improvements               | `type:perf`     |
+| `ci`       | CI/build pipeline changes              | `type:ci`       |
+
+Branch off an up-to-date `main`, naming the branch
+`<type>/<issue-number>-<short-slug>`:
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/123-cursor-pagination
+```
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+using the same vocabulary: `<type>(<scope>): <subject>`, e.g.
+`feat(core): add cursor pagination`. Scope is optional but preferred when the
+change is package-scoped. Keep the subject under about 72 characters and in the
+imperative mood; add a body only when the "why" isn't obvious from the subject.
+
+## Pull requests
+
+1. **Open or claim an issue first.** It is where the acceptance criteria get
+   agreed, and it keeps a PR from being reviewed against a guess at its goal.
+2. **Branch off `main`** using the naming above.
+3. **Write tests alongside the code**, not after. Cover the error and edge
+   paths, and assert exception _codes_ rather than only messages. A bugfix
+   should come with a regression test that fails without the fix.
+4. **Run `pnpm check` and `pnpm format:check`** and make them genuinely pass.
+5. **Fill in the PR template.** The "Public API impact" section is not deleted
+   when there is nothing to report — write `None`. Reviewers rely on it to spot
+   unintended changes to `packages/core/src/index.ts`.
+6. **Reference the issue** with `Closes #<n>`.
+7. **Green CI, then squash merge.**
+
+Update the docs in the same PR when a change alters behavior that an ADR or a
+`docs/internals/architecture/` document describes. Docs drifting from code is a
+review finding, not a follow-up.
+
+## Working on the docs
+
+The site is [VitePress](https://vitepress.dev/):
+
+```bash
+pnpm docs:dev      # local dev server with hot reload
+pnpm docs:build    # production build
+pnpm docs:preview  # serve the production build
+```
+
+`docs/` has two audiences, and it is worth keeping them separate:
+
+- **Adopter-facing** — [`docs/getting-started.md`](docs/getting-started.md),
+  [`docs/using-the-api.md`](docs/using-the-api.md), and
+  [`docs/integrations/`](docs/integrations/). Written for someone building an app
+  with Kavo.
+- **Internal** — [`docs/internals/`](docs/internals/), holding the architecture
+  documents and ADRs. Written for someone changing Kavo itself.
+
+## Releases
+
+Versioning is **lockstep**: every `@kavo/*` package ships at the same version
+([ADR-0004](docs/internals/adr/0004-lockstep-versioning.md)).
+
+Contributors do not bump versions. Releases are cut by maintainers, who push a
+`vX.Y.Z` tag that triggers the publish workflow. A PR that edits a package's
+`version` field will be asked to drop that change.
+
+## Working with Claude Code
+
+Kavo is developed with [Claude Code](https://claude.com/claude-code), and the
+wiring is committed:
+
+- `.claude/commands/` — the issue → implement → review → commit → PR → merge
+  workflow as slash commands.
+- `.claude/agents/` — read-only review agents used in the review fan-out.
+- `.claude/skills/` — repo-specific procedures (adding an operation, a config
+  key, an exception, an ADR).
+
+None of this is required to contribute — the commands above are the whole story,
+and a PR is judged on its diff and a green gate either way.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[Apache License 2.0](LICENSE), the same license that covers the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,14 +64,20 @@ pnpm check
 
 It runs, in order:
 
-| Step        | Command                         | What it enforces                                    |
-| ----------- | ------------------------------- | --------------------------------------------------- |
-| `generate`  | Prisma client + fixture schema  | `@kavo/prisma`'s test fixtures exist                |
-| `build`     | `tsc -b`                        | Every package's `src` compiles (project references) |
-| `typecheck` | `tsc -p **/tsconfig.tests.json` | Tests compile, including the type-level tests       |
-| `depcruise` | `dependency-cruiser`            | Package boundaries (see [Invariants](#invariants))  |
-| `lint`      | `oxlint`                        | Lint rules over `packages` and `examples`           |
-| `test`      | `vitest run`                    | The whole suite                                     |
+| Step        | Command                        | What it enforces                                    |
+| ----------- | ------------------------------ | --------------------------------------------------- |
+| `generate`  | Prisma client + fixture schema | `@kavo/prisma`'s test fixtures exist                |
+| `build`     | `tsc -b`                       | Every package's `src` compiles (project references) |
+| `typecheck` | one `tsc -p` per project       | Tests compile, including the type-level tests       |
+| `depcruise` | `dependency-cruiser`           | Package boundaries (see [Invariants](#invariants))  |
+| `lint`      | `oxlint`                       | Lint rules over `packages` and `examples`           |
+| `test`      | `vitest run`                   | The whole suite                                     |
+
+Note that `typecheck` is a hand-maintained list — the root script names each
+project's `tsconfig.tests.json` explicitly, with no glob and no discovery. **If
+you add a package, or add a first `tests/` directory to one, append it to the
+root `typecheck` script yourself**, or its tests are silently never typechecked
+and the `*.test-d.ts` guarantee below does not hold for it.
 
 **The gate is never worked around.** A red `pnpm check` is not shipped, and a
 test is never weakened, skipped, or narrowed to make it pass. If a change makes
@@ -91,9 +97,14 @@ pnpm format:check  # what CI actually runs
 The full suite is `pnpm test`. While iterating, narrow it:
 
 ```bash
-pnpm vitest run packages/core/tests/filter-parser.spec.ts   # one file
-pnpm vitest run -t "coerces numeric ids"                    # one test by name
+pnpm vitest run packages/core/tests/filter-parser.spec.ts          # one file
+pnpm vitest run -t "coerces JavaScript number syntax"              # one test by name
 ```
+
+`-t` is a substring match against the test title, and a filter that matches
+nothing **skips every test and still exits 0**. A green run is only meaningful
+if the summary line shows tests actually ran — check the passed count, not the
+exit code.
 
 A few things about the test setup that are easy to trip over:
 
@@ -134,9 +145,10 @@ Plus, not published:
   marketplace.
 - `docs/` — the VitePress site, and the internal design docs and ADRs.
 
-`@kavo/core` is the hub. Every spoke depends on core and on nothing else in the
-workspace; spokes never import each other, and meet only through the host
-framework's DI container.
+`@kavo/core` is the hub: it depends on nothing, and everything else depends on
+it. The edges are not all equivalent, though — ORM adapters and protocol
+bindings are leaves, while a framework binding is allowed one sideways edge. See
+[Invariants](#invariants) for the exact directions.
 
 ## Invariants
 
@@ -146,14 +158,31 @@ that explains why.
 - **Core imports nothing and has zero runtime dependencies** —
   [ADR-0005](docs/internals/adr/0005-core-zero-runtime-dependencies.md). Core has
   no knowledge of TypeORM, Prisma, Mongoose, or Nest.
-- **Dependency inversion is strict: spokes depend on core, core never depends on
-  an edge** — [ADR-0001](docs/internals/adr/0001-clean-architecture-core-owns-contracts.md).
-  In practice that means adapters, framework bindings, and protocol bindings
-  import the `@kavo/core` barrel only — no deep imports into another package's
-  internals, and no spoke-to-spoke imports. Spokes meet through the host
-  framework's DI container, never through a direct import. (Where those packages
-  live on disk — `orms/`, `frameworks/`, `protocols/` — is
-  [ADR-0002](docs/internals/adr/0002-package-topology.md).)
+- **Dependency inversion is strict: core never depends on an edge** —
+  [ADR-0001](docs/internals/adr/0001-clean-architecture-core-owns-contracts.md).
+  Beyond that, the allowed directions are specific, and it is worth learning them
+  precisely rather than as "nothing imports anything":
+
+  | Package kind                        | May import                         | Never imports                   |
+  | ----------------------------------- | ---------------------------------- | ------------------------------- |
+  | `@kavo/core`                        | nothing                            | anything                        |
+  | ORM adapters (`orms/*`)             | the `@kavo/core` barrel            | a framework or protocol binding |
+  | Protocol bindings (`protocols/*`)   | the `@kavo/core` barrel            | a framework binding             |
+  | Framework bindings (`frameworks/*`) | core **and its own protocol glue** | an ORM adapter                  |
+
+  So `@kavo/nest` really does import `@kavo/graphql` and `@kavo/mcp` directly —
+  that is the sanctioned `frameworks/* → protocols/*` edge from
+  [ADR-0016](docs/internals/adr/0016-graphql-protocols-package.md), and it is
+  one-directional: a protocol binding never imports `@kavo/nest` back, which is
+  what keeps it host-framework-agnostic. What is genuinely forbidden is a
+  framework binding importing an **ORM adapter** — adapters reach Nest's
+  container through DI, never through an import.
+
+  Deep imports into another package's internals are rejected in every direction;
+  packages meet at the `@kavo/core` barrel. (Where packages live on disk is
+  [ADR-0002](docs/internals/adr/0002-package-topology.md) for `orms/` and
+  `frameworks/`, and ADR-0016 for `protocols/`.)
+
 - **The core barrel is an explicit named list** —
   [ADR-0010](docs/internals/adr/0010-explicit-named-barrel.md).
   `packages/core/src/index.ts` uses no `export *`, so the public surface changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,11 @@ They start their own containers and need no manual database setup, but they do
 need a Docker daemon the current user can talk to. Without one, `pnpm check`
 fails in those suites.
 
+Network access matters too, at least on a cold checkout: `@kavo/mongoose`'s unit
+tests and the `nest-mongoose` example use `mongodb-memory-server`, which
+downloads a `mongod` binary on first use and caches it. On a restricted network
+that download fails with an error that has nothing to do with Docker.
+
 ## Getting set up
 
 ```bash
@@ -92,6 +97,12 @@ pnpm prettify      # writes formatting fixes
 pnpm format:check  # what CI actually runs
 ```
 
+One thing the gate does **not** cover: CI installs with
+`pnpm install --frozen-lockfile` _before_ running it, and neither `pnpm check`
+nor `pnpm format:check` validates `pnpm-lock.yaml`. If you add, remove, or bump
+a dependency, commit the regenerated lockfile — otherwise CI fails at the install
+step, before the gate you verified locally ever runs.
+
 ## Running tests
 
 The full suite is `pnpm test`. While iterating, narrow it:
@@ -101,10 +112,15 @@ pnpm vitest run packages/core/tests/filter-parser.spec.ts          # one file
 pnpm vitest run -t "coerces JavaScript number syntax"              # one test by name
 ```
 
-`-t` is a substring match against the test title, and a filter that matches
-nothing **skips every test and still exits 0**. A green run is only meaningful
-if the summary line shows tests actually ran — check the passed count, not the
-exit code.
+`-t` takes a **regular expression** (`--testNamePattern`), matched unanchored
+against the full test name. A plain string therefore behaves like a substring
+search, but a title copied verbatim from a spec file that contains `(`, `)`,
+`[`, `.`, `+`, or `|` will not match itself — escape those or pick a plainer
+fragment.
+
+Either way, a filter that matches nothing **skips every test and still exits 0**.
+A green run is only meaningful if the summary line shows tests actually ran —
+check the passed count, not the exit code.
 
 A few things about the test setup that are easy to trip over:
 
@@ -163,12 +179,16 @@ that explains why.
   Beyond that, the allowed directions are specific, and it is worth learning them
   precisely rather than as "nothing imports anything":
 
-  | Package kind                        | May import                         | Never imports                   |
-  | ----------------------------------- | ---------------------------------- | ------------------------------- |
-  | `@kavo/core`                        | nothing                            | anything                        |
-  | ORM adapters (`orms/*`)             | the `@kavo/core` barrel            | a framework or protocol binding |
-  | Protocol bindings (`protocols/*`)   | the `@kavo/core` barrel            | a framework binding             |
-  | Framework bindings (`frameworks/*`) | core **and its own protocol glue** | an ORM adapter                  |
+  | Package kind                        | May import                         | Never imports                   | Blocked by                     |
+  | ----------------------------------- | ---------------------------------- | ------------------------------- | ------------------------------ |
+  | `@kavo/core`                        | nothing                            | anything                        | `core-imports-nothing`         |
+  | ORM adapters (`orms/*`)             | the `@kavo/core` barrel            | a framework or protocol binding | `<orm>-only-imports-core`\*    |
+  | Protocol bindings (`protocols/*`)   | the `@kavo/core` barrel            | a framework binding             | `<protocol>-only-imports-core` |
+  | Framework bindings (`frameworks/*`) | core **and its own protocol glue** | an ORM adapter                  | `nest-only-imports-core`       |
+
+  \* The adapter rules currently block only framework packages. An adapter
+  importing a _protocol_ package would pass `pnpm depcruise` today — it is
+  still wrong, and review is what catches it.
 
   So `@kavo/nest` really does import `@kavo/graphql` and `@kavo/mcp` directly —
   that is the sanctioned `frameworks/* → protocols/*` edge from
@@ -178,8 +198,12 @@ that explains why.
   framework binding importing an **ORM adapter** — adapters reach Nest's
   container through DI, never through an import.
 
-  Deep imports into another package's internals are rejected in every direction;
-  packages meet at the `@kavo/core` barrel. (Where packages live on disk is
+  Packages meet at the `@kavo/core` barrel rather than reaching into each
+  other's `src/`. Two rules enforce that around core specifically —
+  `no-cross-package-deep-imports-core` (an edge deep-importing core) and
+  `no-cross-package-deep-imports-adapters` (core deep-importing an edge) — so an
+  edge-to-edge deep import is convention held up by review, not by the gate.
+  (Where packages live on disk is
   [ADR-0002](docs/internals/adr/0002-package-topology.md) for `orms/` and
   `frameworks/`, and ADR-0016 for `protocols/`.)
 
@@ -197,10 +221,11 @@ that explains why.
   Class-definition time is the only moment Nest's router scan can see generated
   methods.
 
-The first two are checked mechanically by `.dependency-cruiser.cjs` — an illegal
-import fails `pnpm depcruise`, which is part of `pnpm check`. It will name the
-violated rule (`core-imports-nothing`, `nest-only-imports-core`,
-`no-cross-package-deep-imports-core`, and so on).
+The first two are checked by `.dependency-cruiser.cjs` — an illegal import fails
+`pnpm depcruise`, which is part of `pnpm check`, and the error names the violated
+rule. Read that file before assuming a boundary is machine-checked: as the two
+notes above show, its coverage is deliberately narrower than the invariants it
+supports, so a green `depcruise` is not proof a change respects them.
 
 The others are checked in review. Before changing behavior an ADR governs, read
 that ADR — several are referenced by name from code comments.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,10 @@ Fewer tokens, ship faster.
 
 Pick the ORM and framework/protocol bindings you need; `@kavo/core` has zero
 runtime dependencies.
+
+## Contributing
+
+Bug reports, issues, and pull requests are welcome.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) covers getting a working checkout, the
+`pnpm check` gate every change has to pass, and the architectural invariants a
+PR needs to respect.


### PR DESCRIPTION
## What & why

Adds a root `CONTRIBUTING.md`. The repo had an issue template, a PR template, CI,
and a documented internal workflow, but nothing that takes an outside contributor
from `git clone` to a green `pnpm check`.

It covers the things that silently cost a first-timer an afternoon: `pnpm check`
needs `pnpm generate` to have run, three e2e suites provision real databases via
Testcontainers and so need a Docker daemon, tests live in `tests/` and never in
`src/`, `*.test-d.ts` files are verified by `tsc` rather than executed, and
`.dependency-cruiser.cjs` rejects imports that look perfectly reasonable.

Naming conventions and the filter-operator grammar are **linked, not restated**,
so this file cannot drift from `CLAUDE.md` or from
`docs/internals/architecture/05-query-grammar.md`.

`README.md` gains a short Contributing section pointing at it.

Closes #79

## Public API impact

None. No `@kavo/*` package source is touched.

## Testing

No tests added; docs-only change with no runtime surface.

`pnpm check` — **green**: 54 test files, 896 tests, depcruise clean (242 modules,
854 dependencies). `pnpm format:check` — green. All relative links in
`CONTRIBUTING.md` verified to resolve.

## Review round — three errors found and fixed

A review pass caught three factual errors in the first draft. All were verified
against the tree before fixing, and all are now corrected in `c7f49e4`:

**1. The package-boundary rule was wrong (blocking).** The draft said spokes
"never import each other, and meet only through the host framework's DI
container". False: `packages/frameworks/nest/package.json` declares
`@kavo/graphql` and `@kavo/mcp` under `dependencies`, and
`src/mcp/base-kavo-mcp.controller.ts:4` imports `resolveKavoMcpTools` statically.
That edge is sanctioned — ADR-0016 states framework packages "may depend on a
protocol package to build framework-specific glue … but never the reverse", and
`nest-only-imports-core` blocks nest from **ORM adapters** only. The stronger
claim would have pushed contributors into needless DI indirection, or produced
review findings filed against correct code, while burying the rule that is
actually load-bearing. Replaced with a four-row table giving the real permitted
direction per package kind.

**2. ADR-0002 was cited for the `protocols/` folder (blocking).** It does not
establish it — ADR-0016 does, and opens by noting ADR-0002 "never had to answer"
that question. Citation split.

**3. A documented test filter matched nothing (blocking).**
`pnpm vitest run -t "coerces numeric ids"` names no test in the repo. Verified:
it **skips all 896 tests and exits 0**. A contributor adapting that pattern gets
a green run over zero executed tests and concludes their change is covered.
Replaced with a filter that matches (verified: 1 passed), plus an explicit note
that `-t` is substring-matched and a non-matching filter is silently green.

Also corrected: the gate table showed `tsc -p **/tsconfig.tests.json`, which is
not runnable — the real script is nine hand-written invocations, so a new package
is silently never typechecked unless appended by hand. The doc now says so.

### Wiring fixes (`691e230`)

Errors 1 and 3 both **originated in this repo's own instructions**, so fixing
only the contributor-facing copy would leave the source to re-seed them:

- `CLAUDE.md`, `.claude/skills/write-tests/SKILL.md`, and
  `.claude/agents/kavo-test-auditor.md` all carried the dead
  `-t "coerces numeric ids"` example — i.e. it sat in exactly the places an agent
  copies from. Fixed in all three.
- `.claude/agents/kavo-test-auditor.md` also cited
  `packages/core/tests/query/filter-parser.spec.ts`, which does not exist.
- `CLAUDE.md` said `@kavo/nest` wires GraphQL in "via DI, never via a direct
  import" — it is a direct (lazy) import, with `@kavo/graphql` under
  `dependencies`. Reworded to state the real invariant: the direction is
  one-way, protocols never import frameworks back.

## Review notes

Worth checking hardest: the **Prisma** claims. `@kavo/prisma`'s `src` models the
client structurally in `prisma-client-like.ts` specifically so a library package
need not assume `prisma generate` ran, so `pnpm build` works without it — it is
`typecheck` and `test` that need it. An earlier draft asserted the opposite.

Two corrections to issue #79 itself, made deliberately rather than copied: it
said six packages (`@kavo/mcp` landed after it was drafted, so the table lists
**seven**), and it cited ADR-0002 for the barrel rule when the dependency-
inversion rule is **ADR-0001**.

### Known, out of scope

- **Lockstep drift**: `@kavo/prisma` is at `0.5.0` while the other six are at
  `0.6.0`, contradicting ADR-0004. `publish.yml` only checks the pushed tag
  against `packages/core/package.json`, so a `v0.6.0` tag would publish
  `@kavo/prisma@0.5.0` without complaint. Pre-existing; deserves its own issue.
- **Suite flakiness**: full-suite runs fail intermittently with a different test
  each time, concentrated in the container-backed e2e suites. Several runs since
  have been clean, including every gate run for this PR. Pre-existing on `main`
  and unrelated to a docs-only diff; also deserves its own issue.
