### PR TITLE
test(prisma): give every spec file its own SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ api.rest
 docs/.vitepress/cache
 packages/orms/prisma/prisma/*.db
 packages/orms/prisma/prisma/*.db-journal
+packages/orms/prisma/prisma/*.db-wal
+packages/orms/prisma/prisma/*.db-shm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,13 @@ pnpm build
 fixture schema is SQLite, and `packages/orms/prisma/prisma/.env` is committed
 with a working `DATABASE_URL`.
 
+What it pushes is a **template**, `prisma/template.db`, which no test opens.
+`tests/support/client.ts` copies it per client, so each spec file writes to a
+database of its own — SQLite admits one writer at a time, and one shared file
+made the suite flaky under CI load. The copies live in a scratch directory
+that `tests/support/global-setup.ts` creates per vitest run and deletes when
+the run ends.
+
 Note what it is _not_ for. `@kavo/prisma`'s own `src` never imports
 `@prisma/client` — it models the client structurally in
 `prisma-client-like.ts`, precisely so a library package does not assume the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,13 @@ A few things about the test setup that are easy to trip over:
 - **The SWC transform is required.** TypeORM entities and Nest DI rely on
   decorator metadata, which vitest's default esbuild transform cannot emit. That
   is why `unplugin-swc` is in the vitest config — don't remove it.
+- **`@kavo/prisma`'s specs need the `globalSetup` in the vitest config.** It
+  creates the scratch directory their database copies are written into and
+  deletes it when the run ends. Remove it, or run those specs under a config
+  that omits it, and every `newTestPrismaClient()` throws
+  `KAVO_PRISMA_SCRATCH_ROOT is unset` — the fixture provisioner refuses to fall
+  back to the OS temp directory, because a copy made outside that root is one
+  nothing ever deletes.
 - **An e2e spec binds its app with `listen(app)`, never `app.init()`.** The
   helper lives in each package's `tests/support/listen.ts`. `init()` leaves
   `getHttpServer()` unbound, so supertest binds it per request — `listen(0)` on

--- a/docs/internals/architecture/14-prisma-adapter.md
+++ b/docs/internals/architecture/14-prisma-adapter.md
@@ -114,3 +114,12 @@ SQLite (`tests/adapter.spec.ts`, `tests/soft-delete.spec.ts`,
 `tests/includes.spec.ts`), per-package testing as specified — the shared
 test schema and generated client are built by `pnpm generate`
 (`prisma generate` + `prisma db push`), which `pnpm check` runs first.
+
+The schema is shared; the database is not. `db push` writes a template
+(`prisma/template.db`) that no test opens, and `tests/support/client.ts`
+copies it per client into a scratch directory `tests/support/global-setup.ts`
+provisions for the run and removes afterwards. Vitest runs spec files in
+parallel workers and SQLite admits one writer at a time, so a single file
+turned each `beforeEach` write chain into a lock other files could stall
+behind — a `P1008` socket timeout under CI load. One database per client
+removes the contention instead of widening the timeout around it.

--- a/packages/orms/prisma/prisma/.env
+++ b/packages/orms/prisma/prisma/.env
@@ -1,1 +1,1 @@
-DATABASE_URL="file:./dev.db"
+DATABASE_URL="file:./template.db"

--- a/packages/orms/prisma/prisma/schema.prisma
+++ b/packages/orms/prisma/prisma/schema.prisma
@@ -3,6 +3,10 @@
 // Prisma has no equivalent of "define an entity inline in a test file", so
 // every fixture model used across tests/*.spec.ts lives in this one schema,
 // generating one shared PrismaClient the test files reuse.
+//
+// `pnpm generate` pushes this schema to `template.db`, which no test opens:
+// `tests/support/client.ts` copies it per client, so parallel spec files never
+// contend for one SQLite file (issue #101).
 generator client {
   provider = "prisma-client-js"
 }

--- a/packages/orms/prisma/prisma/schema.prisma
+++ b/packages/orms/prisma/prisma/schema.prisma
@@ -80,3 +80,10 @@ model Invoice {
   number     String
   archivedAt DateTime?
 }
+
+// ── database-isolation.spec.ts ──────────────────────────────────────────
+
+model Scratch {
+  id    Int    @id @default(autoincrement())
+  label String
+}

--- a/packages/orms/prisma/tests/database-isolation.spec.ts
+++ b/packages/orms/prisma/tests/database-isolation.spec.ts
@@ -1,57 +1,133 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { newTestPrismaClient, provisionTestDatabase } from "./support/client.js";
-import { SCRATCH_ROOT_ENV } from "./support/global-setup.js";
+import { join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { TEMPLATE_DATABASE, newTestPrismaClient, provisionTestDatabase } from "./support/client.js";
+import setup, { SCRATCH_ROOT_ENV } from "./support/global-setup.js";
+
+const PRISMA_DIRECTORY = fileURLToPath(new URL("../prisma/", import.meta.url));
 
 /**
  * The fixture-provisioning contract itself. Every other spec file in this
  * package opens a `beforeEach` with a chain of `deleteMany()` writes, and
  * vitest runs those files in parallel workers; SQLite admits one writer at a
  * time, so a single shared file made the suite fail with `P1008` under CI load
- * (issue #101). These tests pin the property that removed the contention:
- * one database file per client, never a shared one.
+ * (issue #101). These tests pin the properties that removed the contention —
+ * one database per client — and the two that keep the fix from decaying
+ * silently: copies land where something deletes them, and a copy carries every
+ * committed transaction the template does.
  */
 describe("test-fixture database provisioning", () => {
   it("gives every client a database of its own", async () => {
     const first = newTestPrismaClient();
     const second = newTestPrismaClient();
     try {
-      await first.invoice.create({ data: { number: "INV-101" } });
+      await first.scratch.create({ data: { label: "isolation" } });
 
-      expect(await first.invoice.count()).toBe(1);
-      expect(await second.invoice.count()).toBe(0);
+      expect(await first.scratch.count()).toBe(1);
+      expect(await second.scratch.count()).toBe(0);
     } finally {
       await first.$disconnect();
       await second.$disconnect();
     }
   });
 
-  it("copies the template to a fresh path on every call", () => {
+  it("copies the template into the run's scratch root, byte for byte", () => {
+    const scratchRoot = process.env[SCRATCH_ROOT_ENV];
     const first = provisionTestDatabase();
     const second = provisionTestDatabase();
 
     expect(first).not.toBe(second);
-    expect(existsSync(first)).toBe(true);
-    expect(existsSync(second)).toBe(true);
+    for (const copy of [first, second]) {
+      // Containment is the half of the design that fails silently: a copy
+      // outside the scratch root works, and leaks, because nothing deletes it.
+      expect(copy.startsWith(`${scratchRoot}${sep}`)).toBe(true);
+      expect(readFileSync(copy).equals(readFileSync(TEMPLATE_DATABASE))).toBe(true);
+    }
+  });
+
+  it("carries committed-but-uncheckpointed WAL frames to the copy, without the rebuild-on-open wal-index", async () => {
+    const staging = provisionTestDatabase();
+    // A read, not just the pragma, is what maps the wal-index and takes
+    // SQLite's deadman-switch lock — that lock is why the writer's close
+    // below skips its checkpoint and leaves the WAL on disk to be copied.
+    const holder = newTestPrismaClient(staging);
+    await holder.$queryRawUnsafe("PRAGMA journal_mode=WAL;");
+    await holder.scratch.count();
+    try {
+      const writer = newTestPrismaClient(staging);
+      await writer.scratch.create({ data: { label: "uncheckpointed" } });
+      await writer.$disconnect();
+
+      // Without this the assertions below would pass vacuously if a future
+      // SQLite or Prisma checkpointed on close after all.
+      expect(existsSync(`${staging}-wal`)).toBe(true);
+      expect(existsSync(`${staging}-shm`)).toBe(true);
+
+      const copy = provisionTestDatabase(staging);
+      // The wal-index is derived state SQLite rebuilds on open. Copying a
+      // stale one can make SQLite treat it as authoritative and skip
+      // recovering the frames below — silent row loss, which is the failure
+      // this whole change exists to remove.
+      expect(existsSync(`${copy}-shm`)).toBe(false);
+
+      const reader = newTestPrismaClient(copy);
+      try {
+        expect(await reader.scratch.findMany()).toEqual([{ id: expect.any(Number), label: "uncheckpointed" }]);
+      } finally {
+        await reader.$disconnect();
+      }
+    } finally {
+      await holder.$disconnect();
+    }
+  });
+
+  it("opens the database `pnpm generate` was told to push", () => {
+    const declared = /^DATABASE_URL="file:(?<path>.+)"$/m.exec(readFileSync(join(PRISMA_DIRECTORY, ".env"), "utf8"));
+
+    // Two files have to name one database. When they drift, `pnpm generate`
+    // still succeeds and the suite fails with "run `pnpm generate` first".
+    expect(resolve(PRISMA_DIRECTORY, declared?.groups?.path ?? "")).toBe(TEMPLATE_DATABASE);
   });
 
   it("fails with a fixable message when the template has not been generated", () => {
     const missing = join(tmpdir(), "kavo-prisma-no-such-template.db");
 
     expect(() => provisionTestDatabase(missing)).toThrow(/pnpm generate/);
+    expect(() => provisionTestDatabase(missing)).toThrow(missing);
   });
 
   it("refuses to provision outside the run's scratch root", () => {
     // Falling back to the OS temp directory here would work, and leak a
     // fixture database per client forever — nothing else deletes those.
-    const scratchRoot = process.env[SCRATCH_ROOT_ENV];
-    delete process.env[SCRATCH_ROOT_ENV];
+    vi.stubEnv(SCRATCH_ROOT_ENV, undefined);
     try {
       expect(() => provisionTestDatabase()).toThrow(new RegExp(SCRATCH_ROOT_ENV));
     } finally {
-      if (scratchRoot !== undefined) process.env[SCRATCH_ROOT_ENV] = scratchRoot;
+      vi.unstubAllEnvs();
     }
+  });
+});
+
+describe("the run's scratch root", () => {
+  it("is a directory while the run lasts and is gone afterwards", () => {
+    // `setup()` assigns the variable itself, so `vi.stubEnv` cannot stand in
+    // here; the save-and-restore window is synchronous and cannot interleave.
+    const runRoot = process.env[SCRATCH_ROOT_ENV];
+    const teardown = setup();
+    const root = process.env[SCRATCH_ROOT_ENV] ?? "";
+    try {
+      expect(root).not.toBe(runRoot);
+      expect(statSync(root).isDirectory()).toBe(true);
+    } finally {
+      teardown();
+      if (runRoot !== undefined) process.env[SCRATCH_ROOT_ENV] = runRoot;
+    }
+
+    // Teardown is the entire reason this hook sits in the root vitest config:
+    // drop it and every run leaves a tree of SQLite copies behind.
+    expect(existsSync(root)).toBe(false);
+    expect(process.env[SCRATCH_ROOT_ENV]).toBe(runRoot);
   });
 });

--- a/packages/orms/prisma/tests/database-isolation.spec.ts
+++ b/packages/orms/prisma/tests/database-isolation.spec.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { newTestPrismaClient, provisionTestDatabase } from "./support/client.js";
+import { SCRATCH_ROOT_ENV } from "./support/global-setup.js";
 
 /**
  * The fixture-provisioning contract itself. Every other spec file in this
@@ -40,5 +41,17 @@ describe("test-fixture database provisioning", () => {
     const missing = join(tmpdir(), "kavo-prisma-no-such-template.db");
 
     expect(() => provisionTestDatabase(missing)).toThrow(/pnpm generate/);
+  });
+
+  it("refuses to provision outside the run's scratch root", () => {
+    // Falling back to the OS temp directory here would work, and leak a
+    // fixture database per client forever — nothing else deletes those.
+    const scratchRoot = process.env[SCRATCH_ROOT_ENV];
+    delete process.env[SCRATCH_ROOT_ENV];
+    try {
+      expect(() => provisionTestDatabase()).toThrow(new RegExp(SCRATCH_ROOT_ENV));
+    } finally {
+      if (scratchRoot !== undefined) process.env[SCRATCH_ROOT_ENV] = scratchRoot;
+    }
   });
 });

--- a/packages/orms/prisma/tests/database-isolation.spec.ts
+++ b/packages/orms/prisma/tests/database-isolation.spec.ts
@@ -1,0 +1,44 @@
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { newTestPrismaClient, provisionTestDatabase } from "./support/client.js";
+
+/**
+ * The fixture-provisioning contract itself. Every other spec file in this
+ * package opens a `beforeEach` with a chain of `deleteMany()` writes, and
+ * vitest runs those files in parallel workers; SQLite admits one writer at a
+ * time, so a single shared file made the suite fail with `P1008` under CI load
+ * (issue #101). These tests pin the property that removed the contention:
+ * one database file per client, never a shared one.
+ */
+describe("test-fixture database provisioning", () => {
+  it("gives every client a database of its own", async () => {
+    const first = newTestPrismaClient();
+    const second = newTestPrismaClient();
+    try {
+      await first.invoice.create({ data: { number: "INV-101" } });
+
+      expect(await first.invoice.count()).toBe(1);
+      expect(await second.invoice.count()).toBe(0);
+    } finally {
+      await first.$disconnect();
+      await second.$disconnect();
+    }
+  });
+
+  it("copies the template to a fresh path on every call", () => {
+    const first = provisionTestDatabase();
+    const second = provisionTestDatabase();
+
+    expect(first).not.toBe(second);
+    expect(existsSync(first)).toBe(true);
+    expect(existsSync(second)).toBe(true);
+  });
+
+  it("fails with a fixable message when the template has not been generated", () => {
+    const missing = join(tmpdir(), "kavo-prisma-no-such-template.db");
+
+    expect(() => provisionTestDatabase(missing)).toThrow(/pnpm generate/);
+  });
+});

--- a/packages/orms/prisma/tests/metadata.spec.ts
+++ b/packages/orms/prisma/tests/metadata.spec.ts
@@ -85,15 +85,21 @@ describe("buildEntityMetadata — bootstrap error paths", () => {
 });
 
 describe("createInfrastructure — adapter bootstrap error path", () => {
-  it("throws ConfigurationException when Prisma Client has no delegate for the resolved model name", () => {
+  it("throws ConfigurationException when Prisma Client has no delegate for the resolved model name", async () => {
     const client = newTestPrismaClient();
-    const infrastructure = createInfrastructure(client as never, {
-      datamodel: ghostDatamodel,
-      entities: [Ghost],
-    });
-    // Metadata resolution succeeds (Ghost matches ghostDatamodel); the real
-    // Prisma Client just has no `ghost` delegate, since no such model exists
-    // in the actual schema — this is the adapter constructor's own guard.
-    expect(() => infrastructure.adapterFor(Ghost)).toThrow(ConfigurationException);
+    try {
+      const infrastructure = createInfrastructure(client as never, {
+        datamodel: ghostDatamodel,
+        entities: [Ghost],
+      });
+      // Metadata resolution succeeds (Ghost matches ghostDatamodel); the real
+      // Prisma Client just has no `ghost` delegate, since no such model exists
+      // in the actual schema — this is the adapter constructor's own guard.
+      expect(() => infrastructure.adapterFor(Ghost)).toThrow(ConfigurationException);
+    } finally {
+      // Each client owns a database file now, and the run's scratch root is
+      // removed at teardown — an undisconnected client leaves that file open.
+      await client.$disconnect();
+    }
   });
 });

--- a/packages/orms/prisma/tests/support/client.ts
+++ b/packages/orms/prisma/tests/support/client.ts
@@ -8,8 +8,11 @@ import { SCRATCH_ROOT_ENV } from "./global-setup.js";
  * The SQLite file `pnpm generate` (`prisma db push`) builds from
  * `prisma/schema.prisma`. No test ever opens it: it is a *template*, copied
  * per client, which is what keeps the spec files from sharing one database.
+ *
+ * Must name the same file as `DATABASE_URL` in `prisma/.env`, which is what
+ * `prisma db push` writes; `database-isolation.spec.ts` pins the pair.
  */
-const TEMPLATE_DATABASE = fileURLToPath(new URL("../../prisma/template.db", import.meta.url));
+export const TEMPLATE_DATABASE = fileURLToPath(new URL("../../prisma/template.db", import.meta.url));
 
 /**
  * A finished `db push` leaves a checkpointed, sidecar-free database behind,
@@ -17,6 +20,11 @@ const TEMPLATE_DATABASE = fileURLToPath(new URL("../../prisma/template.db", impo
  * committed transaction the template does. `-shm` is deliberately *not*
  * copied: it is a derived wal-index that SQLite rebuilds on open, and a
  * copied one can be stale enough to make SQLite skip recovering the `-wal`.
+ *
+ * `-wal` and the `-shm` exclusion are pinned by
+ * `database-isolation.spec.ts`. `-journal` is not: a rollback journal only
+ * outlives its transaction after a crash mid-`db push`, and the only test
+ * that could cover it would restate this array rather than exercise SQLite.
  */
 const DATABASE_FILE_SUFFIXES = ["", "-journal", "-wal"];
 
@@ -61,7 +69,11 @@ export function provisionTestDatabase(templatePath: string = TEMPLATE_DATABASE):
  * because a plain `vitest run` has no reason to have that variable set; the
  * CLI commands that build the template (`generate`, `db push`) load it from
  * `prisma/.env` on their own.
+ *
+ * `databasePath` exists for the one case a fresh copy cannot serve: two
+ * clients that must meet on the same file, which is how
+ * `database-isolation.spec.ts` builds a database with an unfinished WAL.
  */
-export function newTestPrismaClient(): PrismaClient {
-  return new PrismaClient({ datasourceUrl: `file:${provisionTestDatabase()}` });
+export function newTestPrismaClient(databasePath: string = provisionTestDatabase()): PrismaClient {
+  return new PrismaClient({ datasourceUrl: `file:${databasePath}` });
 }

--- a/packages/orms/prisma/tests/support/client.ts
+++ b/packages/orms/prisma/tests/support/client.ts
@@ -1,14 +1,57 @@
+import { copyFileSync, existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { PrismaClient } from "@prisma/client";
+import { SCRATCH_ROOT_ENV } from "./global-setup.js";
 
 /**
- * One shared SQLite file, pushed by `pnpm generate` (`prisma db push`)
- * against `prisma/schema.prisma` before the suite runs. `datasourceUrl` is
- * passed explicitly — bypassing `env("DATABASE_URL")` — because a plain
- * `vitest run` has no reason to have that variable set; the CLI commands
- * that build the schema (`generate`, `db push`) load it from
+ * The SQLite file `pnpm generate` (`prisma db push`) builds from
+ * `prisma/schema.prisma`. No test ever opens it: it is a *template*, copied
+ * per client, which is what keeps the spec files from sharing one database.
+ */
+const TEMPLATE_DATABASE = fileURLToPath(new URL("../../prisma/template.db", import.meta.url));
+
+/**
+ * SQLite spreads one database over up to three files. A finished `db push`
+ * leaves a checkpointed, journal-free database behind, but copy whatever
+ * sidecars do exist so a copy can never be a torn read of the template.
+ */
+const DATABASE_FILE_SUFFIXES = ["", "-journal", "-wal", "-shm"];
+
+/**
+ * Copies the template database to a fresh directory under this run's scratch
+ * root (`tests/support/global-setup.ts`, which also removes it afterwards) and
+ * returns the copy's path. Exported for its own error path; specs want
+ * {@link newTestPrismaClient}.
+ */
+export function provisionTestDatabase(templatePath: string = TEMPLATE_DATABASE): string {
+  if (!existsSync(templatePath)) {
+    throw new Error(`No Prisma test-fixture database at ${templatePath} — run \`pnpm generate\` first.`);
+  }
+  const directory = mkdtempSync(join(process.env[SCRATCH_ROOT_ENV] ?? tmpdir(), "db-"));
+  const databasePath = join(directory, basename(templatePath));
+  for (const suffix of DATABASE_FILE_SUFFIXES) {
+    if (existsSync(`${templatePath}${suffix}`)) copyFileSync(`${templatePath}${suffix}`, `${databasePath}${suffix}`);
+  }
+  return databasePath;
+}
+
+/**
+ * A Prisma Client bound to a database file of its own.
+ *
+ * Vitest runs spec files in parallel workers and SQLite admits one writer at a
+ * time, so pointing every spec at one file made the suite a lottery on a
+ * loaded CI runner: a `beforeEach` write chain in one file could hold the file
+ * lock long enough for another file's query to die with `P1008` (issue #101).
+ * Copying the template per client removes the contended resource rather than
+ * widening the timeout around it, so the specs still run in parallel.
+ *
+ * `datasourceUrl` is passed explicitly — bypassing `env("DATABASE_URL")` —
+ * because a plain `vitest run` has no reason to have that variable set; the
+ * CLI commands that build the template (`generate`, `db push`) load it from
  * `prisma/.env` on their own.
  */
 export function newTestPrismaClient(): PrismaClient {
-  const url = new URL("../../prisma/dev.db", import.meta.url);
-  return new PrismaClient({ datasourceUrl: `file:${url.pathname}` });
+  return new PrismaClient({ datasourceUrl: `file:${provisionTestDatabase()}` });
 }

--- a/packages/orms/prisma/tests/support/client.ts
+++ b/packages/orms/prisma/tests/support/client.ts
@@ -1,5 +1,4 @@
 import { copyFileSync, existsSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { PrismaClient } from "@prisma/client";
@@ -13,11 +12,13 @@ import { SCRATCH_ROOT_ENV } from "./global-setup.js";
 const TEMPLATE_DATABASE = fileURLToPath(new URL("../../prisma/template.db", import.meta.url));
 
 /**
- * SQLite spreads one database over up to three files. A finished `db push`
- * leaves a checkpointed, journal-free database behind, but copy whatever
- * sidecars do exist so a copy can never be a torn read of the template.
+ * A finished `db push` leaves a checkpointed, sidecar-free database behind,
+ * but copy whatever recovery sidecars do exist so the copy carries every
+ * committed transaction the template does. `-shm` is deliberately *not*
+ * copied: it is a derived wal-index that SQLite rebuilds on open, and a
+ * copied one can be stale enough to make SQLite skip recovering the `-wal`.
  */
-const DATABASE_FILE_SUFFIXES = ["", "-journal", "-wal", "-shm"];
+const DATABASE_FILE_SUFFIXES = ["", "-journal", "-wal"];
 
 /**
  * Copies the template database to a fresh directory under this run's scratch
@@ -29,7 +30,16 @@ export function provisionTestDatabase(templatePath: string = TEMPLATE_DATABASE):
   if (!existsSync(templatePath)) {
     throw new Error(`No Prisma test-fixture database at ${templatePath} — run \`pnpm generate\` first.`);
   }
-  const directory = mkdtempSync(join(process.env[SCRATCH_ROOT_ENV] ?? tmpdir(), "db-"));
+  // No silent fallback to the OS temp directory: a copy made outside this
+  // run's scratch root has nothing to delete it, so a missing global setup
+  // would leak a fixture database per client instead of being noticed.
+  const scratchRoot = process.env[SCRATCH_ROOT_ENV];
+  if (scratchRoot === undefined) {
+    throw new Error(
+      `${SCRATCH_ROOT_ENV} is unset — vitest's globalSetup (tests/support/global-setup.ts) did not run for this process.`,
+    );
+  }
+  const directory = mkdtempSync(join(scratchRoot, "db-"));
   const databasePath = join(directory, basename(templatePath));
   for (const suffix of DATABASE_FILE_SUFFIXES) {
     if (existsSync(`${templatePath}${suffix}`)) copyFileSync(`${templatePath}${suffix}`, `${databasePath}${suffix}`);

--- a/packages/orms/prisma/tests/support/global-setup.ts
+++ b/packages/orms/prisma/tests/support/global-setup.ts
@@ -1,0 +1,29 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Where `tests/support/client.ts` puts the per-client SQLite copies it
+ * provisions. Set here rather than fixed, so two vitest runs of this repo at
+ * once cannot delete each other's databases; read from the environment
+ * because workers are separate processes that inherit it at spawn time.
+ */
+export const SCRATCH_ROOT_ENV = "KAVO_PRISMA_SCRATCH_ROOT";
+
+/**
+ * One scratch root per vitest run, removed when the run ends.
+ *
+ * This is the counterpart to the per-client database copies (issue #101):
+ * teardown has to happen here, in the main process, because vitest kills its
+ * workers — a `process.on("exit")` handler inside one never runs, and the
+ * copies would pile up in the OS temp directory instead.
+ */
+export default function setup(): () => void {
+  const root = mkdtempSync(join(tmpdir(), "kavo-prisma-"));
+  process.env[SCRATCH_ROOT_ENV] = root;
+
+  return () => {
+    delete process.env[SCRATCH_ROOT_ENV];
+    rmSync(root, { recursive: true, force: true });
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,5 +40,9 @@ export default defineConfig({
     exclude: ["**/node_modules/**", "**/dist/**"],
     environment: "node",
     testTimeout: 30_000,
+    // @kavo/prisma's specs each get their own copy of the pushed SQLite
+    // fixture, so parallel workers never contend for one file (issue #101).
+    // Only the main process can clean those copies up — vitest kills workers.
+    globalSetup: ["./packages/orms/prisma/tests/support/global-setup.ts"],
   },
 });


### PR DESCRIPTION
## What

`@kavo/prisma`'s specs no longer share one SQLite file. `prisma db push` now
writes a **template** (`prisma/template.db`) that no test opens;
`tests/support/client.ts` copies it per client into a scratch directory, so the
spec files keep running in parallel workers with nothing contended between them.

## Why

`check (node lts/*)` failed on #97 with a Prisma `P1008` while two other Node
versions passed the identical commit, and a re-run went green — a load-dependent
race, not a code defect. Every spec pointed at `prisma/dev.db`, vitest runs spec
files in parallel workers, and three of the six specs open `beforeEach` with a
chain of `deleteMany()` **writes**. SQLite admits one writer at a time, so a busy
writer could hold the file lock long enough for another file's query to exhaust
the query engine's socket timeout. The models never overlap — the contention was
purely the physical file lock.

Removing the shared resource, rather than widening the timeout around it, is the
fix (the same disposition as #91).

Two details worth review attention:

- **Cleanup runs in the main process.** My first attempt cleaned up via
  `process.on("exit")` inside the worker and leaked 8 directories per run —
  vitest kills its workers, so worker-side exit handlers never fire. A
  `globalSetup` provisions one scratch root per run and removes it at teardown.
  Per run rather than at a fixed path, so two concurrent vitest runs cannot
  delete each other's databases.
- **Recovery sidecars are copied** (`-journal`, `-wal`) when present, so the copy
  carries every committed transaction the template does. `-shm` is deliberately
  not copied — see the review commit below.

A missing template now fails with ``run `pnpm generate` first`` instead of
silently creating an empty database that fails later with "no such table".

## Public API impact

None. Tests, test support, `vitest.config.ts`, `.gitignore` and docs only — no
`src` changes, no change to any published package's surface. `pnpm generate` is
otherwise unchanged, so a clean checkout still needs no manual setup.

## Testing

- **`pnpm vitest run packages/orms/prisma` × 30 consecutive: all green**, with 0
  leaked scratch directories afterwards. Re-run in full after each round of
  review fixes.
- **6 concurrent full prisma runs: all 6 exit 0.** This is the check that
  actually exercises the fix — sequential local runs never reproduced the
  failure (0/15 on `main`, per the issue), while concurrent runs put real
  contention on the shared file.
- **`tests/database-isolation.spec.ts`** pins the whole contract: one database
  per client, copies land inside the run's scratch root byte-for-byte, the
  scratch root is a directory during the run and gone after teardown, the
  `.env` ↔ `TEMPLATE_DATABASE` filename pair agrees, the missing-template and
  unset-scratch-root guards fire, and a copy carries committed-but-uncheckpointed
  WAL frames without the stale wal-index.
- **Verified by mutation, not by inspection.** Six separate breaks — sharing one
  database, dropping `-wal`, re-adding `-shm`, provisioning outside the scratch
  root, a teardown that stops deleting, and a diverging `.env` filename — each
  killed by exactly one test, with the baseline green.
- **`pnpm check` passes**: 58 files, 950 tests, depcruise clean (252 modules,
  897 dependencies), typecheck and lint clean. `pnpm docs:links` and
  `pnpm format:check` pass.

## Review notes

Out of scope per the issue: the `beforeEach` `deleteMany()` chains are untouched.
They are now redundant work rather than a contention source — a separate cleanup.

`/code-review` raised two findings, both fixed in the third commit:

- Copying the `-shm` sidecar is unsafe. It is a derived wal-index SQLite rebuilds
  on open; if the template ever carries a `-wal`, a stale copied `-shm` can make
  SQLite skip recovering committed frames, so the copy silently loses rows.
- Falling back to `os.tmpdir()` when `KAVO_PRISMA_SCRATCH_ROOT` is unset degraded
  silently — a process where `globalSetup` did not run would pass while leaking a
  fixture database per client. It now throws, naming the variable and the file
  that sets it.

Docs resynced: `CONTRIBUTING.md`'s setup section and
`docs/internals/architecture/14-prisma-adapter.md` §7 both described `pnpm
generate` as pushing the database the tests read.

Closes #101

