### PR TITLE
ci: build the docs site on every PR so docs breakage gates the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,9 @@ jobs:
   docs:
     name: docs
     runs-on: ubuntu-latest
-    # The build takes ~30s; a bound turns a hung SSR render into a fast red
-    # instead of letting it sit on a runner for GitHub's 6-hour default.
+    # The build itself takes seconds; a bound turns a hung SSR render into a
+    # fast red instead of letting it sit on a runner for GitHub's 6-hour
+    # default.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,32 @@ jobs:
 
       - name: Check formatting
         run: pnpm format:check
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm check` does not build the docs site, so a dead link or a broken
+      # theme component would otherwise only surface in the Pages deploy on
+      # `main`, after the PR merged. This builds the site — VitePress fails the
+      # build on dead links — so docs breakage gates the PR instead.
+      # Deliberately not path-filtered: docs/.vitepress/config.mts reads
+      # packages/core/package.json at build time, so a packaging change can
+      # break the docs build without touching docs/. pages.yml still owns
+      # deployment; this job only builds.
+      - name: Build docs
+        run: pnpm docs:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# Every job here only reads the checkout — nothing comments, pushes, or
+# deploys. pages.yml and publish.yml already declare their permissions; this
+# was the one workflow still inheriting the repo default.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
   docs:
     name: docs
     runs-on: ubuntu-latest
+    # The build takes ~30s; a bound turns a hung SSR render into a fast red
+    # instead of letting it sit on a runner for GitHub's 6-hour default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -82,13 +85,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # `pnpm check` does not build the docs site, so a dead link or a broken
-      # theme component would otherwise only surface in the Pages deploy on
-      # `main`, after the PR merged. This builds the site — VitePress fails the
-      # build on dead links — so docs breakage gates the PR instead.
-      # Deliberately not path-filtered: docs/.vitepress/config.mts reads
+      # Not path-filtered on purpose: docs/.vitepress/config.mts reads
       # packages/core/package.json at build time, so a packaging change can
-      # break the docs build without touching docs/. pages.yml still owns
-      # deployment; this job only builds.
+      # break the docs build without touching docs/. Builds only — pages.yml
+      # still owns deployment.
       - name: Build docs
         run: pnpm docs:build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ pnpm test         # vitest run (whole monorepo)
 pnpm depcruise    # enforce package-boundary rules (.dependency-cruiser.cjs)
 pnpm lint         # oxlint over packages/*/src and packages/*/tests
 pnpm prettify     # prettier --write . (printWidth 120)
+pnpm docs:build   # vitepress build docs — a second CI gate that `check` does NOT run
 ```
 
 Run a single test file or test by name:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ CI runs the identical gate on three Node versions (`lts/-1`, `lts/*`,
 ```bash
 pnpm prettify      # writes formatting fixes
 pnpm format:check  # what CI actually runs
-pnpm docs:build    # only if you touched docs/ — a separate CI job gates it
+pnpm docs:build    # a separate CI job gates it — see "Working on the docs"
 ```
 
 One thing the gate does **not** cover: CI installs with
@@ -316,12 +316,14 @@ pnpm docs:preview  # serve the production build
 `pnpm check` does not build the site, but CI does: a separate `docs` job runs
 `pnpm docs:build` on every pull request. VitePress fails that build on dead
 links _between pages under `docs/`_, so a broken cross-reference there fails the
-PR rather than the Pages deploy on `main`. Run it locally before pushing a docs
-change.
+PR rather than the Pages deploy on `main`. The job is deliberately not
+path-filtered — `docs/.vitepress/config.mts` reads `packages/core/package.json`
+at build time — so run it locally before pushing, docs change or not.
 
 The gate's reach stops at what VitePress renders, so these still need a human
-eye: links in files it never renders — this one, the root `README.md`, and
-`docs/README.md` (`srcExclude`d in `config.mts`) — and links pointing at
+eye: links in files it never renders — everything outside `docs/` (this one, the
+root `README.md`, each package's and example's `README.md`) plus
+`docs/README.md`, which `config.mts` `srcExclude`s — and links pointing at
 `CLAUDE.md`, which `ignoreDeadLinks` exempts.
 
 `docs/` has two audiences, and it is worth keeping them separate:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,17 +314,27 @@ pnpm docs:preview  # serve the production build
 ```
 
 `pnpm check` does not build the site, but CI does: a separate `docs` job runs
-`pnpm docs:build` on every pull request. VitePress fails that build on dead
-links _between pages under `docs/`_, so a broken cross-reference there fails the
-PR rather than the Pages deploy on `main`. The job is deliberately not
-path-filtered — `docs/.vitepress/config.mts` reads `packages/core/package.json`
-at build time — so run it locally before pushing, docs change or not.
+`pnpm docs:build` on every pull request and every push to `main`. VitePress fails
+that build on dead links _between pages under `docs/`_, so a broken
+cross-reference there fails the PR rather than the Pages deploy on `main`. The
+job is deliberately not path-filtered — `docs/.vitepress/config.mts` reads
+`packages/core/package.json` at build time — so run it locally before pushing,
+docs change or not.
 
-The gate's reach stops at what VitePress renders, so these still need a human
-eye: links in files it never renders — everything outside `docs/` (this one, the
-root `README.md`, each package's and example's `README.md`) plus
-`docs/README.md`, which `config.mts` `srcExclude`s — and links pointing at
-`CLAUDE.md`, which `ignoreDeadLinks` exempts.
+The gate is narrower than "it checks the links", though. These four categories
+pass a green build and still need a human eye:
+
+- **Anything outside `docs/`** — this file, the root `README.md`, each package's
+  and example's `README.md` — plus `docs/README.md`, which `config.mts`
+  `srcExclude`s. VitePress never renders them, so it never sees their links.
+- **`#anchor` fragments**, even between two rendered pages. VitePress strips the
+  hash before it compares, so `/getting-started#long-gone` passes as long as
+  `getting-started` itself exists.
+- **Links in config or frontmatter rather than markdown** — the `themeConfig.nav`
+  and `sidebar` entries in `config.mts`, and the homepage's `hero.actions` in
+  `docs/index.md`. Renaming a page updates none of them, and the build stays
+  green while the site's own navigation 404s.
+- **Links pointing at `CLAUDE.md`**, which `ignoreDeadLinks` exempts.
 
 `docs/` has two audiences, and it is worth keeping them separate:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ CI runs the identical gate on three Node versions (`lts/-1`, `lts/*`,
 ```bash
 pnpm prettify      # writes formatting fixes
 pnpm format:check  # what CI actually runs
+pnpm docs:build    # only if you touched docs/ — a separate CI job gates it
 ```
 
 One thing the gate does **not** cover: CI installs with
@@ -314,8 +315,14 @@ pnpm docs:preview  # serve the production build
 
 `pnpm check` does not build the site, but CI does: a separate `docs` job runs
 `pnpm docs:build` on every pull request. VitePress fails that build on dead
-links, so a broken relative link fails the PR rather than the Pages deploy on
-`main`. Run it locally before pushing a docs change.
+links _between pages under `docs/`_, so a broken cross-reference there fails the
+PR rather than the Pages deploy on `main`. Run it locally before pushing a docs
+change.
+
+The gate's reach stops at what VitePress renders, so these still need a human
+eye: links in files it never renders — this one, the root `README.md`, and
+`docs/README.md` (`srcExclude`d in `config.mts`) — and links pointing at
+`CLAUDE.md`, which `ignoreDeadLinks` exempts.
 
 `docs/` has two audiences, and it is worth keeping them separate:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ a test fail, either the change is wrong or the test encoded a behavior that is
 being deliberately changed — and the second case belongs in the PR description.
 
 CI runs the identical gate on three Node versions (`lts/-1`, `lts/*`,
-`current`), plus a separate formatting job. Before pushing:
+`current`), plus separate formatting and docs-build jobs. Before pushing:
 
 ```bash
 pnpm prettify      # writes formatting fixes
@@ -311,6 +311,11 @@ pnpm docs:dev      # local dev server with hot reload
 pnpm docs:build    # production build
 pnpm docs:preview  # serve the production build
 ```
+
+`pnpm check` does not build the site, but CI does: a separate `docs` job runs
+`pnpm docs:build` on every pull request. VitePress fails that build on dead
+links, so a broken relative link fails the PR rather than the Pages deploy on
+`main`. Run it locally before pushing a docs change.
 
 `docs/` has two audiences, and it is worth keeping them separate:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,7 +229,3 @@ That column alone is enough for `deleteOne` to soft-delete and for reads to hide
 - **Purge** — `@Kavo(Book, { operations: { purgeOne: true } })` turns on `DELETE /books/:id/purge`, which permanently removes an already-soft-deleted row.
 
 Both can be combined. Attempting to restore a row that isn't deleted, or purge one that is still live, returns a 409, not a silent no-op. Pass `?withDeleted=true` on a read to opt back into seeing soft-deleted rows for that request. See [Soft delete, restore & purge](/internals/architecture/11-soft-delete) for the full behavior — unique-index caveats, cascades, and what's deliberately not built (bulk restore/purge).
-
-<!-- TEMPORARY: proves the CI docs job fails on a dead link. Reverted in the next commit. -->
-
-See [the page that does not exist](/internals/architecture/07-kavo-engine) for more.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,3 +229,7 @@ That column alone is enough for `deleteOne` to soft-delete and for reads to hide
 - **Purge** — `@Kavo(Book, { operations: { purgeOne: true } })` turns on `DELETE /books/:id/purge`, which permanently removes an already-soft-deleted row.
 
 Both can be combined. Attempting to restore a row that isn't deleted, or purge one that is still live, returns a 409, not a silent no-op. Pass `?withDeleted=true` on a read to opt back into seeing soft-deleted rows for that request. See [Soft delete, restore & purge](/internals/architecture/11-soft-delete) for the full behavior — unique-index caveats, cascades, and what's deliberately not built (bulk restore/purge).
+
+<!-- TEMPORARY: proves the CI docs job fails on a dead link. Reverted in the next commit. -->
+
+See [the page that does not exist](/internals/architecture/07-kavo-engine) for more.


### PR DESCRIPTION
## What & why

`pnpm check` never builds the docs site — it is generate + build + typecheck + depcruise + lint + test. The only thing that ran `vitepress build` was `pages.yml`, on push to `main`. So a dead link, a broken theme component under `docs/.vitepress/theme/`, or a config error passed CI, merged, and then failed the deploy job on `main`: the published site kept serving the last good build while `main` was broken, and nobody found out until someone read the Actions tab.

This adds a `docs` job to `ci.yml` that runs `pnpm docs:build`. VitePress checks dead links at build time and exits non-zero, so docs breakage now fails the PR instead of the deploy.

Two deliberate choices:

- **A separate job, not folded into `pnpm check`.** One job on one Node version, mirroring `format`, rather than building the site three times across the `check` matrix. It also keeps CLAUDE.md's description of what `check` runs accurate, so no CLAUDE.md edit was needed.
- **Not path-filtered.** `docs/.vitepress/config.mts` reads `packages/core/package.json` at build time, so a packaging change can break the docs build without touching `docs/`.

`pages.yml` is untouched and still owns deployment; this job only builds.

Closes #86

## Public API impact

None

## Testing

No tests added — this is a workflow-only change, and the thing under test is the CI job itself. It is verified two ways.

**Locally**, in a clean worktree:

| Step | Result |
| --- | --- |
| `pnpm docs:build` baseline | exit **0**, `build complete in 2.13s` |
| append a link to a nonexistent page in `docs/getting-started.md` | exit **1**, `(!) Found dead link … in file getting-started.md` → `[vitepress] 1 dead link(s) found.` |
| revert the link | exit **0** |

Verified gate on the final tree: `pnpm check` **exit 0** — 54 test files, 896 tests passed, 0 dependency violations across 242 modules. `pnpm format:check` **exit 0**.

**In CI**, since the issue asks this PR to show the job red *and* green, the pair is on record in this PR's own check history:

| Run | Commit | `docs` | Other jobs |
| --- | --- | --- | --- |
| [30796865262](https://github.com/kavo-labs/kavo/actions/runs/30796865262) | the change itself | ✅ success | all ✅ |
| [30797055431](https://github.com/kavo-labs/kavo/actions/runs/30797055431) | `a359a1a` adds a dead link | ❌ **failure** | `check` ×3 and `format` all ✅ |
| [30797243988](https://github.com/kavo-labs/kavo/actions/runs/30797243988) | `e9e2042` reverts it | ✅ success | all ✅ |
| [30797455168](https://github.com/kavo-labs/kavo/actions/runs/30797455168) | `db6f9ee` scopes the token | ✅ success | all ✅ |

The red run failed for exactly the right reason and only in the right job:

```
(!) Found dead link /internals/architecture/07-kavo-engine in file getting-started.md
build error:
[vitepress] 1 dead link(s) found.
Error: Process completed with exit code 1.
```

`docs` was the only failing job in that run — `check` on all three Node versions and `format` stayed green, which is the point: nothing else in the gate notices a dead link. The two demo commits cancel out, so the branch's net diff is the workflow job, the CONTRIBUTING note, and the permissions block — verified with `git diff` between the pre- and post-demo commits (empty).

## Review notes

Look hardest at the trigger surface: the job inherits the workflow-level `on: push: branches: [main]` + `pull_request` and the existing `cancel-in-progress` concurrency group, and adds no `paths` filter of its own — the comment in the job records why, so a later "optimization" does not silently reintroduce the gap this closes.

**Addressing the CodeQL review:** it flagged `ci.yml` as having no `permissions` block, leaving its `GITHUB_TOKEN` at the repository default. Valid, and `ci.yml` was the last workflow in the repo like that (`pages.yml` and `publish.yml` already scope theirs). `db6f9ee` adds workflow-level `permissions: contents: read`, which is all any job here needs, and run 30797455168 confirms all five jobs stay green under it.

The `CONTRIBUTING.md` commit is scope added beyond the issue's stated file list: CONTRIBUTING claimed CI runs the gate "plus a separate formatting job", which this change makes untrue. Correcting it is the same anti-drift rule the issue's own Constraints section applies to CLAUDE.md. Drop that commit if you would rather keep the diff to `ci.yml` alone.

Out of scope, per the issue: `docs/README.md`'s dead link to `07-kavo-engine.md` — VitePress `srcExclude`s `README.md`, so this gate will never catch it.