### PR TITLE
chore: fix stale package lists and label metadata across the repo wiring

### DIFF
--- a/.claude/agents/kavo-reviewer.md
+++ b/.claude/agents/kavo-reviewer.md
@@ -64,11 +64,13 @@ and doc sync.
 
 ```
 @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
-                ▲ ▲ ▲ ▲
-                │ │ │ └───── @kavo/prisma
-                │ │ └─────── @kavo/mongoose
-                │ └───────── @kavo/mcp
-                └─────────── @kavo/graphql
+   │            ▲ ▲ ▲ ▲
+   │            │ │ │ └───── @kavo/prisma
+   │            │ │ └─────── @kavo/mongoose
+   │            │ └───────── @kavo/mcp     ◀─┐
+   │            └─────────── @kavo/graphql ◀─┤
+   └──────────── the one sanctioned sideways edge ──┘
+                 (frameworks/* → protocols/*, ADR-0016)
 ```
 
 - **`@kavo/core` imports nothing** — zero runtime dependencies (ADR-0005).
@@ -78,13 +80,30 @@ and doc sync.
   `@kavo/mongoose`, `@kavo/nest`, `@kavo/graphql`, `@kavo/mcp`) imports from
   the `@kavo/core` barrel. Any `@kavo/core/src/...` or relative reach into
   core's internals is a violation.
-- **The spokes never meet** — no ORM adapter may import a framework or
-  protocol binding, and neither `@kavo/graphql` nor `@kavo/mcp` may import
-  `@kavo/nest` back (ADR-0016). The one permitted spoke-to-spoke edge is
+- **The spokes mostly never meet** — the one sanctioned sideways edge is
   `@kavo/nest` → the protocol packages, for its `BaseKavoGraphQLController` /
-  `BaseKavoMcpController` glue, and it is one-directional. Everything else
-  composes only through Nest's DI container. `.dependency-cruiser.cjs` is the
-  precise statement of this — read the rule, don't infer it.
+  `BaseKavoMcpController` glue, and it is one-directional: a protocol binding
+  never imports `@kavo/nest` back (ADR-0016), which is what keeps it
+  host-framework-agnostic. A framework binding importing an **ORM adapter** is
+  genuinely forbidden — adapters reach Nest's container through DI, never an
+  import. Know which half of this the gate actually holds up, because they are
+  not the same:
+
+  | Edge                     | Enforced by                    |
+  | ------------------------ | ------------------------------ |
+  | ORM → framework          | `<orm>-only-imports-core`      |
+  | protocol → ORM/framework | `<protocol>-only-imports-core` |
+  | framework → ORM          | `nest-only-imports-core`       |
+  | **ORM → protocol**       | **nothing — review only**      |
+  | **protocol → protocol**  | **nothing — review only**      |
+
+  The last two rows are the trap. `packages/orms/*/src` importing
+  `@kavo/graphql` or `@kavo/mcp`, or `@kavo/graphql` importing `@kavo/mcp`,
+  **passes `pnpm depcruise` today** — the adapter rules' `to` covers
+  `packages/frameworks` only, and the protocol rules omit each other. Still a
+  violation; you are the thing that catches it. See the footnote under
+  `CONTRIBUTING.md`'s boundary table, which says the same.
+
 - **No leakage through types** — a TypeORM type (`QueryRunner`,
   `EntityMetadata`, `SelectQueryBuilder`) or a Nest type appearing in a core
   signature is a leak even when it compiles. Core's escape hatch for
@@ -94,9 +113,10 @@ and doc sync.
   named list (ADR-0010). No `export *`. Every added export is a public
   commitment; every removed one is potentially breaking.
 
-Run the mechanical gate first — it is cheap and authoritative:
-`pnpm depcruise`. A pass here does **not** end the check: dependency-cruiser
-catches import graphs, not type leakage or barrel intent. Grep changed files
+Run the mechanical gate first — it is cheap, and authoritative for the edges it
+covers: `pnpm depcruise`. A pass here does **not** end the check:
+dependency-cruiser catches import graphs, not type leakage or barrel intent,
+and it does not cover the two edges tabled above. Grep changed files
 for the leak patterns directly: imports of `typeorm`, `@nestjs/*`, or
 `@kavo/core/` (deep) in the wrong package; `export *` anywhere in core's
 barrel. Diff the barrel specifically:
@@ -120,8 +140,8 @@ from source.
   finding.
 - **`docs/internals/architecture/*.md`** — mirrors the packages (query
   grammar, error handling, engine, the TypeORM/Prisma/Mongoose adapters, Nest
-  integration, the GraphQL binding, soft delete, relations). If the change
-  alters behavior one of these documents describes in specifics (not just
+  integration, the GraphQL and MCP bindings, soft delete, relations). If the
+  change alters behavior one of these documents describes in specifics (not just
   "engine gets faster" but "the pipeline now has a new stage", "the wire token
   mapping changed", "a new config key exists at this precedence level"), the
   matching doc should have moved too.

--- a/.claude/agents/kavo-reviewer.md
+++ b/.claude/agents/kavo-reviewer.md
@@ -64,16 +64,27 @@ and doc sync.
 
 ```
 @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
+                ▲ ▲ ▲ ▲
+                │ │ │ └───── @kavo/prisma
+                │ │ └─────── @kavo/mongoose
+                │ └───────── @kavo/mcp
+                └─────────── @kavo/graphql
 ```
 
 - **`@kavo/core` imports nothing** — zero runtime dependencies (ADR-0005).
   Not TypeORM, not Nest, not a utility library. Type-only imports from outside
   core are violations too: core owns its contracts.
-- **Barrel-only consumption** — `@kavo/typeorm` and `@kavo/nest` import from
+- **Barrel-only consumption** — every spoke (`@kavo/typeorm`, `@kavo/prisma`,
+  `@kavo/mongoose`, `@kavo/nest`, `@kavo/graphql`, `@kavo/mcp`) imports from
   the `@kavo/core` barrel. Any `@kavo/core/src/...` or relative reach into
   core's internals is a violation.
-- **The spokes never meet** — the TypeORM adapter must not import the Nest
-  binding, and vice versa. They compose only through Nest's DI container.
+- **The spokes never meet** — no ORM adapter may import a framework or
+  protocol binding, and neither `@kavo/graphql` nor `@kavo/mcp` may import
+  `@kavo/nest` back (ADR-0016). The one permitted spoke-to-spoke edge is
+  `@kavo/nest` → the protocol packages, for its `BaseKavoGraphQLController` /
+  `BaseKavoMcpController` glue, and it is one-directional. Everything else
+  composes only through Nest's DI container. `.dependency-cruiser.cjs` is the
+  precise statement of this — read the rule, don't infer it.
 - **No leakage through types** — a TypeORM type (`QueryRunner`,
   `EntityMetadata`, `SelectQueryBuilder`) or a Nest type appearing in a core
   signature is a leak even when it compiles. Core's escape hatch for
@@ -100,19 +111,20 @@ as breaking.
 because the next planner or reviewer trusts the docs over re-deriving behavior
 from source.
 
-- **`docs/adr/0001`–`0014`** — one ADR per load-bearing decision.
+- **`docs/internals/adr/0001`–`0018`** — one ADR per load-bearing decision.
   A change that introduces a new load-bearing invariant (a new seam, a new
   precedence rule, a new mechanically-enforced boundary) with no corresponding
   ADR is a finding. A change that _contradicts_ an existing ADR without
   superseding it (ADRs are point-in-time decisions; superseding one needs an
   explicit new ADR referencing the old one, not a silent code change) is a
   finding.
-- **`docs/architecture/*.md`** — mirrors the packages (query
-  grammar, error handling, engine, TypeORM adapter, Nest integration, soft
-  delete, relations). If the change alters behavior one of these documents
-  describes in specifics (not just "engine gets faster" but "the pipeline now
-  has a new stage", "the wire token mapping changed", "a new config key exists
-  at this precedence level"), the matching doc should have moved too.
+- **`docs/internals/architecture/*.md`** — mirrors the packages (query
+  grammar, error handling, engine, the TypeORM/Prisma/Mongoose adapters, Nest
+  integration, the GraphQL binding, soft delete, relations). If the change
+  alters behavior one of these documents describes in specifics (not just
+  "engine gets faster" but "the pipeline now has a new stage", "the wire token
+  mapping changed", "a new config key exists at this precedence level"), the
+  matching doc should have moved too.
 - **`docs/glossary.md`** — one canonical name per concept. A new
   operation, config key, or exception introduces a term; check it either
   reuses an existing glossary term or the glossary gained an entry. A rename

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -34,7 +34,7 @@ after it is extra instructions or corrections to fold in during implementation.
    the invariants and ADRs your change touches (registry-driven operations,
    ADR-0006; decoration-time routes, ADR-0012; the explicit named barrel,
    ADR-0010; the composition root freezing after `createCrud`) and read the
-   governing ADR in `docs/adr/` before changing behavior it covers.
+   governing ADR in `docs/internals/adr/` before changing behavior it covers.
    Follow the naming conventions in `CLAUDE.md` — they are normative.
 
 4. **Create the branch, in an isolated worktree.** Follow the `conventions`
@@ -74,7 +74,7 @@ after it is extra instructions or corrections to fold in during implementation.
    make it pass.
 
 9. **Update the docs** if you changed behavior an ADR or a
-   `docs/architecture/` document governs. Silent divergence is a
+   `docs/internals/architecture/` document governs. Silent divergence is a
    review finding.
 
 10. **Leave the changes uncommitted** and report what changed, against the

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -34,10 +34,15 @@ or private.
    - **Context** — why this is worth doing, in two or three sentences.
    - **Acceptance criteria** — a checklist of what must be true when it is done.
      These must be verifiable, not aspirational.
-   - **Affected packages** — `@kavo/core`, `@kavo/typeorm`, `@kavo/nest`,
-     docs, or a combination.
+   - **Affected packages** — any combination of `@kavo/core`,
+     `@kavo/typeorm`, `@kavo/prisma`, `@kavo/mongoose`, `@kavo/nest`,
+     `@kavo/graphql`, `@kavo/mcp`, and docs. That list is every workspace
+     package; cross-check it against `PACKAGE_DIRS` in
+     `.github/workflows/publish.yml` if a new one may have landed. Write
+     `None` for repo-wiring-only work (`.claude/`, `.github/`, tooling)
+     rather than leaving it blank.
    - **Constraints** — the invariants that must survive. Check
-     `docs/adr/` for ones this issue touches (core purity, registry-
+     `docs/internals/adr/` for ones this issue touches (core purity, registry-
      driven operations, the explicit barrel, decoration-time routes, soft
      delete, and relations are common ones) and cite them by number. Also cite
      the naming conventions in `CLAUDE.md` if relevant. Cite only what
@@ -45,9 +50,12 @@ or private.
    - **Out of scope** — what this issue deliberately does not cover.
 
 4. **Label it.** Use the existing labels where they fit. See the
-   `conventions` skill for the `type:` set, and apply
-   `area:core|typeorm|nest|docs`. Create a missing label with
-   `gh label create <name>` only if it fits that scheme.
+   `conventions` skill for the `type:` set, and apply one or more of
+   `area:core|typeorm|prisma|mongoose|nest|graphql|mcp|docs`. The `area:`
+   scheme is deliberately flat — it tracks package names, not the
+   `packages/orms/*` and `packages/protocols/*` directory nesting. Create a missing label with
+   `gh label create <name>` only if it fits that scheme. Repo-wiring-only work
+   gets a `type:` label and no `area:`.
 
 5. **Show it before creating anything.** Print the full drafted issue —
    title, labels, and body exactly as they would be submitted — and stop.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -36,11 +36,12 @@ or private.
      These must be verifiable, not aspirational.
    - **Affected packages** — any combination of `@kavo/core`,
      `@kavo/typeorm`, `@kavo/prisma`, `@kavo/mongoose`, `@kavo/nest`,
-     `@kavo/graphql`, `@kavo/mcp`, and docs. That list is every workspace
-     package; cross-check it against `PACKAGE_DIRS` in
-     `.github/workflows/publish.yml` if a new one may have landed. Write
-     `None` for repo-wiring-only work (`.claude/`, `.github/`, tooling)
-     rather than leaving it blank.
+     `@kavo/graphql`, `@kavo/mcp`, and docs. That list is every **published**
+     package — `pnpm-workspace.yaml` also globs `examples/*`, which are real
+     workspace packages but private and never released. Cross-check against
+     `PACKAGE_DIRS` in `.github/workflows/publish.yml` if a new one may have
+     landed. Write `None` for repo-wiring-only work (`.claude/`, `.github/`,
+     tooling) rather than leaving it blank.
    - **Constraints** — the invariants that must survive. Check
      `docs/internals/adr/` for ones this issue touches (core purity, registry-
      driven operations, the explicit barrel, decoration-time routes, soft

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -74,7 +74,32 @@ workflow.
    If `pnpm check` fails, stop — a release never ships on a red build. Undo
    the version-file edits before stopping so `main` is left clean.
 
-5. **Confirm with the user before doing anything irreversible.** State
+5. **Verify every package already exists on the registry.** A package that has
+   never been published cannot go out through this workflow, because npm's
+   trusted publishers are configured per package on npmjs.com and a package
+   with no versions has no settings page to configure. First publishes are
+   manual, out-of-band, and have to happen **before** the tag:
+
+   ```bash
+   for dir in <PACKAGE_DIRS from step 3>; do
+     NAME=$(node -p "require('./$dir/package.json').name")
+     npm view "$NAME" version >/dev/null 2>&1 || echo "NEVER PUBLISHED: $NAME"
+   done
+   ```
+
+   If anything prints, **stop and tell the user before tagging.** Skipping this
+   is not a cosmetic risk: `publish.yml` publishes `PACKAGE_DIRS` in order and
+   `@kavo/nest` depends on `@kavo/graphql` and `@kavo/mcp` as hard
+   `dependencies`, so a late failure can leave an already-published
+   `@kavo/nest` pointing at a version of a sibling that does not exist —
+   uninstallable, and past npm's unpublish window it cannot be withdrawn.
+
+   To bootstrap one: publish it by hand, then configure its trusted publisher
+   on npmjs.com (`kavo-labs/kavo` + `publish.yml`), confirm `npm view` resolves,
+   and only then release. That first version will lack OIDC provenance; every
+   later release of it through the workflow will have it.
+
+6. **Confirm with the user before doing anything irreversible.** State
    plainly: committing and pushing straight to `main`, then pushing tag
    `vX.Y.Z`, triggers `.github/workflows/publish.yml`, which publishes every
    package in `PACKAGE_DIRS` to the public npm registry and creates a GitHub
@@ -86,19 +111,19 @@ workflow.
    `@kavo/mongoose`, `@kavo/nest`, `@kavo/graphql`, and `@kavo/mcp`, all seven
    at the same version per ADR-0004. A confirmation gate that names a subset
    understates an irreversible public release, which is a release hazard
-   rather than a cosmetic slip. Wait for an explicit go-ahead before step 6.
+   rather than a cosmetic slip. Wait for an explicit go-ahead before step 7.
 
-6. **Commit directly to `main`, then tag and push both:**
+7. **Commit directly to `main`, then tag and push both.** Stage by directory
+   rather than by enumerating packages — step 1 already refused to run on a
+   dirty tree, so the only modified files are the version bumps from step 3 and
+   the lockfile. A hardcoded list here is the same drift hazard as a hardcoded
+   list at the gate, and a worse one, because a missed package fails _green_:
+   the release commit lands without that bump, `publish.yml` only compares
+   `packages/core`'s version to the tag, and the publish loop then sees the old
+   version already on the registry and prints `already published, skipping`.
 
    ```bash
-   git add packages/core/package.json \
-           packages/orms/typeorm/package.json \
-           packages/orms/prisma/package.json \
-           packages/orms/mongoose/package.json \
-           packages/frameworks/nest/package.json \
-           packages/protocols/graphql/package.json \
-           packages/protocols/mcp/package.json \
-           pnpm-lock.yaml
+   git add packages pnpm-lock.yaml
    git commit -m "chore(release): vX.Y.Z"
    git push origin main
    git tag -a vX.Y.Z -m "vX.Y.Z"
@@ -108,7 +133,7 @@ workflow.
    The commit body should list the commit subjects since the last tag as a
    short changelog.
 
-7. **Watch the release workflow** and report the result:
+8. **Watch the release workflow** and report the result:
 
    ```bash
    gh run watch --exit-status $(gh run list --workflow=publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')
@@ -118,6 +143,6 @@ workflow.
    a failed OIDC trusted-publisher match or a stale npm CLI version are the
    most likely causes.
 
-8. **Report**: the tag, the workflow run URL, the published package
+9. **Report**: the tag, the workflow run URL, the published package
    versions, and the GitHub Release URL
    (`gh release view vX.Y.Z --json url --jq .url`).

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -45,12 +45,24 @@ workflow.
    to 0, minor resets patch to 0). State the computed version and _why_
    (which commits triggered the bump level) before touching any files.
 
-3. **Apply the version, in lockstep** (ADR-0004 — [`docs/adr/0004-lockstep-versioning.md`](../../docs/adr/0004-lockstep-versioning.md)):
-   set the new version in `packages/core/package.json`,
-   `packages/orms/typeorm/package.json`,
-   `packages/frameworks/nest/package.json`, and
-   `packages/protocols/graphql/package.json`. Leave `examples/*`
-   (private, unpublished) alone.
+3. **Apply the version, in lockstep** (ADR-0004 — [`docs/internals/adr/0004-lockstep-versioning.md`](../../docs/internals/adr/0004-lockstep-versioning.md)):
+   set the new version in the `package.json` of **every** published package.
+   `PACKAGE_DIRS` in `.github/workflows/publish.yml` is the single source of
+   truth for that set — read it and bump exactly those. Today it is all seven:
+
+   | Directory                    | Package          |
+   | ---------------------------- | ---------------- |
+   | `packages/core`              | `@kavo/core`     |
+   | `packages/orms/typeorm`      | `@kavo/typeorm`  |
+   | `packages/orms/prisma`       | `@kavo/prisma`   |
+   | `packages/orms/mongoose`     | `@kavo/mongoose` |
+   | `packages/frameworks/nest`   | `@kavo/nest`     |
+   | `packages/protocols/graphql` | `@kavo/graphql`  |
+   | `packages/protocols/mcp`     | `@kavo/mcp`      |
+
+   If this table and `PACKAGE_DIRS` ever disagree, `PACKAGE_DIRS` wins — it is
+   what actually publishes — and the table is a bug to fix in the same pass.
+   Leave `examples/*` (private, unpublished) alone.
 
 4. **Regenerate the lockfile and gate:**
 
@@ -64,17 +76,28 @@ workflow.
 
 5. **Confirm with the user before doing anything irreversible.** State
    plainly: committing and pushing straight to `main`, then pushing tag
-   `vX.Y.Z`, triggers `.github/workflows/publish.yml`, which publishes
-   `@kavo/core`, `@kavo/typeorm`, `@kavo/nest`, and `@kavo/graphql` to the
-   public npm registry and creates a GitHub Release for the tag — none of
-   this is meaningfully undoable once pushed. Wait for an explicit
-   go-ahead before step 6.
+   `vX.Y.Z`, triggers `.github/workflows/publish.yml`, which publishes every
+   package in `PACKAGE_DIRS` to the public npm registry and creates a GitHub
+   Release for the tag — none of this is meaningfully undoable once pushed.
+
+   **Name every package explicitly in the prompt**, enumerated from the
+   `PACKAGE_DIRS` you read in step 3 rather than from memory or from a list
+   written here — currently `@kavo/core`, `@kavo/typeorm`, `@kavo/prisma`,
+   `@kavo/mongoose`, `@kavo/nest`, `@kavo/graphql`, and `@kavo/mcp`, all seven
+   at the same version per ADR-0004. A confirmation gate that names a subset
+   understates an irreversible public release, which is a release hazard
+   rather than a cosmetic slip. Wait for an explicit go-ahead before step 6.
 
 6. **Commit directly to `main`, then tag and push both:**
 
    ```bash
-   git add packages/core/package.json packages/orms/typeorm/package.json \
-           packages/frameworks/nest/package.json packages/protocols/graphql/package.json \
+   git add packages/core/package.json \
+           packages/orms/typeorm/package.json \
+           packages/orms/prisma/package.json \
+           packages/orms/mongoose/package.json \
+           packages/frameworks/nest/package.json \
+           packages/protocols/graphql/package.json \
+           packages/protocols/mcp/package.json \
            pnpm-lock.yaml
    git commit -m "chore(release): vX.Y.Z"
    git push origin main

--- a/.claude/skills/add-adr/SKILL.md
+++ b/.claude/skills/add-adr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-adr
-description: When and how to write a new ADR in docs/adr/ — numbering, required sections, and how it must connect to code and the architecture docs. Use when a change makes a load-bearing decision (a seam, an invariant, a boundary rule) rather than just implementing one already on record.
+description: When and how to write a new ADR in docs/internals/adr/ — numbering, required sections, and how it must connect to code and the architecture docs. Use when a change makes a load-bearing decision (a seam, an invariant, a boundary rule) rather than just implementing one already on record.
 ---
 
 # Writing an ADR
 
-Kavo records one ADR per load-bearing decision (`docs/adr/0001`…`0014`).
+Kavo records one ADR per load-bearing decision (`docs/internals/adr/0001`…`0018`).
 They are read before changing the behavior they govern (CLAUDE.md), so an ADR
 is only worth writing when a future change could plausibly get the decision
 wrong without it.
@@ -29,7 +29,7 @@ foreclose.
 
 ## Numbering and location
 
-- File: `docs/adr/00NN-kebab-title.md`, next sequential number —
+- File: `docs/internals/adr/00NN-kebab-title.md`, next sequential number —
   check the highest existing file first, never reuse or renumber.
 - ADRs are **never superseded by editing in place**. If a later decision
   overturns one, the old ADR's `Status` becomes `superseded by ADR-00MM` and
@@ -66,7 +66,7 @@ itself.
 
 An ADR that nothing points to is dead weight:
 
-- Reference it from the relevant `docs/architecture/NN-*.md` doc,
+- Reference it from the relevant `docs/internals/architecture/NN-*.md` doc,
   the way doc 08 §2 and §4 would reference a config ADR.
 - Reference it from the code that implements the decision, the way existing
   comments cite `ADR-0012` or `ADR-0006` — a future reader hitting the

--- a/.claude/skills/add-config-key/SKILL.md
+++ b/.claude/skills/add-config-key/SKILL.md
@@ -6,7 +6,7 @@ description: How to add a new key to KavoSettings — schema, default, merge sem
 # Adding a config key
 
 Kavo has **one** configuration mechanism: `KavoSettings`, merged through a
-single precedence chain (`docs/architecture/08-configuration.md`):
+single precedence chain (`docs/internals/architecture/08-configuration.md`):
 
 ```
 built-in defaults → global (createKavo) → entity (createCrud)
@@ -72,7 +72,7 @@ Finish with `pnpm check`.
 
 ## Docs
 
-Update `docs/architecture/08-configuration.md`'s key table (§1) —
+Update `docs/internals/architecture/08-configuration.md`'s key table (§1) —
 it's the single source of truth for what's configurable, and a key missing
 from it is invisible to the next reader. If the key represents a new
 load-bearing precedent (not just a parameter on an existing mechanism),

--- a/.claude/skills/add-exception/SKILL.md
+++ b/.claude/skills/add-exception/SKILL.md
@@ -6,7 +6,7 @@ description: How to add a new Kavo exception — hierarchy placement, error-code
 # Adding an exception
 
 Kavo has one exception hierarchy, one error-code catalog, and one wire shape
-(RFC 9457 problem details, ADR-0009) — `docs/architecture/06-error-handling.md`.
+(RFC 9457 problem details, ADR-0009) — `docs/internals/architecture/06-error-handling.md`.
 A new failure mode is a new catalog entry, never a raw `Error`, a bare string
 code, or a second serialization path.
 
@@ -67,6 +67,6 @@ mapping table actually recognizes the driver error it claims to.
 ## Docs
 
 Add the row to the error-catalog table in
-`docs/architecture/06-error-handling.md` §2. A code missing from
+`docs/internals/architecture/06-error-handling.md` §2. A code missing from
 that table is invisible to the next reader and to API consumers relying on
 the docs as the catalog's source of truth.

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -5,15 +5,20 @@
  * The rules here are the executable form of the dependency graph:
  *
  *   @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
- *                       ▲
- *                       ├── @kavo/prisma
- *                       ├── @kavo/mongoose
- *                       ├── @kavo/graphql
- *                       └── @kavo/mcp
+ *      │                ▲
+ *      │                ├── @kavo/prisma
+ *      │                ├── @kavo/mongoose
+ *      │                ├── @kavo/graphql ◀─┐
+ *      │                └── @kavo/mcp     ◀─┤
+ *      └── the one sanctioned sideways edge ─┘
+ *          (frameworks/* → protocols/*, ADR-0016; never the reverse)
  *
- * `@kavo/core` imports nothing. Adapters, protocol bindings and framework
- * bindings import the core barrel only — deep imports are not API. An
- * illegal import fails CI here, not in code review.
+ * `@kavo/core` imports nothing. When an edge package imports core it goes
+ * through the barrel — deep imports are not API. An illegal import fails CI
+ * here, not in code review, but note the coverage is not total: an ORM
+ * adapter importing a protocol package, or one protocol importing another,
+ * passes these rules today and is caught only in review. See the footnote
+ * under CONTRIBUTING.md's boundary table.
  */
 module.exports = {
   forbidden: [

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,17 +1,19 @@
 /**
  * Mechanical enforcement of the package boundaries defined in
- * docs/architecture/02-monorepo-and-packages.md.
+ * docs/internals/architecture/02-monorepo-and-packages.md.
  *
  * The rules here are the executable form of the dependency graph:
  *
  *   @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
  *                       ▲
  *                       ├── @kavo/prisma
- *                       └── @kavo/mongoose
+ *                       ├── @kavo/mongoose
+ *                       ├── @kavo/graphql
+ *                       └── @kavo/mcp
  *
- * `@kavo/core` imports nothing. Adapters and framework bindings import the
- * core barrel only — deep imports are not API. An illegal import fails CI
- * here, not in code review.
+ * `@kavo/core` imports nothing. Adapters, protocol bindings and framework
+ * bindings import the core barrel only — deep imports are not API. An
+ * illegal import fails CI here, not in code review.
  */
 module.exports = {
   forbidden: [

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -19,7 +19,9 @@ labels: ""
 
 ## Affected packages
 
-<!-- @kavo/core | @kavo/typeorm | @kavo/nest | docs -->
+<!-- Any combination of: @kavo/core | @kavo/typeorm | @kavo/prisma |
+     @kavo/mongoose | @kavo/nest | @kavo/graphql | @kavo/mcp | docs
+     Write "None" for repo-wiring-only work (.claude/, .github/, tooling). -->
 
 ## Constraints
 


### PR DESCRIPTION
## What & why

The repo grew to **seven** published packages and `docs/adr/` moved under
`docs/internals/` in #59, but a lot of the repo wiring still described the old
three-package shape.

The sharpest one was in `/publish`. Step 5 is the confirm-before-irreversible
gate, and it named four packages while `publish.yml`'s `PACKAGE_DIRS` publishes
seven — so the safety prompt understated what was about to be pushed to the
public npm registry. Steps 3 and 6 carried the same stale list, which would
have left `@kavo/prisma`, `@kavo/mongoose` and `@kavo/mcp` behind at an old
version. Under ADR-0004 lockstep versioning that is a release hazard, not a
cosmetic typo.

The confirmation gate now enumerates packages **from `PACKAGE_DIRS`** rather
than from a list kept in the command, and the table is explicitly marked as
losing to `PACKAGE_DIRS` on disagreement, so the same drift cannot silently
recur.

### Correction to the issue: seven packages, not six

#80 was written before `@kavo/mcp` landed (`3e21a32`) and says "six packages"
throughout. `PACKAGE_DIRS` now lists seven, including `packages/protocols/mcp`.
Per the issue's own constraint — *fix the wiring to match the repo;
`publish.yml` is correct* — everything here is wired to **seven**. This also
means an `area:mcp` label was needed alongside the `area:graphql` the issue
asked for.

## Public API impact

None. No package source changed — `.claude/`, `.github/`, and one comment
header in `.dependency-cruiser.cjs`.

## Testing

`pnpm check` **exit=0** — 54 test files, 896/896 tests, no dependency
violations. `pnpm format:check` **exit=0**. Verified on the final commit with a
clean tree.

Both acceptance-criteria greps verified mechanically:

- `@crudo` and `docs/adr/` across `.claude/`, `.github/`, `CLAUDE.md`, `docs/` → clean
- `publish.md`'s package list now `diff`s exactly against `publish.yml`'s `PACKAGE_DIRS`

## Beyond the literal acceptance criteria

`docs/architecture/` was dead too — the same #59 move, in the same files — so it
is fixed in the same pass (`implement.md`, `kavo-reviewer.md`, three
`.claude/skills/`). Also fixed while in those files: `kavo-reviewer.md`'s
three-package topology diagram, its stale `0001`–`0014` ADR range (18 exist),
and its boundary bullets, which now match what `.dependency-cruiser.cjs`
actually enforces including the one permitted spoke-to-spoke edge
(`@kavo/nest` → the protocol packages, one-directional per ADR-0016).

## Labels applied

`area:core`, `area:typeorm`, `area:nest`, `area:prisma` now say `@kavo/*` (were
`@crudo/*`); `area:docs` says `docs/` (was the nonexistent `packages/docs`);
`area:graphql` and `area:mcp` created at `006b75`, following the per-tier colour
convention (core `1d76db`, ORMs `5319e7`, framework `b60205`, docs `c5def5`).

## Review notes

**Deliberately left**, per the issue's "or explicitly listed in the PR" clause —
the same dead paths outside the AC's grep scope:

- `extensions/skills/` — 12 dead references across 8 files, adopter-facing skills
- shipped package source and READMEs — 6, in `packages/core` and `packages/orms/prisma`

(18 tracked dead references total. An earlier revision of this description said
"10 hits" for `extensions/` — that counted grep *lines*, not occurrences.)

The issue scoped itself to "no package source", and those READMEs publish to
npm, so they want their own issue.

`CLAUDE.md` also left alone: it says "Five packages", lists six, and omits
`@kavo/mcp` — but there were uncommitted edits to that exact section in the
working checkout, so touching it here would only cause a conflict.

**Pre-existing flaky test, unrelated to this change — now root-caused:**
`bootstrap()` in the Nest/example e2e suites calls `app.init()`, never
`app.listen()`, so supertest binds `listen(0)` on the **wildcard** per request
(~130 times per run) while connecting to a hardcoded `127.0.0.1`. That
asymmetry lets a foreign local process holding an ephemeral port answer
instead. Confirmed against `lsof` (`Spotify *:54090`, `agent-ser
127.0.0.1:59938`), and it explains every symptom seen: `Parse Error: Expected
HTTP/, RTSP/ or ICE/` (non-HTTP greeting), a foreign 400/404/405, `socket hang
up`, and hook/test timeouts. Controlled experiment excluding foreign-held
ports: **0/30 failures vs ~10-15% baseline**. Rate measured at 12/117 runs
(~10%) on this branch *and* on pristine `main`. Fix is one line —
`await app.listen(0, "127.0.0.1")`. Follow-up issue.

## Review round

`/review` ran the reviewer fan-out against this PR. Three blocking findings and
three cheap ones were fixed in `55d0689`, `9c2e464`, `515cbaa`:

1. The rewritten boundary bullet in `kavo-reviewer.md` claimed
   `.dependency-cruiser.cjs` was "the precise statement" of a rule set that
   includes ORM → protocol — it isn't. The adapter rules' `to` covers
   `packages/frameworks` only and the protocol rules omit each other, so those
   two edges pass the gate today. Replaced with a per-edge table marking them
   unenforced, matching the footnote already under `CONTRIBUTING.md`'s boundary
   table. Telling a reviewer to trust a gate for an edge it misses is worse
   than saying nothing.
2. Step 6's `git add` was the last hand-maintained package list, and the worst
   place for one: a missed package fails **green**, which is exactly how v0.6.0
   shipped six of seven packages. Now `git add packages pnpm-lock.yaml`.
3. New step 5 refuses to tag while any `PACKAGE_DIRS` entry has never been
   published — see the `@kavo/mcp` hazard below.
4. `issue.md` said "every workspace package"; corrected to **published**
   (`examples/*` are workspace packages too, just private).
5. `kavo-reviewer.md`'s architecture-doc enumeration omitted the MCP binding.
6. Both ASCII diagrams drew the sanctioned `frameworks/* → protocols/*` edge as
   absent.

### Follow-up issues this review surfaced (filed, not fixed here)

- **#89** — restore ADR-0004 lockstep on npm: `@kavo/prisma` is at `0.5.0` while
  the other six are at `0.6.0` and `@kavo/prisma@0.6.0` was never published;
  `@kavo/mcp` has never been published at all despite `@kavo/nest` hard-depending
  on it. This PR prevents recurrence but does not repair the existing skew.
- **#90** — assert lockstep versions in `publish.yml` (it compares only
  `packages/core` to the tag, which is how `v0.6.0` shipped six of seven) and fix
  the `PACKAGE_DIRS` ordering, which puts `nest` before the protocol packages it
  depends on.
- **#91** — fix the ephemeral-port collision making the Nest/example e2e suites
  ~10% flaky, root-caused to `bootstrap()` using `app.init()` instead of
  `app.listen(0, "127.0.0.1")`.
- **#92** — finish the dead docs-path sweep outside this PR's scope (18 tracked
  references, incl. 2 files that ship to npm, plus `docs/glossary.md` and a
  duplicate `14-` doc number) and add a CI link check so the class cannot recur.
- **#93** — `CLAUDE.md` says "Five packages", omits `@kavo/mcp`, and line 53
  contradicts line 51 on whether spokes import each other.

Closes #80

