### PR TITLE
chore: restore @kavo/prisma lockstep version and fix the first-publish bootstrap

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -94,9 +94,37 @@ workflow.
    `@kavo/nest` pointing at a version of a sibling that does not exist —
    uninstallable, and past npm's unpublish window it cannot be withdrawn.
 
-   To bootstrap one: publish it by hand, then configure its trusted publisher
-   on npmjs.com (`kavo-labs/kavo` + `publish.yml`), confirm `npm view` resolves,
-   and only then release. That first version will lack OIDC provenance; every
+   To bootstrap one: publish it by hand — **`pnpm pack` first, then
+   `npm publish` the resulting tarball**, exactly as `publish.yml` does:
+
+   ```bash
+   TARBALL_PREFIX=$(echo "$NAME" | sed 's/^@//; s/\//-/')
+   (cd "$dir" && pnpm pack --pack-destination /tmp/kavo-bootstrap)
+   npm publish /tmp/kavo-bootstrap/"$TARBALL_PREFIX"-*.tgz --access public
+   ```
+
+   A bare `npm publish` from the package directory is **not** equivalent and
+   must never be used: only `pnpm pack` rewrites `workspace:^` into a real
+   semver range, so a directly-published package ships
+   `"@kavo/core": "workspace:^"` verbatim and every `npm install` of it fails
+   with `EUNSUPPORTEDPROTOCOL`. That mistake is unfixable after npm's
+   unpublish window — the version has to be superseded by the next release.
+   `@kavo/prisma@0.5.0`, `@kavo/mongoose@0.6.0` and `@kavo/graphql@0.4.0` were
+   all bootstrapped this way and none of the three can be installed. The first
+   two are still their package's `latest`, so a plain `npm install @kavo/prisma`
+   or `npm install @kavo/mongoose` fails outright today; `@kavo/graphql` was
+   rescued only because a correctly-packed `0.6.0` superseded it, which is the
+   only repair available once the unpublish window has closed.
+
+   Then configure its trusted publisher on npmjs.com (`kavo-labs/kavo` +
+   `publish.yml`) and verify the bootstrap actually resolves — `npm view` only
+   proves the version exists, not that it installs:
+
+   ```bash
+   (cd "$(mktemp -d)" && npm init -y >/dev/null && npm install "$NAME" --dry-run)
+   ```
+
+   Only then release. That first version will lack OIDC provenance; every
    later release of it through the workflow will have it.
 
 6. **Confirm with the user before doing anything irreversible.** State

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -98,9 +98,30 @@ workflow.
    `npm publish` the resulting tarball**, exactly as `publish.yml` does:
 
    ```bash
-   TARBALL_PREFIX=$(echo "$NAME" | sed 's/^@//; s/\//-/')
-   (cd "$dir" && pnpm pack --pack-destination /tmp/kavo-bootstrap)
-   npm publish /tmp/kavo-bootstrap/"$TARBALL_PREFIX"-*.tgz --access public
+   # Name the package explicitly. Do not rely on $dir/$NAME surviving the loop
+   # above — after it exits they hold the *last* PACKAGE_DIRS entry, not the
+   # one that printed NEVER PUBLISHED.
+   dir=<the PACKAGE_DIRS entry that printed NEVER PUBLISHED>
+   NAME=$(node -p "require('./$dir/package.json').name")
+   VERSION=$(node -p "require('./$dir/package.json').version")
+
+   # Build first. `dist/` is gitignored and no package defines prepack,
+   # prepare or prepublishOnly, so `pnpm pack` does not build anything on its
+   # own — CI gets away with it only because `pnpm check` runs before the Pack
+   # step. Packing an unbuilt tree ships a tarball whose "files": ["dist"]
+   # matches nothing: it publishes, it becomes latest, and every import fails.
+   pnpm install --frozen-lockfile && pnpm build || echo "BUILD FAILED — stop here"
+
+   # Pack into a fresh private directory, so the glob cannot pick up a tarball
+   # left behind by an earlier attempt.
+   TARBALL_DIR=$(mktemp -d)
+   (cd "$dir" && pnpm pack --pack-destination "$TARBALL_DIR")
+   TARBALL=$(echo "$TARBALL_DIR"/*.tgz)
+
+   # Confirm what you are about to make permanent, then publish.
+   echo "publishing $NAME@$VERSION from $TARBALL"
+   tar -tzf "$TARBALL" | grep -q "^package/dist/" || echo "NO dist/ — DO NOT PUBLISH"
+   npm publish "$TARBALL" --access public
    ```
 
    A bare `npm publish` from the package directory is **not** equivalent and
@@ -121,8 +142,16 @@ workflow.
    proves the version exists, not that it installs:
 
    ```bash
-   (cd "$(mktemp -d)" && npm init -y >/dev/null && npm install "$NAME" --dry-run)
+   (cd "$(mktemp -d)" && npm init -y >/dev/null && npm install "$NAME@$VERSION" --dry-run)
    ```
+
+   Pin `@$VERSION` rather than letting it resolve `latest` — identical for a
+   genuine first publish, but correct too when this is reused to verify a
+   repair publish. Note what this does **not** prove: `--dry-run` exercises
+   resolution, which is exactly the `workspace:^` failure class above, but it
+   never unpacks the tarball, so it passes happily on a package published with
+   an empty `dist/`. The `tar -tzf` check before publishing is what covers
+   that.
 
    Only then release. That first version will lack OIDC provenance; every
    later release of it through the workflow will have it.

--- a/packages/orms/prisma/package.json
+++ b/packages/orms/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kavo/prisma",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Kavo Prisma adapter — implements @kavo/core's RepositoryAdapter over Prisma Client.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Two commits.

## 1. `chore(prisma)`: restore lockstep version to 0.6.0

Sets `@kavo/prisma`'s in-repo version to `0.6.0`, so all seven packages in
`PACKAGE_DIRS` read the same version. One line; `pnpm install` produced no
lockfile change, because pnpm links workspace deps by path and does not record
their versions.

The `v0.6.0` release commit (`4a904c3`) bumped only four of seven published
packages, because `.claude/commands/publish.md` named a stale package list.
`@kavo/prisma` was left at `0.5.0`, violating ADR-0004. The release still went
green: `publish.yml` compares only `packages/core`'s version to the tag, and
the publish loop then found `@kavo/prisma@0.5.0` already on the registry and
skipped it. The stale list was fixed in #84.

## 2. `chore(publish)`: require `pnpm pack` when bootstrapping a first publish

Found by code review, and **outside issue #89's stated scope** — see the note
at the bottom.

Step 5 said to "publish it by hand" and confirm with `npm view`. Both halves
are wrong, and between them they have already produced three uninstallable
artifacts:

- A bare `npm publish` from a package directory ships
  `"@kavo/core": "workspace:^"` verbatim. Only `pnpm pack` rewrites it into a
  real semver range, which is why `publish.yml` packs before publishing.
- `npm view` cannot detect the result: it proves a version record exists, not
  that it resolves, so it reports success for all three broken packages.

Reproduced in a clean directory with `npm install <pkg> --dry-run`:

| Package | Result |
| --- | --- |
| `@kavo/prisma` (latest 0.5.0) | `Unsupported URL Type "workspace:"` |
| `@kavo/mongoose` (latest 0.6.0) | `Unsupported URL Type "workspace:"` |
| `@kavo/graphql` (latest 0.6.0) | installs — 0.4.0 is broken but superseded |
| `@kavo/typeorm` (latest 0.6.0) | installs |

The confirmation step is now an `npm install --dry-run` into a temp dir, which
actually exercises resolution.

This is not hypothetical: the next action #89 asks for is a hand bootstrap of
`@kavo/mcp`, which under the old wording would have created a fourth broken
package, unfixable once npm's unpublish window closes.

## Public API impact

None. Version metadata and command wiring only — no `src` changes.

## Testing

`pnpm check` green: build + typecheck (9 projects) + depcruise (242 modules,
0 violations) + lint + 896 tests in 54 files. `pnpm prettify` reports
`publish.md` unchanged.

Two runs during this work failed on the pre-existing ~10% e2e flake tracked in
#91 — once `socket hang up` in `binding.e2e.spec.ts`, once a different test in
`app-mariadb.e2e.spec.ts`. Both files are named in #91, and "a different test
failing each run" is that issue's signature. The gate passed clean on re-run
each time.

## Review notes

**This PR does not close #89** — it uses `Refs`, not `Closes`, on purpose. It
delivers only the issue's first acceptance criterion; the rest is npm registry
state needing manual out-of-band publishes plus trusted-publisher setup:

- `@kavo/prisma@0.6.0` backfilled from the **`v0.6.0` tag** (not `main` —
  `main`'s prisma carries the post-0.6.0 `createPrismaInfrastructure` →
  `createInfrastructure` rename, which would make "Kavo 0.6" describe two
  different API shapes alongside `@kavo/typeorm@0.6.0`).
- `@kavo/mcp@0.6.0` bootstrapped from `main` — it did not exist at the tag.

Both tarballs were built with `pnpm pack` and verified: `workspace:^` rewrites
to `^0.6.0` and each installs clean against the published `@kavo/core@0.6.0`.

**The prisma backfill also repairs half of #85.** Publishing the correctly
packed `0.6.0` makes it `latest` and supersedes the uninstallable `0.5.0`.
`@kavo/mongoose` gets no such rescue — its broken artifact is already published
*at* the current lockstep version, so it cannot be repaired in place and needs
the next release. That stays with #85.

Two further notes:

- **`/publish` step 5 only checked package existence.** `@kavo/prisma` already
  exists at 0.5.0, so step 5 passed for it while it was uninstallable. Commit 2
  fixes that check; issue #89's own acceptance criteria inherit the same
  weakness and should use a resolution check too.
- **A clean `npm install @kavo/nest` resolves fine today**, because the
  published `@kavo/nest@0.6.0` predates the `@kavo/mcp` dependency. The
  `ETARGET` risk is prospective, arriving with the next release.

Adding the mechanical lockstep assertion to `publish.yml` remains out of scope
(issue #90).

### Scope note on commit 2

Issue #89 lists `.claude/commands/publish.md` as out of scope, on the grounds
that it was "already fixed in #84". That referred to the stale package list;
this is a different, newly found defect in the same file, and it directly
governs the manual publish step #89 asks for next. Dropping it is a one-liner
(`git rebase --onto HEAD~2 HEAD~1`) if you'd rather it went to its own PR.

Refs #89, #85