### PR TITLE
docs: add npm/yarn/bun install commands and close the install-path gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,36 @@ field selection — no hand-written controller methods.
 
 ## Getting started
 
+**pnpm**
+
 ```bash
 pnpm add @kavo/core @kavo/nest @kavo/typeorm
 ```
+
+**npm**
+
+```bash
+npm install @kavo/core @kavo/nest @kavo/typeorm
+```
+
+**yarn**
+
+```bash
+yarn add @kavo/core @kavo/nest @kavo/typeorm
+```
+
+**bun**
+
+```bash
+bun add @kavo/core @kavo/nest @kavo/typeorm
+```
+
+`@kavo/nest` expects `@nestjs/common`, `@nestjs/core`, `reflect-metadata`, and
+`rxjs` as peers, and `@kavo/typeorm` expects `typeorm` — a Nest app already has
+the first four. Kavo needs Node 20+, an ESM app, and `emitDecoratorMetadata`;
+see [Requirements](https://kavo.js.org/getting-started#requirements) and
+[Peer dependencies](https://kavo.js.org/getting-started#peer-dependencies) for
+the exact versions.
 
 ```ts
 @Kavo(Book)
@@ -57,6 +84,7 @@ Fewer tokens, ship faster.
 | [`@kavo/mongoose`](packages/orms/mongoose)    | Mongoose adapter                                            |
 | [`@kavo/nest`](packages/frameworks/nest)      | NestJS binding — the `@Kavo` decorator and route generation |
 | [`@kavo/graphql`](packages/protocols/graphql) | Host-agnostic GraphQL schema binding                        |
+| [`@kavo/mcp`](packages/protocols/mcp)         | Host-agnostic MCP binding — entities as MCP tools           |
 
 Pick the ORM and framework/protocol bindings you need; `@kavo/core` has zero
 runtime dependencies.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -118,6 +118,7 @@ export default defineConfig({
               { text: "Soft delete", link: "/internals/architecture/11-soft-delete" },
               { text: "Relations and includes", link: "/internals/architecture/12-relations-and-includes" },
               { text: "GraphQL binding", link: "/internals/architecture/13-graphql-binding" },
+              { text: "MCP binding", link: "/internals/architecture/14-mcp-binding" },
               { text: "Prisma adapter", link: "/internals/architecture/14-prisma-adapter" },
               { text: "Mongoose adapter", link: "/internals/architecture/15-mongoose-adapter" },
             ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ These documents and the [ADRs](internals/adr/) are authoritative.
 - [architecture/04-dto-system.md](internals/architecture/04-dto-system.md) — the six slots, derivation rules, resolution, serialization order
 - [architecture/05-query-grammar.md](internals/architecture/05-query-grammar.md) — the query-string grammar reference: operators, rules, limits, coercion
 - [architecture/06-error-handling.md](internals/architecture/06-error-handling.md) — exception hierarchy, error-code catalog, problem details
-- [architecture/07-kavo-engine.md](internals/architecture/07-kavo-engine.md) — request lifecycle, context, built-in handlers, root factory
+- [architecture/07-crud-engine.md](internals/architecture/07-crud-engine.md) — request lifecycle, context, built-in handlers, root factory
 - [architecture/08-configuration.md](internals/architecture/08-configuration.md) — schema, precedence chain, merge semantics, bootstrap validation
 - [architecture/09-typeorm-adapter.md](internals/architecture/09-typeorm-adapter.md) — metadata seam, query translation, error mapping, seams
 - [architecture/10-nestjs-integration.md](internals/architecture/10-nestjs-integration.md) — module design, route generation, exception filter, Swagger
@@ -24,6 +24,8 @@ These documents and the [ADRs](internals/adr/) are authoritative.
 
 - [architecture/11-soft-delete.md](internals/architecture/11-soft-delete.md) — strategy resolution, restore/purge, `withDeleted`, unique-index and cascade edges
 - [architecture/12-relations-and-includes.md](internals/architecture/12-relations-and-includes.md) — relation registry, include resolution, join/batch loading, pagination rule, write-side
+- [architecture/13-graphql-binding.md](internals/architecture/13-graphql-binding.md) — package boundary, schema construction, multi-entity schemas, the Nest binding
+- [architecture/14-mcp-binding.md](internals/architecture/14-mcp-binding.md) — package boundary, toolset construction, result shape and error mapping, the Nest binding
 - [architecture/14-prisma-adapter.md](internals/architecture/14-prisma-adapter.md) — marker classes, metadata seam, query translation, error mapping
 - [architecture/15-mongoose-adapter.md](internals/architecture/15-mongoose-adapter.md) — model identity, ObjectId conversion, populate, relation-path limits
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ A `tsconfig.json` that satisfies all three:
 }
 ```
 
-`useDefineForClassFields: false` is load-bearing at `ES2022` and above. With it on, every declared field is emitted as a class field, so a typical entity's `id!: number` becomes an own property set to `undefined` on construction — overwriting the value TypeORM just assigned while hydrating the row. With it off, only fields that have an initializer are assigned, and the rest are left alone.
+`useDefineForClassFields: false` is load-bearing at `ES2022` and above. With it on, every declared field is emitted as a real class field, so a fresh entity carries an own key for _every_ column — set to `undefined` — whether the adapter hydrated it or not. A partially-hydrated entity then looks fully populated: Kavo projects a response with `Object.keys(entity)` when no field selection narrows it, so those columns surface in the body as `undefined` rather than being absent, and TypeORM's persistence diffing reads them as explicit values. With it off, only fields with an initializer are assigned and the rest are left to the prototype — which is what Kavo's own packages and both example apps compile with.
 
 ## Install
 
@@ -67,34 +67,34 @@ Kavo never bundles your framework or your ORM. Each package declares what it exp
 - **`@kavo/graphql`** — `graphql` (`^17.0.0`).
 - **`@kavo/mcp`** — `@modelcontextprotocol/sdk` (`^1.0.0`).
 
-Three of `@kavo/nest`'s own peers are declared **optional** — `@nestjs/swagger` (`^8.0.0 || ^11.0.0`) for generated OpenAPI docs, `graphql` (`^17.0.0`) for the GraphQL controller, and `@modelcontextprotocol/sdk` (`^1.0.0`) for the MCP controller — so nothing makes you configure a protocol you don't serve. They may still land in your dependency tree either way: `@kavo/nest` depends on `@kavo/graphql` and `@kavo/mcp`, and those two declare `graphql` and `@modelcontextprotocol/sdk` as _required_ peers, which npm auto-installs. Optional here means you never have to import or wire them, not that they are absent from `node_modules`.
+Three of `@kavo/nest`'s own peers are declared **optional** — `@nestjs/swagger` (`^8.0.0 || ^11.0.0`) for generated OpenAPI docs, `graphql` (`^17.0.0`) for the GraphQL controller, and `@modelcontextprotocol/sdk` (`^1.0.0`) for the MCP controller — so nothing makes you configure a protocol you don't serve. They may still land in your dependency tree either way: `@kavo/nest` depends on `@kavo/graphql` and `@kavo/mcp`, and those two declare `graphql` and `@modelcontextprotocol/sdk` as _required_ peers. npm, pnpm, and bun install required peers automatically, so both arrive even in a REST-only app; yarn does not, and reports them as unmet peers instead. Optional here means you never have to import or wire them.
 
 ### GraphQL and MCP
 
 The same entities can be served over GraphQL and the Model Context Protocol, through the same engine.
 
-Inside a Nest app you never install the Kavo bindings directly — `@kavo/nest` already depends on `@kavo/graphql` and `@kavo/mcp`. Add only the protocol library you intend to use:
+Inside a Nest app you never install the Kavo bindings directly — `@kavo/nest` depends on `@kavo/graphql`, and on `@kavo/mcp` as of the next release. Add only the protocol library you intend to use:
 
 ::: code-group
 
 ```bash [pnpm]
-pnpm add graphql                  # GraphQL
-pnpm add @modelcontextprotocol/sdk # MCP
+pnpm add graphql                    # GraphQL
+pnpm add @modelcontextprotocol/sdk  # MCP
 ```
 
 ```bash [npm]
-npm install graphql                  # GraphQL
-npm install @modelcontextprotocol/sdk # MCP
+npm install graphql                    # GraphQL
+npm install @modelcontextprotocol/sdk  # MCP
 ```
 
 ```bash [yarn]
-yarn add graphql                  # GraphQL
-yarn add @modelcontextprotocol/sdk # MCP
+yarn add graphql                    # GraphQL
+yarn add @modelcontextprotocol/sdk  # MCP
 ```
 
 ```bash [bun]
-bun add graphql                  # GraphQL
-bun add @modelcontextprotocol/sdk # MCP
+bun add graphql                    # GraphQL
+bun add @modelcontextprotocol/sdk  # MCP
 ```
 
 :::

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,15 +4,126 @@ Kavo turns your ORM entities into a full REST CRUD API. Define the entity once, 
 
 Today Kavo supports NestJS as the framework, over TypeORM, Prisma, or Mongoose as the ORM. This guide uses Nest + TypeORM as its example stack; see [Nest + Prisma](/integrations/nest/prisma) and [Nest + Mongoose](/integrations/nest/mongoose) for the equivalents.
 
+## Requirements
+
+- **Node.js 20 or newer** — the minimum this project declares. Note that the published packages carry no `engines` field, so your package manager will not warn you on an older release.
+- **ESM** — every `@kavo/*` package ships as ESM only, with no CommonJS entry point. Your app must be ESM too (`"type": "module"` in its `package.json`), which the default `nest new` scaffold is not.
+- **Decorator metadata** — `experimentalDecorators` and `emitDecoratorMetadata` must be on. `@Kavo()` reads your entity's decorator metadata, and so do TypeORM's columns and Nest's DI.
+
+A `tsconfig.json` that satisfies all three:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "useDefineForClassFields": false,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+`useDefineForClassFields: false` is load-bearing at `ES2022` and above. With it on, every declared field is emitted as a class field, so a typical entity's `id!: number` becomes an own property set to `undefined` on construction — overwriting the value TypeORM just assigned while hydrating the row. With it off, only fields that have an initializer are assigned, and the rest are left alone.
+
 ## Install
 
-```bash
+::: code-group
+
+```bash [pnpm]
 pnpm add @kavo/core @kavo/nest @kavo/typeorm
 ```
+
+```bash [npm]
+npm install @kavo/core @kavo/nest @kavo/typeorm
+```
+
+```bash [yarn]
+yarn add @kavo/core @kavo/nest @kavo/typeorm
+```
+
+```bash [bun]
+bun add @kavo/core @kavo/nest @kavo/typeorm
+```
+
+:::
 
 - `@kavo/core` — the engine.
 - `@kavo/nest` — generates the NestJS routes.
 - `@kavo/typeorm` — adapts Kavo to a TypeORM `DataSource`. See [Nest + TypeORM](/integrations/nest/typeorm) for the full wiring.
+
+### Peer dependencies
+
+Kavo never bundles your framework or your ORM. Each package declares what it expects as a peer — a Nest app already has most of them:
+
+- **`@kavo/core`** — none. It has zero runtime dependencies.
+- **`@kavo/nest`** — `@nestjs/common` and `@nestjs/core` (`^10.0.0 || ^11.0.0`), `reflect-metadata` (`^0.1.13 || ^0.2.0`), `rxjs` (`^7.8.0`).
+- **`@kavo/typeorm`** — `typeorm` (`^0.3.20 || ^1.0.0`).
+- **`@kavo/prisma`** — `@prisma/client` (`^5.0.0 || ^6.0.0`).
+- **`@kavo/mongoose`** — `mongoose` (`^7.0.0 || ^8.0.0`).
+- **`@kavo/graphql`** — `graphql` (`^17.0.0`).
+- **`@kavo/mcp`** — `@modelcontextprotocol/sdk` (`^1.0.0`).
+
+Three of `@kavo/nest`'s own peers are declared **optional** — `@nestjs/swagger` (`^8.0.0 || ^11.0.0`) for generated OpenAPI docs, `graphql` (`^17.0.0`) for the GraphQL controller, and `@modelcontextprotocol/sdk` (`^1.0.0`) for the MCP controller — so nothing makes you configure a protocol you don't serve. They may still land in your dependency tree either way: `@kavo/nest` depends on `@kavo/graphql` and `@kavo/mcp`, and those two declare `graphql` and `@modelcontextprotocol/sdk` as _required_ peers, which npm auto-installs. Optional here means you never have to import or wire them, not that they are absent from `node_modules`.
+
+### GraphQL and MCP
+
+The same entities can be served over GraphQL and the Model Context Protocol, through the same engine.
+
+Inside a Nest app you never install the Kavo bindings directly — `@kavo/nest` already depends on `@kavo/graphql` and `@kavo/mcp`. Add only the protocol library you intend to use:
+
+::: code-group
+
+```bash [pnpm]
+pnpm add graphql                  # GraphQL
+pnpm add @modelcontextprotocol/sdk # MCP
+```
+
+```bash [npm]
+npm install graphql                  # GraphQL
+npm install @modelcontextprotocol/sdk # MCP
+```
+
+```bash [yarn]
+yarn add graphql                  # GraphQL
+yarn add @modelcontextprotocol/sdk # MCP
+```
+
+```bash [bun]
+bun add graphql                  # GraphQL
+bun add @modelcontextprotocol/sdk # MCP
+```
+
+:::
+
+Both bindings are host-framework-agnostic, so they also work without Nest. Installed that way you add the Kavo package yourself, alongside `@kavo/core` and whichever ORM adapter you use:
+
+::: code-group
+
+```bash [pnpm]
+pnpm add @kavo/core @kavo/graphql graphql
+pnpm add @kavo/core @kavo/mcp @modelcontextprotocol/sdk
+```
+
+```bash [npm]
+npm install @kavo/core @kavo/graphql graphql
+npm install @kavo/core @kavo/mcp @modelcontextprotocol/sdk
+```
+
+```bash [yarn]
+yarn add @kavo/core @kavo/graphql graphql
+yarn add @kavo/core @kavo/mcp @modelcontextprotocol/sdk
+```
+
+```bash [bun]
+bun add @kavo/core @kavo/graphql graphql
+bun add @kavo/core @kavo/mcp @modelcontextprotocol/sdk
+```
+
+:::
 
 ## Zero-config `@Kavo()`
 

--- a/docs/integrations/nest/mongoose.md
+++ b/docs/integrations/nest/mongoose.md
@@ -4,9 +4,27 @@ Kavo's engine (`@kavo/core`) is ORM-agnostic — it talks to your data through a
 
 If you haven't yet, read [Getting started](/getting-started) first — this page assumes you already know what `@Kavo()` does and just needs the app-wiring.
 
-```bash
+::: code-group
+
+```bash [pnpm]
 pnpm add @kavo/core @kavo/nest @kavo/mongoose
 ```
+
+```bash [npm]
+npm install @kavo/core @kavo/nest @kavo/mongoose
+```
+
+```bash [yarn]
+yarn add @kavo/core @kavo/nest @kavo/mongoose
+```
+
+```bash [bun]
+bun add @kavo/core @kavo/nest @kavo/mongoose
+```
+
+:::
+
+`@kavo/mongoose` expects `mongoose` (`^7.0.0 || ^8.0.0`) as a peer; `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
 
 ## Zero-config wiring
 

--- a/docs/integrations/nest/mongoose.md
+++ b/docs/integrations/nest/mongoose.md
@@ -24,7 +24,7 @@ bun add @kavo/core @kavo/nest @kavo/mongoose
 
 :::
 
-`@kavo/mongoose` expects `mongoose` (`^7.0.0 || ^8.0.0`) as a peer; `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
+`@kavo/mongoose` expects `mongoose` (`^7.0.0 || ^8.0.0`) as a peer — add it to the command above if your app doesn't already have it — and `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
 
 ## Zero-config wiring
 

--- a/docs/integrations/nest/prisma.md
+++ b/docs/integrations/nest/prisma.md
@@ -4,9 +4,27 @@ Kavo's engine (`@kavo/core`) is ORM-agnostic — it talks to your data through a
 
 If you haven't yet, read [Getting started](/getting-started) first — this page assumes you already know what `@Kavo()` does and just needs the app-wiring.
 
-```bash
+::: code-group
+
+```bash [pnpm]
 pnpm add @kavo/core @kavo/nest @kavo/prisma
 ```
+
+```bash [npm]
+npm install @kavo/core @kavo/nest @kavo/prisma
+```
+
+```bash [yarn]
+yarn add @kavo/core @kavo/nest @kavo/prisma
+```
+
+```bash [bun]
+bun add @kavo/core @kavo/nest @kavo/prisma
+```
+
+:::
+
+`@kavo/prisma` expects `@prisma/client` (`^5.0.0 || ^6.0.0`) as a peer; `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
 
 ## Zero-config wiring
 

--- a/docs/integrations/nest/prisma.md
+++ b/docs/integrations/nest/prisma.md
@@ -24,7 +24,7 @@ bun add @kavo/core @kavo/nest @kavo/prisma
 
 :::
 
-`@kavo/prisma` expects `@prisma/client` (`^5.0.0 || ^6.0.0`) as a peer; `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
+`@kavo/prisma` expects `@prisma/client` (`^5.0.0 || ^6.0.0`) as a peer — add it to the command above if your app doesn't already have it — and `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
 
 ## Zero-config wiring
 

--- a/docs/integrations/nest/typeorm.md
+++ b/docs/integrations/nest/typeorm.md
@@ -4,9 +4,27 @@ Kavo's engine (`@kavo/core`) is ORM-agnostic — it talks to your data through a
 
 If you haven't yet, read [Getting started](/getting-started) first — this page assumes you already know what `@Kavo()` does and just needs the app-wiring.
 
-```bash
+::: code-group
+
+```bash [pnpm]
 pnpm add @kavo/core @kavo/nest @kavo/typeorm
 ```
+
+```bash [npm]
+npm install @kavo/core @kavo/nest @kavo/typeorm
+```
+
+```bash [yarn]
+yarn add @kavo/core @kavo/nest @kavo/typeorm
+```
+
+```bash [bun]
+bun add @kavo/core @kavo/nest @kavo/typeorm
+```
+
+:::
+
+`@kavo/typeorm` expects `typeorm` (`^0.3.20 || ^1.0.0`) as a peer; `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
 
 ## Zero-config wiring
 
@@ -66,3 +84,5 @@ export class AppModule {}
 ```
 
 `createInfrastructure(dataSource)` derives both Kavo's entity metadata and its repository adapter from the `DataSource`'s own TypeORM metadata — nothing to declare twice.
+
+A complete, runnable app using all of the above lives in [`examples/nest-typeorm`](https://github.com/kavo-labs/kavo/tree/main/examples/nest-typeorm).

--- a/docs/integrations/nest/typeorm.md
+++ b/docs/integrations/nest/typeorm.md
@@ -24,7 +24,7 @@ bun add @kavo/core @kavo/nest @kavo/typeorm
 
 :::
 
-`@kavo/typeorm` expects `typeorm` (`^0.3.20 || ^1.0.0`) as a peer; `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
+`@kavo/typeorm` expects `typeorm` (`^0.3.20 || ^1.0.0`) as a peer — add it to the command above if your app doesn't already have it — and `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
 
 ## Zero-config wiring
 

--- a/extensions/skills/quick-start/SKILL.md
+++ b/extensions/skills/quick-start/SKILL.md
@@ -77,8 +77,11 @@ TypeORM's entity columns and Nest's DI need it:
 }
 ```
 
-`useDefineForClassFields: false` matters here: with it on, TypeORM's
-`@Column()` decorators can't see field initializers correctly.
+`useDefineForClassFields: false` matters here: with it on, every declared
+field is emitted as a real class field, so a fresh entity carries an own key
+for every column — set to `undefined` — whether the adapter hydrated it or
+not. Partially-hydrated rows then serialize with those columns present as
+`undefined` instead of absent.
 
 ## 4. One plain entity — no DTOs
 


### PR DESCRIPTION
## What and why

Every install snippet in the adopter-facing docs was pnpm-only. pnpm is how this repo is
developed (ADR-0003); it is not an assumption to make about adopters. The docs site now
uses VitePress `::: code-group` tabs for pnpm/npm/yarn/bun, and the README lists the same
four commands as separate fenced blocks so GitHub's copy button yields one command rather
than a four-package-manager script.

The install line was also leaving a lot implicit, so this closes the surrounding gaps on
the same path — the first five minutes of an adopter's experience: peer dependencies with
the ranges from each `package.json`, a Requirements section (Node 20+, ESM-only, the
decorator tsconfig flags), install commands for `@kavo/graphql` and `@kavo/mcp` separated
into the in-Nest and standalone cases, the missing `@kavo/mcp` row in the README package
table, a link to `examples/nest-typeorm`, and a dead link in the docs index.

Closes #87

## Public API impact

None. Documentation only — no package source, no barrel change, no behavior change. The
one non-markdown edit is a sidebar entry in `docs/.vitepress/config.mts`.

## Testing

No tests added; there is no code under test in this diff, and `kavo-test-auditor`
independently confirmed that adding any would be manufactured work. Verified instead:

```
pnpm check         exit 0    54 test files, 896 tests passed
                             depcruise: 242 modules / 854 deps, no violations
pnpm format:check  exit 0
pnpm docs:build    exit 0    3 code-groups / 12 tabs, pnpm-npm-yarn-bun throughout
```

Both anchors the integration pages link to (`#requirements`, `#peer-dependencies`) exist
in the built HTML, and tab labels, command wording, and ordering were checked in the
rendered output rather than only in source. All sixteen `docs/README.md` links were
checked by hand, since `srcExclude: ["README.md"]` means VitePress never sees that file.

Registry check for the documented commands:

| Command | Result |
| --- | --- |
| `npm install @kavo/core @kavo/nest @kavo/typeorm` | OK |
| `npm install @kavo/graphql graphql` | OK |
| `npm install @kavo/mcp` | 404 — not published |
| `npm install @kavo/prisma` | `EUNSUPPORTEDPROTOCOL` |
| `npm install @kavo/mongoose` | `EUNSUPPORTEDPROTOCOL` |

Those last three are #85, not this PR. #87 deliberately documents them anyway rather than
adding a banner that goes stale the moment #85 lands.

## Review

Reviewed with `kavo-reviewer` and `kavo-test-auditor`. Both independently flagged the same
blocking defect, and the last two commits fix it along with everything else raised.

The `useDefineForClassFields` rationale was wrong, and wrong in a way that reads
plausibly. An earlier revision claimed the class field "overwrites the value TypeORM just
assigned while hydrating the row" — but TypeORM constructs first and assigns after
(`EntityMetadata.create` → `new this.target()`, then column assignment), so nothing is
overwritten. The repo's own harness disproves it: `vitest.config.ts` sets `target: es2022`
without `useDefineForClassFields`, so SWC emits `id; name;` for entity fields, and
`packages/orms/typeorm/tests/adapter.spec.ts` hydrates real SQLite rows through that
transform and passes. `tsc` had settled the *emit*; the *consequence* was extrapolated
from it and did not hold.

The recommendation is unchanged and correct — it is what every package and both example
apps compile with. What changed is the stated mechanism, now the observable one: a fresh
entity carries an own key for every column, so a partially-hydrated entity looks fully
populated, and `default-serializer.ts:84`'s `Object.keys(source)` projection emits those
columns as `undefined` instead of omitting them.

Also fixed from review:

- "which npm auto-installs" ignored yarn — which this PR promotes to a first-class option
  and which does **not** auto-install peers. Now scoped to npm/pnpm/bun, with yarn's
  unmet-peer behavior called out.
- "`@kavo/nest` already depends on `@kavo/graphql` and `@kavo/mcp`" is true of `main` but
  not of the installable `@kavo/nest@0.6.0`, whose manifest has no `@kavo/mcp`. Softened
  to "as of the next release" so the instruction does not dead-end.
- Each integration page now says to add the ORM peer if the app lacks it.
- Inline comments in the GraphQL/MCP tabs were a column out of alignment.

## Review notes

- **`extensions/skills/quick-start/SKILL.md` is fixed in its own commit** (`fc84553`),
  which **expands scope past #87**, since that issue puts `extensions/skills/*` out of
  scope. It carried the same incorrect explanation, and leaving it would have shipped two
  different wrong mechanisms. Isolated deliberately so it can be dropped without touching
  the rest.
- **Deferred, needs a packaging decision, not a docs one:** `getting-started.md` documents
  `@modelcontextprotocol/sdk` as a required peer of `@kavo/mcp` (verbatim from
  `package.json`), while `docs/internals/architecture/14-mcp-binding.md` §5 calls it
  optional "for both". Review confirmed this PR picked the correct side and that the
  packaging is what is out of step: because `@kavo/nest` depends on `@kavo/mcp` outright,
  every app installing `@kavo/nest` transitively demands the SDK, so the guarantee the
  lazy-load machinery exists to provide is not delivered at the packaging level. The same
  reasoning applies to `graphql` via `@kavo/graphql` and doc 13 §6. Fold into #85.
- **Peer ranges are behind the registry:** `mongoose` is at 9.x against a `^7 || ^8` peer,
  `@prisma/client` at 7.x against `^5 || ^6`. The PR did what #87 required (copy verbatim
  from `package.json`), so this is packaging drift for #85, not a docs defect.
- **Nothing verifies the hand-copied version ranges.** `pnpm check` never reads `docs/`,
  and `lint` is scoped to `packages`/`examples`. A test is the wrong tool (`vitest.config.ts`
  would need a new glob, and reaching into `docs/` from a package test cuts across the
  boundary `depcruise` enforces); generating the list at docs-build time, the way
  `config.mts` already reads `version`, is the real fix. Separate issue.
- **#86 scope note:** `docs/README.md` is `srcExclude`d, so the dead link this PR fixes
  there would not have been caught by a docs-build gate as currently scoped, and neither
  would the sidebar link in `config.mts`. Worth widening #86.
- Pre-existing: `14-mcp-binding.md` and `14-prisma-adapter.md` share the `14-` prefix, now
  visible as two "14"s in `docs/README.md`'s index. Renumbering is out of scope per #87.

Non-blocking, seen while working: `examples/nest-typeorm/tests/crud-e2e.suite.ts:610` (a
tag-association assertion) failed once on the very first gate run and has passed on every
run since. Looks like a flake in that e2e suite; unrelated to this diff, which cannot
reach it.
