### PR TITLE
feat(mikroorm): add @kavo/mikroorm adapter with parity to @kavo/typeorm

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -48,7 +48,7 @@ workflow.
 3. **Apply the version, in lockstep** (ADR-0004 — [`docs/internals/adr/0004-lockstep-versioning.md`](../../docs/internals/adr/0004-lockstep-versioning.md)):
    set the new version in the `package.json` of **every** published package.
    `PACKAGE_DIRS` in `.github/workflows/publish.yml` is the single source of
-   truth for that set — read it and bump exactly those. Today it is all seven:
+   truth for that set — read it and bump exactly those. Today it is all eight:
 
    | Directory                    | Package          |
    | ---------------------------- | ---------------- |
@@ -56,6 +56,7 @@ workflow.
    | `packages/orms/typeorm`      | `@kavo/typeorm`  |
    | `packages/orms/prisma`       | `@kavo/prisma`   |
    | `packages/orms/mongoose`     | `@kavo/mongoose` |
+   | `packages/orms/mikroorm`     | `@kavo/mikroorm` |
    | `packages/protocols/graphql` | `@kavo/graphql`  |
    | `packages/protocols/mcp`     | `@kavo/mcp`      |
    | `packages/frameworks/nest`   | `@kavo/nest`     |

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -8,6 +8,7 @@
  *      │                ▲
  *      │                ├── @kavo/prisma
  *      │                ├── @kavo/mongoose
+ *      │                ├── @kavo/mikroorm
  *      │                ├── @kavo/graphql ◀─┐
  *      │                └── @kavo/mcp     ◀─┤
  *      └── the one sanctioned sideways edge ┘
@@ -73,6 +74,18 @@ module.exports = {
       to: { path: "^(packages/frameworks|@kavo/nest)" },
     },
     {
+      name: "mikroorm-only-imports-core",
+      severity: "error",
+      comment:
+        "@kavo/mikroorm may depend on @kavo/core and the @mikro-orm/core " +
+        "peer — never on @kavo/nest (ADR-0002). Both spellings are matched: " +
+        "a workspace package specifier does not resolve to a path here, so a " +
+        'path-only rule would miss `from "@kavo/nest"` — the spelling ' +
+        "anyone would actually write.",
+      from: { path: "^packages/orms/mikroorm/src" },
+      to: { path: "^(packages/frameworks|@kavo/nest)" },
+    },
+    {
       name: "nest-only-imports-core",
       severity: "error",
       comment:
@@ -85,7 +98,7 @@ module.exports = {
         "@kavo/nest back (ADR-0016). Package-specifier form matched too, " +
         "per the note on typeorm-only-imports-core.",
       from: { path: "^packages/frameworks/nest/src" },
-      to: { path: "^(packages/orms|@kavo/(typeorm|prisma|mongoose))" },
+      to: { path: "^(packages/orms|@kavo/(typeorm|prisma|mongoose|mikroorm))" },
     },
     {
       name: "graphql-only-imports-core",
@@ -97,7 +110,7 @@ module.exports = {
         "same constraint as an ORM adapter). Package-specifier form matched " +
         "too, per the note on typeorm-only-imports-core.",
       from: { path: "^packages/protocols/graphql/src" },
-      to: { path: "^(packages/orms|packages/frameworks|@kavo/(typeorm|prisma|mongoose|nest))" },
+      to: { path: "^(packages/orms|packages/frameworks|@kavo/(typeorm|prisma|mongoose|mikroorm|nest))" },
     },
     {
       name: "mcp-only-imports-core",
@@ -110,7 +123,7 @@ module.exports = {
         "Package-specifier form matched too, per the note on " +
         "typeorm-only-imports-core.",
       from: { path: "^packages/protocols/mcp/src" },
-      to: { path: "^(packages/orms|packages/frameworks|@kavo/(typeorm|prisma|mongoose|nest))" },
+      to: { path: "^(packages/orms|packages/frameworks|@kavo/(typeorm|prisma|mongoose|mikroorm|nest))" },
     },
     {
       name: "no-cross-package-deep-imports-core",
@@ -161,7 +174,7 @@ module.exports = {
         "core's tests may use the barrel and vitest; this keeps the part that " +
         "still matters — no adapter, no framework — enforced for them too.",
       from: { path: "^packages/core/tests" },
-      to: { path: "^(@kavo/(typeorm|prisma|mongoose|nest|graphql|mcp)|packages/(orms|frameworks|protocols))" },
+      to: { path: "^(@kavo/(typeorm|prisma|mongoose|mikroorm|nest|graphql|mcp)|packages/(orms|frameworks|protocols))" },
     },
     {
       name: "no-circular",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
         packages/orms/typeorm
         packages/orms/prisma
         packages/orms/mongoose
+        packages/orms/mikroorm
         packages/protocols/graphql
         packages/protocols/mcp
         packages/frameworks/nest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What Kavo is
 
-A production-grade CRUD framework for TypeScript: define an entity once (via TypeORM, Prisma, or Mongoose) and get the full REST CRUD surface — filtering, sorting, pagination, nested includes, field selection, optional per-operation DTOs, transactions, and problem-details errors — behind generated NestJS routes, configurable at global → entity → operation → per-call scope.
+A production-grade CRUD framework for TypeScript: define an entity once (via TypeORM, Prisma, Mongoose, or MikroORM) and get the full REST CRUD surface — filtering, sorting, pagination, nested includes, field selection, optional per-operation DTOs, transactions, and problem-details errors — behind generated NestJS routes, configurable at global → entity → operation → per-call scope.
 
 The authoritative sources are `docs/` (architecture notes and ADRs) and the **Conventions** section below, which is normative — naming deviations are review findings. Consult the governing ADR before changing behavior it covers, rather than inventing behavior.
 
@@ -37,13 +37,14 @@ Because the build compiles `src` only, each package also has a `tsconfig.tests.j
 
 ## Architecture
 
-Seven published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, which globs in the two `examples/*` apps as well), plus one sanctioned sideways edge:
+Eight published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, which globs in the two `examples/*` apps as well), plus one sanctioned sideways edge:
 
 ```
 @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
-   │            ▲ ▲ ▲ ▲
-   │            │ │ │ └───── @kavo/prisma
-   │            │ │ └─────── @kavo/mongoose
+   │            ▲ ▲ ▲ ▲ ▲
+   │            │ │ │ │ └─── @kavo/prisma
+   │            │ │ │ └───── @kavo/mongoose
+   │            │ │ └─────── @kavo/mikroorm
    │            │ └───────── @kavo/mcp     ◀─┐
    │            └─────────── @kavo/graphql ◀─┤
    └───── the one sanctioned sideways edge ──┘
@@ -54,6 +55,7 @@ Seven published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, whi
 - **`@kavo/typeorm`** (`packages/orms/typeorm`) — implements core's `RepositoryAdapter` and feeds core's entity-metadata seam from TypeORM metadata. `typeorm` is a peer dependency.
 - **`@kavo/prisma`** (`packages/orms/prisma`) — the same seams over a Prisma Client delegate, fed from Prisma's DMMF. Needs caller-declared marker classes as entity identities (ADR-0017). `@prisma/client` is a peer dependency.
 - **`@kavo/mongoose`** (`packages/orms/mongoose`) — the same seams over a Mongoose model, fed from `schema.paths`. A Mongoose model _is_ the entity identity, so nothing is declared twice, and `ObjectId` converts to a hex string at the adapter boundary (ADR-0018). `mongoose` is a peer dependency.
+- **`@kavo/mikroorm`** (`packages/orms/mikroorm`) — the same seams over a MikroORM `EntityManager`, fed from MikroORM's `MetadataStorage`. A decorated entity class _is_ the identity, as with TypeORM, so it needs no marker classes; the query surface is declarative like Prisma's, so the filter translator nests relation paths rather than building joins. Every operation forks its own `EntityManager`, and soft delete must name its column explicitly (MikroORM declares none). `@mikro-orm/core` is a peer dependency.
 - **`@kavo/nest`** (`packages/frameworks/nest`) — the `@Kavo` decorator and NestJS route generation.
 - **`@kavo/graphql`** (`packages/protocols/graphql`) — host-framework-agnostic GraphQL schema binding: builds a schema over a `createCrud` service, delegating every resolver to the same engine REST uses. Depends only on `@kavo/core` and the `graphql` peer, never on `@kavo/nest` — the `frameworks/* → protocols/*` edge is one-directional (ADR-0016). `@kavo/nest` is the side that imports it, to provide `BaseKavoGraphQLController`; it does so through a lazy `import("@kavo/graphql")` so the peer stays genuinely optional.
 - **`@kavo/mcp`** (`packages/protocols/mcp`) — host-framework-agnostic MCP binding: exposes a `createCrud` service's standard operations as MCP tools, every tool handler a direct call into the same engine REST uses. Same `protocols/*` constraint as `@kavo/graphql` — `@kavo/core` plus the `@modelcontextprotocol/sdk` peer, which it consumes for **types only**, never at runtime. That is why `@kavo/nest` imports it directly rather than lazily, to provide `BaseKavoMcpController`; the one place `@kavo/nest` actually runs the SDK is its zero-config default MCP controller, which lazy-loads it (`load-mcp-sdk.ts`).
@@ -140,4 +142,4 @@ Two rules make this work:
 
 ## Where to read more
 
-`docs/getting-started.md`, `docs/using-the-api.md`, and `docs/integrations/nest/` (per-ORM wiring plus the full `@Kavo`/`KavoModule` configuration reference) are the adopter-facing front door; `docs/internals/` holds the design docs and ADRs (`adr/0001`…`0018`) — one ADR per load-bearing decision. `docs/internals/architecture/` mirrors the packages (query grammar, error handling, engine, the TypeORM/Prisma/Mongoose adapters, Nest integration, the GraphQL and MCP bindings, soft delete, relations). ADRs are referenced by name in code comments; read the referenced ADR before changing the behavior it governs.
+`docs/getting-started.md`, `docs/using-the-api.md`, and `docs/integrations/nest/` (per-ORM wiring plus the full `@Kavo`/`KavoModule` configuration reference) are the adopter-facing front door; `docs/internals/` holds the design docs and ADRs (`adr/0001`…`0018`) — one ADR per load-bearing decision. `docs/internals/architecture/` mirrors the packages (query grammar, error handling, engine, the TypeORM/Prisma/Mongoose/MikroORM adapters, Nest integration, the GraphQL and MCP bindings, soft delete, relations). ADRs are referenced by name in code comments; read the referenced ADR before changing the behavior it governs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Because the build compiles `src` only, each package also has a `tsconfig.tests.j
 
 ## Architecture
 
-Eight published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, which globs in the two `examples/*` apps as well), plus one sanctioned sideways edge:
+Eight published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, which globs in the three `examples/*` apps as well), plus one sanctioned sideways edge:
 
 ```
 @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,13 @@ globally:
 corepack enable
 ```
 
-Docker is not optional. Three test suites provision a real database with
+Docker is not optional. Four test suites provision a real database with
 [Testcontainers](https://testcontainers.com/) rather than mocking one:
 
 - `examples/nest-typeorm/tests/app-postgres.e2e.spec.ts` — Postgres
 - `examples/nest-typeorm/tests/app-mariadb.e2e.spec.ts` — MariaDB
 - `examples/nest-mongoose/tests/app-mongo.e2e.spec.ts` — MongoDB
+- `examples/nest-mikroorm/tests/app-postgres.e2e.spec.ts` — Postgres
 
 They start their own containers and need no manual database setup, but they do
 need a Docker daemon the current user can talk to. Without one, `pnpm check`
@@ -201,7 +202,8 @@ Eight published packages in a strict hub-and-spoke topology:
 
 Plus, not published:
 
-- `examples/` — runnable reference apps (`nest-typeorm`, `nest-mongoose`) that
+- `examples/` — runnable reference apps (`nest-typeorm`, `nest-mongoose`,
+  `nest-mikroorm`) that
   double as the e2e suites.
 - `extensions/` — Claude Code skills shipped as a plugin via this repo's own
   marketplace.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,15 @@ tests and the `nest-mongoose` example use `mongodb-memory-server`, which
 downloads a `mongod` binary on first use and caches it. On a restricted network
 that download fails with an error that has nothing to do with Docker.
 
+One native module is pinned rather than resolved. `@kavo/mikroorm`'s tests run
+on SQLite through `@mikro-orm/better-sqlite`, which depends on
+`better-sqlite3@^11` — a range whose prebuilt binaries stop before current Node,
+so on a newer runtime it falls back to `node-gyp` and fails to compile. The root
+`package.json` therefore carries a `pnpm.overrides` entry raising _that
+dependency alone_ to `better-sqlite3@^13`, which ships prebuilds. It is scoped
+(`"@mikro-orm/better-sqlite>better-sqlite3"`) on purpose, so `@kavo/typeorm`'s
+own SQLite resolution is untouched.
+
 ## Getting set up
 
 ```bash
@@ -177,7 +186,7 @@ A few things about the test setup that are easy to trip over:
 
 ## How the repo is laid out
 
-Seven published packages in a strict hub-and-spoke topology:
+Eight published packages in a strict hub-and-spoke topology:
 
 | Package                                       | Path                         | Role                                       |
 | --------------------------------------------- | ---------------------------- | ------------------------------------------ |
@@ -185,6 +194,7 @@ Seven published packages in a strict hub-and-spoke topology:
 | [`@kavo/typeorm`](packages/orms/typeorm)      | `packages/orms/typeorm`      | TypeORM adapter                            |
 | [`@kavo/prisma`](packages/orms/prisma)        | `packages/orms/prisma`       | Prisma adapter                             |
 | [`@kavo/mongoose`](packages/orms/mongoose)    | `packages/orms/mongoose`     | Mongoose adapter                           |
+| [`@kavo/mikroorm`](packages/orms/mikroorm)    | `packages/orms/mikroorm`     | MikroORM adapter                           |
 | [`@kavo/nest`](packages/frameworks/nest)      | `packages/frameworks/nest`   | NestJS binding — `@Kavo`, route generation |
 | [`@kavo/graphql`](packages/protocols/graphql) | `packages/protocols/graphql` | GraphQL schema binding                     |
 | [`@kavo/mcp`](packages/protocols/mcp)         | `packages/protocols/mcp`     | MCP binding — entities as MCP tools        |
@@ -209,7 +219,7 @@ that explains why.
 
 - **Core imports nothing and has zero runtime dependencies** —
   [ADR-0005](docs/internals/adr/0005-core-zero-runtime-dependencies.md). Core has
-  no knowledge of TypeORM, Prisma, Mongoose, or Nest.
+  no knowledge of TypeORM, Prisma, Mongoose, MikroORM, or Nest.
 - **Dependency inversion is strict: core never depends on an edge** —
   [ADR-0001](docs/internals/adr/0001-clean-architecture-core-owns-contracts.md).
   Beyond that, the allowed directions are specific, and it is worth learning them

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Fewer tokens, ship faster.
 | [`@kavo/typeorm`](packages/orms/typeorm)      | TypeORM adapter                                             |
 | [`@kavo/prisma`](packages/orms/prisma)        | Prisma adapter                                              |
 | [`@kavo/mongoose`](packages/orms/mongoose)    | Mongoose adapter                                            |
+| [`@kavo/mikroorm`](packages/orms/mikroorm)    | MikroORM adapter                                            |
 | [`@kavo/nest`](packages/frameworks/nest)      | NestJS binding — the `@Kavo` decorator and route generation |
 | [`@kavo/graphql`](packages/protocols/graphql) | Host-agnostic GraphQL schema binding                        |
 | [`@kavo/mcp`](packages/protocols/mcp)         | Host-agnostic MCP binding — entities as MCP tools           |

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,6 +52,7 @@ export default defineConfig({
           { text: "Nest + TypeORM", link: "/integrations/nest/typeorm" },
           { text: "Nest + Prisma", link: "/integrations/nest/prisma" },
           { text: "Nest + Mongoose", link: "/integrations/nest/mongoose" },
+          { text: "Nest + MikroORM", link: "/integrations/nest/mikroorm" },
           { text: "Nest configuration", link: "/integrations/nest/configuration" },
         ],
       },
@@ -77,6 +78,7 @@ export default defineConfig({
               { text: "TypeORM", link: "/integrations/nest/typeorm" },
               { text: "Prisma", link: "/integrations/nest/prisma" },
               { text: "Mongoose", link: "/integrations/nest/mongoose" },
+              { text: "MikroORM", link: "/integrations/nest/mikroorm" },
               { text: "Configuration", link: "/integrations/nest/configuration" },
             ],
           },
@@ -121,6 +123,7 @@ export default defineConfig({
               { text: "Prisma adapter", link: "/internals/architecture/14-prisma-adapter" },
               { text: "Mongoose adapter", link: "/internals/architecture/15-mongoose-adapter" },
               { text: "MCP binding", link: "/internals/architecture/16-mcp-binding" },
+              { text: "MikroORM adapter", link: "/internals/architecture/17-mikroorm-adapter" },
             ],
           },
           {

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ These documents and the [ADRs](internals/adr/) are authoritative.
 - [architecture/13-graphql-binding.md](internals/architecture/13-graphql-binding.md) — package boundary, schema construction, multi-entity schemas, the Nest binding
 - [architecture/14-prisma-adapter.md](internals/architecture/14-prisma-adapter.md) — marker classes, metadata seam, query translation, error mapping
 - [architecture/15-mongoose-adapter.md](internals/architecture/15-mongoose-adapter.md) — model identity, ObjectId conversion, populate, relation-path limits
+- [architecture/17-mikroorm-adapter.md](internals/architecture/17-mikroorm-adapter.md) — MetadataStorage seam, FilterQuery translation, per-operation EntityManager forks
 - [architecture/16-mcp-binding.md](internals/architecture/16-mcp-binding.md) — package boundary, toolset construction, result shape and error mapping, the Nest binding
 
 ## Reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 Kavo turns your ORM entities into a full REST CRUD API. Define the entity once, add one decorator, and you get create, read, update, delete, filtering, sorting, pagination, nested includes, and field selection — with no hand-written controller methods.
 
-Today Kavo supports NestJS as the framework, over TypeORM, Prisma, or Mongoose as the ORM. This guide uses Nest + TypeORM as its example stack; see [Nest + Prisma](/integrations/nest/prisma) and [Nest + Mongoose](/integrations/nest/mongoose) for the equivalents.
+Today Kavo supports NestJS as the framework, over TypeORM, Prisma, Mongoose, or MikroORM as the ORM. This guide uses Nest + TypeORM as its example stack; see [Nest + Prisma](/integrations/nest/prisma), [Nest + Mongoose](/integrations/nest/mongoose), and [Nest + MikroORM](/integrations/nest/mikroorm) for the equivalents.
 
 ## Requirements
 
@@ -64,6 +64,7 @@ Kavo never bundles your framework or your ORM. Each package declares what it exp
 - **`@kavo/typeorm`** — `typeorm` (`^0.3.20 || ^1.0.0`).
 - **`@kavo/prisma`** — `@prisma/client` (`^5.0.0 || ^6.0.0`).
 - **`@kavo/mongoose`** — `mongoose` (`^7.0.0 || ^8.0.0`).
+- **`@kavo/mikroorm`** — `@mikro-orm/core` (`^6.0.0`), plus the MikroORM driver package your database needs.
 - **`@kavo/graphql`** — `graphql` (`^17.0.0`).
 - **`@kavo/mcp`** — `@modelcontextprotocol/sdk` (`^1.0.0`).
 

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-[Nest + TypeORM](/integrations/nest/typeorm), [Nest + Prisma](/integrations/nest/prisma), and [Nest + Mongoose](/integrations/nest/mongoose) cover the zero-config path. This page is the field-by-field reference for everything you can configure once zero-config isn't enough: every `@Kavo(Entity, config)` parameter, and every global setting your `KavoModule` can set.
+[Nest + TypeORM](/integrations/nest/typeorm), [Nest + Prisma](/integrations/nest/prisma), [Nest + Mongoose](/integrations/nest/mongoose), and [Nest + MikroORM](/integrations/nest/mikroorm) cover the zero-config path. This page is the field-by-field reference for everything you can configure once zero-config isn't enough: every `@Kavo(Entity, config)` parameter, and every global setting your `KavoModule` can set.
 
 ## How config layers
 

--- a/docs/integrations/nest/mikroorm.md
+++ b/docs/integrations/nest/mikroorm.md
@@ -119,4 +119,6 @@ That declaration is what generates the `PATCH /books/:id/restore` route ([ADR-00
 
 **`@Property({ hidden: true })` wins over a Kavo DTO.** Rows are converted with MikroORM's own `toObject()`, so a hidden property is gone before core sees it, even if a DTO names it.
 
+A complete, runnable app using all of the above lives in [`examples/nest-mikroorm`](https://github.com/kavo-labs/kavo/tree/main/examples/nest-mikroorm) — the same Pet domain `examples/nest-typeorm` serves, under this adapter.
+
 Full design notes, including the metadata mapping and the error-mapping table: [MikroORM adapter](/internals/architecture/17-mikroorm-adapter).

--- a/docs/integrations/nest/mikroorm.md
+++ b/docs/integrations/nest/mikroorm.md
@@ -1,0 +1,122 @@
+# Nest + MikroORM
+
+Kavo's engine (`@kavo/core`) is ORM-agnostic — it talks to your data through a small adapter seam. `@kavo/nest` generates the routes; `@kavo/mikroorm` adapts Kavo to a MikroORM `EntityManager`. This is the complete, minimal wiring for that combination.
+
+If you haven't yet, read [Getting started](/getting-started) first — this page assumes you already know what `@Kavo()` does and just needs the app-wiring.
+
+::: code-group
+
+```bash [pnpm]
+pnpm add @kavo/core @kavo/nest @kavo/mikroorm
+```
+
+```bash [npm]
+npm install @kavo/core @kavo/nest @kavo/mikroorm
+```
+
+```bash [yarn]
+yarn add @kavo/core @kavo/nest @kavo/mikroorm
+```
+
+```bash [bun]
+bun add @kavo/core @kavo/nest @kavo/mikroorm
+```
+
+:::
+
+`@kavo/mikroorm` expects `@mikro-orm/core` (`^6.0.0`) as a peer, plus whichever MikroORM driver package your database needs (`@mikro-orm/postgresql`, `@mikro-orm/mysql`, `@mikro-orm/better-sqlite`, …) — add them to the command above if your app doesn't already have them — and `@kavo/nest` expects the Nest runtime your app already has. See [Peer dependencies](/getting-started#peer-dependencies) for the full list with versions, and [Requirements](/getting-started#requirements) for the Node and TypeScript prerequisites.
+
+## Zero-config wiring
+
+A plain MikroORM entity. Like TypeORM and unlike Prisma, there is nothing to declare twice: an `@Entity()` class is a real runtime class carrying its own metadata, so the class **is** the entity identity `@Kavo()` wants — no marker class and no entity list beyond the one MikroORM already has:
+
+```ts
+// book.entity.ts
+import { Entity, PrimaryKey, Property } from "@mikro-orm/core";
+
+@Entity()
+export class Book {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  title!: string;
+}
+```
+
+`@Kavo(Book)` with no config object — zero-config, the full CRUD surface for free:
+
+```ts
+// book.controller.ts
+import { Controller } from "@nestjs/common";
+import { Kavo } from "@kavo/nest";
+import { Book } from "./book.entity.js";
+
+@Kavo(Book)
+@Controller("books")
+export class BookController {}
+```
+
+```ts
+// app.module.ts
+import { Module } from "@nestjs/common";
+import { KavoModule } from "@kavo/nest";
+import { createInfrastructure } from "@kavo/mikroorm";
+import { MikroORM } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
+import { Book } from "./book.entity.js";
+import { BookController } from "./book.controller.js";
+
+const orm = await MikroORM.init(defineConfig({ dbName: process.env.DB_NAME!, entities: [Book] }));
+
+@Module({
+  imports: [
+    KavoModule.forRoot({
+      infrastructure: createInfrastructure(orm),
+    }),
+  ],
+  controllers: [BookController],
+})
+export class AppModule {}
+```
+
+`createInfrastructure(orm)` derives both Kavo's entity metadata and its repository adapter from the ORM's own registered entities — nothing to declare twice.
+
+It takes the `MikroORM` instance rather than an `EntityManager` on purpose. MikroORM is a Unit-of-Work ORM whose `EntityManager` holds an identity map, so every Kavo operation calls `orm.em.fork()` to get its own — the same isolation a request-scoped `RequestContext` gives a hand-written MikroORM app. You do not need to set up `RequestContext` middleware for Kavo's routes.
+
+## Case-insensitive filtering is opt-in
+
+`filter[name][ilike]=ada%` maps to MikroORM's `$ilike`, which **only PostgreSQL supports** — every other driver receives the token verbatim and fails with a syntax error. MikroORM exposes no way to detect this, so it is a declared setting, defaulting to off:
+
+```ts
+createInfrastructure(orm, { caseInsensitiveFilters: true }); // PostgreSQL
+```
+
+With it off, `ilike` behaves exactly like `like`. On SQLite that is not even a loss — SQLite's own `LIKE` is already ASCII case-insensitive.
+
+## What's different from `@kavo/typeorm`
+
+**Soft delete is declared, not inferred.** MikroORM has no `@DeleteDateColumn` equivalent — its soft-delete pattern is a user-defined `@Filter`, which Kavo cannot detect — so add an ordinary property and name it in config:
+
+```ts
+@Kavo(Book, { softDelete: { field: "deletedAt" } })
+@Controller("books")
+export class BookController {}
+```
+
+That declaration is what generates the `PATCH /books/:id/restore` route ([ADR-0013](/internals/adr/0013-config-declared-soft-delete-operations)). Do not _also_ enable a MikroORM soft-delete `@Filter`: Kavo owns the scoping, and a second default-on predicate would quietly defeat `withDeleted`.
+
+**Filtering and sorting across a relation work natively.** MikroORM nests relation paths in its own query language, so `filter[author.name][eq]=Ada` needs no join bookkeeping — just the allowlist entry, which is its own decision independent of whether the relation may be included:
+
+```ts
+@Kavo(Book, {
+  allowlists: { filterable: ["title", "author.name"] },
+  relations: { edges: { author: { includable: true } } },
+})
+```
+
+**`ESCAPE` in `like` patterns depends on your driver.** MikroORM cannot attach an `ESCAPE` clause, so `\` escaping a literal `%`/`_` works on PostgreSQL and MySQL (which default to backslash) but not on SQLite.
+
+**`@Property({ hidden: true })` wins over a Kavo DTO.** Rows are converted with MikroORM's own `toObject()`, so a hidden property is gone before core sees it, even if a DTO names it.
+
+Full design notes, including the metadata mapping and the error-mapping table: [MikroORM adapter](/internals/architecture/17-mikroorm-adapter).

--- a/docs/internals/architecture/01-system-architecture.md
+++ b/docs/internals/architecture/01-system-architecture.md
@@ -1,7 +1,7 @@
 # 01 — System Architecture
 
-Kavo lets a developer define an entity once (via TypeORM, Prisma, or
-Mongoose) and get the full
+Kavo lets a developer define an entity once (via TypeORM, Prisma,
+Mongoose, or MikroORM) and get the full
 CRUD surface — `createOne` … `purgeOne`, the `*Many` batch variants
 (contracted and registered, but disabled: bulk is the optional half of
 soft delete and this build dropped it) — with filtering, sorting,
@@ -12,10 +12,10 @@ global, entity, operation, and per-call scope.
 v6 scope is deliberately narrow: no validation subsystem, no
 hooks/events, no policy layer, no audit trail. The package set has grown
 past the original three (`@kavo/core`, `@kavo/typeorm`, `@kavo/nest`) by
-adding _edges_, never widening the hub: two further ORM adapters
-(`@kavo/prisma`, `@kavo/mongoose`) and one wire protocol
-(`@kavo/graphql`), each of which cost core no change at all — which is
-the clearest evidence the seams below are real.
+adding _edges_, never widening the hub: three further ORM adapters
+(`@kavo/prisma`, `@kavo/mongoose`, `@kavo/mikroorm`) and one wire
+protocol (`@kavo/graphql`), each of which cost core no change at all —
+which is the clearest evidence the seams below are real.
 
 ## 1. Layers and boundaries (C4 level 2)
 
@@ -41,7 +41,7 @@ flowchart TB
         X[Exception hierarchy + error catalog]
     end
 
-    subgraph adapters["ORM adapters — @kavo/typeorm · @kavo/prisma · @kavo/mongoose"]
+    subgraph adapters["ORM adapters — @kavo/typeorm · @kavo/prisma · @kavo/mongoose · @kavo/mikroorm"]
         T1["RepositoryAdapter implementation"]
         T2["Filter AST → the ORM's own query form"]
         T3[Driver-error → Kavo-exception mapping]
@@ -67,9 +67,10 @@ technology.
 
 ```
 @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
-     │             ▲  ▲  ▲
-     │             │  │  └──── @kavo/prisma
-     ▼ (peer)      │  └─────── @kavo/mongoose
+     │             ▲  ▲  ▲  ▲
+     │             │  │  │  └─ @kavo/prisma
+     │             │  │  └──── @kavo/mongoose
+     ▼ (peer)      │  └─────── @kavo/mikroorm
   @nestjs/*   @kavo/graphql
 ```
 
@@ -77,6 +78,7 @@ technology.
 - `@kavo/typeorm` imports `@kavo/core` + `typeorm` (peer). Never `@kavo/nest`.
 - `@kavo/prisma` imports `@kavo/core` + `@prisma/client` (peer). Same rule.
 - `@kavo/mongoose` imports `@kavo/core` + `mongoose` (peer). Same rule.
+- `@kavo/mikroorm` imports `@kavo/core` + `@mikro-orm/core` (peer). Same rule.
 - `@kavo/graphql` imports `@kavo/core` + `graphql` (peer) — a
   `protocols/*` package, host-framework-agnostic (ADR-0016).
 - `@kavo/nest` imports `@kavo/core`, `@nestjs/*` (peers), and optionally
@@ -96,13 +98,14 @@ references — an illegal import fails CI, not code review.
 | `@kavo/typeorm`  | `RepositoryAdapter`/`FilterBuilder` over TypeORM; error mapping; relation loading       | NestJS, `@kavo/nest`         |
 | `@kavo/prisma`   | The same contracts over a Prisma Client delegate; marker classes (ADR-0017)             | NestJS, `@kavo/nest`         |
 | `@kavo/mongoose` | The same contracts over a Mongoose model; `ObjectId` conversion (ADR-0018)              | NestJS, `@kavo/nest`         |
+| `@kavo/mikroorm` | The same contracts over a MikroORM `EntityManager`; per-operation forks (doc 17)        | NestJS, `@kavo/nest`         |
 | `@kavo/graphql`  | `GraphQLSchema` over a `createCrud` service (ADR-0016)                                  | any ORM or framework package |
 | `@kavo/nest`     | `@Kavo` decorator, module wiring, route generation, exception filter, Swagger           | any ORM adapter              |
 
 ORM independence inside core began as a structural discipline when only
-TypeORM existed; the Prisma and Mongoose adapters are what cashed it in.
-Neither required a single change to core — including Mongoose, whose
-`ObjectId` primary key and join-free query language are as far from
+TypeORM existed; the Prisma, Mongoose, and MikroORM adapters are what
+cashed it in. None required a single change to core — including Mongoose,
+whose `ObjectId` primary key and join-free query language are as far from
 TypeORM's model as the seam has been asked to stretch (ADR-0018).
 
 ## 4. Request lifecycle (first pass — authoritative version in doc 7)

--- a/docs/internals/architecture/02-monorepo-and-packages.md
+++ b/docs/internals/architecture/02-monorepo-and-packages.md
@@ -19,7 +19,9 @@ kavo/
 │  │  │  └─ src/index.ts
 │  │  ├─ prisma/              # @kavo/prisma
 │  │  │  └─ src/index.ts
-│  │  └─ mongoose/            # @kavo/mongoose
+│  │  ├─ mongoose/            # @kavo/mongoose
+│  │  │  └─ src/index.ts
+│  │  └─ mikroorm/            # @kavo/mikroorm
 │  │     └─ src/index.ts
 │  ├─ frameworks/
 │  │  └─ nest/                # @kavo/nest
@@ -46,7 +48,10 @@ ahead of real work landing (ADR-0002, ADR-0016). `@kavo/prisma` and
 from the TypeORM adapter's shape (marker classes standing in for Prisma's
 lack of runtime entity classes), and ADR-0018 for Mongoose's two (a model
 is already the entity identity, and `ObjectId` converts at the adapter
-boundary rather than widening core's `EntityId`).
+boundary rather than widening core's `EntityId`). `@kavo/mikroorm` is the
+fourth, and needed no ADR of its own: a decorated MikroORM entity class is
+already the identity, exactly as under TypeORM, so the only decisions it
+makes are adapter-local and live in doc 17.
 
 ## 2. Responsibility statements
 
@@ -67,6 +72,11 @@ boundary rather than widening core's `EntityId`).
   Mongoose (same shape again: adapter, filter translation, error mapping),
   under the same no-framework rule. See ADR-0018 and doc 15 for the two
   places a document store diverges from a relational one.
+- **`@kavo/mikroorm`** exists to translate core's persistence contracts to
+  MikroORM (same shape again: adapter, filter translation, error mapping),
+  under the same no-framework rule. See doc 17 for the two places it splits
+  the difference between its siblings — TypeORM's decorated-class metadata
+  seam, Prisma's declarative query surface.
 - **`@kavo/nest`** exists to bind Kavo to NestJS (module, decorator,
   route generation, exception filter, Swagger). It can't depend on TypeORM
   or `@kavo/typeorm` — it sees persistence only as an injected
@@ -176,7 +186,7 @@ dual ESM+CJS output is a future deliverable.
 ## 6. Build strategy
 
 `tsc -b` against the solution file: incremental (`.tsbuildinfo`),
-project-reference-ordered (core → typeorm/prisma/mongoose/graphql/mcp → nest),
+project-reference-ordered (core → typeorm/prisma/mongoose/mikroorm/graphql/mcp → nest),
 each package emitting
 `dist/` with declarations + declaration maps. Consumers inside the
 workspace resolve `@kavo/*` via pnpm workspace links to the built
@@ -214,10 +224,11 @@ uninstallable — and npm does not allow republishing a version to correct it.
 | `@kavo/typeorm`  | `@kavo/core`                               | `typeorm`                                                                                                                          |
 | `@kavo/prisma`   | `@kavo/core`                               | `@prisma/client`                                                                                                                   |
 | `@kavo/mongoose` | `@kavo/core`                               | `mongoose`                                                                                                                         |
+| `@kavo/mikroorm` | `@kavo/core`                               | `@mikro-orm/core`                                                                                                                  |
 | `@kavo/graphql`  | `@kavo/core`                               | `graphql`                                                                                                                          |
 | `@kavo/mcp`      | `@kavo/core`                               | `@modelcontextprotocol/sdk`                                                                                                        |
 | `@kavo/nest`     | `@kavo/core`, `@kavo/graphql`, `@kavo/mcp` | `@nestjs/common`, `@nestjs/core`, `graphql`, `@modelcontextprotocol/sdk` (+ `@nestjs/swagger`, all three protocol peers, optional) |
 
 Peers, not dependencies, because the consumer's app owns the TypeORM/Prisma/
-Mongoose/Nest instance — a second copy via a nested dependency would fracture
+Mongoose/MikroORM/Nest instance — a second copy via a nested dependency would fracture
 `instanceof` checks and DI tokens.

--- a/docs/internals/architecture/02-monorepo-and-packages.md
+++ b/docs/internals/architecture/02-monorepo-and-packages.md
@@ -34,7 +34,9 @@ kavo/
 ├─ examples/                  # reference applications, one per framework+ORM pairing
 │  ├─ nest-typeorm/           # @kavo/example-nest-typeorm
 │  │  └─ src/index.ts
-│  └─ nest-mongoose/          # @kavo/example-nest-mongoose
+│  ├─ nest-mongoose/          # @kavo/example-nest-mongoose
+│  │  └─ src/index.ts
+│  └─ nest-mikroorm/          # @kavo/example-nest-mikroorm
 │     └─ src/index.ts
 └─ docs/                      # this documentation
 ```
@@ -144,7 +146,7 @@ Two independent enforcement layers:
 ## 4. Workspace tooling: pnpm + plain scripts (ADR-0003)
 
 pnpm workspaces with **plain root scripts**, no
-task runner. The entire build graph is seven packages and two example apps,
+task runner. The entire build graph is eight packages and three example apps,
 whose ordering is already fully expressed by TS project references — `tsc -b`
 performs incremental, dependency-ordered, cached builds natively. A task runner
 (turborepo/nx) would add a second place where the graph is declared, a

--- a/docs/internals/architecture/06-error-handling.md
+++ b/docs/internals/architecture/06-error-handling.md
@@ -63,8 +63,8 @@ params; core ships the English defaults.
 
 Adapter errors are translated by the adapter's own table — each adapter
 has one, keyed on whatever its driver reports (`@kavo/typeorm` doc 09 §5,
-`@kavo/prisma` doc 14 §5, `@kavo/mongoose` doc 15 §6) — _inside_ the
-adapter;
+`@kavo/prisma` doc 14 §5, `@kavo/mongoose` doc 15 §6, `@kavo/mikroorm`
+doc 17 §6) — _inside_ the adapter;
 whatever reaches the engine unrecognized becomes `PersistenceException`
 with the original as `cause` — never swallowed. Whether `cause` details
 leak into responses is governed by `errors.exposeInternals` (default

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -244,7 +244,11 @@ manual-method-wins, custom + service-only operations, the service token,
 the soft-delete routes, relation includes, and the
 Swagger body/hint schemas. The full-stack paths are the reference apps'
 suites: Nest → engine → TypeORM → SQLite/Postgres in
-`examples/nest-typeorm`, and Nest → engine → Mongoose → MongoDB in
-`examples/nest-mongoose`. The Mongoose one is what proves route generation
+`examples/nest-typeorm`, Nest → engine → Mongoose → MongoDB in
+`examples/nest-mongoose`, and Nest → engine → MikroORM → SQLite/Postgres in
+`examples/nest-mikroorm`. The Mongoose one is what proves route generation
 composes with a document store — string `_id`s, `populate`-loaded
-includes, and config-declared soft-delete routes.
+includes, and config-declared soft-delete routes. The MikroORM one serves
+the _same_ Pet domain as the TypeORM app, deliberately: running one domain
+under two SQL adapters is what shows the seam carrying its weight rather
+than the routes having been shaped around one ORM.

--- a/docs/internals/architecture/11-soft-delete.md
+++ b/docs/internals/architecture/11-soft-delete.md
@@ -32,13 +32,17 @@ such a column, otherwise the one the ORM declares
 `@kavo/typeorm`). Explicit configuration wins over detection; an entity
 with neither costs nothing.
 
-Only `@kavo/typeorm` can supply the detection half: neither Prisma nor
-Mongoose has a declaration that marks a column as the delete marker, so
-both report `softDeleteField: null` and soft delete there is _always_
-explicit `softDelete.field` configuration (ADR-0017, ADR-0018). One
-consequence is worth naming: because those adapters cannot mark the
-marker column generated the way `@kavo/typeorm` does, it stays writable
-through an ordinary update unless a DTO excludes it — see doc 15 §7.
+Only `@kavo/typeorm` can supply the detection half: none of Prisma,
+Mongoose, or MikroORM has a declaration that marks a column as the delete
+marker, so all three report `softDeleteField: null` and soft delete there
+is _always_ explicit `softDelete.field` configuration (ADR-0017,
+ADR-0018, doc 17 §5). MikroORM comes closest — it has a soft-delete
+pattern — but it is a user-defined `@Filter`, a query concern rather than
+a column declaration, and nothing in it is detectable as "this column is
+the marker". One consequence is worth naming: because those adapters
+cannot mark the marker column generated the way `@kavo/typeorm` does, it
+stays writable through an ordinary update unless a DTO excludes it — see
+doc 15 §7.
 
 Resolution runs at every settings scope, so an operation or a single call
 may narrow it (`operations: { deleteOne: { softDelete: { strategy: "hard" } } }`),
@@ -90,9 +94,9 @@ excludes deleted rows, so the adapter opts in with `.withDeleted()` for
 for `onlyDeleted`; for an ordinary column named through config, the
 adapter adds `<alias>.<field> IS NULL` (default) or
 `<alias>.<field> IS NOT NULL` (`onlyDeleted`) itself. `@kavo/prisma` and
-`@kavo/mongoose` have no ORM-declared marker column at all (ADR-0017,
-ADR-0018), so both flags are always the same plain field-predicate over
-the configured `softDelete.field`.
+`@kavo/mongoose`, and `@kavo/mikroorm` have no ORM-declared marker column
+at all (ADR-0017, ADR-0018, doc 17 §5), so both flags are always the same
+plain field-predicate over the configured `softDelete.field`.
 
 ## 4. Edges
 

--- a/docs/internals/architecture/12-relations-and-includes.md
+++ b/docs/internals/architecture/12-relations-and-includes.md
@@ -108,14 +108,16 @@ registrations of the same entity — one per route, each with its own
 strategy — exactly as `blogs` and `joinedBlogs` do in
 `packages/orms/typeorm/tests/includes.spec.ts`.
 
-The join/batch distinction is a _SQL_ concern, and only `@kavo/typeorm`
-acts on it. Prisma's `include` and Mongoose's `populate` both resolve a
-relation as their own separate, internally batched query — never a
-row-multiplying join — so a to-many include cannot disturb root
-pagination there regardless of the strategy core resolved. Both adapters
-therefore ignore `IncludeNode.strategy` entirely (doc 14 §3, doc 15 §3);
-core still resolves it, because the contract is the same everywhere and
-an adapter that _does_ join needs the answer.
+The join/batch distinction is a concern of _writing SQL by hand_, and
+only `@kavo/typeorm` acts on it. Prisma's `include`, Mongoose's
+`populate`, and MikroORM's `populate` each resolve a relation with their
+own separate queries and apply `limit`/`offset` to the root regardless —
+never a row-multiplying join the caller has to compensate for — so a
+to-many include cannot disturb root pagination there whatever strategy
+core resolved. Those three adapters therefore ignore
+`IncludeNode.strategy` entirely (doc 14 §3, doc 15 §3, doc 17 §3); core
+still resolves it, because the contract is the same everywhere and an
+adapter that _does_ join needs the answer.
 
 A many-to-many edge is nothing special here: metadata maps
 `isManyToMany` to cardinality `"many"` exactly like `isOneToMany`, so it

--- a/docs/internals/architecture/17-mikroorm-adapter.md
+++ b/docs/internals/architecture/17-mikroorm-adapter.md
@@ -1,0 +1,275 @@
+# 17 — MikroORM Adapter
+
+`@kavo/mikroorm` implements `RepositoryAdapter` (= `EntityReader` +
+`EntityWriter`) over a MikroORM `EntityManager` and feeds core's metadata
+seam from MikroORM's own `MetadataStorage`. Core scope matches
+`@kavo/typeorm` (doc 09): CRUD with hard delete, filtering (incl. `NOT`
+and relation paths), sorting, pagination, optional counting, soft
+delete/restore/purge (doc 11), and relation loading (doc 12).
+`@mikro-orm/core` is a peerDependency; `@kavo/core` never imports it.
+
+Where this adapter sits between the other two SQL adapters is worth stating
+up front, because nearly every design choice below follows from it:
+MikroORM has **TypeORM's entity model** (real decorated runtime classes
+carrying their own metadata) and **Prisma's query surface** (a declarative
+`FilterQuery` object that nests relation paths natively, not a SQL string
+builder). So the metadata seam mirrors `@kavo/typeorm` and the translation
+seam mirrors `@kavo/prisma`.
+
+## 1. Entities are their own identity — no marker classes
+
+A MikroORM `@Entity()` class is a real runtime class, so this adapter gets
+an entity's `ClassRef` identity for free exactly as `@kavo/typeorm` does.
+There is no counterpart to ADR-0017's marker classes (which exist because
+Prisma erases its models at compile time) and none to ADR-0018 (which
+records that a Mongoose model _is_ the identity): the class the caller
+passes to `createCrud` is the class MikroORM registered, matched by name
+through `orm.getMetadata()`.
+
+`createInfrastructure(orm)` therefore takes nothing but the ORM instance —
+no `entities` list, no datamodel — and neither does `createMikroOrmKavo`.
+An entity MikroORM never registered is refused at bootstrap with
+`KAVO_CONFIGURATION_ERROR` rather than failing per request.
+
+### Metadata mapping
+
+| Core `EntityMetadata` | MikroORM source                                               |
+| --------------------- | ------------------------------------------------------------- |
+| `name`                | `meta.className`                                              |
+| `idField`             | `meta.primaryKeys[0]` — more than one is refused              |
+| `fields`              | properties with `kind: "scalar"` or `"embedded"`              |
+| `relations`           | properties with any other `kind` (`m:1`, `1:1`, `1:m`, `m:n`) |
+| `softDeleteField`     | always `null` — see §5                                        |
+
+Three details are less obvious than the table suggests:
+
+**Field kind comes from `runtimeType`, not the column type.** MikroORM
+normalizes `runtimeType` to the JavaScript type a property actually holds,
+which is what core must coerce toward. A `bigint` or `decimal` column
+surfaces as `string` there and is reported as `string` — reading `number`
+off the column type instead would corrupt values past 2⁵³. The declared
+`type` is consulted only as a fallback, for the custom types whose
+`runtimeType` is `"any"` and therefore narrows nothing (`JsonType`).
+
+**Generated is a union of four independent flags.** MikroORM has no single
+"the caller cannot write this" marker, so `generated` is true for an
+auto-increment or database-generated column, a property with an
+`onCreate`/`onUpdate` hook (the equivalent of TypeORM's
+`@CreateDateColumn`/`@UpdateDateColumn`), an optimistic-lock
+`version: true`, and `persist: false`.
+
+**Embeddable child properties are dropped.** An `@Embedded()` property
+contributes both the object-valued parent (`kind: "embedded"`) and one
+child per inner column, carrying an `embedded: [parent, child]`
+back-reference and a name that is an implementation detail (`address~city`
+when stored as an object, `billing_city` when inlined). Only the parent is
+addressable on the wire, so the children are filtered out rather than
+leaked into derived DTOs and allowlists. The parent is reported as `json`.
+
+## 2. Query translation (Filter AST → MikroORM `FilterQuery`)
+
+The translator is a pure function over core's AST — no query-builder state,
+no join aliases, no parameter numbering — because MikroORM nests relation
+paths natively and adds the join itself. A dotted field simply nests one
+level deeper, the same shape `@kavo/prisma`'s translator produces.
+
+| AST operator  | MikroORM                                     |
+| ------------- | -------------------------------------------- |
+| `EQ` / `NE`   | `$eq` / `$ne` (`$ne: null` is `IS NOT NULL`) |
+| `GT`…`LTE`    | `$gt`, `$gte`, `$lt`, `$lte`                 |
+| `IN`/`NOT_IN` | `$in` / `$nin`                               |
+| `LIKE`        | `$like`                                      |
+| `ILIKE`       | `$ilike`, or `$like` — see below             |
+| `BETWEEN`     | `{ $gte, $lte }`                             |
+| `IS_NULL`     | `$eq: null`                                  |
+| `IS_NOT_NULL` | `$ne: null`                                  |
+| `AND`/`OR`    | `$and` / `$or`                               |
+| `NOT`         | `$not` over the group's single child         |
+
+Every comparison is wrapped in an explicit operator (`{ $eq: v }`, never
+the bare `{ field: v }` shorthand). Core coerces filter values to scalars
+upstream, so this is defence in depth — but an object arriving through the
+shorthand would be spliced in as _operators_, and the boundary's job is to
+be safe on its own terms.
+
+Falling through the operator switch is impossible: the union is proven
+total at build time with `assertNever`, and a forged AST raises
+`PersistenceException` (500) rather than silently dropping the predicate
+and widening the result set.
+
+**The degenerate empty groups need care.** MikroORM rejects an empty
+`$and`/`$or` outright, and `$not: {}` negates _no condition at all_, which
+it renders as match-everything — the exact opposite of what an empty `OR`
+or `NOT` means. An empty `$in` on the primary key is the one spelling
+MikroORM turns into a genuine contradiction on every driver, so that is how
+"matches nothing" is written. (Core's parser enforces group arity, so these
+only guard hand-built ASTs passed programmatically.)
+
+**`ILIKE` is a declared capability, not a detected one.** `$ilike` works on
+PostgreSQL and nowhere else — SQLite, MySQL, and MongoDB receive the token
+verbatim and fail with a syntax error. MikroORM's `Platform` exposes
+nothing to detect this from, so it is
+`MikroOrmInfrastructureOptions.caseInsensitiveFilters`, the same posture
+`@kavo/prisma` takes for `mode: "insensitive"`.
+
+It defaults to **`false`**, where `@kavo/prisma`'s equivalent defaults to
+`true`. The defaults differ because the failure modes are not symmetric
+here: declaring it off on PostgreSQL costs case-insensitivity, while
+leaving it on anywhere else makes every `ILIKE` query throw. On SQLite the
+default is not even a loss — SQLite's own `LIKE` is already ASCII
+case-insensitive.
+
+## 3. Includes: `populate`, and no join/batch split
+
+Core resolves `IncludeNode.strategy` to `join` or `batch` (doc 12), and
+this adapter **ignores it**, exactly as `@kavo/prisma` does.
+
+`@kavo/typeorm` translates the split because it drives a raw SQL query
+builder, where a to-many `JOIN` multiplies root rows and separate batched
+queries are how that trap is avoided. MikroORM resolves `populate` with its
+own queries and applies `limit`/`offset` to the root regardless of load
+strategy, so a to-many include never disturbs pagination here — there is
+nothing left for the distinction to control. MikroORM's own `strategy`
+option is per-query rather than per-relation anyway, so it could not
+express a mixed include tree even if it were wanted.
+
+The include tree is flattened to MikroORM's dotted `populate` paths
+(`["articles", "articles.notes"]`). Soft-deleted related rows are excluded
+from every include, to-one and to-many alike, through a nested
+`populateWhere` mirroring the tree's shape — the same rule the other
+adapters apply, and a root `withDeleted` never widens an included relation.
+When no included relation is soft-deletable, `populateWhere` is omitted
+entirely so MikroORM's own default (`PopulateHint.ALL`) stands.
+
+## 4. The EntityManager is forked per operation
+
+MikroORM is a Unit-of-Work ORM: an `EntityManager` owns an identity map
+caching every entity it has loaded. Holding one across requests would serve
+stale rows and leak one caller's entities into another's, so **every
+adapter method starts from `orm.em.fork()`** — the same scope a
+request-scoped `RequestContext` gives a hand-written MikroORM application.
+That is also why `createInfrastructure` takes the `MikroORM` instance
+rather than an `EntityManager`: it needs something to fork _from_.
+
+Rows are converted to plain objects at the boundary with
+`wrap(entity).toObject()`. This is required, not cosmetic: a to-many
+relation is a `Collection<T>`, not an array, and core's `DefaultSerializer`
+branches on `Array.isArray` to decide whether an included relation is a
+list or a single row — a `Collection` would fall down the single-row path
+and serialize its internal fields. `@kavo/mongoose` converts documents at
+the same seam for the same reason.
+
+Two consequences of `toObject()` are behavior, not implementation detail:
+an unpopulated relation collapses to its primary key (harmless — core emits
+a relation key only for an included node), and **MikroORM's own property
+options apply before core sees the row**, so a
+`@Property({ hidden: true })` is dropped and a custom `serializer` runs
+first. The ORM's declaration wins there, even over a Kavo DTO that names
+the property.
+
+Writes go through the Unit of Work — `em.create` / `wrap(entity).assign`
+then `flush` — so lifecycle hooks, `onUpdate` properties, and relation
+diffing behave as they would in a hand-written application. `update` and
+`patch` share one load-merge-flush primitive; the _shape_ of the payload
+differs because the DTO layer differs, not the persistence mechanics. The
+row is loaded first regardless, to turn a missing id into a 404, so the
+merge costs no extra query. The soft-delete marker writes and the hard
+deletes use `nativeUpdate`/`nativeDelete`, whose affected-row count is what
+turns a repeat delete into a 404 rather than a silent success.
+
+Core's deserializer narrows a relation value to `{ id }` (ADR-0014), while
+MikroORM associates by the bare primary-key value and would read a nested
+`{ id }` as a request to _create_ a new entity — so relation values are
+unwrapped to the bare key before reaching `create`/`assign`.
+
+## 5. Soft delete is always configured, never detected
+
+`softDeleteField` is always `null` on this adapter's metadata. MikroORM
+declares no delete-date column: its soft-delete pattern is a user-defined
+`@Filter`, which is a query concern rather than a column declaration, so
+there is nothing for the metadata seam to detect. Soft delete therefore
+needs an explicit `softDelete.field` in Kavo config — the same position
+`@kavo/prisma` and `@kavo/mongoose` are in, and unlike `@kavo/typeorm`,
+whose `@DeleteDateColumn` makes zero-config soft delete work.
+
+There is consequently one marker shape to handle rather than TypeORM's two:
+the marker is always an ordinary property, so the `IS NULL` /
+`IS NOT NULL` predicate is always spelled out, for all three scopes
+(default, `withDeleted`, `onlyDeleted`).
+
+**Do not also enable a MikroORM `@Filter` for soft delete.** Kavo owns the
+scoping through `softDelete.field`; a default-on MikroORM filter would AND
+a second predicate onto every query and quietly defeat `withDeleted`. Use
+one or the other.
+
+## 6. Error-mapping table
+
+| MikroORM condition                               | Exception                         |
+| ------------------------------------------------ | --------------------------------- |
+| `UniqueConstraintViolationException`             | `ConflictException` (409)         |
+| `ForeignKeyConstraintViolationException`         | `ConflictException` (409)         |
+| `DeadlockException` / `LockWaitTimeoutException` | `TransactionException`, retryable |
+| anything else                                    | `PersistenceException` (500)      |
+
+The same four rows `@kavo/typeorm`'s table has (doc 06), reached
+differently. MikroORM normalizes each driver's native error into its own
+exception hierarchy before it surfaces, so this adapter matches on those
+classes rather than recognizing Postgres SQLSTATEs, MySQL errnos, and
+SQLite extended codes itself. Every driver MikroORM supports is covered by
+that normalization; anything it does not recognize falls through to
+`PersistenceException`, and the original error always travels as `cause`.
+
+Note the line the table draws: only unique and foreign-key violations are
+conflicts. A `NotNullConstraintViolationException` or
+`CheckConstraintViolationException` is not the caller's to resolve, so it
+stays a 500 — the same boundary `@kavo/typeorm` draws when its SQLite
+message sniff declines to match a `NOT NULL` failure.
+
+A soft-deleted row still occupies its unique indexes, so re-creating "the
+same" row after a soft delete raises a 409 — the honest answer, since the
+value _is_ taken. Kavo never rewrites indexes; the fix is a partial unique
+index scoped to live rows.
+
+## 7. Adapter-specific caveats
+
+**`LIKE` escapes are driver-dependent.** MikroORM offers no way to attach
+an `ESCAPE` clause to a `LIKE`, so the query grammar's `\` escape for a
+literal `%`/`_` (doc 05) is honored only by drivers that default to
+backslash — PostgreSQL and MySQL do; SQLite has no default escape
+character, so `filter[name][like]=100\%` matches the literal text `100\`
+followed by anything rather than the string `100%`. `@kavo/typeorm` emits
+`ESCAPE '\'` explicitly and does not have this gap.
+
+**The soft-delete marker is writable.** Because nothing declares it, the
+marker is an ordinary property: a plain `PATCH` of it will soft-delete a
+row, bypassing `deleteOne`'s already-deleted check. It cannot _revive_ one
+— writes are scoped to the live set, so a soft-deleted row 404s on
+`PUT`/`PATCH`. This is the shared hole `@kavo/prisma` and `@kavo/mongoose`
+have; the fix (excluding the resolved `softDelete.field` from the writable
+projection) belongs in core. Until then, register an explicit
+`update`/`patch` DTO that omits the marker whenever `purgeOne` is enabled.
+
+**Composite primary keys are refused** at bootstrap, matching every other
+adapter — single-identifier entities are a v6 scope decision, not a
+MikroORM limitation.
+
+**No transactions.** `TransactionManager` is unimplemented here, as it is
+across every Kavo adapter today — see the `@remarks` on that interface in
+`@kavo/core`. This is parity with `@kavo/typeorm`, which also never reads
+`context.transaction`, not a gap specific to this adapter.
+
+**`@mikro-orm/core` v6 only.** The peer range is `^6.0.0`. MikroORM v7
+removed decorators entirely in favour of `defineEntity`/`EntitySchema`,
+which changes how an entity's `ClassRef` identity is obtained — the premise
+§1 rests on — so v7 is not claimed until it is actually tested.
+
+## 8. Performance posture
+
+Counting is a dedicated `em.count` issued only when `query.count` is true,
+so `total: null` costs zero queries — never fetch-then-length. Pagination
+is `limit`/`offset` on the root, applied by MikroORM independently of
+`populate`, so relation loading never multiplies the rows pagination
+counts. Metadata derivation and adapter construction are cached per entity
+at bootstrap, not repeated per request. The per-operation `em.fork()` is
+cheap — it allocates a manager and an empty identity map, it does not touch
+the connection pool.

--- a/docs/internals/architecture/17-mikroorm-adapter.md
+++ b/docs/internals/architecture/17-mikroorm-adapter.md
@@ -29,7 +29,7 @@ through `orm.getMetadata()`.
 `createInfrastructure(orm)` therefore takes nothing but the ORM instance —
 no `entities` list, no datamodel — and neither does `createMikroOrmKavo`.
 An entity MikroORM never registered is refused at bootstrap with
-`KAVO_CONFIGURATION_ERROR` rather than failing per request.
+`KAVO_CONFIG_INVALID` rather than failing per request.
 
 ### Metadata mapping
 
@@ -41,7 +41,7 @@ An entity MikroORM never registered is refused at bootstrap with
 | `relations`           | properties with any other `kind` (`m:1`, `1:1`, `1:m`, `m:n`) |
 | `softDeleteField`     | always `null` — see §5                                        |
 
-Three details are less obvious than the table suggests:
+Five details are less obvious than the table suggests:
 
 **Field kind comes from `runtimeType`, not the column type.** MikroORM
 normalizes `runtimeType` to the JavaScript type a property actually holds,
@@ -57,6 +57,35 @@ auto-increment or database-generated column, a property with an
 `onCreate`/`onUpdate` hook (the equivalent of TypeORM's
 `@CreateDateColumn`/`@UpdateDateColumn`), an optimistic-lock
 `version: true`, and `persist: false`.
+
+**A relation target is resolved from `targetMeta`, never by calling the
+declaration.** MikroORM accepts two spellings, and they do not arrive the
+same: `@ManyToOne(() => Owner)` leaves `property.entity` a thunk, while
+`@ManyToOne("Owner")` leaves it a plain **string**. The string spelling is
+not exotic — it is what keeps a bidirectional relation's import cycle off
+the runtime graph, so it is exactly what a codebase with a `no-circular`
+dependency rule (this one included, see doc 02 §3) reaches for. Calling
+`property.entity()` would therefore throw for half the codebases using this
+adapter. `targetMeta` is what both spellings have in common; a
+metadata-storage lookup by entity name backs it up, and the declared thunk
+is the last resort. Resolution is deferred until the thunk core holds is
+actually called, because a bidirectional relation's target may not be
+registered yet when this entity's metadata is derived.
+
+**The single-table-inheritance discriminator is reported generated.** With
+`@Entity({ discriminatorColumn: "species" })` on a base and
+`discriminatorValue` on each subtype, MikroORM synthesizes a `species`
+property on every subtype's metadata. It is write-only bookkeeping: MikroORM
+sets it from the subtype being persisted, never hydrates it onto a loaded
+entity, and never emits it from `toObject` — so it cannot reach a response
+whatever Kavo does, matching `@kavo/typeorm`, where the discriminator has no
+entity property at all. What the flag stops is the _inbound_ direction. Left
+un-generated it would join the writable projection, and a client sending
+`species: "cat"` when creating a Dog would write a row that entity's own
+repository can no longer load. Note the column is read from the inheritance
+**root**'s metadata: MikroORM records `discriminatorColumn` only there,
+while the property itself is inherited by every subtype — and a subtype is
+what a caller passes to `createCrud`.
 
 **Embeddable child properties are dropped.** An `@Embedded()` property
 contributes both the object-valued parent (`kind: "embedded"`) and one
@@ -134,12 +163,32 @@ option is per-query rather than per-relation anyway, so it could not
 express a mixed include tree even if it were wanted.
 
 The include tree is flattened to MikroORM's dotted `populate` paths
-(`["articles", "articles.notes"]`). Soft-deleted related rows are excluded
-from every include, to-one and to-many alike, through a nested
-`populateWhere` mirroring the tree's shape — the same rule the other
-adapters apply, and a root `withDeleted` never widens an included relation.
-When no included relation is soft-deletable, `populateWhere` is omitted
-entirely so MikroORM's own default (`PopulateHint.ALL`) stands.
+(`["articles", "articles.notes"]`).
+
+**Soft-deleted related rows are pruned in memory, not in the query** — the
+one place this adapter does something the other two do in SQL, and it is
+forced. `populateWhere` looks like the right tool and is a trap at more than
+one level: a nested condition
+(`{ articles: { deletedAt: null, notes: { deletedAt: null } } }`) is read by
+MikroORM as a relation-path predicate on the **parent**, so an article whose
+notes are all deleted — or which simply has none — is dropped from the
+blog's collection entirely instead of arriving with `notes: []`. The dotted
+spelling (`{ "articles.notes": … }`) MikroORM rejects outright, and the
+parent-only spelling silently leaves every deeper level unscoped. So the
+adapter populates everything and walks the loaded tree, which is correct at
+any depth.
+
+The rule itself is unchanged from the other adapters: soft-deleted related
+rows are excluded from every include, to-one and to-many alike, and a root
+`withDeleted` never widens an included relation — the prune runs regardless
+of the root's scope. The same walk also guarantees every included relation
+is _present_ (`[]` for a to-many, `null` for a to-one), because core's
+serializer reads an absent key as "never hydrated" and skips it.
+
+The cost is that soft-deleted related rows are fetched and then discarded.
+Soft-deleted _roots_ are still excluded in SQL by `scopeToLive`, which is
+where the volume is; the alternatives here are wrong rather than merely
+slower.
 
 ## 4. The EntityManager is forked per operation
 
@@ -187,10 +236,17 @@ unwrapped to the bare key before reaching `create`/`assign`.
 `softDeleteField` is always `null` on this adapter's metadata. MikroORM
 declares no delete-date column: its soft-delete pattern is a user-defined
 `@Filter`, which is a query concern rather than a column declaration, so
-there is nothing for the metadata seam to detect. Soft delete therefore
-needs an explicit `softDelete.field` in Kavo config — the same position
+there is nothing for the metadata seam to detect — the same position
 `@kavo/prisma` and `@kavo/mongoose` are in, and unlike `@kavo/typeorm`,
-whose `@DeleteDateColumn` makes zero-config soft delete work.
+whose `@DeleteDateColumn` the seam reports.
+
+**That is not the same as "soft delete is off until you configure it."**
+`softDelete` defaults to `{ field: "deletedAt", strategy: "auto" }`, and
+`resolveSoftDelete` matches the configured _name_ against the entity's own
+columns before falling back to `softDeleteField`. So an entity carrying a
+plain `deletedAt` property is soft-deletable with no config whatsoever. What
+reporting `null` actually costs is narrower and sharper: the adapter cannot
+mark the marker column generated, so it stays **client-writable** — see §7.
 
 There is consequently one marker shape to handle rather than TypeORM's two:
 the marker is always an ordinary property, so the `IS NULL` /
@@ -240,14 +296,53 @@ character, so `filter[name][like]=100\%` matches the literal text `100\`
 followed by anything rather than the string `100%`. `@kavo/typeorm` emits
 `ESCAPE '\'` explicitly and does not have this gap.
 
-**The soft-delete marker is writable.** Because nothing declares it, the
-marker is an ordinary property: a plain `PATCH` of it will soft-delete a
-row, bypassing `deleteOne`'s already-deleted check. It cannot _revive_ one
-— writes are scoped to the live set, so a soft-deleted row 404s on
-`PUT`/`PATCH`. This is the shared hole `@kavo/prisma` and `@kavo/mongoose`
-have; the fix (excluding the resolved `softDelete.field` from the writable
-projection) belongs in core. Until then, register an explicit
-`update`/`patch` DTO that omits the marker whenever `purgeOne` is enabled.
+**The soft-delete marker is writable, and it is enabled by default.**
+Because nothing declares it, the marker is an ordinary non-generated
+property, so it joins the derived writable projection: a plain `PATCH` of it
+soft-deletes a row, bypassing `deleteOne`'s already-deleted check, any
+per-operation override on `deleteOne`, and even
+`operations: { deleteOne: false }`. With `purgeOne` enabled that is a
+two-request permanent delete through the update route. It cannot _revive_ a
+row — writes are scoped to the live set, so a soft-deleted row 404s on
+`PUT`/`PATCH`.
+
+Read that together with §5: because `strategy: "auto"` matches the column
+_name_, this surface is live on any entity with a `deletedAt` property and
+no `dto` block — nobody has to opt in. This is the shared hole
+`@kavo/prisma` and `@kavo/mongoose` have (only `@kavo/typeorm` escapes it,
+because `@DeleteDateColumn` is detectable and therefore markable), and the
+real fix — subtracting the resolved `softDelete.field` from
+`DefaultDeserializer`'s writable projection — belongs in core. Until then,
+register an explicit `update`/`patch` DTO that omits the marker, as
+`examples/nest-mikroorm`'s `OwnerController` does.
+
+**A primary key that is not auto-increment is client-writable.**
+`isGenerated` reads MikroORM's own flags, and `@PrimaryKey() id: string =
+v4()` — the idiomatic UUID spelling — carries none of them, so the key lands
+in the writable projection and a `PATCH` can rewrite a row's identity. A
+numeric `@PrimaryKey()` gets `autoincrement: true` and is safe.
+`@kavo/typeorm` has the same gap for `@PrimaryColumn`, so this is parity
+rather than a regression, but the risky spelling is the common one here.
+Name the write DTOs explicitly for any entity with a caller-assigned key.
+
+**A `hidden` or `lazy` property is dropped from the seam entirely.** Not
+just from responses: excluding it from `fields` is what keeps it off the
+_default allowlists_, because a column that is invisible in the body but
+filterable in the database is a blind extraction oracle
+(`filter[passwordHash][like]=a%` answered by the row count). The trade is
+the one `@kavo/mongoose` documents for `select: false` (doc 15 §1): Kavo
+does not manage such a property at all — not readable, writable, filterable,
+or sortable — so write it through a custom operation or the ORM directly.
+
+**`findOne` by query goes through `em.find` with `limit: 1`.** MikroORM's
+entity validator rejects `em.findOne` with an empty `where` outright, while
+`em.find` accepts it — and an unfiltered query is a legitimate shape here,
+since `EntityReader.findOne`'s contract is "first match of the query, or
+`null`" and a query with no filter matches everything. Routing through
+`em.find` keeps that contract without an empty-where special case; the two
+are otherwise the same query. (No generated route reaches this — the standard
+`findOne` operation is by id — but a custom handler calling
+`service.engine.execute` does.)
 
 **Composite primary keys are refused** at bootstrap, matching every other
 adapter — single-identifier entities are a v6 scope decision, not a
@@ -273,3 +368,19 @@ counts. Metadata derivation and adapter construction are cached per entity
 at bootstrap, not repeated per request. The per-operation `em.fork()` is
 cheap — it allocates a manager and an empty identity map, it does not touch
 the connection pool.
+
+## 9. The reference application
+
+`examples/nest-mikroorm` serves the **same Pet domain** as
+`examples/nest-typeorm` — single-table inheritance, an `Owner` relation both
+ways, a one-to-one `Address`, a many-to-many `Tag` edge — through
+`@Kavo`-generated Nest routes over this adapter. Running one domain under two
+SQL adapters is the point: where the two apps behave identically, the seam is
+carrying its weight; where they differ (soft delete declared rather than
+inferred, relation paths filterable rather than refused), the difference is
+real and documented above.
+
+Its e2e suite runs twice from one set of assertions — in-memory SQLite with
+no Docker, and a Testcontainers Postgres. The Postgres run is the only place
+`caseInsensitiveFilters: true` is exercised, which is what keeps §2's claim
+about the `false` default honest rather than merely asserted.

--- a/examples/nest-mikroorm/README.md
+++ b/examples/nest-mikroorm/README.md
@@ -1,0 +1,95 @@
+# nest-mikroorm
+
+The same Pet domain as [`nest-typeorm`](../nest-typeorm) — single-table
+inheritance (`Cat`/`Dog` over one `pet` table), an `Owner` relation both ways, a
+one-to-one `Address`, and a many-to-many `Tag` edge — served over HTTP by the
+real stack: `@Kavo(...)`-generated NestJS routes → CRUD engine →
+`@kavo/mikroorm` → a real database, with filtering, sorting, pagination, DTO
+projections (`item` vs. leaner `list`), layered config, Swagger docs, and RFC
+9457 problem-details errors.
+
+Running the _same domain_ under a different adapter is the point. Where this app
+behaves identically to `nest-typeorm`, that is the seam doing its job; where it
+differs, the difference is real and worth seeing.
+
+```bash
+pnpm build && pnpm --filter @kavo/example-nest-mikroorm start
+# → http://localhost:3002/cats   (Swagger at /docs)
+```
+
+It runs on in-memory SQLite by default, so there is nothing to install. Set
+`PGDATABASE` (plus the usual `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`) to point
+it at a Postgres instead:
+
+```bash
+docker run --rm -e POSTGRES_PASSWORD=kavo -p 5432:5432 postgres:18-alpine
+pnpm build && PGDATABASE=postgres PGPASSWORD=kavo pnpm --filter @kavo/example-nest-mikroorm start
+```
+
+## What differs from `nest-typeorm`
+
+**Soft delete is declared, not inferred.** `Owner` is soft-deletable in both
+apps, but TypeORM's `@DeleteDateColumn` says so on the entity, and MikroORM has
+no equivalent — its soft-delete pattern is a user-defined `@Filter`, which is a
+query concern rather than a column declaration. So `deletedAt` is an ordinary
+nullable property and `OwnerController` names it through `softDelete.field`.
+That one config line is what enables soft delete _and_ what puts
+`PATCH /owners/:id/restore` on the router.
+
+It also means the marker is not automatically un-writable, which is why every
+`Owner` DTO slot omits `deletedAt` and every allowlist excludes it. With
+`purgeOne` enabled, a stampable marker would be a path to a permanent delete —
+see doc 17 §7, and the e2e test that pins it down.
+
+**Relation paths are filterable and sortable.** `filter[owner.name][eq]=Ada` and
+`sort=-owner.name` work here, because MikroORM nests a relation path in its own
+query language and adds the join itself. (`@kavo/mongoose` refuses the same
+query outright.) It is still an allowlist decision, independent of whether the
+relation may be included.
+
+**Relations are declared by name, not by class.** `@ManyToOne("Owner")` rather
+than `@ManyToOne(() => Owner)`, with a type-only import alongside — the same
+reason `nest-typeorm`'s entities use TypeORM's string targets. A value import
+both ways would make `Owner`↔`Pet` a runtime import cycle, which
+`.dependency-cruiser.cjs`'s `no-circular` rule forbids. The adapter resolves the
+target class off MikroORM's `targetMeta` either way.
+
+**There is no second entity registry.** `createInfrastructure` takes the
+`MikroORM` instance itself, and the instance already carries its entity
+metadata — so unlike `nest-typeorm` there is no `DatabaseModule` assembling a
+`DataSource`, and unlike `@kavo/prisma` there are no marker classes.
+
+It takes the ORM instance rather than an `EntityManager` on purpose: every
+adapter operation forks its own manager, which is the isolation a request-scoped
+`RequestContext` would otherwise give. This app needs no MikroORM middleware.
+
+**`AddressController` is plain CRUD here.** `nest-typeorm`'s version is the
+reference for `@Override` and fully custom routes; that machinery belongs to
+`@kavo/nest` rather than to any adapter, so repeating it would add bulk without
+exercising anything MikroORM-specific.
+
+## The e2e suites
+
+Both suites run the same assertions — `tests/crud-e2e.suite.ts` holds them, and
+each spec differs only in which database it points the app at. One behavioral
+spec, two drivers, no forked assertions (the same split `nest-typeorm` uses).
+
+| Spec                             | Database                                         |
+| -------------------------------- | ------------------------------------------------ |
+| `tests/app.e2e.spec.ts`          | in-memory SQLite — no Docker, nothing to install |
+| `tests/app-postgres.e2e.spec.ts` | Testcontainers `postgres:18-alpine`              |
+
+The Postgres suite is not merely a second connection string: it is the only
+place `caseInsensitiveFilters: true` is exercised. `ILIKE` maps to MikroORM's
+`$ilike`, which **only PostgreSQL supports** — every other driver receives the
+token verbatim and fails with a syntax error — so the flag is declared rather
+than detected, and defaults to `false`.
+
+The suite's ILIKE assertion passes both ways: a real `ILIKE` on Postgres, and a
+degraded `$like` on SQLite, whose own `LIKE` is already ASCII case-insensitive.
+That both hold is exactly the argument for the `false` default.
+
+```bash
+pnpm vitest run examples/nest-mikroorm/tests/app.e2e.spec.ts           # no Docker
+pnpm vitest run examples/nest-mikroorm/tests/app-postgres.e2e.spec.ts  # needs Docker
+```

--- a/examples/nest-mikroorm/package.json
+++ b/examples/nest-mikroorm/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@kavo/example-nest-mikroorm",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Kavo reference application over NestJS + MikroORM (Pet example: single-table inheritance, relations both ways, relation-path filtering, and config-declared soft delete).",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "@kavo/core": "workspace:*",
+    "@kavo/mikroorm": "workspace:*",
+    "@kavo/nest": "workspace:*",
+    "@mikro-orm/better-sqlite": "^6.6.14",
+    "@mikro-orm/core": "^6.6.14",
+    "@mikro-orm/postgresql": "^6.6.14",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/swagger": "^11.0.0",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/testing": "^11.0.0",
+    "@testcontainers/postgresql": "^12.0.4",
+    "@types/supertest": "^7.2.1",
+    "supertest": "^7.0.0"
+  }
+}

--- a/examples/nest-mikroorm/src/address/address.controller.ts
+++ b/examples/nest-mikroorm/src/address/address.controller.ts
@@ -1,0 +1,25 @@
+import { Controller } from "@nestjs/common";
+import { Kavo } from "@kavo/nest";
+import { Address } from "./address.entity.js";
+import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
+
+/**
+ * Plain CRUD over the inverse side of the one-to-one. `Owner` owns the join
+ * column, so an address is associated by writing `{"address": 1}` on an
+ * owner (ADR-0014), never the other way round.
+ *
+ * Kept deliberately plain here: `nest-typeorm`'s `AddressController` is the
+ * reference for `@Override` and fully custom routes, and that machinery is
+ * `@kavo/nest`'s rather than any adapter's — repeating it would add bulk
+ * without exercising anything MikroORM-specific.
+ */
+@Kavo(Address, {
+  dto: {
+    create: CreateAddressDto,
+    update: UpdateAddressDto,
+    item: AddressItemDto,
+    list: AddressListDto,
+  },
+})
+@Controller("addresses")
+export class AddressController {}

--- a/examples/nest-mikroorm/src/address/address.dtos.ts
+++ b/examples/nest-mikroorm/src/address/address.dtos.ts
@@ -1,0 +1,33 @@
+/**
+ * DTO slots for the Address route. Plain initialized-field classes, same
+ * rationale as every other entity's DTOs (see `cat.dtos.ts`).
+ */
+
+/** `create` slot — request body for POST /addresses. */
+export class CreateAddressDto {
+  street = "";
+  city = "";
+  postalCode = "";
+}
+
+/** `update` slot — request body for PUT /addresses/:id (patch derives from it). */
+export class UpdateAddressDto {
+  street = "";
+  city = "";
+  postalCode = "";
+}
+
+/** `item` slot — the detail projection. */
+export class AddressItemDto {
+  id = 0;
+  street = "";
+  city = "";
+  postalCode = "";
+}
+
+/** `list` slot — a leaner projection for list responses. */
+export class AddressListDto {
+  id = 0;
+  street = "";
+  city = "";
+}

--- a/examples/nest-mikroorm/src/address/address.entity.ts
+++ b/examples/nest-mikroorm/src/address/address.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, OneToOne, PrimaryKey, Property } from "@mikro-orm/core";
+// Type-only import + string relation target, same reasoning as
+// `pet.entity.ts`: the Owner↔Address cycle stays off the runtime graph.
+import type { Owner } from "../owner/owner.entity.js";
+
+/**
+ * The inverse side of the example's one-to-one relation: `Owner` owns the
+ * join column (`owner.entity.ts`), so `Address` never writes an owner
+ * through its own routes — it only carries the inverse property MikroORM
+ * needs to resolve the mapping.
+ */
+@Entity()
+export class Address {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  street!: string;
+
+  @Property({ type: "string" })
+  city!: string;
+
+  @Property({ type: "string" })
+  postalCode!: string;
+
+  @OneToOne("Owner", undefined, { mappedBy: "address", nullable: true })
+  owner: Owner | null = null;
+}

--- a/examples/nest-mikroorm/src/app.module.ts
+++ b/examples/nest-mikroorm/src/app.module.ts
@@ -1,0 +1,62 @@
+import { Module, type DynamicModule } from "@nestjs/common";
+import type { MikroORM } from "@mikro-orm/core";
+import { KavoModule } from "@kavo/nest";
+import { createInfrastructure } from "@kavo/mikroorm";
+import { AddressController } from "./address/address.controller.js";
+import { CatController } from "./cat/cat.controller.js";
+import { DogController } from "./dog/dog.controller.js";
+import { OwnerController } from "./owner/owner.controller.js";
+import { TagController } from "./tag/tag.controller.js";
+
+export interface AppOptions {
+  /** An already-initialized ORM — see `database.ts` for the two flavours. */
+  readonly orm: MikroORM;
+  /**
+   * Whether the driver supports MikroORM's `$ilike`. **PostgreSQL only** —
+   * every other driver receives the token verbatim and fails with a syntax
+   * error, which is why this is a declared setting rather than something
+   * the adapter detects (doc 17 §2). Left `false` for the SQLite flavour,
+   * where it costs nothing: SQLite's own `LIKE` is already ASCII
+   * case-insensitive.
+   */
+  readonly caseInsensitiveFilters?: boolean;
+}
+
+/**
+ * Reference wiring: the app hands `@kavo/nest` its infrastructure (here
+ * MikroORM's) — the packages never import each other (package boundary;
+ * adapters meet the framework in the DI container).
+ *
+ * Like the Mongoose example and unlike `nest-typeorm`, there is no entity
+ * list and no `DataSource` to assemble here, because the `MikroORM`
+ * instance already carries its own entity metadata — the same reason this
+ * adapter needs no marker classes.
+ *
+ * `createInfrastructure` takes the ORM instance rather than an
+ * `EntityManager` on purpose: every adapter operation forks its own manager
+ * from it, so it needs something to fork *from*.
+ */
+@Module({})
+export class AppModule {
+  static forRoot(options: AppOptions): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        KavoModule.forRoot({
+          infrastructure: createInfrastructure(options.orm, {
+            caseInsensitiveFilters: options.caseInsensitiveFilters ?? false,
+          }),
+          defaults: {
+            pagination: { defaultLimit: 20, maxLimit: 100 },
+            errors: { exposeInternals: false },
+            // App-wide default: off unless an entity opts back in via its own
+            // `operations.restoreOne`. `OwnerController` does exactly that,
+            // which is what makes the precedence chain visible here.
+            operations: { restoreOne: false },
+          },
+        }),
+      ],
+      controllers: [OwnerController, CatController, DogController, TagController, AddressController],
+    };
+  }
+}

--- a/examples/nest-mikroorm/src/cat/cat.controller.ts
+++ b/examples/nest-mikroorm/src/cat/cat.controller.ts
@@ -1,0 +1,40 @@
+import { Controller } from "@nestjs/common";
+import { Kavo } from "@kavo/nest";
+import { Cat } from "./cat.entity.js";
+import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.js";
+
+/**
+ * CRUD over the concrete `Cat` subtype: one decorator, zero methods.
+ * Binding `@Kavo` to the child (never the abstract `Pet` base) is what lets
+ * MikroORM write the `species` discriminator from the subtype on insert.
+ * Routes: POST /cats, GET /cats, GET/PUT/DELETE /cats/:id (PATCH disabled).
+ *
+ * `include=owner` embeds the owner; `owner` is also writable by id
+ * (`{"owner": 1}` on create — ADR-0014). `include=tags` embeds the cat's
+ * tags across the many-to-many pivot; `tags` is likewise writable by an
+ * array of ids.
+ */
+@Kavo(Cat, {
+  dto: {
+    create: CreateCatDto,
+    update: UpdateCatDto,
+    item: CatItemDto,
+    list: CatListDto,
+  },
+  pagination: { defaultLimit: 10, maxLimit: 50 },
+  // Explicit include-lists (the plain form, contrast Owner's `{ exclude }`):
+  // `indoor`, `livesLeft`, and `createdAt` are still returned in every
+  // response (`CatItemDto` includes them), just not queryable — narrower
+  // than "every own column" without excluding anything by name.
+  allowlists: {
+    filterable: ["id", "name", "age", "size", "owner.name"],
+    sortable: ["id", "name", "age", "owner.name"],
+    selectable: ["id", "name", "age", "size"],
+  },
+  relations: { edges: { owner: { includable: true }, tags: { includable: true } } },
+  operations: {
+    patchOne: false,
+  },
+})
+@Controller("cats")
+export class CatController {}

--- a/examples/nest-mikroorm/src/cat/cat.dtos.ts
+++ b/examples/nest-mikroorm/src/cat/cat.dtos.ts
@@ -1,0 +1,61 @@
+import { enumProp } from "@kavo/nest";
+import { PetSizeEnum } from "../pet/pet.entity.js";
+import { TagItemDto } from "../tag/tag.dtos.js";
+
+/**
+ * DTO slots for the Cat route. Fields are initialized so the classes carry
+ * their shape at runtime — that is what lets the default serializer project
+ * responses (and Swagger document them) with no decorator machinery.
+ *
+ * The `species` discriminator is absent from every slot, as in the TypeORM
+ * example — and here it would be absent regardless: MikroORM keeps it as
+ * write-only bookkeeping that never hydrates onto an entity, and the adapter
+ * reports it generated so no client payload can reach it either.
+ */
+
+/** `create` slot — request body for POST /cats. */
+export class CreateCatDto {
+  name = "";
+  age = 0;
+  size = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
+  indoor = false;
+  livesLeft = 9;
+  // Association by id (ADR-0014): send the owner's id, or an `{ id }`
+  // reference. Deep nested writes are deliberately out of scope.
+  owner: number | null = null;
+  // Same mechanism over a to-many edge: an array of tag ids (or `{ id }`
+  // refs) replaces the full set of associated tags.
+  tags: number[] = [];
+}
+
+/** `update` slot — request body for PUT /cats/:id (patch derives from it). */
+export class UpdateCatDto {
+  name = "";
+  age = 0;
+  size = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
+  indoor = false;
+  livesLeft = 0;
+  owner: number | null = null;
+  tags: number[] = [];
+}
+
+/** `item` slot — the detail projection. */
+export class CatItemDto {
+  id = 0;
+  name = "";
+  age = 0;
+  size = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
+  indoor = false;
+  livesLeft = 0;
+  createdAt: Date = new Date(0);
+  // Documented as an array of tags; the shape is documentation, the include
+  // decides the load — absent from a plain GET.
+  tags: TagItemDto[] = [];
+}
+
+/** `list` slot — a leaner projection for list responses. */
+export class CatListDto {
+  id = 0;
+  name = "";
+  indoor = false;
+}

--- a/examples/nest-mikroorm/src/cat/cat.entity.ts
+++ b/examples/nest-mikroorm/src/cat/cat.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, Property } from "@mikro-orm/core";
+import { Pet } from "../pet/pet.entity.js";
+
+/**
+ * A concrete Pet subtype. Child columns must be nullable under single-table
+ * inheritance (rows of sibling types leave them empty).
+ *
+ * `extends Pet` is a real runtime import, but it is one-directional —
+ * `pet.entity.ts` never imports its subtypes, because `discriminatorValue`
+ * on the child is what registers the mapping, not a `discriminatorMap` on
+ * the base. That is what keeps this edge acyclic.
+ */
+@Entity({ discriminatorValue: "cat" })
+export class Cat extends Pet {
+  @Property({ type: "boolean", nullable: true })
+  indoor!: boolean;
+
+  @Property({ type: "number", nullable: true })
+  livesLeft!: number;
+}

--- a/examples/nest-mikroorm/src/database.ts
+++ b/examples/nest-mikroorm/src/database.ts
@@ -1,0 +1,57 @@
+import { MikroORM } from "@mikro-orm/core";
+import { defineConfig as defineSqliteConfig } from "@mikro-orm/better-sqlite";
+import { defineConfig as definePostgresConfig } from "@mikro-orm/postgresql";
+import { Address } from "./address/address.entity.js";
+import { Cat } from "./cat/cat.entity.js";
+import { Dog } from "./dog/dog.entity.js";
+import { Owner } from "./owner/owner.entity.js";
+import { Pet } from "./pet/pet.entity.js";
+import { Tag } from "./tag/tag.entity.js";
+
+/**
+ * Every entity this app registers, in one place — MikroORM's own list, and
+ * the only one: unlike `@kavo/prisma` there are no marker classes to keep in
+ * sync, and unlike `nest-typeorm` there is no second registry, because the
+ * `MikroORM` instance *is* what `createInfrastructure` reads.
+ *
+ * The abstract `Pet` base is registered alongside its subtypes: MikroORM
+ * needs the inheritance root to resolve the discriminator, and `Owner.pets`
+ * targets it.
+ */
+const entities = [Owner, Pet, Cat, Dog, Tag, Address];
+
+/** Connection details for the Postgres flavour of this example. */
+export interface PostgresOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly user: string;
+  readonly password: string;
+  readonly dbName: string;
+}
+
+/**
+ * The default flavour: SQLite in memory, so the example runs — and its e2e
+ * suite passes — with no database to install and no Docker daemon.
+ *
+ * `allowGlobalContext` is deliberately left off (its default). `@kavo/mikroorm`
+ * forks an `EntityManager` per operation, which is the isolation a
+ * request-scoped `RequestContext` would otherwise provide, so an app wired
+ * this way needs no MikroORM middleware for Kavo's routes — and leaving the
+ * guard on means any code that *does* reach for the global EM fails loudly.
+ */
+export async function createSqliteOrm(): Promise<MikroORM> {
+  const orm = await MikroORM.init(defineSqliteConfig({ dbName: ":memory:", entities }));
+  await orm.schema.createSchema();
+  return orm;
+}
+
+/**
+ * The Postgres flavour. Worth having as more than a second connection
+ * string: `caseInsensitiveFilters` is only *true* here, because MikroORM's
+ * `$ilike` is PostgreSQL-only — see `AppModule.forRoot` and doc 17 §2.
+ */
+export async function createPostgresOrm(options: PostgresOptions): Promise<MikroORM> {
+  const orm = await MikroORM.init(definePostgresConfig({ ...options, entities }));
+  await orm.schema.refreshDatabase();
+  return orm;
+}

--- a/examples/nest-mikroorm/src/dog/dog.controller.ts
+++ b/examples/nest-mikroorm/src/dog/dog.controller.ts
@@ -1,0 +1,19 @@
+import { Controller } from "@nestjs/common";
+import { Kavo } from "@kavo/nest";
+import { Dog } from "./dog.entity.js";
+
+/**
+ * CRUD over the concrete `Dog` subtype. Uses the root default pagination
+ * (defaultLimit 20, maxLimit 100) — no entity-scope override. No `dto`
+ * block: every slot falls back to the entity-derived default
+ * (`DefaultDtoResolver`), so requests and responses are shaped straight from
+ * `Dog`'s own MikroORM metadata rather than a hand-written DTO.
+ *
+ * That makes this route the one place the derived defaults are visible end
+ * to end — and the one place worth checking that the `species` discriminator
+ * is not among them: MikroORM never hydrates it, and the adapter reports it
+ * generated, so a client can neither read it back nor write it.
+ */
+@Kavo(Dog)
+@Controller("dogs")
+export class DogController {}

--- a/examples/nest-mikroorm/src/dog/dog.entity.ts
+++ b/examples/nest-mikroorm/src/dog/dog.entity.ts
@@ -1,0 +1,15 @@
+import { Entity, Property } from "@mikro-orm/core";
+import { Pet } from "../pet/pet.entity.js";
+
+/**
+ * A concrete Pet subtype. Child columns must be nullable under single-table
+ * inheritance (rows of sibling types leave them empty).
+ */
+@Entity({ discriminatorValue: "dog" })
+export class Dog extends Pet {
+  @Property({ type: "string", nullable: true })
+  breed!: string;
+
+  @Property({ type: "boolean", nullable: true })
+  goodBoy!: boolean;
+}

--- a/examples/nest-mikroorm/src/main.ts
+++ b/examples/nest-mikroorm/src/main.ts
@@ -1,0 +1,51 @@
+import "reflect-metadata";
+import { NestFactory } from "@nestjs/core";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { AppModule } from "./app.module.js";
+import { createPostgresOrm, createSqliteOrm } from "./database.js";
+
+/**
+ * The Pet example over MikroORM — the same domain `nest-typeorm` serves,
+ * under a different adapter. Runs on in-memory SQLite by default, so
+ * `pnpm start` needs nothing installed; set the usual `PG*` variables to
+ * point it at a Postgres instead:
+ *
+ *   docker run --rm -e POSTGRES_PASSWORD=kavo -p 5432:5432 postgres:18-alpine
+ *   PGDATABASE=postgres PGPASSWORD=kavo node dist/main.js
+ */
+async function bootstrap(): Promise<void> {
+  const usePostgres = process.env["PGDATABASE"] !== undefined;
+  const orm = usePostgres
+    ? await createPostgresOrm({
+        host: process.env["PGHOST"] ?? "127.0.0.1",
+        port: Number(process.env["PGPORT"] ?? 5432),
+        user: process.env["PGUSER"] ?? "postgres",
+        password: process.env["PGPASSWORD"] ?? "postgres",
+        dbName: process.env["PGDATABASE"] ?? "postgres",
+      })
+    : await createSqliteOrm();
+
+  // `$ilike` is PostgreSQL-only; on any other driver it is a syntax error.
+  const app = await NestFactory.create(AppModule.forRoot({ orm, caseInsensitiveFilters: usePostgres }));
+
+  const document = SwaggerModule.createDocument(
+    app,
+    new DocumentBuilder()
+      .setTitle("Kavo — Pet example (MikroORM)")
+      .setDescription(
+        "Cats, dogs, owners, tags and addresses: full CRUD over HTTP " +
+          "through @kavo/mikroorm, with single-table inheritance, filtering, " +
+          "sorting, pagination, layered config, RFC 9457 problem-details " +
+          "errors, `?include=owner`/`?include=pets`/`?include=tags` " +
+          "relations loaded by populate, filtering and sorting across a " +
+          "relation path, and soft delete with restore/purge on owners.",
+      )
+      .setVersion("0.0.0")
+      .build(),
+  );
+  SwaggerModule.setup("docs", app, document);
+
+  await app.listen(3002);
+}
+
+void bootstrap();

--- a/examples/nest-mikroorm/src/owner/owner.controller.ts
+++ b/examples/nest-mikroorm/src/owner/owner.controller.ts
@@ -1,0 +1,51 @@
+import { Controller } from "@nestjs/common";
+import { Kavo } from "@kavo/nest";
+import { Owner } from "./owner.entity.js";
+import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./owner.dtos.js";
+
+/**
+ * CRUD over the relation side. The unique `email` column is what surfaces a
+ * database unique-violation as an RFC 9457 409 conflict.
+ *
+ * Soft delete: `softDelete.field` names an ordinary nullable column, because
+ * nothing in a MikroORM entity can declare a delete marker (doc 17 §5) —
+ * this is the one config line that turns `deletedAt` into the marker *and*
+ * puts `PATCH /owners/:id/restore` on the router (ADR-0013: route generation
+ * runs before any ORM metadata exists, so config is what it can read).
+ * `restoreOne: true` is explicit rather than relying on the soft-delete
+ * auto-enable, because `AppModule` sets a global
+ * `defaults.operations.restoreOne: false` — this entity opts back in, which
+ * is the point of the precedence chain: entity config wins over the global
+ * default.
+ *
+ * `deletedAt` is excluded from every allowlist *and* absent from all four
+ * DTO slots. Both matter: the allowlists keep it un-queryable, and the write
+ * slots keep it un-writable — which the adapter cannot do for us here,
+ * since an undeclared marker is an ordinary column that a plain `PATCH`
+ * could otherwise stamp behind `deleteOne`'s back (doc 17 §7). With
+ * `purgeOne` enabled, that would be a permanent delete.
+ */
+@Kavo(Owner, {
+  dto: {
+    create: CreateOwnerDto,
+    update: UpdateOwnerDto,
+    item: OwnerItemDto,
+    list: OwnerListDto,
+  },
+  softDelete: { field: "deletedAt" },
+  allowlists: {
+    filterable: { exclude: ["deletedAt"] },
+    sortable: { exclude: ["deletedAt"] },
+    selectable: { exclude: ["deletedAt"] },
+  },
+  // `include=pets` — opt-in per relation, and a to-many. `address` is the
+  // to-one counterpart. Neither disturbs root pagination: MikroORM resolves
+  // `populate` with its own queries either way (doc 17 §3).
+  relations: { edges: { pets: { includable: true }, address: { includable: true } } },
+  operations: {
+    purgeOne: true,
+    restoreOne: true,
+  },
+})
+@Controller("owners")
+export class OwnerController {}

--- a/examples/nest-mikroorm/src/owner/owner.dtos.ts
+++ b/examples/nest-mikroorm/src/owner/owner.dtos.ts
@@ -1,0 +1,66 @@
+import { enumProp, oneOfArray } from "@kavo/nest";
+import { CatItemDto } from "../cat/cat.dtos.js";
+import { AddressItemDto } from "../address/address.dtos.js";
+import { PetSizeEnum } from "../pet/pet.entity.js";
+
+/**
+ * DTO slots for the Owner route. See `cat.dtos.ts` for the rationale behind
+ * plain initialized-field classes.
+ */
+
+/**
+ * Used only for `OwnerItemDto.pets`'s polymorphic union below —
+ * `DogController` registers no `dto` block of its own (every `/dogs` slot
+ * resolves entity-derived), so this is the one place `Dog`'s item shape
+ * needs a concrete DTO class.
+ */
+export class DogItemDto {
+  id = 0;
+  name = "";
+  age = 0;
+  size = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
+  breed = "";
+  goodBoy = false;
+  createdAt: Date = new Date(0);
+}
+
+/** `create` slot — request body for POST /owners. */
+export class CreateOwnerDto {
+  name = "";
+  email = "";
+  startedAt: Date | null = null;
+  // Association by id (ADR-0014): send the address's id, or an `{ id }`
+  // reference. Deep nested writes are deliberately out of scope.
+  address: number | null = null;
+}
+
+/** `update` slot — request body for PUT /owners/:id (patch derives from it). */
+export class UpdateOwnerDto {
+  name = "";
+  email = "";
+  startedAt: Date | null = null;
+  address: number | null = null;
+}
+
+/** `item` slot — the detail projection. */
+export class OwnerItemDto {
+  id = 0;
+  name = "";
+  email = "";
+  startedAt: Date | null = null;
+  createdAt: Date = new Date(0);
+  // Documented as a `oneOf` array of pet subtypes. The declaration is the
+  // shape, not the load: the field appears only when asked for with
+  // `?include=pets`, so a plain GET does not pay for the relation.
+  pets = oneOfArray<CatItemDto | DogItemDto>([CatItemDto, DogItemDto]);
+  // Documented the same way: shape only, present in the response solely
+  // when `?include=address` asks for it.
+  address: AddressItemDto | null = null;
+}
+
+/** `list` slot — a leaner projection for list responses. */
+export class OwnerListDto {
+  id = 0;
+  name = "";
+  email = "";
+}

--- a/examples/nest-mikroorm/src/owner/owner.entity.ts
+++ b/examples/nest-mikroorm/src/owner/owner.entity.ts
@@ -1,0 +1,51 @@
+import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, Property } from "@mikro-orm/core";
+// Type-only imports + string relation targets keep the Owner↔Pet and
+// Owner↔Address cycles off the runtime graph — see `pet.entity.ts`.
+import type { Address } from "../address/address.entity.js";
+import type { Pet } from "../pet/pet.entity.js";
+
+/**
+ * The relation side of the example: an Owner has many Pets.
+ *
+ * Owners are soft-deletable, but — unlike the TypeORM example's `Owner`,
+ * which only needs `@DeleteDateColumn` — nothing in a MikroORM entity can
+ * declare a delete marker. `deletedAt` is an ordinary nullable property and
+ * `OwnerController` names it through `softDelete.field`; that config is the
+ * only thing that turns it into the marker (doc 17 §5).
+ *
+ * Caveat worth seeing in a reference app: a soft-deleted owner still
+ * occupies the unique `email` index, so re-creating one after deleting it
+ * is a 409 until the index is made partial
+ * (`… ON owner (email) WHERE deleted_at IS NULL`).
+ */
+@Entity()
+export class Owner {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  name!: string;
+
+  @Property({ type: "string", unique: true })
+  email!: string;
+
+  /** A nullable, client-writable date column — unlike the generated `createdAt`. */
+  @Property({ type: "Date", nullable: true })
+  startedAt: Date | null = null;
+
+  @OneToMany("Pet", "owner")
+  pets = new Collection<Pet>(this);
+
+  // The owning side of the one-to-one: Owner carries the nullable join
+  // column. `owner: true` is what makes this the owning side, the MikroORM
+  // counterpart of TypeORM's explicit `@JoinColumn`.
+  @OneToOne("Address", undefined, { owner: true, nullable: true })
+  address: Address | null = null;
+
+  @Property({ type: "Date", onCreate: () => new Date() })
+  createdAt!: Date;
+
+  /** The soft-delete marker, named by `OwnerController`'s `softDelete.field`. */
+  @Property({ type: "Date", nullable: true })
+  deletedAt: Date | null = null;
+}

--- a/examples/nest-mikroorm/src/pet/pet.entity.ts
+++ b/examples/nest-mikroorm/src/pet/pet.entity.ts
@@ -1,0 +1,56 @@
+import { Collection, Entity, Enum, ManyToMany, ManyToOne, PrimaryKey, Property } from "@mikro-orm/core";
+// Type-only imports + string relation targets keep the Owner↔Pet cycle off
+// the runtime import graph, which `.dependency-cruiser.cjs`'s `no-circular`
+// rule forbids (type-only edges are exempt). MikroORM resolves "Owner" and
+// "Tag" by entity name during metadata discovery, and `@kavo/mikroorm` reads
+// the resolved class off `targetMeta` rather than calling the declaration —
+// see doc 17 §1.
+import type { Owner } from "../owner/owner.entity.js";
+import type { Tag } from "../tag/tag.entity.js";
+
+/** Enum column shared by every Pet subtype. */
+export enum PetSizeEnum {
+  Small = "small",
+  Medium = "medium",
+  Large = "large",
+}
+
+/**
+ * The single-table inheritance base. `Pet` is never served directly — you
+ * cannot create a bare Pet, only a concrete Cat or Dog — so the class is
+ * `abstract`. `discriminatorColumn` names the column MikroORM writes itself
+ * from the subtype being persisted.
+ *
+ * Like the TypeORM example's base, that column has no entity property worth
+ * speaking of: MikroORM never hydrates it and never serializes it, so it
+ * cannot reach a response. The adapter still reports it *generated*, which
+ * is what keeps it out of the writable projection — see doc 17 §1.
+ */
+@Entity({ abstract: true, discriminatorColumn: "species" })
+export abstract class Pet {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  name!: string;
+
+  @Property({ type: "number" })
+  age!: number;
+
+  // An enum column: the adapter surfaces it as the `enum` FieldKind with its
+  // allowed values, so filters coerce against the set.
+  @Enum({ items: () => PetSizeEnum })
+  size: PetSizeEnum = PetSizeEnum.Medium;
+
+  @ManyToOne("Owner", { nullable: true })
+  owner: Owner | null = null;
+
+  // Owning side of the many-to-many edge: `include=tags` loads through the
+  // pivot table MikroORM creates. Unidirectional — `Tag` has no inverse
+  // `pets` field, since nothing browses pets from a tag.
+  @ManyToMany("Tag", undefined, { owner: true })
+  tags = new Collection<Tag>(this);
+
+  @Property({ type: "Date", onCreate: () => new Date() })
+  createdAt!: Date;
+}

--- a/examples/nest-mikroorm/src/tag/tag.controller.ts
+++ b/examples/nest-mikroorm/src/tag/tag.controller.ts
@@ -1,0 +1,19 @@
+import { Controller } from "@nestjs/common";
+import { Kavo } from "@kavo/nest";
+import { Tag } from "./tag.entity.js";
+import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.js";
+
+/**
+ * Plain CRUD over `Tag`, the many-to-many side pets associate by id
+ * (`include=tags` on `/cats`).
+ */
+@Kavo(Tag, {
+  dto: {
+    create: CreateTagDto,
+    update: UpdateTagDto,
+    item: TagItemDto,
+    list: TagListDto,
+  },
+})
+@Controller("tags")
+export class TagController {}

--- a/examples/nest-mikroorm/src/tag/tag.dtos.ts
+++ b/examples/nest-mikroorm/src/tag/tag.dtos.ts
@@ -1,0 +1,26 @@
+/**
+ * DTO slots for the Tag route. Plain initialized-field classes, same
+ * rationale as every other entity's DTOs (see `cat.dtos.ts`).
+ */
+
+/** `create` slot — request body for POST /tags. */
+export class CreateTagDto {
+  name = "";
+}
+
+/** `update` slot — request body for PUT /tags/:id (patch derives from it). */
+export class UpdateTagDto {
+  name = "";
+}
+
+/** `item` slot — the detail projection. */
+export class TagItemDto {
+  id = 0;
+  name = "";
+}
+
+/** `list` slot — same shape as `item`; a tag has nothing left to trim. */
+export class TagListDto {
+  id = 0;
+  name = "";
+}

--- a/examples/nest-mikroorm/src/tag/tag.entity.ts
+++ b/examples/nest-mikroorm/src/tag/tag.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryKey, Property } from "@mikro-orm/core";
+
+/**
+ * A label shared across pets. Unidirectional: `Tag` carries no
+ * back-reference to `Pet` because nothing in this app browses pets from a
+ * tag — the owning `@ManyToMany` lives on `Pet` (ADR-0014's id-association
+ * path, over a many-to-many edge).
+ */
+@Entity()
+export class Tag {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  name!: string;
+}

--- a/examples/nest-mikroorm/tests/app-postgres.e2e.spec.ts
+++ b/examples/nest-mikroorm/tests/app-postgres.e2e.spec.ts
@@ -1,0 +1,62 @@
+import "reflect-metadata";
+import { afterAll, beforeAll } from "vitest";
+import type { MikroORM } from "@mikro-orm/core";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { AppModule } from "../src/app.module.js";
+import { createPostgresOrm } from "../src/database.js";
+import { registerCrudE2eSuite } from "./crud-e2e.suite.js";
+import { listen } from "./support/listen.js";
+
+/**
+ * Same suite as `app.e2e.spec.ts`, against a real Postgres provisioned by
+ * Testcontainers instead of in-memory SQLite.
+ *
+ * This is the only place `caseInsensitiveFilters: true` is exercised, and
+ * it is the reason this spec exists rather than being a second connection
+ * string. `$ilike` reaches PostgreSQL verbatim, so the suite's ILIKE
+ * assertion is a genuine `ILIKE` here and a degraded `$like` on SQLite —
+ * both passing is what the flag's `false` default rests on. It also puts
+ * the adapter's conflict mapping in front of a real Postgres unique index
+ * (SQLSTATE 23505) rather than SQLite's.
+ */
+let container: StartedPostgreSqlContainer;
+let orm: MikroORM;
+let app: INestApplication;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:18-alpine").start();
+  orm = await createPostgresOrm({
+    host: container.getHost(),
+    port: container.getPort(),
+    user: container.getUsername(),
+    password: container.getPassword(),
+    dbName: container.getDatabase(),
+  });
+
+  const moduleRef = await Test.createTestingModule({
+    imports: [AppModule.forRoot({ orm, caseInsensitiveFilters: true })],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  await listen(app);
+}, 120_000);
+
+afterAll(async () => {
+  // Each step is guarded: a failure closing the app must still stop the
+  // container, or the runner leaks a Postgres for the rest of the session.
+  try {
+    if (app !== undefined) await app.close();
+  } finally {
+    try {
+      if (orm !== undefined) await orm.close();
+    } finally {
+      if (container !== undefined) await container.stop();
+    }
+  }
+}, 30_000);
+
+registerCrudE2eSuite(
+  () => app,
+  () => orm,
+);

--- a/examples/nest-mikroorm/tests/app.e2e.spec.ts
+++ b/examples/nest-mikroorm/tests/app.e2e.spec.ts
@@ -1,0 +1,47 @@
+import "reflect-metadata";
+import { afterAll, beforeAll } from "vitest";
+import type { MikroORM } from "@mikro-orm/core";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { AppModule } from "../src/app.module.js";
+import { createSqliteOrm } from "../src/database.js";
+import { registerCrudE2eSuite } from "./crud-e2e.suite.js";
+import { listen } from "./support/listen.js";
+
+/**
+ * The default suite: in-memory SQLite, so `pnpm check` gets the full
+ * Nest → engine → MikroORM → database path with no Docker daemon, no
+ * downloads, and no manual setup.
+ *
+ * `caseInsensitiveFilters` is left at its default `false` here — `$ilike`
+ * is PostgreSQL-only, and on SQLite the degraded `$like` is already ASCII
+ * case-insensitive, so the suite's ILIKE assertion holds either way.
+ * `app-postgres.e2e.spec.ts` runs the same assertions with the flag on,
+ * against the one driver where it is a real `ILIKE`.
+ */
+let orm: MikroORM;
+let app: INestApplication;
+
+beforeAll(async () => {
+  orm = await createSqliteOrm();
+
+  const moduleRef = await Test.createTestingModule({
+    imports: [AppModule.forRoot({ orm })],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  await listen(app);
+}, 60_000);
+
+afterAll(async () => {
+  // An `app.close()` rejection must not strand the ORM's connection pool.
+  try {
+    if (app !== undefined) await app.close();
+  } finally {
+    if (orm !== undefined) await orm.close();
+  }
+});
+
+registerCrudE2eSuite(
+  () => app,
+  () => orm,
+);

--- a/examples/nest-mikroorm/tests/crud-e2e.suite.ts
+++ b/examples/nest-mikroorm/tests/crud-e2e.suite.ts
@@ -1,0 +1,464 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import type { MikroORM } from "@mikro-orm/core";
+import type { INestApplication } from "@nestjs/common";
+import { boundServer, type SupertestTarget } from "./support/listen.js";
+
+/**
+ * The Pet example served by the real stack — generated Nest routes → engine
+ * → `@kavo/mikroorm` → a real database — with filtering, sorting,
+ * pagination, DTO projections, layered config, and problem-details errors.
+ *
+ * Same domain as `nest-typeorm`: single-table inheritance (Cat/Dog over one
+ * `pet` table), an Owner relation both ways, a one-to-one Address, and a
+ * many-to-many Tag edge. Running the *same shape* under a different adapter
+ * is the point — anything that behaves differently here is either a real
+ * MikroORM difference worth seeing, or a bug.
+ *
+ * Parameterized by `getApp`/`getOrm` so the same suite runs unchanged
+ * against both the in-memory SQLite app (`app.e2e.spec.ts`) and the
+ * Testcontainers-provisioned Postgres app (`app-postgres.e2e.spec.ts`) —
+ * one behavioral spec, two drivers, no forked assertions.
+ */
+export function registerCrudE2eSuite(getApp: () => INestApplication, getOrm: () => MikroORM): void {
+  function server(): SupertestTarget {
+    // The spec that registered this suite must have bootstrapped with
+    // `listen(app)`, not `app.init()`, and must not have closed the app:
+    // `boundServer` rejects every shape supertest would answer by binding
+    // a wildcard port per request, which is the collision behind #91.
+    return boundServer(getApp().getHttpServer() as SupertestTarget);
+  }
+
+  async function seed(): Promise<void> {
+    const cats = [
+      { name: "Whiskers", age: 36, size: "small", indoor: true, livesLeft: 9 },
+      { name: "Mittens", age: 45, size: "medium", indoor: false, livesLeft: 7 },
+      { name: "Shadow", age: 41, size: "small", indoor: true, livesLeft: 8 },
+      { name: "Tigger", age: 28, size: "large", indoor: false, livesLeft: 9 },
+    ];
+    for (const cat of cats) {
+      await request(server()).post("/cats").send(cat).expect(201);
+    }
+  }
+
+  async function newOwner(name = "Ada", email = "ada@x.io"): Promise<number> {
+    const created = await request(server()).post("/owners").send({ name, email }).expect(201);
+    return created.body.id as number;
+  }
+
+  describe("Pet example app (MikroORM)", () => {
+    beforeEach(async () => {
+      // Truncate between tests rather than rebuilding the schema: the ORM is
+      // bootstrapped once per spec file. `clearDatabase` also resets the
+      // identity map, which matters because the suite drives the app over
+      // HTTP while occasionally asserting through a forked EntityManager.
+      await getOrm().schema.clearDatabase();
+    });
+
+    it("runs the full CRUD lifecycle over HTTP", async () => {
+      const created = await request(server())
+        .post("/cats")
+        .send({ name: "First", age: 3, size: "small", indoor: true, livesLeft: 9 })
+        .expect(201);
+      expect(created.body).toMatchObject({ name: "First", age: 3, size: "small", indoor: true, livesLeft: 9 });
+      const id = created.body.id as number;
+
+      const fetched = await request(server()).get(`/cats/${id}`).expect(200);
+      // The CatItemDto projection exactly — note no `species` and no `owner`.
+      expect(Object.keys(fetched.body).sort()).toEqual([
+        "age",
+        "createdAt",
+        "id",
+        "indoor",
+        "livesLeft",
+        "name",
+        "size",
+      ]);
+
+      await request(server())
+        .put(`/cats/${id}`)
+        .send({ name: "Renamed", age: 4, size: "large", indoor: false, livesLeft: 8 })
+        .expect(200);
+      const after = await request(server()).get(`/cats/${id}`).expect(200);
+      expect(after.body).toMatchObject({ name: "Renamed", age: 4, size: "large" });
+
+      // PATCH is disabled on this route by `operations.patchOne: false`.
+      await request(server()).patch(`/cats/${id}`).send({ name: "Nope" }).expect(404);
+
+      await request(server()).delete(`/cats/${id}`).expect(204);
+      await request(server()).get(`/cats/${id}`).expect(404);
+    });
+
+    it("filters, sorts, and paginates through the query grammar", async () => {
+      await seed();
+      const list = await request(server()).get("/cats?filter[age][gte]=36&sort=-age&limit=2&offset=1").expect(200);
+
+      expect(list.body).toMatchObject({ limit: 2, offset: 1, total: 3 });
+      expect(list.body.items.map((cat: { name: string }) => cat.name)).toEqual(["Shadow", "Whiskers"]);
+      // CatListDto is leaner than the item projection.
+      expect(Object.keys(list.body.items[0]).sort()).toEqual(["id", "indoor", "name"]);
+    });
+
+    it("filters on the enum column", async () => {
+      await seed();
+      const small = await request(server()).get("/cats?filter[size][eq]=small&sort=name").expect(200);
+      expect(small.body.items.map((cat: { name: string }) => cat.name)).toEqual(["Shadow", "Whiskers"]);
+    });
+
+    it("supports OR groups and IN sets from the wire", async () => {
+      await seed();
+      const either = await request(server())
+        .get("/cats?filter[or][0][name][eq]=Mittens&filter[or][1][name][eq]=Tigger&sort=name")
+        .expect(200);
+      expect(either.body.items.map((cat: { name: string }) => cat.name)).toEqual(["Mittens", "Tigger"]);
+
+      const inSet = await request(server()).get("/cats?filter[size][in]=small,large&sort=name").expect(200);
+      expect(inSet.body.items).toHaveLength(3);
+    });
+
+    it("matches ILIKE case-insensitively on every driver", async () => {
+      // The one query `caseInsensitiveFilters` decides. On Postgres it is a
+      // real `$ilike`, enabled by `app-postgres.e2e.spec.ts`; on SQLite it
+      // degrades to `$like`, which is already ASCII case-insensitive there.
+      // Same assertion either way — the whole argument for defaulting the
+      // flag to `false` (doc 17 §2).
+      await seed();
+      const matched = await request(server()).get("/cats?filter[name][ilike]=whisk%25").expect(200);
+      expect(matched.body.items.map((cat: { name: string }) => cat.name)).toEqual(["Whiskers"]);
+    });
+
+    it("applies sparse fieldsets after DTO mapping", async () => {
+      await seed();
+      const list = await request(server()).get("/cats?fields=id,name&limit=1&sort=name").expect(200);
+      expect(Object.keys(list.body.items[0]).sort()).toEqual(["id", "name"]);
+    });
+
+    it("restricts filterable, sortable, and selectable to an explicit list", async () => {
+      await seed();
+      // `livesLeft` is returned by CatItemDto but is not on any allowlist.
+      await request(server()).get("/cats?filter[livesLeft][eq]=9").expect(400);
+      await request(server()).get("/cats?sort=livesLeft").expect(400);
+      await request(server()).get("/cats?fields=id,livesLeft").expect(400);
+    });
+
+    it("honors the entity-scope pagination override (defaultLimit 10, max 50)", async () => {
+      await seed();
+      const capped = await request(server()).get("/cats?limit=999").expect(200);
+      expect(capped.body.limit).toBe(50);
+      // /dogs takes the root default instead — no entity-scope override.
+      const dogs = await request(server()).get("/dogs?limit=999").expect(200);
+      expect(dogs.body.limit).toBe(100);
+    });
+
+    it("rejects bad queries with RFC 9457 problem details", async () => {
+      const invalid = await request(server())
+        .get("/cats?filter[nope][eq]=x")
+        .expect(400)
+        .expect("Content-Type", /application\/problem\+json/);
+      expect(invalid.body).toMatchObject({ code: "KAVO_QUERY_INVALID", status: 400 });
+      expect(invalid.body.errors[0]).toMatchObject({ field: "nope" });
+
+      await request(server()).get("/cats?filter[size][eq]=enormous").expect(400);
+      await request(server()).get("/owners?withDeleted=true&onlyDeleted=true").expect(400);
+      await request(server()).get("/cats/424242").expect(404);
+    });
+
+    it("scopes each route to its subtype via the discriminator", async () => {
+      // Single-table inheritance: both rows live in one table, and each
+      // route must see only its own subtype. MikroORM writes `species` from
+      // the subtype being persisted.
+      await request(server())
+        .post("/cats")
+        .send({ name: "Whiskers", age: 3, size: "small", indoor: true, livesLeft: 9 })
+        .expect(201);
+      await request(server())
+        .post("/dogs")
+        .send({ name: "Rex", age: 5, size: "large", breed: "lab", goodBoy: true })
+        .expect(201);
+
+      const cats = await request(server()).get("/cats").expect(200);
+      expect(cats.body.items.map((cat: { name: string }) => cat.name)).toEqual(["Whiskers"]);
+      const dogs = await request(server()).get("/dogs").expect(200);
+      expect(dogs.body.items.map((dog: { name: string }) => dog.name)).toEqual(["Rex"]);
+    });
+
+    it("falls back to entity-derived DTOs on /dogs, and never lets a client write the discriminator", async () => {
+      // `DogController` declares no `dto` block, so every slot is derived
+      // from MikroORM's own metadata — which is what makes the discriminator
+      // visible here at all.
+      const created = await request(server())
+        .post("/dogs")
+        .send({ name: "Rex", age: 5, size: "large", breed: "lab", goodBoy: true, species: "cat", id: 9999 })
+        .expect(201);
+
+      // `id` is auto-increment and `species` is the discriminator: both are
+      // reported generated, so both are stripped from the write. A
+      // client-set discriminator would otherwise produce a row this entity's
+      // own repository can no longer load (doc 17 §1).
+      expect(created.body.id).not.toBe(9999);
+      // And it never comes back out: MikroORM keeps the discriminator as
+      // write-only bookkeeping that never hydrates onto an entity, so it
+      // reaches no response even on the route with entity-derived DTOs.
+      expect(created.body).not.toHaveProperty("species");
+      expect(created.body).toMatchObject({ name: "Rex", breed: "lab", goodBoy: true });
+
+      // And it stays a Dog: writing `species` on update is ignored too.
+      await request(server()).patch(`/dogs/${created.body.id}`).send({ species: "cat" }).expect(200);
+      expect((await request(server()).get("/dogs").expect(200)).body.items).toHaveLength(1);
+    });
+
+    it("embeds relations both ways: a to-one owner and a to-many pets", async () => {
+      const ownerId = await newOwner();
+      await request(server())
+        .post("/cats")
+        .send({ name: "Whiskers", age: 3, size: "small", indoor: true, livesLeft: 9, owner: ownerId })
+        .expect(201);
+
+      const cats = await request(server()).get("/cats?include=owner").expect(200);
+      expect(cats.body.items[0].owner).toMatchObject({ id: ownerId, name: "Ada" });
+
+      const owners = await request(server()).get("/owners?include=pets").expect(200);
+      expect(Array.isArray(owners.body.items[0].pets)).toBe(true);
+      expect(owners.body.items[0].pets).toMatchObject([{ name: "Whiskers" }]);
+    });
+
+    it("embeds a two-level include (cat -> owner -> pets)", async () => {
+      const ownerId = await newOwner();
+      await request(server())
+        .post("/cats")
+        .send({ name: "Whiskers", age: 3, size: "small", indoor: true, livesLeft: 9, owner: ownerId })
+        .expect(201);
+
+      const nested = await request(server()).get("/cats?include=owner.pets").expect(200);
+      expect(nested.body.items[0].owner.pets).toMatchObject([{ name: "Whiskers" }]);
+    });
+
+    it("keeps a relation out of the response until it is included", async () => {
+      const ownerId = await newOwner();
+      await request(server())
+        .post("/cats")
+        .send({ name: "Whiskers", age: 3, size: "small", indoor: true, livesLeft: 9, owner: ownerId })
+        .expect(201);
+
+      const plain = await request(server()).get("/cats").expect(200);
+      expect(plain.body.items[0]).not.toHaveProperty("owner");
+    });
+
+    it("filters and sorts across a relation path", async () => {
+      // The capability that separates this adapter from `@kavo/mongoose`,
+      // which refuses `owner.name` outright: MikroORM nests a relation path
+      // in its own query language and adds the join itself.
+      const ada = await newOwner("Ada", "ada@x.io");
+      const zoe = await newOwner("Zoe", "zoe@x.io");
+      await request(server())
+        .post("/cats")
+        .send({ name: "AdaCat", age: 3, size: "small", indoor: true, livesLeft: 9, owner: ada })
+        .expect(201);
+      await request(server())
+        .post("/cats")
+        .send({ name: "ZoeCat", age: 4, size: "small", indoor: true, livesLeft: 9, owner: zoe })
+        .expect(201);
+
+      const filtered = await request(server()).get("/cats?filter[owner.name][eq]=Ada").expect(200);
+      expect(filtered.body.items.map((cat: { name: string }) => cat.name)).toEqual(["AdaCat"]);
+
+      const sorted = await request(server()).get("/cats?sort=-owner.name").expect(200);
+      expect(sorted.body.items.map((cat: { name: string }) => cat.name)).toEqual(["ZoeCat", "AdaCat"]);
+    });
+
+    it("does not fan out root rows when a to-many include is paginated", async () => {
+      // MikroORM resolves `populate` with its own queries and applies
+      // limit/offset to the root either way, which is why this adapter
+      // ignores IncludeNode.strategy (doc 17 §3).
+      const ownerId = await newOwner();
+      for (const name of ["One", "Two", "Three"]) {
+        await request(server())
+          .post("/cats")
+          .send({ name, age: 3, size: "small", indoor: true, livesLeft: 9, owner: ownerId })
+          .expect(201);
+      }
+
+      const page = await request(server()).get("/owners?include=pets&limit=1").expect(200);
+      expect(page.body).toMatchObject({ total: 1, limit: 1 });
+      expect(page.body.items).toHaveLength(1);
+      expect(page.body.items[0].pets).toHaveLength(3);
+    });
+
+    it("associates an owner with an address by id and embeds it via include (one-to-one)", async () => {
+      const address = await request(server())
+        .post("/addresses")
+        .send({ street: "1 Main", city: "Springfield", postalCode: "12345" })
+        .expect(201);
+      const created = await request(server())
+        .post("/owners")
+        .send({ name: "Ada", email: "ada@x.io", address: address.body.id })
+        .expect(201);
+
+      const fetched = await request(server()).get(`/owners/${created.body.id}?include=address`).expect(200);
+      expect(fetched.body.address).toMatchObject({ street: "1 Main", city: "Springfield" });
+
+      // A null one-to-one round-trips as null, not as a missing key.
+      const orphan = await newOwner("Grace", "grace@x.io");
+      const withoutAddress = await request(server()).get(`/owners/${orphan}?include=address`).expect(200);
+      expect(withoutAddress.body.address).toBeNull();
+    });
+
+    it("associates tags by id and embeds them via a many-to-many include", async () => {
+      const tagIds: number[] = [];
+      for (const name of ["fluffy", "loud"]) {
+        const tag = await request(server()).post("/tags").send({ name }).expect(201);
+        tagIds.push(tag.body.id as number);
+      }
+      const cat = await request(server())
+        .post("/cats")
+        .send({ name: "Whiskers", age: 3, size: "small", indoor: true, livesLeft: 9, tags: tagIds })
+        .expect(201);
+
+      const fetched = await request(server()).get(`/cats/${cat.body.id}?include=tags`).expect(200);
+      expect(Array.isArray(fetched.body.tags)).toBe(true);
+      expect(fetched.body.tags.map((tag: { name: string }) => tag.name).sort()).toEqual(["fluffy", "loud"]);
+
+      // Replacing the set is the documented association semantic (ADR-0014).
+      await request(server())
+        .put(`/cats/${cat.body.id}`)
+        .send({ name: "Whiskers", age: 3, size: "small", indoor: true, livesLeft: 9, tags: [tagIds[0]] })
+        .expect(200);
+      const reduced = await request(server()).get(`/cats/${cat.body.id}?include=tags`).expect(200);
+      expect(reduced.body.tags.map((tag: { name: string }) => tag.name)).toEqual(["fluffy"]);
+    });
+
+    it("counts and slices distinct roots even when a cat has several tags", async () => {
+      const tagIds: number[] = [];
+      for (const name of ["a", "b", "c"]) {
+        const tag = await request(server()).post("/tags").send({ name }).expect(201);
+        tagIds.push(tag.body.id as number);
+      }
+      for (const name of ["One", "Two"]) {
+        await request(server())
+          .post("/cats")
+          .send({ name, age: 3, size: "small", indoor: true, livesLeft: 9, tags: tagIds })
+          .expect(201);
+      }
+
+      const page = await request(server()).get("/cats?include=tags&limit=1&sort=name").expect(200);
+      expect(page.body.total).toBe(2);
+      expect(page.body.items).toHaveLength(1);
+      expect(page.body.items[0].tags).toHaveLength(3);
+    });
+
+    it("keeps include an opt-in allowlist entry, not a free pass", async () => {
+      await seed();
+      // `Cat.owner`/`Cat.tags` are includable; nothing else is, and an
+      // unknown relation is refused rather than ignored.
+      await request(server()).get("/cats?include=nope").expect(400);
+      // `Tag` opens no relations at all.
+      await request(server()).get("/tags?include=pets").expect(400);
+    });
+
+    it("soft-deletes, restores, and purges owners", async () => {
+      const id = await newOwner();
+
+      await request(server()).delete(`/owners/${id}`).expect(204);
+      expect((await request(server()).get("/owners").expect(200)).body.total).toBe(0);
+      expect((await request(server()).get("/owners?withDeleted=true").expect(200)).body.total).toBe(1);
+      expect((await request(server()).get("/owners?onlyDeleted=true").expect(200)).body.total).toBe(1);
+      // Deleting twice is a state conflict, not a missing row.
+      await request(server()).delete(`/owners/${id}`).expect(409);
+      // A soft-deleted row is invisible to writes as well as reads.
+      await request(server()).patch(`/owners/${id}`).send({ name: "Zombie" }).expect(404);
+
+      const restored = await request(server()).patch(`/owners/${id}/restore`).expect(200);
+      expect(restored.body).toMatchObject({ id, name: "Ada" });
+      expect((await request(server()).get("/owners").expect(200)).body.total).toBe(1);
+
+      // Purge only ever removes an already-deleted row.
+      await request(server()).delete(`/owners/${id}/purge`).expect(409);
+      await request(server()).delete(`/owners/${id}`).expect(204);
+      await request(server()).delete(`/owners/${id}/purge`).expect(204);
+      expect((await request(server()).get("/owners?withDeleted=true").expect(200)).body.total).toBe(0);
+    });
+
+    it("keeps deletedAt out of the allowlists and out of every DTO slot", async () => {
+      await newOwner();
+      // The allowlists use `{ exclude: ["deletedAt"] }`.
+      await request(server()).get("/owners?filter[deletedAt][isNull]=true").expect(400);
+      await request(server()).get("/owners?sort=deletedAt").expect(400);
+      await request(server()).get("/owners?fields=id,deletedAt").expect(400);
+
+      const list = await request(server()).get("/owners").expect(200);
+      expect(list.body.items[0]).not.toHaveProperty("deletedAt");
+    });
+
+    it("refuses to soft-delete an owner through a plain write", async () => {
+      // Because MikroORM declares no delete marker, `deletedAt` is an
+      // ordinary column that the adapter cannot mark generated — the write
+      // DTOs are what keep it unwritable (doc 17 §7). With `purgeOne`
+      // enabled, a stampable marker would be an unauthenticated path to a
+      // permanent delete.
+      const id = await newOwner();
+      await request(server()).patch(`/owners/${id}`).send({ deletedAt: "2020-01-01T00:00:00.000Z" }).expect(200);
+
+      // Still live, and still not purgeable.
+      expect((await request(server()).get("/owners").expect(200)).body.total).toBe(1);
+      await request(server()).delete(`/owners/${id}/purge`).expect(409);
+    });
+
+    it("leaves hard-delete entities without restore or purge routes", async () => {
+      const tag = await request(server()).post("/tags").send({ name: "plain" }).expect(201);
+      await request(server()).patch(`/tags/${tag.body.id}/restore`).expect(404);
+      await request(server()).delete(`/tags/${tag.body.id}/purge`).expect(404);
+    });
+
+    it("maps unique violations to 409 conflict problem details", async () => {
+      await newOwner("Ada", "dup@x.io");
+      const conflict = await request(server())
+        .post("/owners")
+        .send({ name: "Ada again", email: "dup@x.io" })
+        .expect(409)
+        .expect("Content-Type", /application\/problem\+json/);
+      expect(conflict.body).toMatchObject({ code: "KAVO_CONFLICT", status: 409 });
+    });
+
+    it("still conflicts on a unique index held by a soft-deleted owner", async () => {
+      // Documented adapter guidance: a soft-deleted row keeps its unique
+      // index entries, and the fix is a partial index — not a Kavo rewrite.
+      const id = await newOwner("Ada", "held@x.io");
+      await request(server()).delete(`/owners/${id}`).expect(204);
+      await request(server()).post("/owners").send({ name: "Ada again", email: "held@x.io" }).expect(409);
+    });
+
+    it("round-trips the nullable startedAt date on owners", async () => {
+      const created = await request(server())
+        .post("/owners")
+        .send({ name: "Ada", email: "ada@x.io", startedAt: "2024-03-01T00:00:00.000Z" })
+        .expect(201);
+      expect(new Date(created.body.startedAt as string).toISOString()).toBe("2024-03-01T00:00:00.000Z");
+
+      const cleared = await request(server()).patch(`/owners/${created.body.id}`).send({ startedAt: null }).expect(200);
+      expect(cleared.body.startedAt).toBeNull();
+    });
+
+    it("ignores client-sent generated columns", async () => {
+      const created = await request(server())
+        .post("/owners")
+        .send({ id: 4242, name: "Ada", email: "ada@x.io", createdAt: "1999-01-01T00:00:00.000Z" })
+        .expect(201);
+      expect(created.body.id).not.toBe(4242);
+      expect(new Date(created.body.createdAt as string).getUTCFullYear()).not.toBe(1999);
+    });
+
+    it("does not serve a stale row from a previous request's identity map", async () => {
+      // MikroORM caches every entity an EntityManager has loaded. The
+      // adapter forks a fresh one per operation precisely so a second
+      // request cannot be answered from the first one's cache (doc 17 §4).
+      const id = await newOwner();
+      await request(server()).get(`/owners/${id}`).expect(200);
+
+      const em = getOrm().em.fork();
+      await em.nativeUpdate("Owner", { id }, { name: "Changed underneath" });
+
+      const refetched = await request(server()).get(`/owners/${id}`).expect(200);
+      expect(refetched.body.name).toBe("Changed underneath");
+    });
+  });
+}

--- a/examples/nest-mikroorm/tests/support/listen.ts
+++ b/examples/nest-mikroorm/tests/support/listen.ts
@@ -1,0 +1,67 @@
+import type { Server } from "node:http";
+import type { INestApplication } from "@nestjs/common";
+import type request from "supertest";
+
+/** What `request(...)` accepts — the app under test, already bound. */
+export type SupertestTarget = Parameters<typeof request>[0];
+
+/** The host supertest connects to, hardcoded in its `Test` constructor. */
+const LOOPBACK = "127.0.0.1";
+
+/**
+ * Assert `server` is bound to the loopback *right now*, and hand it back for
+ * `request(...)`.
+ *
+ * Every `server()` accessor in the e2e suites goes through this, because
+ * each of the three ways the binding can be wrong is silent on its own and
+ * supertest recovers from all of them the same ruinous way — by calling
+ * `listen(0)` itself:
+ *
+ * - **absent** (`undefined`) — the spec never reached its bootstrap;
+ * - **unbound** (`address()` is `null`) — the app was only `init()`ed, or was
+ *   closed earlier in the test;
+ * - **bound to the wildcard** (`address().address` is `::`) — `listen(0)`
+ *   without a host. This is the one a null-check misses: the address is
+ *   non-null and looks healthy, while supertest still connects to
+ *   `127.0.0.1` and can reach a foreign process holding that port.
+ */
+export function boundServer(server: SupertestTarget | undefined): SupertestTarget {
+  const address = (server as Server | undefined)?.address();
+  if (address === null || address === undefined || typeof address === "string" || address.address !== LOOPBACK) {
+    throw new Error(
+      `expected a server bound to ${LOOPBACK}, got ${JSON.stringify(address) ?? "undefined"} — ` +
+        "bootstrap with listen(app) rather than app.init(), and do not close it mid-test",
+    );
+  }
+  return server as SupertestTarget;
+}
+
+/**
+ * Bind `app` to an ephemeral port on the loopback, and hand back the
+ * listening server for `request(...)`.
+ *
+ * Use this instead of `app.init()` in any suite that drives the app over
+ * HTTP. `init()` leaves `getHttpServer()` unbound, so supertest binds it
+ * itself, once per request: `listen(0)` on the **wildcard**, then a connect
+ * to a hardcoded `127.0.0.1` (supertest 7, `lib/test.js`). That asymmetry is
+ * a lottery over the ephemeral range — a wildcard `bind(0)` can be handed a
+ * port an unrelated local process already holds on the loopback, and the
+ * request is then delivered to that process, which is what made these suites
+ * ~10% flaky (issue #91). Binding once, on the address supertest connects
+ * to, removes the lottery.
+ *
+ * The `await` is load-bearing: `listen(0, host)` resolves the host
+ * asynchronously, unlike the no-host path, so the port exists only once the
+ * promise settles. `boundServer` is what pins that down — it cannot fail
+ * while the `await` is there, and fires the moment someone drops it.
+ *
+ * `packages/frameworks/nest/tests/support/listen.ts` and `examples/nest-typeorm/tests/support/listen.ts` hold copies of this file whose function
+ * bodies are byte-identical. Importing one of the others is what
+ * `.dependency-cruiser.cjs`'s `tests-no-other-package-internals` forbids,
+ * and the alternative — a shared home outside every package that owns it —
+ * buys less than it costs for ten lines. Change all three together.
+ */
+export async function listen(app: INestApplication): Promise<SupertestTarget> {
+  await app.listen(0, LOOPBACK);
+  return boundServer(app.getHttpServer() as SupertestTarget);
+}

--- a/examples/nest-mikroorm/tsconfig.json
+++ b/examples/nest-mikroorm/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "useDefineForClassFields": false
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/orms/mikroorm" },
+    { "path": "../../packages/frameworks/nest" }
+  ]
+}

--- a/examples/nest-mikroorm/tsconfig.tests.json
+++ b/examples/nest-mikroorm/tsconfig.tests.json
@@ -1,0 +1,19 @@
+{
+  // Typecheck-only project for `tests/` — see packages/core/tsconfig.tests.json.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "useDefineForClassFields": false,
+    "types": ["node"],
+    "paths": {
+      "@kavo/core": ["../../packages/core/src/index.ts"],
+      "@kavo/mikroorm": ["../../packages/orms/mikroorm/src/index.ts"],
+      "@kavo/nest": ["../../packages/frameworks/nest/src/index.ts"]
+    }
+  },
+  "include": ["tests"]
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "depcruise": "depcruise packages examples --config .dependency-cruiser.cjs",
     "generate": "pnpm --filter @kavo/prisma run generate",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.tests.json && tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/orms/prisma/tsconfig.tests.json && tsc -p packages/orms/mongoose/tsconfig.tests.json && tsc -p packages/orms/mikroorm/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/protocols/mcp/tsconfig.tests.json && tsc -p examples/nest-typeorm/tsconfig.tests.json && tsc -p examples/nest-mongoose/tsconfig.tests.json",
+    "typecheck": "tsc -p tsconfig.tests.json && tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/orms/prisma/tsconfig.tests.json && tsc -p packages/orms/mongoose/tsconfig.tests.json && tsc -p packages/orms/mikroorm/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/protocols/mcp/tsconfig.tests.json && tsc -p examples/nest-typeorm/tsconfig.tests.json && tsc -p examples/nest-mongoose/tsconfig.tests.json && tsc -p examples/nest-mikroorm/tsconfig.tests.json",
     "lint": "oxlint packages examples tests .github/scripts",
     "prettify": "prettier --write .",
     "format:check": "prettier --check .",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,18 @@
   "engines": {
     "node": ">=20"
   },
+  "pnpm": {
+    "overrides": {
+      "@mikro-orm/better-sqlite>better-sqlite3": "^13.0.2"
+    }
+  },
   "scripts": {
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "depcruise": "depcruise packages examples --config .dependency-cruiser.cjs",
     "generate": "pnpm --filter @kavo/prisma run generate",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.tests.json && tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/orms/prisma/tsconfig.tests.json && tsc -p packages/orms/mongoose/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/protocols/mcp/tsconfig.tests.json && tsc -p examples/nest-typeorm/tsconfig.tests.json && tsc -p examples/nest-mongoose/tsconfig.tests.json",
+    "typecheck": "tsc -p tsconfig.tests.json && tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/orms/prisma/tsconfig.tests.json && tsc -p packages/orms/mongoose/tsconfig.tests.json && tsc -p packages/orms/mikroorm/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/protocols/mcp/tsconfig.tests.json && tsc -p examples/nest-typeorm/tsconfig.tests.json && tsc -p examples/nest-mongoose/tsconfig.tests.json",
     "lint": "oxlint packages examples tests .github/scripts",
     "prettify": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/orms/mikroorm/README.md
+++ b/packages/orms/mikroorm/README.md
@@ -1,0 +1,109 @@
+# @kavo/mikroorm
+
+MikroORM adapter for Kavo: implements `RepositoryAdapter`
+(`EntityReader` + `EntityWriter`) from `@kavo/core` over a MikroORM
+`EntityManager`. `TransactionManager` is not implemented — see the
+`@remarks` on that interface in `@kavo/core`.
+
+**May depend on:** `@kavo/core`, `@mikro-orm/core` (peer). **Never on:**
+`@kavo/nest` or any framework.
+
+Fully implemented: CRUD, filtering/sorting/pagination (including across
+relation paths), soft delete/restore/purge (explicit `softDelete.field`
+only — MikroORM declares no delete-marker column the way TypeORM's
+`@DeleteDateColumn` does), and nested relation includes (via `populate`).
+
+## Usage
+
+Like `@kavo/typeorm` and unlike `@kavo/prisma`, there is nothing to declare
+twice: a MikroORM entity is a real runtime class carrying its own metadata,
+so the class you pass to `createCrud` _is_ the identity core needs — no
+marker classes, no `entities` list beyond the one MikroORM already has.
+
+```ts
+import { Collection, Entity, ManyToOne, OneToMany, PrimaryKey, Property, MikroORM } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/postgresql";
+import { createMikroOrmKavo } from "@kavo/mikroorm";
+
+@Entity()
+class Author {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  name!: string;
+
+  @OneToMany(() => Book, (book) => book.author)
+  books = new Collection<Book>(this);
+}
+
+const orm = await MikroORM.init(defineConfig({ dbName: "app", entities: [Author, Book] }));
+const kavo = createMikroOrmKavo(orm, { caseInsensitiveFilters: true });
+
+const authors = kavo.createCrud(Author);
+```
+
+`createInfrastructure`/`createMikroOrmKavo` take the `MikroORM` instance
+itself rather than an `EntityManager`: every adapter operation calls
+`orm.em.fork()` to get its own manager, which is what keeps one request's
+identity map out of the next one's.
+
+## `caseInsensitiveFilters`
+
+`ILIKE` maps to MikroORM's `$ilike`, which **only PostgreSQL supports** —
+SQLite, MySQL, and MongoDB pass the token through to the driver and fail
+with a syntax error. MikroORM's `Platform` exposes nothing to detect this
+from, so it is a declared setting, defaulting to `false` (the value that
+works everywhere). Turn it on for PostgreSQL.
+
+With it off, `ILIKE` translates exactly like `LIKE`. On SQLite that is not
+even a loss — SQLite's own `LIKE` is already ASCII case-insensitive.
+
+## Known limitations
+
+- **`LIKE` escapes are driver-dependent.** MikroORM has no way to attach an
+  `ESCAPE` clause to a `LIKE`, so the query grammar's `\` escape for a
+  literal `%`/`_` is honored only by drivers that default to backslash
+  (PostgreSQL, MySQL). On SQLite, which has no default escape character,
+  `filter[name][like]=100\%` matches the literal text `100\` followed by
+  anything, rather than the string `100%`.
+- **`IncludeNode.strategy` is ignored.** MikroORM resolves `populate` with
+  its own queries and applies `limit`/`offset` to the root either way, so
+  the join/batch distinction has nothing to control here — and MikroORM's
+  `strategy` option is per-query rather than per-relation, so it could not
+  express a mixed include tree anyway. Same posture as `@kavo/prisma`.
+- **MikroORM's own property options win at the boundary.** Rows are
+  converted with `wrap(entity).toObject()`, so a
+  `@Property({ hidden: true })` is dropped and a custom `serializer` runs
+  before core ever sees the row — a hidden property stays hidden even if a
+  Kavo DTO names it.
+- **The soft-delete marker is writable.** Nothing in a MikroORM entity
+  declares a delete column, so `deletedAt` is an ordinary property and a
+  plain `PATCH` of it will soft-delete a row, bypassing `deleteOne`'s
+  already-deleted check. It cannot _revive_ one: writes are scoped to the
+  live set, so a soft-deleted row 404s on `PUT`/`PATCH`. This is the same
+  hole `@kavo/prisma` and `@kavo/mongoose` have — only `@kavo/typeorm`
+  escapes it, because `@DeleteDateColumn` is detectable — and the fix
+  belongs in core. Until then, register an explicit `update`/`patch` DTO
+  that omits the marker whenever you enable `purgeOne`.
+- **A MikroORM `@Filter` is applied on top of Kavo's scoping.** Kavo owns
+  soft-delete scoping through `softDelete.field`; a default-on MikroORM
+  soft-delete filter would AND a second predicate onto every query and
+  quietly defeat `withDeleted`. Use one or the other, not both.
+- **No transactions.** The `TransactionManager` seam is unbuilt across every
+  Kavo adapter today.
+- **Composite primary keys are refused.** `buildEntityMetadata` raises
+  `KAVO_CONFIGURATION_ERROR` for an entity with more than one `@PrimaryKey`.
+
+## Soft delete and unique indexes
+
+A soft-deleted row still occupies its unique indexes, so re-creating "the
+same" row after a soft delete raises a 409 conflict — the honest answer,
+since the value _is_ taken. The fix is a partial unique index scoped to
+live rows:
+
+```sql
+CREATE UNIQUE INDEX author_email_live ON author (email) WHERE deleted_at IS NULL;
+```
+
+Full design notes: [`docs/internals/architecture/17-mikroorm-adapter.md`](../../../docs/internals/architecture/17-mikroorm-adapter.md).

--- a/packages/orms/mikroorm/README.md
+++ b/packages/orms/mikroorm/README.md
@@ -9,9 +9,11 @@ MikroORM adapter for Kavo: implements `RepositoryAdapter`
 `@kavo/nest` or any framework.
 
 Fully implemented: CRUD, filtering/sorting/pagination (including across
-relation paths), soft delete/restore/purge (explicit `softDelete.field`
-only — MikroORM declares no delete-marker column the way TypeORM's
-`@DeleteDateColumn` does), and nested relation includes (via `populate`).
+relation paths), soft delete/restore/purge, and nested relation includes
+(via `populate`). MikroORM declares no delete-marker column the way
+TypeORM's `@DeleteDateColumn` does, so the seam reports none — but read the
+soft-delete note under "Known limitations" before assuming that means soft
+delete is off until you configure it.
 
 ## Usage
 
@@ -67,25 +69,46 @@ even a loss — SQLite's own `LIKE` is already ASCII case-insensitive.
   (PostgreSQL, MySQL). On SQLite, which has no default escape character,
   `filter[name][like]=100\%` matches the literal text `100\` followed by
   anything, rather than the string `100%`.
+- **Soft-deleted related rows are pruned in memory.** MikroORM's
+  `populateWhere` cannot express per-level scoping: nesting a child condition
+  makes it a predicate on the _parent_, so a parent with no surviving
+  children disappears instead of coming back empty. The adapter populates
+  everything and prunes the loaded tree, which is correct at any depth but
+  does fetch soft-deleted related rows before discarding them. Soft-deleted
+  _roots_ are still excluded in SQL.
 - **`IncludeNode.strategy` is ignored.** MikroORM resolves `populate` with
   its own queries and applies `limit`/`offset` to the root either way, so
   the join/batch distinction has nothing to control here — and MikroORM's
   `strategy` option is per-query rather than per-relation, so it could not
   express a mixed include tree anyway. Same posture as `@kavo/prisma`.
 - **MikroORM's own property options win at the boundary.** Rows are
-  converted with `wrap(entity).toObject()`, so a
-  `@Property({ hidden: true })` is dropped and a custom `serializer` runs
-  before core ever sees the row — a hidden property stays hidden even if a
-  Kavo DTO names it.
-- **The soft-delete marker is writable.** Nothing in a MikroORM entity
-  declares a delete column, so `deletedAt` is an ordinary property and a
-  plain `PATCH` of it will soft-delete a row, bypassing `deleteOne`'s
-  already-deleted check. It cannot _revive_ one: writes are scoped to the
-  live set, so a soft-deleted row 404s on `PUT`/`PATCH`. This is the same
-  hole `@kavo/prisma` and `@kavo/mongoose` have — only `@kavo/typeorm`
-  escapes it, because `@DeleteDateColumn` is detectable — and the fix
-  belongs in core. Until then, register an explicit `update`/`patch` DTO
-  that omits the marker whenever you enable `purgeOne`.
+  converted with `wrap(entity).toObject()`, so a custom `serializer` runs
+  before core ever sees the row.
+- **The soft-delete marker is writable, and it is on by default.** Nothing
+  in a MikroORM entity declares a delete column, so the adapter cannot mark
+  it generated — but `softDelete` defaults to
+  `{ field: "deletedAt", strategy: "auto" }` and core matches that _name_
+  against your columns, so any entity with a `deletedAt` property is
+  soft-deletable with no config at all. The marker then sits in the derived
+  writable projection: a plain `PATCH` of it soft-deletes a row, bypassing
+  `deleteOne`'s already-deleted check and even
+  `operations: { deleteOne: false }`. It cannot _revive_ one — writes are
+  scoped to the live set, so a soft-deleted row 404s on `PUT`/`PATCH`. This
+  is the same hole `@kavo/prisma` and `@kavo/mongoose` have (only
+  `@kavo/typeorm` escapes it, because `@DeleteDateColumn` is detectable and
+  therefore markable), and the fix belongs in core. Until then, register an
+  explicit `update`/`patch` DTO that omits the marker.
+- **A non-auto-increment primary key is client-writable.**
+  `@PrimaryKey() id: string = v4()` carries none of MikroORM's generated
+  flags, so a `PATCH` can rewrite a row's identity. A numeric `@PrimaryKey()`
+  is auto-increment and safe. Name the write DTOs explicitly for any entity
+  with a caller-assigned key.
+- **`hidden` and `lazy` properties are dropped from Kavo entirely.** Not
+  merely hidden from responses — excluding them from the metadata seam is
+  what keeps them off the default filter/sort allowlists, where an invisible
+  but filterable column is a blind extraction oracle. The trade is the one
+  `@kavo/mongoose` makes for `select: false`: Kavo does not manage such a
+  property at all, so write it through a custom operation or the ORM.
 - **A MikroORM `@Filter` is applied on top of Kavo's scoping.** Kavo owns
   soft-delete scoping through `softDelete.field`; a default-on MikroORM
   soft-delete filter would AND a second predicate onto every query and
@@ -93,7 +116,7 @@ even a loss — SQLite's own `LIKE` is already ASCII case-insensitive.
 - **No transactions.** The `TransactionManager` seam is unbuilt across every
   Kavo adapter today.
 - **Composite primary keys are refused.** `buildEntityMetadata` raises
-  `KAVO_CONFIGURATION_ERROR` for an entity with more than one `@PrimaryKey`.
+  `KAVO_CONFIG_INVALID` for an entity with more than one `@PrimaryKey`.
 
 ## Soft delete and unique indexes
 

--- a/packages/orms/mikroorm/package.json
+++ b/packages/orms/mikroorm/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@kavo/mikroorm",
+  "version": "0.6.0",
+  "description": "Kavo MikroORM adapter — implements @kavo/core's RepositoryAdapter over a MikroORM EntityManager.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kavo-labs/kavo.git",
+    "directory": "packages/orms/mikroorm"
+  },
+  "homepage": "https://github.com/kavo-labs/kavo/tree/main/packages/orms/mikroorm#readme",
+  "type": "module",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@kavo/core": "workspace:^"
+  },
+  "peerDependencies": {
+    "@mikro-orm/core": "^6.0.0"
+  },
+  "devDependencies": {
+    "@mikro-orm/core": "^6.6.14",
+    "@mikro-orm/better-sqlite": "^6.6.14",
+    "reflect-metadata": "^0.2.2"
+  }
+}

--- a/packages/orms/mikroorm/src/error-mapping.ts
+++ b/packages/orms/mikroorm/src/error-mapping.ts
@@ -1,0 +1,60 @@
+import type { ErrorContext } from "@kavo/core";
+import { ConflictException, KavoException, PersistenceException, TransactionException } from "@kavo/core";
+import {
+  DeadlockException,
+  ForeignKeyConstraintViolationException,
+  LockWaitTimeoutException,
+  UniqueConstraintViolationException,
+} from "@mikro-orm/core";
+
+/**
+ * The error-mapping table: driver error → Kavo exception.
+ *
+ * | MikroORM condition                          | Exception                          |
+ * | ------------------------------------------- | ---------------------------------- |
+ * | `UniqueConstraintViolationException`        | ConflictException                  |
+ * | `ForeignKeyConstraintViolationException`    | ConflictException                  |
+ * | `DeadlockException` / `LockWaitTimeoutException` | TransactionException (retryable) |
+ * | anything else                               | PersistenceException with `cause`  |
+ *
+ * The same four rows `@kavo/typeorm`'s table has, reached differently:
+ * MikroORM normalizes each driver's native error into its own exception
+ * hierarchy before it surfaces, so this matches on those classes rather than
+ * on Postgres SQLSTATEs, MySQL errnos, and SQLite extended codes the way the
+ * TypeORM adapter must. Every driver MikroORM supports is covered by that
+ * normalization, and anything it does not recognize falls through to
+ * `PersistenceException` — the original error always travels as `cause`,
+ * never swallowed.
+ *
+ * **Soft delete and unique indexes.** A soft-deleted row still occupies its
+ * unique indexes, so re-creating "the same" row after a soft delete raises a
+ * unique violation — mapped here to a 409 like any other conflict, which is
+ * the honest answer: the value *is* taken. Kavo never rewrites indexes; the
+ * standard fix is a partial/filtered unique index on the live rows only,
+ * e.g. in Postgres
+ * `CREATE UNIQUE INDEX … ON author (email) WHERE deleted_at IS NULL`
+ * (SQLite supports the same form; MySQL needs a generated column).
+ */
+export function mapDriverError(error: unknown, context: ErrorContext): KavoException {
+  if (error instanceof KavoException) return error;
+
+  const entity = context.entityName ?? "entity";
+
+  if (error instanceof UniqueConstraintViolationException || error instanceof ForeignKeyConstraintViolationException) {
+    return new ConflictException({
+      messageParams: { entity },
+      context,
+      cause: error,
+    });
+  }
+
+  if (error instanceof DeadlockException || error instanceof LockWaitTimeoutException) {
+    return new TransactionException({ retryable: true, context, cause: error });
+  }
+
+  return new PersistenceException({
+    messageParams: { operation: context.operation ?? "unknown" },
+    context,
+    cause: error,
+  });
+}

--- a/packages/orms/mikroorm/src/filter-translator.ts
+++ b/packages/orms/mikroorm/src/filter-translator.ts
@@ -1,0 +1,153 @@
+import type { Filter, FilterCondition, FilterExpression, FilterScalar } from "@kavo/core";
+import { assertNever } from "@kavo/core";
+
+/**
+ * A MikroORM `FilterQuery`, built structurally as a plain object. MikroORM's
+ * own `FilterQuery<T>` is entity-generic and deliberately not used here: the
+ * translator works from core's AST, which is not tied to a MikroORM entity
+ * type, and a plain object is what lets this be unit-tested without a
+ * database.
+ */
+export type MikroWhere = Record<string, unknown>;
+
+export interface FilterTranslatorOptions {
+  /**
+   * The entity's primary-key property. Used only to spell a contradiction
+   * for the degenerate empty-group cases — see {@link matchesNothing}.
+   */
+  readonly idField: string;
+  /**
+   * Whether the target driver supports MikroORM's `$ilike` operator.
+   * PostgreSQL does; SQLite, MySQL, and MongoDB do not — MikroORM passes
+   * `ilike` straight through to SQL, so on those drivers it is a syntax
+   * error rather than a degraded match. A MikroORM `Platform` exposes
+   * nothing to detect this from, so it is a caller-declared setting (see
+   * `MikroOrmInfrastructureOptions.caseInsensitiveFilters`), the same
+   * posture `@kavo/prisma` takes for `mode: "insensitive"`.
+   *
+   * Unlike `@kavo/prisma` this defaults to **`false`**, because the two
+   * failure modes are not symmetric: declaring it off on PostgreSQL costs
+   * case-insensitivity, while leaving it on anywhere else makes every
+   * `ILIKE` query throw. On SQLite the default is not even a loss —
+   * SQLite's own `LIKE` is already ASCII case-insensitive.
+   */
+  readonly caseInsensitiveFilters: boolean;
+}
+
+/**
+ * A predicate that matches no row.
+ *
+ * MikroORM rejects an empty `$and`/`$or` outright, and `$not: {}` negates
+ * *no condition at all*, which it renders as a match-everything rather than
+ * a match-nothing — the opposite of what these cases need. An empty `$in`
+ * is the one spelling MikroORM turns into a genuine contradiction on every
+ * driver, which is why this is expressed against the primary key rather
+ * than with a bare connective.
+ */
+function matchesNothing(idField: string): MikroWhere {
+  return { [idField]: { $in: [] } };
+}
+
+/**
+ * Filter AST → MikroORM `FilterQuery`.
+ *
+ * Like `@kavo/prisma`'s translator and unlike `@kavo/typeorm`'s, this needs
+ * no query-builder state — no join aliases, no parameter numbering. MikroORM
+ * nests relation paths natively (`{ author: { name: { $eq: "Ada" } } }`) and
+ * adds the join itself, so a relation-path field nests the same translation
+ * one level deeper instead of registering a join.
+ *
+ * Every comparison is wrapped in an explicit operator (`{ $eq: v }`, never
+ * the bare `{ field: v }` shorthand). Core coerces filter values to scalars
+ * upstream, so this is defence in depth rather than the only guard — but an
+ * object arriving through the shorthand would be spliced in as *operators*,
+ * and the boundary's job is to be safe on its own terms.
+ */
+export function translateFilter<Entity>(
+  filter: Filter<Entity>,
+  options: FilterTranslatorOptions,
+): MikroWhere | undefined {
+  const root = filter.root;
+  if (root === null) return undefined;
+  return translateExpression(root, options);
+}
+
+function translateExpression(expression: FilterExpression, options: FilterTranslatorOptions): MikroWhere {
+  if (expression.kind === "condition") {
+    return translateCondition(expression, options);
+  }
+
+  const children = expression.children.map((child) => translateExpression(child, options));
+
+  if (expression.operator === "NOT") {
+    // Core's parser gives a NOT group exactly one child. With no child there
+    // is nothing to negate, and "not (anything)" matches nothing.
+    return children.length === 0 ? matchesNothing(options.idField) : { $not: children[0]! };
+  }
+
+  // The parser enforces arity, so the empty cases only guard hand-built ASTs
+  // passed programmatically — but MikroORM rejects an empty `$and`/`$or`, so
+  // the identity for each connective is spelled explicitly.
+  if (children.length === 0) {
+    return expression.operator === "OR" ? matchesNothing(options.idField) : {};
+  }
+  return expression.operator === "OR" ? { $or: children } : { $and: children };
+}
+
+/** Nest `condition.field` (`"author.name"`) into MikroORM's native relation-path shape. */
+function nest(field: string, leaf: Record<string, unknown>): MikroWhere {
+  return field.split(".").reduceRight<Record<string, unknown>>((inner, segment) => ({ [segment]: inner }), leaf);
+}
+
+function translateCondition(condition: FilterCondition, options: FilterTranslatorOptions): MikroWhere {
+  const field = condition.field as string;
+  const value = condition.value;
+
+  switch (condition.operator) {
+    case "EQ":
+      return nest(field, { $eq: value as FilterScalar });
+    case "NE":
+      // `$ne: null` is MikroORM's `IS NOT NULL`, so a null value needs no
+      // separate branch the way the SQL-string translator's does.
+      return nest(field, { $ne: value as FilterScalar });
+    case "GT":
+      return nest(field, { $gt: value });
+    case "GTE":
+      return nest(field, { $gte: value });
+    case "LT":
+      return nest(field, { $lt: value });
+    case "LTE":
+      return nest(field, { $lte: value });
+    case "IN":
+      // MikroORM renders an empty `$in` as a contradiction rather than
+      // emitting invalid `IN ()`, and an empty `$nin` as a tautology — the
+      // same answers `@kavo/typeorm` has to spell out by hand because it
+      // writes the SQL itself.
+      return nest(field, { $in: value as readonly FilterScalar[] });
+    case "NOT_IN":
+      return nest(field, { $nin: value as readonly FilterScalar[] });
+    case "LIKE":
+      // The pattern reaches SQL `LIKE` verbatim. MikroORM has no way to
+      // attach an `ESCAPE` clause, so the grammar's `\` escape for a literal
+      // `%`/`_` is honored only by drivers that default to backslash
+      // (PostgreSQL, MySQL) — not by SQLite, which has no default escape
+      // character. See doc 17, "Adapter-specific caveats".
+      return nest(field, { $like: value as string });
+    case "ILIKE":
+      return nest(field, options.caseInsensitiveFilters ? { $ilike: value as string } : { $like: value as string });
+    case "BETWEEN": {
+      const [low, high] = value as readonly FilterScalar[];
+      return nest(field, { $gte: low, $lte: high });
+    }
+    case "IS_NULL":
+      return nest(field, { $eq: null });
+    case "IS_NOT_NULL":
+      return nest(field, { $ne: null });
+    default:
+      // Every AST operator must translate to a predicate. Falling through
+      // silently would drop the condition and widen the result set, so the
+      // union is proven total here at build time — the same guarantee the
+      // other adapters' translators give.
+      return assertNever(condition.operator, "filter operator");
+  }
+}

--- a/packages/orms/mikroorm/src/index.ts
+++ b/packages/orms/mikroorm/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @kavo/mikroorm — MikroORM adapter for Kavo.
+ *
+ * Implements `@kavo/core`'s `RepositoryAdapter` over a MikroORM
+ * `EntityManager` and feeds core's entity-metadata seam from MikroORM's own
+ * `MetadataStorage`. `@mikro-orm/core` is a peerDependency; `@kavo/core`
+ * never imports it.
+ */
+export { MikroOrmRepositoryAdapter } from "./mikro-orm-repository-adapter.js";
+export { translateFilter, type FilterTranslatorOptions, type MikroWhere } from "./filter-translator.js";
+export { buildEntityMetadata } from "./metadata.js";
+export { mapDriverError } from "./error-mapping.js";
+export { toPlain, toPlainAll } from "./plain-entity.js";
+export { createInfrastructure, createMikroOrmKavo, type MikroOrmInfrastructureOptions } from "./infrastructure.js";

--- a/packages/orms/mikroorm/src/infrastructure.ts
+++ b/packages/orms/mikroorm/src/infrastructure.ts
@@ -1,0 +1,82 @@
+import type {
+  ClassRef,
+  EntityMetadata,
+  KavoInfrastructure,
+  KavoInstance,
+  KavoOptions,
+  RepositoryAdapter,
+} from "@kavo/core";
+import { createKavo } from "@kavo/core";
+import type { MikroORM } from "@mikro-orm/core";
+import { buildEntityMetadata } from "./metadata.js";
+import { MikroOrmRepositoryAdapter } from "./mikro-orm-repository-adapter.js";
+
+/**
+ * What MikroORM needs beyond the ORM instance. Nothing is required — a
+ * MikroORM entity is a real runtime class carrying its own metadata, so the
+ * ORM instance alone supplies both halves of core's infrastructure seam,
+ * exactly as a TypeORM `DataSource` does and unlike `@kavo/prisma`, which
+ * needs caller-declared marker classes (ADR-0017).
+ */
+export interface MikroOrmInfrastructureOptions {
+  /**
+   * Whether the driver supports MikroORM's `$ilike` operator — PostgreSQL
+   * does; SQLite, MySQL, and MongoDB reject it as a syntax error. Defaults
+   * to `false`, the setting that works on every driver; turn it on for
+   * PostgreSQL to make `ILIKE` genuinely case-insensitive. See
+   * `FilterTranslatorOptions`.
+   */
+  readonly caseInsensitiveFilters?: boolean;
+}
+
+/**
+ * The MikroORM implementation of core's infrastructure seam: metadata and
+ * adapters derived from one `MikroORM` instance, cached per entity (metadata
+ * derivation and adapter construction are bootstrap work, not per-request
+ * work) — same shape as `@kavo/typeorm`'s `createInfrastructure`.
+ *
+ * The instance is held rather than an `EntityManager`, because every adapter
+ * operation forks its own manager from it; see `MikroOrmRepositoryAdapter`.
+ */
+export function createInfrastructure(orm: MikroORM, options: MikroOrmInfrastructureOptions = {}): KavoInfrastructure {
+  const metadataCache = new Map<ClassRef, EntityMetadata>();
+  const adapterCache = new Map<ClassRef, RepositoryAdapter>();
+
+  function metadataFor<Entity extends object>(entity: ClassRef<Entity>): EntityMetadata<Entity> {
+    let metadata = metadataCache.get(entity);
+    if (metadata === undefined) {
+      metadata = buildEntityMetadata(orm, entity) as EntityMetadata;
+      metadataCache.set(entity, metadata);
+    }
+    return metadata as EntityMetadata<Entity>;
+  }
+
+  return {
+    metadataFor,
+    adapterFor<Entity extends object>(entity: ClassRef<Entity>) {
+      let adapter = adapterCache.get(entity);
+      if (adapter === undefined) {
+        adapter = new MikroOrmRepositoryAdapter(orm, metadataFor(entity), {
+          caseInsensitiveFilters: options.caseInsensitiveFilters ?? false,
+        }) as RepositoryAdapter;
+        adapterCache.set(entity, adapter);
+      }
+      return adapter as RepositoryAdapter<Entity>;
+    },
+  };
+}
+
+/**
+ * Sugar for the common case: a Kavo root instance wired to one MikroORM
+ * instance, so `kavo.createCrud(Author)` is genuinely zero-config.
+ */
+export function createMikroOrmKavo(
+  orm: MikroORM,
+  options: MikroOrmInfrastructureOptions & Omit<KavoOptions, "infrastructure"> = {},
+): KavoInstance {
+  const { caseInsensitiveFilters, ...kavoOptions } = options;
+  return createKavo({
+    ...kavoOptions,
+    infrastructure: createInfrastructure(orm, { caseInsensitiveFilters }),
+  });
+}

--- a/packages/orms/mikroorm/src/metadata.ts
+++ b/packages/orms/mikroorm/src/metadata.ts
@@ -1,0 +1,147 @@
+import type { ClassRef, EntityMetadata, FieldKind, FieldMetadata, RelationDescriptor } from "@kavo/core";
+import { ConfigurationException } from "@kavo/core";
+import type { EntityProperty, MikroORM } from "@mikro-orm/core";
+
+/**
+ * Translate a MikroORM property's declared type into the ORM-independent
+ * `FieldKind` core coerces against.
+ *
+ * `runtimeType` is preferred over `type`: MikroORM normalizes the former to
+ * the JavaScript type the property actually holds (`"string"`, `"Date"`),
+ * which is what core must coerce toward — a `bigint` or `decimal` column
+ * surfaces as `"string"` there, and `string` is genuinely the right target
+ * for it. The declared `type` is still consulted as a fallback, because
+ * `runtimeType` is `"any"` for the custom types that carry no JavaScript
+ * equivalent (`JsonType`). An unrecognized type degrades to `string` —
+ * comparison still works, coercion just doesn't narrow.
+ */
+function fieldKindOf(property: EntityProperty): FieldKind {
+  if (property.enum === true) return "enum";
+  const type = String(property.runtimeType ?? property.type).toLowerCase();
+  if (type === "date") return "date";
+  if (type === "boolean" || type === "bool") return "boolean";
+  if (type === "number" || type === "bigint") return "number";
+  if (type === "string") return "string";
+  if (type === "object" || type === "json" || type === "jsonb") return "json";
+  // Fall back to the declared column type for anything `runtimeType` did not
+  // already answer (a custom `type: "int8"`, a driver-native column type).
+  const declared = String(property.type).toLowerCase();
+  if (/^(int|integer|tinyint|smallint|mediumint|bigint|float|double|real|decimal|numeric|number)/.test(declared)) {
+    return "number";
+  }
+  if (/^(bool|boolean)/.test(declared)) return "boolean";
+  if (/^(date|datetime|timestamp|time)/.test(declared)) return "date";
+  if (/^(json|jsonb)/.test(declared)) return "json";
+  return "string";
+}
+
+/**
+ * Whether a property is written by the database or the ORM rather than by
+ * the caller — excluded from the derived `create`/`update`/`patch` defaults
+ * and stripped from write payloads by the default deserializer.
+ *
+ * MikroORM has no single flag for this, so the four independent ways a
+ * property becomes non-caller-writable are each checked: an auto-increment
+ * or database-generated column, an `onCreate`/`onUpdate` hook (the
+ * equivalent of TypeORM's `@CreateDateColumn`/`@UpdateDateColumn`), an
+ * optimistic-lock `@Property({ version: true })`, and `persist: false`,
+ * which is not stored at all.
+ */
+function isGenerated(property: EntityProperty): boolean {
+  return (
+    property.autoincrement === true ||
+    property.generated !== undefined ||
+    property.onCreate !== undefined ||
+    property.onUpdate !== undefined ||
+    property.version === true ||
+    property.persist === false
+  );
+}
+
+/** MikroORM's relation `kind` discriminators that carry many rows. */
+const TO_MANY = new Set(["1:m", "m:n"]);
+
+/**
+ * Build the core `EntityMetadata` for one entity from MikroORM's own
+ * `MetadataStorage`: the adapter feeds core's metadata seam; core never sees
+ * MikroORM types.
+ *
+ * Unlike `@kavo/prisma`, no marker class is needed (ADR-0017 exists because
+ * Prisma erases its models at compile time) — a MikroORM entity is a real
+ * runtime class that already carries its own metadata, so the class the
+ * caller passes to `createCrud` *is* the identity, exactly as in
+ * `@kavo/typeorm`.
+ */
+export function buildEntityMetadata<Entity extends object>(
+  orm: MikroORM,
+  entity: ClassRef<Entity>,
+): EntityMetadata<Entity> {
+  const metadata = orm.getMetadata().find(entity.name);
+  if (metadata === undefined) {
+    throw new ConfigurationException(
+      entity.name,
+      "entity",
+      `MikroORM has no registered entity named '${entity.name}'; ` +
+        `add it to the 'entities' array the ORM was initialized with`,
+    );
+  }
+
+  if (metadata.primaryKeys.length !== 1) {
+    throw new ConfigurationException(
+      metadata.className,
+      "primaryKeys",
+      `Kavo v6 requires exactly one primary key; found ${metadata.primaryKeys.length}`,
+    );
+  }
+
+  const properties = Object.values(metadata.properties) as EntityProperty[];
+
+  const fields: FieldMetadata[] = properties
+    // An embeddable contributes *two* kinds of property: the object-valued
+    // parent (`kind: "embedded"`, what a caller addresses) and one child per
+    // inner column, carrying an `embedded: [parent, child]` back-reference
+    // and a name that is an implementation detail (`addr~city`,
+    // `inline_city`). Only the parent belongs on the wire, so the children
+    // are dropped rather than leaked into DTOs and allowlists.
+    .filter((property) => property.embedded === undefined)
+    .filter((property) => property.kind === "scalar" || property.kind === "embedded")
+    .map((property) => ({
+      name: property.name,
+      kind: property.kind === "embedded" ? "json" : fieldKindOf(property),
+      nullable: property.nullable === true,
+      generated: isGenerated(property),
+      ...(property.items !== undefined && {
+        enumValues: property.items.map((value) => String(value)),
+      }),
+    }));
+
+  const relations: RelationDescriptor[] = properties
+    .filter((property) => property.kind !== "scalar" && property.kind !== "embedded")
+    .map((property) => ({
+      name: property.name,
+      // `property.entity` is MikroORM's own lazy target thunk, which is what
+      // keeps a bidirectional relation off the runtime import graph — and it
+      // resolves to the *class*, which is the identity core matches
+      // registered entities by.
+      target: () => property.entity() as ClassRef,
+      cardinality: TO_MANY.has(property.kind) ? ("many" as const) : ("one" as const),
+      // Inclusion is an opt-in allowlist; ORM metadata only supplies shape,
+      // never permission.
+      includable: false,
+      strategy: "auto" as const,
+    }));
+
+  return {
+    entity,
+    name: metadata.className,
+    idField: metadata.primaryKeys[0]!,
+    fields,
+    relations,
+    // MikroORM declares no delete-date marker of its own — its soft-delete
+    // pattern is a user-defined `@Filter`, which is a query concern rather
+    // than a column declaration, so there is nothing here to detect. Soft
+    // delete therefore needs an explicit `softDelete.field` in Kavo config;
+    // see doc 17, "Adapter-specific caveats".
+    softDeleteField: null,
+  };
+}

--- a/packages/orms/mikroorm/src/metadata.ts
+++ b/packages/orms/mikroorm/src/metadata.ts
@@ -62,6 +62,40 @@ function isGenerated(property: EntityProperty): boolean {
 const TO_MANY = new Set(["1:m", "m:n"]);
 
 /**
+ * The lazy target-class thunk for one relation.
+ *
+ * A relation target can be declared two ways, and they do *not* arrive the
+ * same: `@ManyToOne(() => Owner)` leaves `property.entity` a thunk, while
+ * `@ManyToOne("Owner")` — the spelling that keeps a bidirectional relation's
+ * import cycle off the runtime graph, and therefore the one a
+ * `dependency-cruiser`-checked codebase reaches for — leaves it a plain
+ * **string**. Calling it would throw for half the codebases that use this
+ * adapter.
+ *
+ * `targetMeta` is what both spellings have in common: MikroORM resolves it
+ * during metadata discovery either way. The metadata-storage lookup behind
+ * it covers a target discovered after this thunk was built, and the declared
+ * thunk is the last resort. The resolution is deferred until the thunk is
+ * called, because a bidirectional relation's target may not be registered at
+ * the time this entity's metadata is derived.
+ */
+function targetOf(orm: MikroORM, property: EntityProperty, owner: string): () => ClassRef {
+  return () => {
+    const resolved = property.targetMeta?.class ?? orm.getMetadata().find(String(property.type))?.class;
+    if (resolved !== undefined) return resolved as ClassRef;
+    if (typeof property.entity === "function") {
+      return (property.entity as () => ClassRef)();
+    }
+    throw new ConfigurationException(
+      owner,
+      `relations.${property.name}`,
+      `cannot resolve the target entity of relation '${property.name}'; ` +
+        `MikroORM reports its type as '${String(property.type)}', which is not a registered entity`,
+    );
+  };
+}
+
+/**
  * Build the core `EntityMetadata` for one entity from MikroORM's own
  * `MetadataStorage`: the adapter feeds core's metadata seam; core never sees
  * MikroORM types.
@@ -95,6 +129,7 @@ export function buildEntityMetadata<Entity extends object>(
   }
 
   const properties = Object.values(metadata.properties) as EntityProperty[];
+  const discriminatorColumn = metadata.root?.discriminatorColumn ?? metadata.discriminatorColumn;
 
   const fields: FieldMetadata[] = properties
     // An embeddable contributes *two* kinds of property: the object-valued
@@ -104,12 +139,36 @@ export function buildEntityMetadata<Entity extends object>(
     // `inline_city`). Only the parent belongs on the wire, so the children
     // are dropped rather than leaked into DTOs and allowlists.
     .filter((property) => property.embedded === undefined)
+    // `hidden: true` is MikroORM's "never expose this" — `toObject` drops it,
+    // so it can never reach a response. Excluding it from the metadata seam
+    // as well, rather than relying on that, is what stops it from landing on
+    // the *default allowlists*: a filterable-but-invisible column is a blind
+    // extraction oracle, where `filter[passwordHash][like]=a%` is answered by
+    // the row count even though the value is projected out of the body.
+    // `lazy: true` is excluded for the same reason — it is not loaded with
+    // the entity, so a DTO naming it would emit `undefined` while a filter on
+    // it still ran in the database. `@kavo/mongoose` excludes its
+    // `select: false` paths on identical reasoning (doc 15 §1). The trade is
+    // the same one it documents: Kavo does not manage such a property at all,
+    // so write it through a custom operation or the ORM directly.
+    .filter((property) => property.hidden !== true && property.lazy !== true)
     .filter((property) => property.kind === "scalar" || property.kind === "embedded")
     .map((property) => ({
       name: property.name,
       kind: property.kind === "embedded" ? "json" : fieldKindOf(property),
       nullable: property.nullable === true,
-      generated: isGenerated(property),
+      // The single-table-inheritance discriminator: write-only bookkeeping
+      // MikroORM manages itself from the subtype being persisted. It never
+      // hydrates onto an entity and never survives `toObject`, so it cannot
+      // reach a response either way — what this flag stops is the *inbound*
+      // direction. Left un-generated it would join the writable projection,
+      // and a client sending `species: "cat"` on a Dog would produce a row
+      // that entity's own repository can no longer load.
+      //
+      // Read from `root`, because MikroORM records `discriminatorColumn` only
+      // on the inheritance root while the property itself is inherited by
+      // every subtype — and a subtype is what a caller passes to `createCrud`.
+      generated: isGenerated(property) || property.name === discriminatorColumn,
       ...(property.items !== undefined && {
         enumValues: property.items.map((value) => String(value)),
       }),
@@ -119,11 +178,11 @@ export function buildEntityMetadata<Entity extends object>(
     .filter((property) => property.kind !== "scalar" && property.kind !== "embedded")
     .map((property) => ({
       name: property.name,
-      // `property.entity` is MikroORM's own lazy target thunk, which is what
-      // keeps a bidirectional relation off the runtime import graph — and it
-      // resolves to the *class*, which is the identity core matches
-      // registered entities by.
-      target: () => property.entity() as ClassRef,
+      // Resolved lazily and from `targetMeta` rather than by calling
+      // `property.entity` — see `targetOf`, which exists because a
+      // string-declared target (the spelling that keeps a bidirectional
+      // relation's cycle off the runtime graph) leaves `entity` a string.
+      target: targetOf(orm, property, metadata.className),
       cardinality: TO_MANY.has(property.kind) ? ("many" as const) : ("one" as const),
       // Inclusion is an opt-in allowlist; ORM metadata only supplies shape,
       // never permission.
@@ -139,9 +198,14 @@ export function buildEntityMetadata<Entity extends object>(
     relations,
     // MikroORM declares no delete-date marker of its own — its soft-delete
     // pattern is a user-defined `@Filter`, which is a query concern rather
-    // than a column declaration, so there is nothing here to detect. Soft
-    // delete therefore needs an explicit `softDelete.field` in Kavo config;
-    // see doc 17, "Adapter-specific caveats".
+    // than a column declaration, so there is nothing here to detect.
+    //
+    // This is *not* the same as "soft delete is off until configured".
+    // `softDelete` defaults to `{ field: "deletedAt", strategy: "auto" }`, and
+    // core matches that name against the entity's own columns — so a plain
+    // `deletedAt` property enables soft delete with no config at all. What
+    // reporting `null` here really costs is the ability to mark the marker
+    // generated, which is why it stays client-writable. See doc 17 §5 and §7.
     softDeleteField: null,
   };
 }

--- a/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
+++ b/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
@@ -15,6 +15,23 @@ import { translateFilter, type FilterTranslatorOptions, type MikroWhere } from "
 import { toPlain, toPlainAll } from "./plain-entity.js";
 
 /**
+ * The subset of MikroORM's `FindOptions` this adapter constructs.
+ *
+ * Declared rather than borrowed: MikroORM's own `FindOptions<T, …>` is
+ * generic over the entity and its populate hints, which the adapter cannot
+ * supply from core's untyped `IncludeTree`. But the *keys* are Kavo's own
+ * construction, and typing them is what makes a typo a compile error — a
+ * silent `populatewhere` would drop the soft-delete scoping from every
+ * include and leave only one test to notice.
+ */
+interface MikroFindOptions {
+  readonly orderBy?: readonly Record<string, unknown>[];
+  readonly populate?: readonly string[];
+  readonly limit?: number;
+  readonly offset?: number;
+}
+
+/**
  * `RepositoryAdapter` over a MikroORM `EntityManager`: CRUD with hard *or*
  * soft delete, restore, purge, filtering, sorting, pagination, optional
  * counting, and nested relation includes.
@@ -92,7 +109,7 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
         query?.onlyDeleted ?? false,
       );
       const row = await this.fork().findOne(this.entity, where as never, this.populateOptions(include) as never);
-      return row === null ? null : toPlain(row);
+      return row === null ? null : pruneIncluded(toPlain(row), include);
     } catch (error) {
       throw mapDriverError(error, errorContext(context));
     }
@@ -100,12 +117,23 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
 
   async findOne(query: NormalizedQueryContext<Entity>, context: KavoContext<Entity>): Promise<Entity | null> {
     try {
-      const row = await this.fork().findOne(
+      // `em.find(…, { limit: 1 })` rather than `em.findOne`: MikroORM's
+      // validator rejects `em.findOne` with an empty `where` outright, and an
+      // unfiltered query is a legitimate shape here — `findOne`'s contract is
+      // "first match of the query, or null", and a query with no filter
+      // matches everything. `em.find` accepts it, so routing through it keeps
+      // the contract without an empty-where special case. The two are
+      // otherwise identical: `findOne` is itself a limit-1 `find`.
+      const rows = await this.fork().find(
         this.entity,
         this.buildWhere(query, context) as never,
-        this.buildFindOptions(query) as never,
+        {
+          ...this.buildFindOptions(query),
+          limit: 1,
+        } as never,
       );
-      return row === null ? null : toPlain(row);
+      const row = rows[0];
+      return row === undefined ? null : pruneIncluded(toPlain(row), query.include);
     } catch (error) {
       throw mapDriverError(error, errorContext(context));
     }
@@ -122,7 +150,7 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
           limit: query.pagination.limit,
         } as never,
       );
-      return toPlainAll(rows);
+      return toPlainAll(rows).map((row) => pruneIncluded(row, query.include));
     } catch (error) {
       throw mapDriverError(error, errorContext(context));
     }
@@ -150,7 +178,7 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
     );
   }
 
-  private buildFindOptions(query: NormalizedQueryContext<Entity>): Record<string, unknown> {
+  private buildFindOptions(query: NormalizedQueryContext<Entity>): MikroFindOptions {
     const orderBy = query.sort.map((sort) => nestOrderBy(sort.field as string, sort.direction));
     return {
       ...(orderBy.length > 0 && { orderBy }),
@@ -161,23 +189,20 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
   // ── Relation includes ───────────────────────────────────────────────
 
   /**
-   * Translate a validated `IncludeTree` into MikroORM's `populate` paths
-   * plus, when any included relation is soft-deletable, the `populateWhere`
-   * that keeps deleted related rows out.
+   * Translate a validated `IncludeTree` into MikroORM's `populate` paths.
    *
-   * Soft-deleted related rows are excluded from every include, to-one and
-   * to-many alike — the same rule `@kavo/typeorm` and `@kavo/prisma` apply.
-   * A root `withDeleted` is the root's own opt-in only; it never widens an
-   * included relation.
+   * Soft-delete scoping of included rows is deliberately **not** done here —
+   * see {@link pruneIncluded}. MikroORM's `populateWhere` cannot express it:
+   * a nested condition (`{ articles: { deletedAt: null, notes: { deletedAt:
+   * null } } }`) is read as a relation-path predicate on the *parent*, so an
+   * article with no live notes is dropped from the parent's collection
+   * altogether rather than coming back with an empty one. The dotted spelling
+   * MikroORM rejects outright, and the parent-only spelling silently leaves
+   * every deeper level unscoped.
    */
-  private populateOptions(tree: IncludeTree): Record<string, unknown> {
+  private populateOptions(tree: IncludeTree): MikroFindOptions {
     const paths = populatePaths(tree);
-    if (paths.length === 0) return {};
-    const populateWhere = includeSoftDeleteWhere(tree);
-    return {
-      populate: paths,
-      ...(populateWhere !== undefined && { populateWhere }),
-    };
+    return paths.length === 0 ? {} : { populate: paths };
   }
 
   // ── Soft delete ──────────────────────────────────────────────────────
@@ -386,9 +411,59 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
  * write one cascade setting away from working, which is precisely what
  * ADR-0014 rules out: relations are associated by id, never deep-written.
  */
+/**
+ * Apply the two include-tree rules core expects of a loaded row: every
+ * included relation is **present**, and no soft-deleted related row is in it.
+ *
+ * Both are done here, in memory, rather than in the query — see
+ * `populateOptions` for why `populateWhere` cannot do the second one without
+ * silently dropping parents. The cost is that soft-deleted related rows are
+ * fetched and then discarded; the alternative spellings are wrong rather than
+ * merely slower, so this is the honest trade. Soft-deleted *roots* are still
+ * excluded in SQL (`scopeToLive`), which is where the volume is.
+ *
+ * "Present" matters because core's serializer treats an absent key as "the
+ * adapter never hydrated this" and skips it — so an included to-many that
+ * matches nothing must be `[]`, not missing. A root `withDeleted` never
+ * widens an included relation: this prunes regardless of the root's scope.
+ */
+function pruneIncluded<Row>(row: Row, tree: IncludeTree): Row {
+  const source = row as Record<string, unknown>;
+  for (const node of Object.values(tree)) {
+    const name = node.relation.name;
+    const value = source[name];
+    const deleted = (candidate: unknown): boolean => {
+      if (node.softDelete.strategy !== "soft") return false;
+      const marker = (candidate as Record<string, unknown>)[node.softDelete.field];
+      return marker !== null && marker !== undefined;
+    };
+
+    if (Array.isArray(value)) {
+      const live = value.filter((child) => !deleted(child));
+      for (const child of live) pruneIncluded(child, node.children);
+      source[name] = live;
+      continue;
+    }
+    // A to-one that was populated is an object; anything else (a bare foreign
+    // key from an uninitialized reference, `undefined`, `null`) becomes null.
+    if (value !== null && typeof value === "object" && !deleted(value)) {
+      pruneIncluded(value, node.children);
+      continue;
+    }
+    source[name] = node.relation.cardinality === "many" ? [] : null;
+  }
+  return row;
+}
+
 function unwrapAssociation(value: unknown, idField: string): unknown {
   if (value === null || value === undefined) return null;
-  if (Array.isArray(value)) return value.map((element) => unwrapAssociation(element, idField));
+  if (Array.isArray(value)) {
+    // Nulls are filtered, not mapped through, exactly as core's `associate`
+    // does: a to-many element carrying no id contributes nothing, and passing
+    // `[null]` to `em.create`/`assign` would fail at the driver as a 500
+    // instead of being ignored.
+    return value.map((element) => unwrapAssociation(element, idField)).filter((element) => element !== null);
+  }
   if (typeof value === "object") {
     return (value as Record<string, unknown>)[idField] ?? null;
   }
@@ -409,23 +484,6 @@ function populatePaths(tree: IncludeTree, prefix = ""): string[] {
     paths.push(...populatePaths(node.children, path));
   }
   return paths;
-}
-
-/**
- * The nested `populateWhere` excluding soft-deleted rows from included
- * relations, or `undefined` when no included relation is soft-deletable —
- * MikroORM's default (`PopulateHint.ALL`) is the right behavior then, and
- * passing an empty object would needlessly override it.
- */
-function includeSoftDeleteWhere(tree: IncludeTree): Record<string, unknown> | undefined {
-  const where: Record<string, unknown> = {};
-  for (const node of Object.values(tree)) {
-    const children = includeSoftDeleteWhere(node.children);
-    const live = node.softDelete.strategy === "soft" ? { [node.softDelete.field]: null } : undefined;
-    if (live === undefined && children === undefined) continue;
-    where[node.relation.name] = { ...live, ...children };
-  }
-  return Object.keys(where).length === 0 ? undefined : where;
 }
 
 /** `"author.name"` + `"asc"` → `{ author: { name: "asc" } }`. */

--- a/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
+++ b/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
@@ -1,0 +1,445 @@
+import type {
+  ClassRef,
+  EntityId,
+  EntityMetadata,
+  IncludeTree,
+  KavoContext,
+  NormalizedQueryContext,
+  RepositoryAdapter,
+  ResolvedSoftDelete,
+} from "@kavo/core";
+import { AlreadyDeletedException, ConfigurationException, NotDeletedException, NotFoundException } from "@kavo/core";
+import { wrap, type EntityManager, type MikroORM } from "@mikro-orm/core";
+import { mapDriverError } from "./error-mapping.js";
+import { translateFilter, type FilterTranslatorOptions, type MikroWhere } from "./filter-translator.js";
+import { toPlain, toPlainAll } from "./plain-entity.js";
+
+/**
+ * `RepositoryAdapter` over a MikroORM `EntityManager`: CRUD with hard *or*
+ * soft delete, restore, purge, filtering, sorting, pagination, optional
+ * counting, and nested relation includes.
+ *
+ * Two things are specific to MikroORM and load-bearing:
+ *
+ * **Every method forks the EntityManager.** MikroORM is a Unit-of-Work ORM:
+ * an `EntityManager` owns an identity map that caches every entity it has
+ * loaded, and reusing one across requests would serve stale rows and leak
+ * one caller's entities into another's. `orm.em` is the *root* manager and
+ * is not meant to be queried directly; `orm.em.fork()` gives each operation
+ * a clean, isolated one, which is the same scope a request-scoped
+ * `RequestContext` would give a hand-written MikroORM application.
+ *
+ * **`IncludeNode.strategy` is deliberately ignored**, exactly as in
+ * `@kavo/prisma` and unlike `@kavo/typeorm`. The TypeORM adapter translates
+ * the join/batch split because it drives a raw SQL query builder, where a
+ * to-many `JOIN` multiplies root rows and separate batched queries are how
+ * that is avoided. MikroORM resolves `populate` with its own queries and
+ * applies `limit`/`offset` to the root regardless of the load strategy, so a
+ * to-many include never disturbs pagination here. There is nothing left for
+ * the distinction to control, and MikroORM's `strategy` option is per-query
+ * rather than per-relation anyway — it could not express a mixed tree.
+ */
+export class MikroOrmRepositoryAdapter<Entity extends object> implements RepositoryAdapter<Entity> {
+  private readonly entity: ClassRef<Entity>;
+  private readonly idField: string;
+  private readonly filterOptions: FilterTranslatorOptions;
+  /**
+   * Relation property name → the target entity's primary-key property.
+   * Resolved lazily: a bidirectional relation's target may not be registered
+   * with MikroORM's metadata storage at the time this adapter is built.
+   */
+  private readonly relationIdFields: ReadonlyMap<string, () => string>;
+
+  constructor(
+    private readonly orm: MikroORM,
+    metadata: EntityMetadata<Entity>,
+    options: { caseInsensitiveFilters?: boolean } = {},
+  ) {
+    this.entity = metadata.entity;
+    this.idField = metadata.idField;
+    this.filterOptions = {
+      idField: metadata.idField,
+      caseInsensitiveFilters: options.caseInsensitiveFilters ?? false,
+    };
+    const relationIdFields = new Map<string, () => string>();
+    for (const relation of metadata.relations) {
+      relationIdFields.set(relation.name, () => {
+        const target = this.orm.getMetadata().find(relation.target().name);
+        return target?.primaryKeys[0] ?? "id";
+      });
+    }
+    this.relationIdFields = relationIdFields;
+  }
+
+  /** A clean, isolated `EntityManager` for one operation — see the class doc. */
+  private fork(): EntityManager {
+    return this.orm.em.fork();
+  }
+
+  // ── Reads ────────────────────────────────────────────────────────────
+
+  async findOneById(
+    id: EntityId,
+    query: NormalizedQueryContext<Entity> | null,
+    context: KavoContext<Entity>,
+  ): Promise<Entity | null> {
+    try {
+      const include = query?.include ?? {};
+      const where = this.scopeToLive(
+        { [this.idField]: id },
+        context,
+        query?.withDeleted ?? false,
+        query?.onlyDeleted ?? false,
+      );
+      const row = await this.fork().findOne(this.entity, where as never, this.populateOptions(include) as never);
+      return row === null ? null : toPlain(row);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  async findOne(query: NormalizedQueryContext<Entity>, context: KavoContext<Entity>): Promise<Entity | null> {
+    try {
+      const row = await this.fork().findOne(
+        this.entity,
+        this.buildWhere(query, context) as never,
+        this.buildFindOptions(query) as never,
+      );
+      return row === null ? null : toPlain(row);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  async findMany(query: NormalizedQueryContext<Entity>, context: KavoContext<Entity>): Promise<readonly Entity[]> {
+    try {
+      const rows = await this.fork().find(
+        this.entity,
+        this.buildWhere(query, context) as never,
+        {
+          ...this.buildFindOptions(query),
+          offset: query.pagination.offset,
+          limit: query.pagination.limit,
+        } as never,
+      );
+      return toPlainAll(rows);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  async count(query: NormalizedQueryContext<Entity>, context: KavoContext<Entity>): Promise<number> {
+    try {
+      // A dedicated count query — never fetch-then-length: the engine only
+      // calls this when `query.count` is true, so `total: null` costs zero
+      // queries. No populate: counting matching roots never needs their
+      // relations.
+      return await this.fork().count(this.entity, this.buildWhere(query, context) as never);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  /** The translated filter, narrowed to the request's soft-delete scope. */
+  private buildWhere(query: NormalizedQueryContext<Entity>, context: KavoContext<Entity>): MikroWhere {
+    return this.scopeToLive(
+      translateFilter(query.filter, this.filterOptions),
+      context,
+      query.withDeleted,
+      query.onlyDeleted,
+    );
+  }
+
+  private buildFindOptions(query: NormalizedQueryContext<Entity>): Record<string, unknown> {
+    const orderBy = query.sort.map((sort) => nestOrderBy(sort.field as string, sort.direction));
+    return {
+      ...(orderBy.length > 0 && { orderBy }),
+      ...this.populateOptions(query.include),
+    };
+  }
+
+  // ── Relation includes ───────────────────────────────────────────────
+
+  /**
+   * Translate a validated `IncludeTree` into MikroORM's `populate` paths
+   * plus, when any included relation is soft-deletable, the `populateWhere`
+   * that keeps deleted related rows out.
+   *
+   * Soft-deleted related rows are excluded from every include, to-one and
+   * to-many alike — the same rule `@kavo/typeorm` and `@kavo/prisma` apply.
+   * A root `withDeleted` is the root's own opt-in only; it never widens an
+   * included relation.
+   */
+  private populateOptions(tree: IncludeTree): Record<string, unknown> {
+    const paths = populatePaths(tree);
+    if (paths.length === 0) return {};
+    const populateWhere = includeSoftDeleteWhere(tree);
+    return {
+      populate: paths,
+      ...(populateWhere !== undefined && { populateWhere }),
+    };
+  }
+
+  // ── Soft delete ──────────────────────────────────────────────────────
+
+  /**
+   * Three-way soft-delete scope: exclude deleted rows by default, include
+   * both live and deleted with `withDeleted`, or restrict to only deleted
+   * with `onlyDeleted` (mutually exclusive — validated upstream).
+   *
+   * There is one shape to handle rather than TypeORM's two: MikroORM
+   * declares no delete-date column of its own, so the marker is always an
+   * ordinary property and always needs its predicate spelled out.
+   */
+  private scopeToLive(
+    where: MikroWhere | undefined,
+    context: KavoContext<Entity>,
+    withDeleted: boolean,
+    onlyDeleted = false,
+  ): MikroWhere {
+    const softDelete = context.config.softDelete;
+    if (softDelete.strategy !== "soft") return where ?? {};
+    if (onlyDeleted) return and(where, { [softDelete.field]: { $ne: null } });
+    if (withDeleted) return where ?? {};
+    return and(where, { [softDelete.field]: { $eq: null } });
+  }
+
+  /** The resolved strategy, refused when an operation requires soft. */
+  private requireSoftDelete(context: KavoContext<Entity>, operation: string): ResolvedSoftDelete & { field: string } {
+    const softDelete = context.config.softDelete;
+    if (softDelete.strategy !== "soft") {
+      throw new ConfigurationException(
+        context.entityName,
+        "softDelete",
+        `'${operation}' requires a soft-deletable entity, but '${context.entityName}' ` +
+          `resolves to a hard delete strategy`,
+      );
+    }
+    return softDelete;
+  }
+
+  private isDeleted(row: Record<string, unknown>, field: string): boolean {
+    return row[field] !== null && row[field] !== undefined;
+  }
+
+  /** One row by id, as a plain object, under the given soft-delete scope. */
+  private async byId(
+    id: EntityId,
+    context: KavoContext<Entity>,
+    withDeleted: boolean,
+  ): Promise<Record<string, unknown> | null> {
+    const where = this.scopeToLive({ [this.idField]: id }, context, withDeleted);
+    const row = await this.fork().findOne(this.entity, where as never);
+    return row === null ? null : (toPlain(row) as Record<string, unknown>);
+  }
+
+  // ── Writes ───────────────────────────────────────────────────────────
+
+  async create(data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+    try {
+      const em = this.fork();
+      const created = em.create(this.entity, this.toWriteData(data) as never);
+      await em.flush();
+      return toPlain(created as Entity);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  async update(id: EntityId, data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+    return this.mergeAndFlush(id, data, context);
+  }
+
+  async patch(id: EntityId, data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+    return this.mergeAndFlush(id, data, context);
+  }
+
+  /**
+   * update and patch share one load-merge-flush primitive: the *shape* of
+   * `data` differs (full body vs. sparse) because the DTO layer differs, not
+   * the persistence mechanics.
+   *
+   * This goes through the Unit of Work rather than `nativeUpdate` — one
+   * managed entity, assigned and flushed — so lifecycle hooks,
+   * `onUpdate` properties, and relation diffing all behave as they would in
+   * a hand-written MikroORM application. The row is loaded first anyway, to
+   * turn a missing id into `NotFoundException`, so this costs no extra
+   * query.
+   */
+  private async mergeAndFlush(id: EntityId, data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+    try {
+      const em = this.fork();
+      // Scoped to live rows: a soft-deleted row is invisible to updates,
+      // exactly as it is to reads. Reviving one is `restore`'s job.
+      const where = this.scopeToLive({ [this.idField]: id }, context, false);
+      const existing = await em.findOne(this.entity, where as never);
+      if (existing === null) throw this.notFound(id, context);
+      wrap(existing).assign(this.toWriteData(data) as never, { em });
+      await em.flush();
+      return toPlain(existing);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  async delete(id: EntityId, context: KavoContext<Entity>): Promise<void> {
+    const softDelete = context.config.softDelete;
+    try {
+      if (softDelete.strategy === "hard") {
+        const affected = await this.fork().nativeDelete(this.entity, { [this.idField]: id } as never);
+        if (affected === 0) throw this.notFound(id, context);
+        return;
+      }
+      const { field } = softDelete;
+      const existing = await this.byId(id, context, true);
+      if (existing === null) throw this.notFound(id, context);
+      if (this.isDeleted(existing, field)) {
+        throw new AlreadyDeletedException({
+          messageParams: { entity: context.entityName, id: String(id) },
+          context: errorContext(context),
+        });
+      }
+      await this.fork().nativeUpdate(this.entity, { [this.idField]: id } as never, { [field]: new Date() } as never);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  async restore(id: EntityId, context: KavoContext<Entity>): Promise<Entity> {
+    try {
+      const { field } = this.requireSoftDelete(context, "restore");
+      const existing = await this.byId(id, context, true);
+      if (existing === null) throw this.notFound(id, context);
+      if (!this.isDeleted(existing, field)) {
+        throw new NotDeletedException({
+          messageParams: { entity: context.entityName, id: String(id) },
+          context: errorContext(context),
+        });
+      }
+      await this.fork().nativeUpdate(this.entity, { [this.idField]: id } as never, { [field]: null } as never);
+      // Clearing the marker is a single-field write with no relation
+      // involvement, so the already-loaded row is corrected in place rather
+      // than re-read.
+      existing[field] = null;
+      return existing as Entity;
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  async purge(id: EntityId, context: KavoContext<Entity>): Promise<void> {
+    const softDelete = context.config.softDelete;
+    try {
+      if (softDelete.strategy === "soft") {
+        // Purge is the second step of a two-step delete: it removes a row
+        // that is already soft-deleted, never a live one.
+        const existing = await this.byId(id, context, true);
+        if (existing === null) throw this.notFound(id, context);
+        if (!this.isDeleted(existing, softDelete.field)) {
+          throw new NotDeletedException({
+            messageParams: { entity: context.entityName, id: String(id) },
+            context: errorContext(context),
+          });
+        }
+      }
+      const affected = await this.fork().nativeDelete(this.entity, { [this.idField]: id } as never);
+      if (affected === 0) throw this.notFound(id, context);
+    } catch (error) {
+      throw mapDriverError(error, errorContext(context));
+    }
+  }
+
+  /**
+   * Normalize the engine's write payload for MikroORM.
+   *
+   * Core's default deserializer narrows a relation value to `{ id }` (or an
+   * array of them) — association by id, ADR-0014. MikroORM associates by
+   * *primary key value*, and would read a nested `{ id }` object as a
+   * request to create a new entity, so each relation value is unwrapped to
+   * the bare key before it reaches `create`/`assign`.
+   */
+  private toWriteData(data: Partial<Entity>): Record<string, unknown> {
+    const result: Record<string, unknown> = { ...data };
+    for (const [name, idFieldOf] of this.relationIdFields) {
+      if (!(name in result)) continue;
+      result[name] = unwrapAssociation(result[name], idFieldOf());
+    }
+    return result;
+  }
+
+  private notFound(id: EntityId, context: KavoContext<Entity>): NotFoundException {
+    return new NotFoundException({
+      messageParams: { entity: context.entityName, id: String(id) },
+      context: errorContext(context),
+    });
+  }
+}
+
+/**
+ * `{ id: 5 }` → `5`; arrays element-wise; scalars and `null` unchanged.
+ *
+ * An object carrying no id becomes `null` rather than being passed through.
+ * That mirrors core's own `associate()` exactly, and it matters because core
+ * only narrows a relation when the *target* entity is in its catalog — a
+ * relation whose target was never `createCrud`-ed arrives here as whatever
+ * the client sent. Handing that object to `em.create` would put a nested
+ * write one cascade setting away from working, which is precisely what
+ * ADR-0014 rules out: relations are associated by id, never deep-written.
+ */
+function unwrapAssociation(value: unknown, idField: string): unknown {
+  if (value === null || value === undefined) return null;
+  if (Array.isArray(value)) return value.map((element) => unwrapAssociation(element, idField));
+  if (typeof value === "object") {
+    return (value as Record<string, unknown>)[idField] ?? null;
+  }
+  return value;
+}
+
+/** Combine two predicates, keeping `undefined` from degenerating into `{}`. */
+function and(where: MikroWhere | undefined, extra: MikroWhere): MikroWhere {
+  return where === undefined ? extra : { $and: [where, extra] };
+}
+
+/** The include tree flattened to the dotted paths MikroORM's `populate` takes. */
+function populatePaths(tree: IncludeTree, prefix = ""): string[] {
+  const paths: string[] = [];
+  for (const node of Object.values(tree)) {
+    const path = prefix === "" ? node.relation.name : `${prefix}.${node.relation.name}`;
+    paths.push(path);
+    paths.push(...populatePaths(node.children, path));
+  }
+  return paths;
+}
+
+/**
+ * The nested `populateWhere` excluding soft-deleted rows from included
+ * relations, or `undefined` when no included relation is soft-deletable —
+ * MikroORM's default (`PopulateHint.ALL`) is the right behavior then, and
+ * passing an empty object would needlessly override it.
+ */
+function includeSoftDeleteWhere(tree: IncludeTree): Record<string, unknown> | undefined {
+  const where: Record<string, unknown> = {};
+  for (const node of Object.values(tree)) {
+    const children = includeSoftDeleteWhere(node.children);
+    const live = node.softDelete.strategy === "soft" ? { [node.softDelete.field]: null } : undefined;
+    if (live === undefined && children === undefined) continue;
+    where[node.relation.name] = { ...live, ...children };
+  }
+  return Object.keys(where).length === 0 ? undefined : where;
+}
+
+/** `"author.name"` + `"asc"` → `{ author: { name: "asc" } }`. */
+function nestOrderBy(field: string, direction: "asc" | "desc"): Record<string, unknown> {
+  const segments = field.split(".");
+  return segments.slice(0, -1).reduceRight<Record<string, unknown>>((inner, segment) => ({ [segment]: inner }), {
+    [segments[segments.length - 1]!]: direction,
+  });
+}
+
+function errorContext<Entity>(context: KavoContext<Entity>) {
+  return {
+    entityName: context.entityName,
+    operation: context.operation,
+    correlationId: context.correlationId,
+  };
+}

--- a/packages/orms/mikroorm/src/plain-entity.ts
+++ b/packages/orms/mikroorm/src/plain-entity.ts
@@ -19,10 +19,13 @@ import { wrap } from "@mikro-orm/core";
  *    to-many as `[]`. That is harmless — core's serializer emits a relation
  *    key only for nodes on the request's include tree — and it is why a
  *    relation must be `include=`d to appear as an object.
- * 2. **MikroORM's own property options apply.** A `@Property({ hidden: true })`
- *    is dropped and a custom `serializer` runs before core ever sees the row.
- *    The ORM's declaration wins here, so a hidden property stays hidden even
- *    if a Kavo DTO names it. See doc 17, "Adapter-specific caveats".
+ * 2. **MikroORM's own property options apply.** A custom `serializer` runs
+ *    before core ever sees the row, and a `@Property({ hidden: true })` is
+ *    dropped. The hidden case is belt-and-braces rather than the guard:
+ *    `buildEntityMetadata` excludes such a property from the seam entirely,
+ *    which is what keeps it off the default filter/sort allowlists too — a
+ *    column invisible in the body but filterable in the database would be a
+ *    blind extraction oracle. See doc 17, "Adapter-specific caveats".
  */
 export function toPlain<Entity extends object>(entity: Entity): Entity {
   return wrap(entity).toObject() as Entity;

--- a/packages/orms/mikroorm/src/plain-entity.ts
+++ b/packages/orms/mikroorm/src/plain-entity.ts
@@ -1,0 +1,34 @@
+import { wrap } from "@mikro-orm/core";
+
+/**
+ * MikroORM entity instance → plain object, at the adapter boundary.
+ *
+ * This conversion is **required**, not a convenience. A MikroORM to-many
+ * relation is a `Collection<T>`, not an array, and core's `DefaultSerializer`
+ * branches on `Array.isArray` to decide whether an included relation is a
+ * list or a single row — a `Collection` would fall down the single-row path
+ * and serialize its internal fields instead of its items. `@kavo/mongoose`
+ * converts documents at the same seam and for the same reason: core consumes
+ * plain data, so the ORM's own row representation stops here.
+ *
+ * `wrap(entity).toObject()` is what performs it, which has two consequences
+ * worth naming because they are behavior, not implementation detail:
+ *
+ * 1. **Unpopulated relations collapse to their primary key.** A to-one that
+ *    was not populated comes back as the raw foreign key (`author: 1`) and a
+ *    to-many as `[]`. That is harmless — core's serializer emits a relation
+ *    key only for nodes on the request's include tree — and it is why a
+ *    relation must be `include=`d to appear as an object.
+ * 2. **MikroORM's own property options apply.** A `@Property({ hidden: true })`
+ *    is dropped and a custom `serializer` runs before core ever sees the row.
+ *    The ORM's declaration wins here, so a hidden property stays hidden even
+ *    if a Kavo DTO names it. See doc 17, "Adapter-specific caveats".
+ */
+export function toPlain<Entity extends object>(entity: Entity): Entity {
+  return wrap(entity).toObject() as Entity;
+}
+
+/** {@link toPlain} over a list, for the `findMany` path. */
+export function toPlainAll<Entity extends object>(entities: readonly Entity[]): readonly Entity[] {
+  return entities.map((entity) => toPlain(entity));
+}

--- a/packages/orms/mikroorm/tests/adapter.spec.ts
+++ b/packages/orms/mikroorm/tests/adapter.spec.ts
@@ -1,0 +1,445 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from "@mikro-orm/core";
+import {
+  ConflictException,
+  NotFoundException,
+  PersistenceException,
+  QueryValidationException,
+  type DefaultKavoService,
+  type KavoInstance,
+} from "@kavo/core";
+import { buildEntityMetadata, createMikroOrmKavo } from "@kavo/mikroorm";
+import { clearDatabase, newTestOrm } from "./support/database.js";
+
+// Explicit property types throughout: the swc test transform emits decorator
+// metadata, but explicit types keep entities transform-agnostic — the same
+// reason `@kavo/typeorm`'s suite spells its column types out.
+@Entity()
+class Author {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string", unique: true })
+  email!: string;
+
+  @Property({ type: "string" })
+  name!: string;
+
+  @Property({ type: "number" })
+  age!: number;
+
+  @Property({ type: "string" })
+  status: string = "active";
+
+  @Property({ type: "string", nullable: true })
+  bio: string | null = null;
+
+  @Property({ type: "Date", onCreate: () => new Date() })
+  createdAt!: Date;
+
+  @OneToMany(() => Book, (book) => book.author)
+  books = new Collection<Book>(this);
+}
+
+@Entity()
+class Book {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  title!: string;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+}
+
+let orm: MikroORM;
+let kavo: KavoInstance;
+let authors: DefaultKavoService<Author>;
+
+beforeAll(async () => {
+  orm = await newTestOrm([Author, Book]);
+  kavo = createMikroOrmKavo(orm);
+  authors = kavo.createCrud(Author) as DefaultKavoService<Author>;
+});
+
+afterAll(async () => {
+  await orm.close();
+});
+
+beforeEach(async () => {
+  await clearDatabase(orm);
+});
+
+/** The persisted foreign key of one book, read straight from the database. */
+async function readAuthorId(bookId: number): Promise<number | undefined> {
+  const row = await orm.em.fork().findOne(Book, { id: bookId }, { populate: ["author"] });
+  return row?.author.id;
+}
+
+async function seed(): Promise<void> {
+  const rows = [
+    { email: "ada@x.io", name: "Ada", age: 36, status: "active" },
+    { email: "grace@x.io", name: "Grace", age: 45, status: "active" },
+    { email: "alan@x.io", name: "Alan", age: 41, status: "banned" },
+    { email: "joan@x.io", name: "Joan", age: 28, status: "pending" },
+  ];
+  for (const row of rows) await authors.createOne(row as never);
+}
+
+describe("metadata derivation seam", () => {
+  it("derives fields, id, generated flags, and relations", () => {
+    const metadata = buildEntityMetadata(orm, Author);
+    expect(metadata.name).toBe("Author");
+    expect(metadata.idField).toBe("id");
+    const byName = Object.fromEntries(metadata.fields.map((field) => [field.name, field]));
+    expect(byName["id"]).toMatchObject({ kind: "number", generated: true });
+    expect(byName["email"]).toMatchObject({ kind: "string", generated: false });
+    expect(byName["age"]).toMatchObject({ kind: "number", generated: false });
+    expect(byName["createdAt"]).toMatchObject({ kind: "date", generated: true });
+    expect(byName["bio"]).toMatchObject({ nullable: true });
+    expect(byName["books"]).toBeUndefined(); // relations are not fields
+    expect(metadata.relations.map((relation) => relation.name)).toEqual(["books"]);
+    expect(metadata.relations[0]).toMatchObject({ cardinality: "many", includable: false });
+    // The lazy target thunk resolves to the class itself — the identity core
+    // matches registered entities by, with no marker class in sight.
+    expect(metadata.relations[0]!.target()).toBe(Book);
+  });
+
+  it("reports the to-one side of the same relation as cardinality 'one'", () => {
+    const metadata = buildEntityMetadata(orm, Book);
+    expect(metadata.relations).toMatchObject([{ name: "author", cardinality: "one" }]);
+    expect(metadata.relations[0]!.target()).toBe(Author);
+  });
+
+  it("refuses an entity MikroORM never registered", () => {
+    class Ghost {
+      id!: number;
+    }
+    expect(() => buildEntityMetadata(orm, Ghost)).toThrowError(/no registered entity named 'Ghost'/);
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — CRUD", () => {
+  it("creates, reads, updates, patches, deletes against the real database", async () => {
+    const created = await authors.createOne({
+      email: "ada@x.io",
+      name: "Ada",
+      age: 36,
+    } as never);
+    expect(created).toMatchObject({ name: "Ada", status: "active" });
+    const id = (created as Author).id;
+
+    const fetched = await authors.findOne(id);
+    expect(fetched).toMatchObject({ email: "ada@x.io" });
+
+    await authors.updateOne(id, { email: "ada@x.io", name: "Ada L", age: 37 } as never);
+    const patched = await authors.patchOne(id, { age: 38 } as never);
+    expect(patched).toMatchObject({ name: "Ada L", age: 38 });
+
+    await authors.deleteOne(id);
+    await expect(authors.findOne(id)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("throws NotFound for updates/deletes on missing rows", async () => {
+    await expect(authors.updateOne(4242, { name: "x" } as never)).rejects.toBeInstanceOf(NotFoundException);
+    await expect(authors.deleteOne(4242)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("maps unique violations to ConflictException (error-mapping table)", async () => {
+    await authors.createOne({ email: "dup@x.io", name: "A", age: 1 } as never);
+    await expect(authors.createOne({ email: "dup@x.io", name: "B", age: 2 } as never)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it("returns plain objects, never live MikroORM entities", async () => {
+    // The adapter converts at its boundary: a `Collection` would break core's
+    // `Array.isArray` branch in the serializer, and a managed entity would
+    // carry an identity map into the response.
+    await seed();
+    const list = await authors.findMany();
+    for (const item of list.items) {
+      expect(Object.getPrototypeOf(item)).toBe(Object.prototype);
+    }
+  });
+
+  it("does not leak a stale identity map between calls", async () => {
+    // Every operation forks its own EntityManager; a shared one would answer
+    // the second read from the first read's identity map.
+    const created = (await authors.createOne({ email: "a@x.io", name: "Ada", age: 36 } as never)) as Author;
+    await orm.em.fork().nativeUpdate(Author, { id: created.id }, { name: "Renamed outside Kavo" });
+    expect(await authors.findOne(created.id)).toMatchObject({ name: "Renamed outside Kavo" });
+  });
+
+  it("associates a relation by id on create and on patch", async () => {
+    // Core's deserializer narrows a relation to `{ id }` (ADR-0014); MikroORM
+    // associates by the bare primary key, so the adapter unwraps it.
+    const books = kavo.createCrud(Book) as DefaultKavoService<Book>;
+    const ada = (await authors.createOne({ email: "ada@x.io", name: "Ada", age: 36 } as never)) as Author;
+    const alan = (await authors.createOne({ email: "alan@x.io", name: "Alan", age: 41 } as never)) as Author;
+
+    // The association is asserted against the database, not the response:
+    // core's serializer emits a relation key only for an included node, so a
+    // written-but-not-included relation is correctly absent from the result.
+    const created = (await books.createOne({ title: "Notes", author: ada.id } as never)) as Book;
+    expect(created).toMatchObject({ title: "Notes" });
+    expect(await readAuthorId(created.id)).toBe(ada.id);
+
+    await books.patchOne(created.id, { author: { id: alan.id } } as never);
+    expect(await readAuthorId(created.id)).toBe(alan.id);
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — relation writes are association-only", () => {
+  it("refuses to deep-write a relation whose target Kavo never registered", async () => {
+    // Core narrows a relation to `{ id }` only when the *target* entity is in
+    // its catalog; a target that was never `createCrud`-ed arrives at the
+    // adapter as whatever the client sent. Handing that object to
+    // `em.create` would leave a nested write one cascade setting away from
+    // working — ADR-0014 says relations are associated by id, never
+    // deep-written, so the object is dropped instead.
+    const isolated = createMikroOrmKavo(orm);
+    const books = isolated.createCrud(Book) as DefaultKavoService<Book>;
+    const before = await orm.em.fork().count(Author, {});
+
+    await expect(
+      books.createOne({ title: "smuggled", author: { email: "evil@x.io", name: "Injected", age: 1 } } as never),
+    ).rejects.toBeInstanceOf(PersistenceException);
+
+    expect(await orm.em.fork().count(Author, {})).toBe(before);
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — query translation", () => {
+  it("filters, sorts, and paginates in the database", async () => {
+    await seed();
+    const list = await authors.findMany({
+      filter: {
+        kind: "condition",
+        field: "status",
+        operator: "EQ",
+        value: "active",
+      },
+      sort: [{ field: "age", direction: "desc" }],
+      limit: 1,
+      offset: 1,
+    });
+    expect(list.items.map((author) => (author as Author).name)).toEqual(["Ada"]);
+    expect(list.total).toBe(2); // total counts all matches, not the page
+    expect(list.limit).toBe(1);
+    expect(list.offset).toBe(1);
+  });
+
+  it("translates OR groups and NOT nodes", async () => {
+    await seed();
+    const either = await authors.findMany({
+      filter: {
+        kind: "group",
+        operator: "OR",
+        children: [
+          { kind: "condition", field: "name", operator: "EQ", value: "Ada" },
+          { kind: "condition", field: "status", operator: "EQ", value: "banned" },
+        ],
+      },
+      sort: [{ field: "name", direction: "asc" }],
+    });
+    expect(either.items.map((author) => (author as Author).name)).toEqual(["Ada", "Alan"]);
+
+    const negated = await authors.findMany({
+      filter: {
+        kind: "group",
+        operator: "NOT",
+        children: [{ kind: "condition", field: "status", operator: "EQ", value: "active" }],
+      },
+      sort: [{ field: "age", direction: "asc" }],
+    });
+    expect(negated.items.map((author) => (author as Author).name)).toEqual(["Joan", "Alan"]);
+  });
+
+  it("translates IN, BETWEEN, LIKE, ILIKE and null checks", async () => {
+    await seed();
+    const joan = (await authors.findMany()).items
+      .map((author) => author as Author)
+      .find((author) => author.name === "Joan")!;
+    await authors.patchOne(joan.id, { bio: "wrote code" } as never);
+
+    const inSet = await authors.findMany({
+      filter: {
+        kind: "condition",
+        field: "status",
+        operator: "IN",
+        value: ["banned", "pending"],
+      },
+    });
+    expect(inSet.items).toHaveLength(2);
+
+    const notIn = await authors.findMany({
+      filter: {
+        kind: "condition",
+        field: "status",
+        operator: "NOT_IN",
+        value: ["banned", "pending"],
+      },
+    });
+    expect(notIn.items).toHaveLength(2);
+
+    const between = await authors.findMany({
+      filter: {
+        kind: "condition",
+        field: "age",
+        operator: "BETWEEN",
+        value: [40, 50],
+      },
+    });
+    expect(between.items.map((author) => (author as Author).name).sort()).toEqual(["Alan", "Grace"]);
+
+    const like = await authors.findMany({
+      filter: { kind: "condition", field: "name", operator: "LIKE", value: "A%" },
+    });
+    expect(like.items.map((author) => (author as Author).name).sort()).toEqual(["Ada", "Alan"]);
+
+    // SQLite's own LIKE is ASCII case-insensitive, so ILIKE degrading to
+    // `$like` under the default `caseInsensitiveFilters: false` still matches
+    // — see the adapter doc's note on why that default is the portable one.
+    const ilike = await authors.findMany({
+      filter: { kind: "condition", field: "name", operator: "ILIKE", value: "a%" },
+    });
+    expect(ilike.items.map((author) => (author as Author).name).sort()).toEqual(["Ada", "Alan"]);
+
+    const withBio = await authors.findMany({
+      filter: { kind: "condition", field: "bio", operator: "IS_NOT_NULL", value: true },
+    });
+    expect(withBio.items.map((author) => (author as Author).name)).toEqual(["Joan"]);
+
+    const withoutBio = await authors.findMany({
+      filter: { kind: "condition", field: "bio", operator: "IS_NULL", value: true },
+    });
+    expect(withoutBio.items).toHaveLength(3);
+  });
+
+  it("matches nothing on an empty IN set instead of erroring", async () => {
+    await seed();
+    const list = await authors.findMany({
+      filter: { kind: "condition", field: "status", operator: "IN", value: [] },
+    });
+    expect(list.items).toHaveLength(0);
+  });
+
+  it("matches everything on an empty NOT IN set", async () => {
+    await seed();
+    const list = await authors.findMany({
+      filter: { kind: "condition", field: "status", operator: "NOT_IN", value: [] },
+    });
+    expect(list.items).toHaveLength(4);
+  });
+
+  it("applies the configured defaultSort when the caller supplies no sort", async () => {
+    await seed();
+    const withDefault = kavo.createCrud(Author, {
+      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+    }) as DefaultKavoService<Author>;
+    const list = await withDefault.findMany();
+    expect(list.items.map((author) => (author as Author).name)).toEqual(["Joan", "Ada", "Alan", "Grace"]);
+  });
+
+  it("keeps defaultSort-ordered pages disjoint and stable across offsets", async () => {
+    await seed();
+    const withDefault = kavo.createCrud(Author, {
+      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+    }) as DefaultKavoService<Author>;
+    const page1 = await withDefault.findMany({ limit: 2, offset: 0 });
+    const page2 = await withDefault.findMany({ limit: 2, offset: 2 });
+    const names1 = page1.items.map((author) => (author as Author).name);
+    const names2 = page2.items.map((author) => (author as Author).name);
+    expect(names1).toEqual(["Joan", "Ada"]);
+    expect(names2).toEqual(["Alan", "Grace"]);
+    expect(new Set([...names1, ...names2]).size).toBe(4); // disjoint, no repeats/skips
+  });
+
+  it("skips the count query when counting is disabled", async () => {
+    await seed();
+    const list = await authors.findMany(undefined, {
+      settings: { pagination: { count: false } },
+    });
+    expect(list.total).toBeNull();
+    expect(list.items).toHaveLength(4);
+  });
+
+  it("refuses an operator outside the AST enum rather than dropping the predicate", async () => {
+    await seed();
+    // The parser can never emit this, but a programmatic caller hand-builds
+    // the AST and `validateExpression` checks allowlists, not operators.
+    // Falling through the translator's switch would add no predicate at all —
+    // the caller asked to narrow to one row and would silently get all four
+    // back. The guard surfaces as PersistenceException: a forged AST is an
+    // internal contract violation (500), not a bad request.
+    await expect(
+      authors.findMany({
+        filter: {
+          kind: "condition",
+          field: "status",
+          operator: "SOUNDS_LIKE" as never,
+          value: "active",
+        },
+      }),
+    ).rejects.toBeInstanceOf(PersistenceException);
+  });
+
+  it("still rejects non-allowlisted programmatic filters", async () => {
+    await expect(
+      authors.findMany({
+        filter: {
+          kind: "condition",
+          field: "books.title" as never,
+          operator: "EQ",
+          value: "x",
+        },
+      }),
+    ).rejects.toBeInstanceOf(QueryValidationException);
+  });
+
+  it("filters on relation paths when explicitly allowlisted", async () => {
+    const scoped = kavo.createCrud(Book, {
+      allowlists: { filterable: ["title", "author.name" as never] },
+    }) as DefaultKavoService<Book>;
+    await seed();
+    const all = (await authors.findMany()).items.map((author) => author as Author);
+    const ada = all.find((author) => author.name === "Ada")!;
+    const alan = all.find((author) => author.name === "Alan")!;
+
+    const em = orm.em.fork();
+    em.create(Book, { title: "Notes", author: em.getReference(Author, ada.id) });
+    em.create(Book, { title: "Other", author: em.getReference(Author, alan.id) });
+    await em.flush();
+
+    const list = await scoped.findMany({
+      filter: {
+        kind: "condition",
+        field: "author.name" as never,
+        operator: "EQ",
+        value: "Ada",
+      },
+    });
+    expect(list.items.map((book) => (book as Book).title)).toEqual(["Notes"]);
+  });
+
+  it("sorts on an allowlisted relation path", async () => {
+    const scoped = kavo.createCrud(Book, {
+      allowlists: { sortable: ["title", "author.name" as never] },
+    }) as DefaultKavoService<Book>;
+    await seed();
+    const all = (await authors.findMany()).items.map((author) => author as Author);
+    const ada = all.find((author) => author.name === "Ada")!;
+    const alan = all.find((author) => author.name === "Alan")!;
+
+    const em = orm.em.fork();
+    em.create(Book, { title: "By Alan", author: em.getReference(Author, alan.id) });
+    em.create(Book, { title: "By Ada", author: em.getReference(Author, ada.id) });
+    await em.flush();
+
+    const list = await scoped.findMany({ sort: [{ field: "author.name" as never, direction: "asc" }] });
+    expect(list.items.map((book) => (book as Book).title)).toEqual(["By Ada", "By Alan"]);
+  });
+});

--- a/packages/orms/mikroorm/tests/adapter.spec.ts
+++ b/packages/orms/mikroorm/tests/adapter.spec.ts
@@ -1,7 +1,8 @@
 import "reflect-metadata";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from "@mikro-orm/core";
+import { Collection, Entity, ManyToMany, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from "@mikro-orm/core";
 import {
+  ConfigurationException,
   ConflictException,
   NotFoundException,
   PersistenceException,
@@ -9,7 +10,7 @@ import {
   type DefaultKavoService,
   type KavoInstance,
 } from "@kavo/core";
-import { buildEntityMetadata, createMikroOrmKavo } from "@kavo/mikroorm";
+import { buildEntityMetadata, createInfrastructure, createMikroOrmKavo } from "@kavo/mikroorm";
 import { clearDatabase, newTestOrm } from "./support/database.js";
 
 // Explicit property types throughout: the swc test transform emits decorator
@@ -40,6 +41,20 @@ class Author {
 
   @OneToMany(() => Book, (book) => book.author)
   books = new Collection<Book>(this);
+
+  // The owning side of a many-to-many, so array-valued relation writes have
+  // somewhere to land.
+  @ManyToMany(() => Shelf, undefined, { owner: true })
+  shelves = new Collection<Shelf>(this);
+}
+
+@Entity()
+class Shelf {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  label!: string;
 }
 
 @Entity()
@@ -50,8 +65,9 @@ class Book {
   @Property({ type: "string" })
   title!: string;
 
-  @ManyToOne(() => Author)
-  author!: Author;
+  // Nullable, so an association can be *cleared* as well as set.
+  @ManyToOne(() => Author, { nullable: true })
+  author: Author | null = null;
 }
 
 let orm: MikroORM;
@@ -59,7 +75,7 @@ let kavo: KavoInstance;
 let authors: DefaultKavoService<Author>;
 
 beforeAll(async () => {
-  orm = await newTestOrm([Author, Book]);
+  orm = await newTestOrm([Author, Book, Shelf]);
   kavo = createMikroOrmKavo(orm);
   authors = kavo.createCrud(Author) as DefaultKavoService<Author>;
 });
@@ -75,7 +91,7 @@ beforeEach(async () => {
 /** The persisted foreign key of one book, read straight from the database. */
 async function readAuthorId(bookId: number): Promise<number | undefined> {
   const row = await orm.em.fork().findOne(Book, { id: bookId }, { populate: ["author"] });
-  return row?.author.id;
+  return row?.author?.id;
 }
 
 async function seed(): Promise<void> {
@@ -86,6 +102,24 @@ async function seed(): Promise<void> {
     { email: "joan@x.io", name: "Joan", age: 28, status: "pending" },
   ];
   for (const row of rows) await authors.createOne(row as never);
+}
+
+/** A normalized query with no filter — what a custom handler hands the reader. */
+function unfilteredQuery() {
+  return {
+    filter: { root: null },
+    sort: [],
+    include: {},
+    fields: { root: null, relations: {} },
+    pagination: { limit: 10, offset: 0 },
+    count: false,
+    withDeleted: false,
+    onlyDeleted: false,
+  };
+}
+
+function hardDeleteContext() {
+  return { entityName: "Author", operation: "findOne", config: { softDelete: { strategy: "hard" } } };
 }
 
 describe("metadata derivation seam", () => {
@@ -100,7 +134,7 @@ describe("metadata derivation seam", () => {
     expect(byName["createdAt"]).toMatchObject({ kind: "date", generated: true });
     expect(byName["bio"]).toMatchObject({ nullable: true });
     expect(byName["books"]).toBeUndefined(); // relations are not fields
-    expect(metadata.relations.map((relation) => relation.name)).toEqual(["books"]);
+    expect(metadata.relations.map((relation) => relation.name).sort()).toEqual(["books", "shelves"]);
     expect(metadata.relations[0]).toMatchObject({ cardinality: "many", includable: false });
     // The lazy target thunk resolves to the class itself — the identity core
     // matches registered entities by, with no marker class in sight.
@@ -117,7 +151,15 @@ describe("metadata derivation seam", () => {
     class Ghost {
       id!: number;
     }
-    expect(() => buildEntityMetadata(orm, Ghost)).toThrowError(/no registered entity named 'Ghost'/);
+    let thrown: unknown;
+    try {
+      buildEntityMetadata(orm, Ghost);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationException);
+    expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+    expect((thrown as Error).message).toMatch(/no registered entity named 'Ghost'/);
   });
 });
 
@@ -204,11 +246,99 @@ describe("MikroOrmRepositoryAdapter — relation writes are association-only", (
     const books = isolated.createCrud(Book) as DefaultKavoService<Book>;
     const before = await orm.em.fork().count(Author, {});
 
-    await expect(
-      books.createOne({ title: "smuggled", author: { email: "evil@x.io", name: "Injected", age: 1 } } as never),
-    ).rejects.toBeInstanceOf(PersistenceException);
+    const created = (await books.createOne({
+      title: "smuggled",
+      author: { email: "evil@x.io", name: "Injected", age: 1 },
+    } as never)) as Book;
 
+    // The row is created, the smuggled object is not: an id-less relation
+    // value becomes `null`, so no Author is written and none is associated.
     expect(await orm.em.fork().count(Author, {})).toBe(before);
+    expect(await readAuthorId(created.id)).toBeUndefined();
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — relation writes", () => {
+  async function newShelf(label: string): Promise<number> {
+    const em = orm.em.fork();
+    const shelf = em.create(Shelf, { label } as never);
+    await em.flush();
+    return (shelf as Shelf).id;
+  }
+
+  /** The shelf ids actually persisted against one author. */
+  async function shelvesOf(authorId: number): Promise<string[]> {
+    const row = await orm.em.fork().findOne(Author, { id: authorId }, { populate: ["shelves"] });
+    return row!.shelves
+      .getItems()
+      .map((shelf) => shelf.label)
+      .sort();
+  }
+
+  it("associates a to-many by an array of ids and of { id } references", async () => {
+    const a = await newShelf("A");
+    const b = await newShelf("B");
+    const created = (await authors.createOne({
+      email: "ada@x.io",
+      name: "Ada",
+      age: 36,
+      shelves: [a, { id: b }],
+    } as never)) as Author;
+
+    expect(await shelvesOf(created.id)).toEqual(["A", "B"]);
+  });
+
+  it("drops id-less elements from a to-many write instead of failing the whole request", async () => {
+    // Core's own `associate` filters nulls out of an array; the adapter's
+    // unwrap must too. A relation whose target is not in core's catalog
+    // arrives here as the raw client value, so `[{}]` and `[null]` are
+    // shapes that really can reach this code — and passing `[null]` to
+    // `em.create` fails at the driver as a 500 rather than being ignored.
+    const a = await newShelf("A");
+    const created = (await authors.createOne({
+      email: "ada@x.io",
+      name: "Ada",
+      age: 36,
+      shelves: [{ id: a }, {}, null],
+    } as never)) as Author;
+
+    expect(await shelvesOf(created.id)).toEqual(["A"]);
+  });
+
+  it("clears a to-one association when the payload sends null", async () => {
+    const books = kavo.createCrud(Book) as DefaultKavoService<Book>;
+    const ada = (await authors.createOne({ email: "ada@x.io", name: "Ada", age: 36 } as never)) as Author;
+    const book = (await books.createOne({ title: "Notes", author: ada.id } as never)) as Book;
+    expect(await readAuthorId(book.id)).toBe(ada.id);
+
+    await books.patchOne(book.id, { author: null } as never);
+    expect(await readAuthorId(book.id)).toBeUndefined();
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — findOne by query", () => {
+  it("returns the first row when the query carries no filter at all", async () => {
+    // Regression: MikroORM's validator rejects `em.findOne` with an empty
+    // `where` outright, while `em.find` accepts it. An unfiltered query is a
+    // legitimate shape — `findOne`'s contract is "first match of the query,
+    // or null", and no filter matches everything — so routing it through
+    // `em.findOne` turned a valid read into a 500. Not reachable from a
+    // generated route (the standard `findOne` is by id), but it is exactly
+    // what a custom handler or a direct adapter call produces.
+    await seed();
+    const reader = createInfrastructure(orm).adapterFor(Author);
+    const row = await reader.findOne(unfilteredQuery() as never, hardDeleteContext() as never);
+    expect(row).not.toBeNull();
+  });
+
+  it("still applies sort and soft-delete scope on the unfiltered path", async () => {
+    await seed();
+    const reader = createInfrastructure(orm).adapterFor(Author);
+    const row = (await reader.findOne(
+      { ...unfilteredQuery(), sort: [{ field: "age", direction: "asc" }] } as never,
+      hardDeleteContext() as never,
+    )) as Author | null;
+    expect(row).toMatchObject({ name: "Joan" }); // the youngest, not just any row
   });
 });
 

--- a/packages/orms/mikroorm/tests/error-mapping.spec.ts
+++ b/packages/orms/mikroorm/tests/error-mapping.spec.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  CheckConstraintViolationException,
+  DeadlockException,
+  DriverException,
+  ForeignKeyConstraintViolationException,
+  LockWaitTimeoutException,
+  NotNullConstraintViolationException,
+  UniqueConstraintViolationException,
+} from "@mikro-orm/core";
+import type { ErrorContext } from "@kavo/core";
+import {
+  ConflictException,
+  NotFoundException,
+  PersistenceException,
+  QueryValidationException,
+  TransactionException,
+} from "@kavo/core";
+import { mapDriverError } from "@kavo/mikroorm";
+
+const context: ErrorContext = {
+  entityName: "Author",
+  operation: "createOne",
+  correlationId: "req-1",
+};
+
+/**
+ * MikroORM builds each of these from the driver's own error, which is what
+ * this adapter matches on instead of the SQLSTATEs and errnos `@kavo/typeorm`
+ * has to recognize itself.
+ */
+const conflicts = [
+  ["a unique violation", new UniqueConstraintViolationException(new Error("UNIQUE constraint failed: author.email"))],
+  ["a foreign-key violation", new ForeignKeyConstraintViolationException(new Error("FOREIGN KEY constraint failed"))],
+] as const;
+
+const retryable = [
+  ["a deadlock", new DeadlockException(new Error("deadlock detected"))],
+  ["a lock-wait timeout", new LockWaitTimeoutException(new Error("lock wait timeout exceeded"))],
+] as const;
+
+const fallbacks = [
+  ["a not-null violation", new NotNullConstraintViolationException(new Error("NOT NULL constraint failed"))],
+  ["a check violation", new CheckConstraintViolationException(new Error("CHECK constraint failed"))],
+  ["an unrecognized driver failure", new DriverException(new Error("relation does not exist"))],
+] as const;
+
+describe("mapDriverError — conflicts", () => {
+  it.each(conflicts)("maps %s to a 409 conflict", (_name, error) => {
+    const mapped = mapDriverError(error, context);
+    expect(mapped).toBeInstanceOf(ConflictException);
+    expect(mapped).toMatchObject({ code: "KAVO_CONFLICT", status: 409 });
+  });
+
+  it("names the entity in the conflict's message params", () => {
+    expect(mapDriverError(conflicts[0][1], context).messageParams).toEqual({ entity: "Author" });
+  });
+
+  it("falls back to a generic entity name when the context has none", () => {
+    expect(mapDriverError(conflicts[0][1], {}).messageParams).toEqual({ entity: "entity" });
+  });
+
+  it("maps a unique violation held by a soft-deleted row to a plain conflict", () => {
+    // Per the note in `error-mapping.ts`: a soft-deleted row keeps its unique
+    // index entries, and the honest answer is "the value is taken" — no
+    // soft-delete-aware code. The integration path is covered by
+    // soft-delete.spec.ts; this pins the mapping itself.
+    const mapped = mapDriverError(
+      new UniqueConstraintViolationException(new Error("UNIQUE constraint failed: ticket.reference")),
+      { entityName: "Ticket", operation: "createOne" },
+    );
+    expect(mapped.code).toBe("KAVO_CONFLICT");
+    expect(mapped.status).toBe(409);
+  });
+});
+
+describe("mapDriverError — serialization failures and deadlocks", () => {
+  it.each(retryable)("maps %s to a retryable transaction failure", (_name, error) => {
+    const mapped = mapDriverError(error, context);
+    expect(mapped).toBeInstanceOf(TransactionException);
+    expect(mapped).toMatchObject({ code: "KAVO_TRANSACTION_FAILED", status: 500 });
+    expect((mapped as TransactionException).retryable).toBe(true);
+  });
+});
+
+describe("mapDriverError — the fallback row", () => {
+  it.each(fallbacks)("maps %s to a persistence failure", (_name, error) => {
+    // Only unique and foreign-key violations are conflicts. A constraint
+    // failure of another kind is not the caller's to resolve, so it must not
+    // become a 409 — the same line `@kavo/typeorm`'s table draws.
+    const mapped = mapDriverError(error, context);
+    expect(mapped).toBeInstanceOf(PersistenceException);
+    expect(mapped).toMatchObject({ code: "KAVO_PERSISTENCE_FAILED", status: 500 });
+  });
+
+  it("carries the failing operation from the error context", () => {
+    expect(mapDriverError(fallbacks[0][1], context).messageParams).toEqual({ operation: "createOne" });
+  });
+
+  it("reports the operation as 'unknown' when the context does not name one", () => {
+    expect(mapDriverError(fallbacks[0][1], { entityName: "Author" }).messageParams).toEqual({ operation: "unknown" });
+  });
+
+  it("wraps errors that are not MikroORM driver exceptions at all", () => {
+    for (const raw of [new Error("ECONNRESET"), "boom", null]) {
+      const mapped = mapDriverError(raw, context);
+      expect(mapped).toBeInstanceOf(PersistenceException);
+      expect(mapped.cause).toBe(raw);
+    }
+  });
+
+  it("does not treat a look-alike error as a constraint violation", () => {
+    // Only MikroORM's own normalized exceptions are trusted; an error merely
+    // named like one is not a driver error.
+    const lookAlike = Object.assign(new Error("unique violation"), {
+      name: "UniqueConstraintViolationException",
+    });
+    expect(mapDriverError(lookAlike, context)).toBeInstanceOf(PersistenceException);
+  });
+});
+
+describe("mapDriverError — cause and context propagation", () => {
+  const everyRow = [...conflicts, ...retryable, ...fallbacks] as const;
+
+  it("keeps the original driver error as cause in every mapped case", () => {
+    for (const [, error] of everyRow) {
+      expect(mapDriverError(error, context).cause).toBe(error);
+    }
+  });
+
+  it("carries the error context onto every mapped exception", () => {
+    for (const [, error] of everyRow) {
+      expect(mapDriverError(error, context).context).toEqual(context);
+    }
+  });
+});
+
+describe("mapDriverError — Kavo exceptions pass through", () => {
+  it("returns an already-mapped exception by identity, not a copy", () => {
+    // The adapter raises `NotFoundException` itself (affected === 0); a
+    // second trip through the table must not restate it as a 500.
+    for (const original of [
+      new NotFoundException({ messageParams: { entity: "Author", id: "7" } }),
+      new ConflictException({ messageParams: { entity: "Author" } }),
+      new QueryValidationException([{ field: "age", code: "KAVO_QUERY_INVALID_VALUE", detail: "bad" }]),
+      new TransactionException({ retryable: true }),
+    ]) {
+      expect(mapDriverError(original, context)).toBe(original);
+    }
+  });
+
+  it("leaves the passed-through exception's own context untouched", () => {
+    const original = new NotFoundException({ context: { entityName: "Book" } });
+    expect(mapDriverError(original, context).context).toEqual({ entityName: "Book" });
+  });
+});

--- a/packages/orms/mikroorm/tests/filter-translator.spec.ts
+++ b/packages/orms/mikroorm/tests/filter-translator.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { Filter, FilterExpression } from "@kavo/core";
+import type { FilterTranslatorOptions } from "@kavo/mikroorm";
+import { translateFilter } from "@kavo/mikroorm";
+
+const options: FilterTranslatorOptions = { idField: "id", caseInsensitiveFilters: false };
+const insensitive: FilterTranslatorOptions = { idField: "id", caseInsensitiveFilters: true };
+
+/** The translator takes a `Filter`, which is just a root expression holder. */
+function filterOf(root: FilterExpression | null): Filter {
+  return { root } as Filter;
+}
+
+function translate(root: FilterExpression | null, opts = options): unknown {
+  return translateFilter(filterOf(root), opts);
+}
+
+function condition(field: string, operator: string, value: unknown): FilterExpression {
+  return { kind: "condition", field, operator, value } as unknown as FilterExpression;
+}
+
+describe("translateFilter — shape", () => {
+  it("returns undefined for an empty filter, so no `where` is sent at all", () => {
+    expect(translate(null)).toBeUndefined();
+  });
+
+  it("wraps every comparison in an explicit operator, never the bare shorthand", () => {
+    // Defence in depth: `{ field: value }` would splice an object value in as
+    // *operators*, which is the injection shape this spelling forecloses.
+    expect(translate(condition("name", "EQ", "Ada"))).toEqual({ name: { $eq: "Ada" } });
+    expect(translate(condition("name", "EQ", { $ne: "" }))).toEqual({ name: { $eq: { $ne: "" } } });
+  });
+});
+
+describe("translateFilter — operators", () => {
+  it.each([
+    ["EQ", "Ada", { name: { $eq: "Ada" } }],
+    ["NE", "Ada", { name: { $ne: "Ada" } }],
+    ["GT", 30, { name: { $gt: 30 } }],
+    ["GTE", 30, { name: { $gte: 30 } }],
+    ["LT", 30, { name: { $lt: 30 } }],
+    ["LTE", 30, { name: { $lte: 30 } }],
+    ["IN", ["a", "b"], { name: { $in: ["a", "b"] } }],
+    ["NOT_IN", ["a", "b"], { name: { $nin: ["a", "b"] } }],
+    ["LIKE", "A%", { name: { $like: "A%" } }],
+    ["BETWEEN", [1, 9], { name: { $gte: 1, $lte: 9 } }],
+    ["IS_NULL", true, { name: { $eq: null } }],
+    ["IS_NOT_NULL", true, { name: { $ne: null } }],
+  ])("maps %s to its MikroORM operator", (operator, value, expected) => {
+    expect(translate(condition("name", operator, value))).toEqual(expected);
+  });
+
+  it("degrades ILIKE to $like unless the driver is declared to support $ilike", () => {
+    expect(translate(condition("name", "ILIKE", "a%"))).toEqual({ name: { $like: "a%" } });
+    expect(translate(condition("name", "ILIKE", "a%"), insensitive)).toEqual({ name: { $ilike: "a%" } });
+  });
+
+  it("throws rather than dropping an operator outside the AST enum", () => {
+    // A dropped predicate would silently widen the result set; the union is
+    // proven total at build time and guarded at run time.
+    expect(() => translate(condition("name", "SOUNDS_LIKE", "x"))).toThrowError(/filter operator/);
+  });
+});
+
+describe("translateFilter — relation paths", () => {
+  it("nests a dotted path into MikroORM's native relation shape", () => {
+    expect(translate(condition("author.name", "EQ", "Ada"))).toEqual({ author: { name: { $eq: "Ada" } } });
+  });
+
+  it("nests a multi-segment path all the way down", () => {
+    expect(translate(condition("author.city.name", "EQ", "Paris"))).toEqual({
+      author: { city: { name: { $eq: "Paris" } } },
+    });
+  });
+});
+
+describe("translateFilter — groups", () => {
+  const left = condition("name", "EQ", "Ada");
+  const right = condition("age", "GT", 30);
+
+  it("maps AND and OR groups onto $and / $or", () => {
+    expect(translate({ kind: "group", operator: "AND", children: [left, right] } as FilterExpression)).toEqual({
+      $and: [{ name: { $eq: "Ada" } }, { age: { $gt: 30 } }],
+    });
+    expect(translate({ kind: "group", operator: "OR", children: [left, right] } as FilterExpression)).toEqual({
+      $or: [{ name: { $eq: "Ada" } }, { age: { $gt: 30 } }],
+    });
+  });
+
+  it("maps a NOT group onto $not over its single child", () => {
+    expect(translate({ kind: "group", operator: "NOT", children: [left] } as FilterExpression)).toEqual({
+      $not: { name: { $eq: "Ada" } },
+    });
+  });
+
+  it("nests groups without losing precedence", () => {
+    const nested = {
+      kind: "group",
+      operator: "AND",
+      children: [left, { kind: "group", operator: "OR", children: [right, condition("age", "LT", 10)] }],
+    } as unknown as FilterExpression;
+    expect(translate(nested)).toEqual({
+      $and: [{ name: { $eq: "Ada" } }, { $or: [{ age: { $gt: 30 } }, { age: { $lt: 10 } }] }],
+    });
+  });
+
+  it("spells the degenerate empty groups as real predicates", () => {
+    // MikroORM rejects an empty `$and`/`$or`, and `$not: {}` negates no
+    // condition at all — which it renders as match-*everything*, the exact
+    // opposite of what an empty OR or NOT means. An empty `$in` on the
+    // primary key is the one portable contradiction.
+    const empty = (operator: string) =>
+      translate({ kind: "group", operator, children: [] } as unknown as FilterExpression);
+    expect(empty("OR")).toEqual({ id: { $in: [] } });
+    expect(empty("NOT")).toEqual({ id: { $in: [] } });
+    expect(empty("AND")).toEqual({});
+  });
+});

--- a/packages/orms/mikroorm/tests/includes.spec.ts
+++ b/packages/orms/mikroorm/tests/includes.spec.ts
@@ -45,12 +45,17 @@ class Note {
 
   @ManyToOne(() => Article, { nullable: true })
   article: Article | null = null;
+
+  /** Soft-deletable too, so a nested include has a marker at *both* levels. */
+  @Property({ type: "Date", nullable: true })
+  deletedAt: Date | null = null;
 }
 
 let orm: MikroORM;
 let kavo: KavoInstance;
 let blogs: DefaultKavoService<Blog>;
 let articles: DefaultKavoService<Article>;
+let notes: DefaultKavoService<Note>;
 
 beforeAll(async () => {
   orm = await newTestOrm([Blog, Article, Note]);
@@ -65,7 +70,10 @@ beforeAll(async () => {
     // independent of whether the relation may be included.
     allowlists: { filterable: ["id", "title", "blog.name"] },
   } as never) as DefaultKavoService<Article>;
-  kavo.createCrud(Note, { relations: { edges: { article: { includable: true } } } });
+  notes = kavo.createCrud(Note, {
+    softDelete: { strategy: "soft", field: "deletedAt" },
+    relations: { edges: { article: { includable: true } } },
+  }) as DefaultKavoService<Note>;
 });
 
 afterAll(async () => {
@@ -191,6 +199,53 @@ describe("Includes and soft delete", () => {
       (row) => row.id === articleId,
     );
     expect(deleted?.notes).toHaveLength(1);
+  });
+});
+
+describe("Includes and soft delete, two levels down", () => {
+  it("excludes soft-deleted rows at every level of a nested include", async () => {
+    // `includeSoftDeleteWhere` merges a node's own `{ field: null }` with its
+    // children's nested conditions. With only one soft-deletable level the
+    // children half is always `undefined`, so the merge never actually runs —
+    // this is the case that exercises both halves together.
+    const { articleId } = await seed();
+    const em = orm.em.fork();
+    const extra = em.create(Note, { body: "second note", article: em.getReference(Article, articleId) });
+    await em.flush();
+    await notes.deleteOne(extra.id);
+
+    const list = await blogs.findMany({ include: ["articles.notes" as never] });
+    const embedded = (list.items[0] as unknown as { articles: { title: string; notes: { body: string }[] }[] })
+      .articles;
+    const includes = embedded.find((article) => article.title === "Includes")!;
+    // The live note survives; the soft-deleted one is gone from the nested level.
+    expect(includes.notes.map((note) => note.body)).toEqual(["typo on line 3"]);
+  });
+});
+
+describe("Nested includes keep parents that have no surviving children", () => {
+  it("returns an article with no live notes, rather than dropping it", async () => {
+    // The trap `populateWhere` walked into: expressing the deeper level's
+    // soft-delete scope as a nested condition made MikroORM read it as a
+    // relation-path predicate on the *parent*, so an article whose notes were
+    // all deleted (or which had none) vanished from the blog's collection
+    // entirely instead of coming back with `notes: []`.
+    const { articleId } = await seed();
+    const em = orm.em.fork();
+    const note = em.create(Note, { body: "doomed", article: em.getReference(Article, articleId) });
+    await em.flush();
+    await notes.deleteOne(note.id);
+
+    const list = await blogs.findMany({ include: ["articles.notes" as never] });
+    const embedded = (list.items[0] as unknown as { articles: { title: string; notes: { body: string }[] }[] })
+      .articles;
+
+    // Both articles survive: one with its remaining live note, one with none.
+    expect(embedded.map((article) => article.title).sort()).toEqual(["Includes", "Soft delete"]);
+    expect(embedded.find((article) => article.title === "Includes")!.notes.map((n) => n.body)).toEqual([
+      "typo on line 3",
+    ]);
+    expect(embedded.find((article) => article.title === "Soft delete")!.notes).toEqual([]);
   });
 });
 

--- a/packages/orms/mikroorm/tests/includes.spec.ts
+++ b/packages/orms/mikroorm/tests/includes.spec.ts
@@ -1,0 +1,210 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from "@mikro-orm/core";
+import type { DefaultKavoService, KavoInstance } from "@kavo/core";
+import { createMikroOrmKavo } from "@kavo/mikroorm";
+import { clearDatabase, newTestOrm } from "./support/database.js";
+
+@Entity()
+class Blog {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  name!: string;
+
+  @OneToMany(() => Article, (article) => article.blog)
+  articles = new Collection<Article>(this);
+}
+
+@Entity()
+class Article {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  title!: string;
+
+  @ManyToOne(() => Blog, { nullable: true })
+  blog: Blog | null = null;
+
+  @OneToMany(() => Note, (note) => note.article)
+  notes = new Collection<Note>(this);
+
+  @Property({ type: "Date", nullable: true })
+  deletedAt: Date | null = null;
+}
+
+@Entity()
+class Note {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  body!: string;
+
+  @ManyToOne(() => Article, { nullable: true })
+  article: Article | null = null;
+}
+
+let orm: MikroORM;
+let kavo: KavoInstance;
+let blogs: DefaultKavoService<Blog>;
+let articles: DefaultKavoService<Article>;
+
+beforeAll(async () => {
+  orm = await newTestOrm([Blog, Article, Note]);
+  kavo = createMikroOrmKavo(orm);
+  blogs = kavo.createCrud(Blog, {
+    relations: { edges: { articles: { includable: true } } },
+  }) as DefaultKavoService<Blog>;
+  articles = kavo.createCrud(Article, {
+    softDelete: { strategy: "soft", field: "deletedAt" },
+    relations: { edges: { blog: { includable: true }, notes: { includable: true } } },
+    // Filtering across a relation path is its own allowlist decision,
+    // independent of whether the relation may be included.
+    allowlists: { filterable: ["id", "title", "blog.name"] },
+  } as never) as DefaultKavoService<Article>;
+  kavo.createCrud(Note, { relations: { edges: { article: { includable: true } } } });
+});
+
+afterAll(async () => {
+  await orm.close();
+});
+
+beforeEach(async () => {
+  await clearDatabase(orm);
+});
+
+/** One blog, two articles, one note on the first article. */
+async function seed(): Promise<{ blogId: number; articleId: number }> {
+  const em = orm.em.fork();
+  const blog = em.create(Blog, { name: "Kavo weekly" });
+  const first = em.create(Article, { title: "Includes", blog });
+  em.create(Article, { title: "Soft delete", blog });
+  em.create(Note, { body: "typo on line 3", article: first });
+  await em.flush();
+  return { blogId: blog.id, articleId: first.id };
+}
+
+describe("MikroOrmRepositoryAdapter — to-one includes", () => {
+  it("embeds a to-one relation", async () => {
+    const { blogId } = await seed();
+    const list = await articles.findMany({ include: ["blog"], sort: [{ field: "id", direction: "asc" }] });
+    expect(list.items[0]).toMatchObject({ title: "Includes", blog: { id: blogId, name: "Kavo weekly" } });
+  });
+
+  it("supports include on findOne with identical semantics", async () => {
+    const { articleId, blogId } = await seed();
+    const item = await articles.findOne(articleId, { include: ["blog"] } as never);
+    expect(item).toMatchObject({ blog: { id: blogId } });
+  });
+
+  it("combines an include with a filter on the same relation path", async () => {
+    await seed();
+    const list = await articles.findMany({
+      include: ["blog"],
+      filter: { kind: "condition", field: "blog.name" as never, operator: "EQ", value: "Kavo weekly" },
+    });
+    expect(list.items).toHaveLength(2);
+    expect(list.items[0]).toMatchObject({ blog: { name: "Kavo weekly" } });
+  });
+
+  it("returns null for a to-one relation with no related row", async () => {
+    const em = orm.em.fork();
+    em.create(Article, { title: "Orphan" });
+    await em.flush();
+    const list = await articles.findMany({ include: ["blog"] });
+    expect(list.items[0]).toMatchObject({ blog: null });
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — to-many includes", () => {
+  it("embeds a to-many relation without disturbing root pagination", async () => {
+    await seed();
+    const list = await blogs.findMany({ include: ["articles"] });
+    // One root row, not one per article: MikroORM resolves `populate` with
+    // its own queries, so a to-many never multiplies the rows pagination
+    // counts — which is why this adapter ignores IncludeNode.strategy.
+    expect(list.items).toHaveLength(1);
+    expect(list.total).toBe(1);
+    expect((list.items[0] as unknown as { articles: unknown[] }).articles).toHaveLength(2);
+  });
+
+  it("paginates roots, then populates — a page of one still gets its children", async () => {
+    await seed();
+    const em = orm.em.fork();
+    em.create(Blog, { name: "Empty" });
+    await em.flush();
+
+    const page = await blogs.findMany({ include: ["articles"], limit: 1, offset: 0 });
+    expect(page.items).toHaveLength(1);
+    expect(page.total).toBe(2);
+    expect((page.items[0] as unknown as { articles: unknown[] }).articles).toHaveLength(2);
+  });
+
+  it("loads a nested level below a to-many node", async () => {
+    await seed();
+    const list = await blogs.findMany({ include: ["articles.notes" as never] });
+    const embedded = (list.items[0] as unknown as { articles: { title: string; notes: unknown[] }[] }).articles;
+    expect(embedded.find((article) => article.title === "Includes")?.notes).toHaveLength(1);
+    expect(embedded.find((article) => article.title === "Soft delete")?.notes).toEqual([]);
+  });
+
+  it("returns an empty array for a root with no related rows", async () => {
+    const em = orm.em.fork();
+    em.create(Blog, { name: "Empty" });
+    await em.flush();
+    const list = await blogs.findMany({ include: ["articles"] });
+    expect((list.items[0] as unknown as { articles: unknown[] }).articles).toEqual([]);
+  });
+
+  it("returns a to-many as a real array, not a MikroORM Collection", async () => {
+    // The conversion at the adapter boundary is what makes this true; a
+    // `Collection` would fail core's `Array.isArray` branch and serialize as
+    // a single object.
+    await seed();
+    const list = await blogs.findMany({ include: ["articles"] });
+    expect(Array.isArray((list.items[0] as unknown as { articles: unknown }).articles)).toBe(true);
+  });
+});
+
+describe("Includes and soft delete", () => {
+  it("excludes soft-deleted related rows", async () => {
+    const { articleId } = await seed();
+    await articles.deleteOne(articleId);
+
+    const list = await blogs.findMany({ include: ["articles"] });
+    const embedded = (list.items[0] as unknown as { articles: { title: string }[] }).articles;
+    expect(embedded.map((article) => article.title)).toEqual(["Soft delete"]);
+  });
+
+  it("keeps a root withDeleted from widening the relation", async () => {
+    const { articleId } = await seed();
+    await articles.deleteOne(articleId);
+
+    // `withDeleted` is the *root's* opt-in; the included relation stays
+    // scoped to live rows.
+    const list = await articles.findMany({ withDeleted: true, include: ["notes"] });
+    expect(list.items).toHaveLength(2);
+    const deleted = (list.items as unknown as readonly { id: number; notes: unknown[] }[]).find(
+      (row) => row.id === articleId,
+    );
+    expect(deleted?.notes).toHaveLength(1);
+  });
+});
+
+describe("Sparse fieldsets on included nodes", () => {
+  it("narrows the embedded shape and strips keys fetched for stitching", async () => {
+    await seed();
+    const list = await blogs.findMany({
+      include: ["articles"],
+      fields: { root: ["id", "name"], relations: { articles: ["title"] } },
+    });
+    expect(list.items[0]).toEqual({
+      id: expect.any(Number),
+      name: "Kavo weekly",
+      articles: [{ title: "Includes" }, { title: "Soft delete" }],
+    });
+  });
+});

--- a/packages/orms/mikroorm/tests/metadata.spec.ts
+++ b/packages/orms/mikroorm/tests/metadata.spec.ts
@@ -1,7 +1,18 @@
 import "reflect-metadata";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { Embeddable, Embedded, Entity, Enum, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
-import type { FieldMetadata } from "@kavo/core";
+import {
+  Collection,
+  Embeddable,
+  Embedded,
+  Entity,
+  Enum,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  Property,
+} from "@mikro-orm/core";
+import { ConfigurationException, type FieldMetadata } from "@kavo/core";
 import { buildEntityMetadata } from "@kavo/mikroorm";
 import { newTestOrm } from "./support/database.js";
 
@@ -48,6 +59,14 @@ class Widget {
 
   @Property({ type: "string", persist: false })
   computed!: string;
+
+  /** MikroORM's "never expose this" — a password hash, an API key. */
+  @Property({ type: "string", hidden: true, nullable: true })
+  secret: string | null = null;
+
+  /** Not loaded with the entity, so a filter on it would outrun the DTO. */
+  @Property({ type: "string", lazy: true, nullable: true })
+  bulky: string | null = null;
 }
 
 let orm: MikroORM;
@@ -113,6 +132,21 @@ describe("buildEntityMetadata — generated properties", () => {
   });
 });
 
+describe("buildEntityMetadata — never-expose properties", () => {
+  it.each(["secret", "bulky"])("drops the %s property from the metadata seam entirely", (field) => {
+    // Not merely hidden from responses: excluded from `fields`, so it never
+    // reaches the derived DTOs *or* the default filterable/sortable
+    // allowlists. A column that is invisible in the body but filterable in
+    // the database is a blind extraction oracle —
+    // `filter[secret][like]=sk_live_9%` answered by the row count.
+    expect(byName[field]).toBeUndefined();
+  });
+
+  it("still exposes ordinary properties alongside them", () => {
+    expect(byName["name"]).toBeDefined();
+  });
+});
+
 describe("buildEntityMetadata — embeddables", () => {
   it("exposes the embeddable property and drops its inner columns", async () => {
     @Embeddable()
@@ -150,6 +184,77 @@ describe("buildEntityMetadata — embeddables", () => {
   });
 });
 
+describe("buildEntityMetadata — relation targets", () => {
+  it("resolves a target declared by name, not just by class thunk", async () => {
+    // `@ManyToOne(() => Owner)` leaves `property.entity` a thunk, but
+    // `@ManyToOne("Owner")` — the spelling that keeps a bidirectional
+    // relation's import cycle off the runtime graph, which
+    // `.dependency-cruiser.cjs` forbids — leaves it a plain *string*.
+    // Calling it would throw, and core matches relation targets by class
+    // identity, so a string would break include projection outright.
+    @Entity()
+    class Kennel {
+      @PrimaryKey({ type: "number" })
+      id!: number;
+
+      @OneToMany("Hound", "kennel")
+      hounds = new Collection<object>(this);
+    }
+
+    @Entity()
+    class Hound {
+      @PrimaryKey({ type: "number" })
+      id!: number;
+
+      @ManyToOne("Kennel", { nullable: true })
+      kennel: object | null = null;
+    }
+
+    const named = await newTestOrm([Kennel, Hound]);
+    try {
+      expect(buildEntityMetadata(named, Hound).relations[0]!.target()).toBe(Kennel);
+      expect(buildEntityMetadata(named, Kennel).relations[0]!.target()).toBe(Hound);
+    } finally {
+      await named.close();
+    }
+  });
+});
+
+describe("buildEntityMetadata — single-table inheritance", () => {
+  it("reports inherited columns and marks the discriminator generated", async () => {
+    @Entity({ abstract: true, discriminatorColumn: "species" })
+    abstract class Beast {
+      @PrimaryKey({ type: "number" })
+      id!: number;
+
+      @Property({ type: "string" })
+      name!: string;
+    }
+
+    @Entity({ discriminatorValue: "feline" })
+    class Feline extends Beast {
+      @Property({ type: "boolean", nullable: true })
+      indoor!: boolean;
+    }
+
+    const sti = await newTestOrm([Beast, Feline]);
+    try {
+      const byField = Object.fromEntries(buildEntityMetadata(sti, Feline).fields.map((field) => [field.name, field]));
+      // The subtype's own column and the base's both surface.
+      expect(byField["name"]).toMatchObject({ kind: "string", generated: false });
+      expect(byField["indoor"]).toMatchObject({ kind: "boolean", generated: false });
+      // The discriminator is write-only bookkeeping MikroORM manages from
+      // the subtype being persisted. Marking it generated is what keeps it
+      // out of the *writable* projection: a client sending `species` for a
+      // different subtype would produce a row this entity's own repository
+      // can no longer load.
+      expect(byField["species"]).toMatchObject({ generated: true });
+    } finally {
+      await sti.close();
+    }
+  });
+});
+
 describe("buildEntityMetadata — refusals", () => {
   it("refuses a composite primary key", async () => {
     @Entity()
@@ -166,9 +271,15 @@ describe("buildEntityMetadata — refusals", () => {
 
     const composite = await newTestOrm([Membership]);
     try {
-      expect(() => buildEntityMetadata(composite, Membership)).toThrowError(
-        /requires exactly one primary key; found 2/,
-      );
+      let thrown: unknown;
+      try {
+        buildEntityMetadata(composite, Membership);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ConfigurationException);
+      expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((thrown as Error).message).toMatch(/requires exactly one primary key; found 2/);
     } finally {
       await composite.close();
     }

--- a/packages/orms/mikroorm/tests/metadata.spec.ts
+++ b/packages/orms/mikroorm/tests/metadata.spec.ts
@@ -1,0 +1,176 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Embeddable, Embedded, Entity, Enum, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import type { FieldMetadata } from "@kavo/core";
+import { buildEntityMetadata } from "@kavo/mikroorm";
+import { newTestOrm } from "./support/database.js";
+
+enum Status {
+  Active = "active",
+  Banned = "banned",
+}
+
+@Entity()
+class Widget {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  name!: string;
+
+  @Property({ type: "number" })
+  count!: number;
+
+  @Property({ type: "boolean" })
+  active!: boolean;
+
+  @Property({ type: "Date" })
+  releasedOn!: Date;
+
+  @Property({ type: "json", nullable: true })
+  payload: unknown = null;
+
+  @Enum({ items: () => Status })
+  status: Status = Status.Active;
+
+  /** A column whose JavaScript representation is not its column type. */
+  @Property({ columnType: "bigint", type: "bigint" })
+  serial!: string;
+
+  @Property({ type: "Date", onCreate: () => new Date() })
+  createdAt!: Date;
+
+  @Property({ type: "Date", onUpdate: () => new Date(), nullable: true })
+  updatedAt: Date | null = null;
+
+  @Property({ type: "number", version: true })
+  version!: number;
+
+  @Property({ type: "string", persist: false })
+  computed!: string;
+}
+
+let orm: MikroORM;
+let byName: Record<string, FieldMetadata>;
+
+beforeAll(async () => {
+  orm = await newTestOrm([Widget]);
+  byName = Object.fromEntries(buildEntityMetadata(orm, Widget).fields.map((field) => [field.name, field]));
+});
+
+afterAll(async () => {
+  await orm.close();
+});
+
+describe("buildEntityMetadata — field kinds", () => {
+  it.each([
+    ["name", "string"],
+    ["count", "number"],
+    ["active", "boolean"],
+    ["releasedOn", "date"],
+    ["payload", "json"],
+    ["status", "enum"],
+  ])("maps %s to the %s field kind", (field, kind) => {
+    expect(byName[field]).toMatchObject({ kind });
+  });
+
+  it("follows the runtime representation, not the column type, for bigint", () => {
+    // MikroORM hands a `bigint` column to JavaScript as a string to keep
+    // precision, so `string` is what core must coerce toward — reading
+    // `number` off the column type would corrupt values past 2^53.
+    expect(byName["serial"]).toMatchObject({ kind: "string" });
+  });
+
+  it("falls back to the declared type when there is no JavaScript equivalent", () => {
+    // `JsonType`'s `runtimeType` is `"any"`, which narrows nothing; the
+    // declared type is the only thing left that says "json".
+    expect(byName["payload"]).toMatchObject({ kind: "json" });
+  });
+
+  it("carries the enum's allowed values as the coercion allowlist", () => {
+    expect(byName["status"]?.enumValues).toEqual(["active", "banned"]);
+  });
+
+  it("reports nullability from the property declaration", () => {
+    expect(byName["payload"]).toMatchObject({ nullable: true });
+    expect(byName["name"]).toMatchObject({ nullable: false });
+  });
+});
+
+describe("buildEntityMetadata — generated properties", () => {
+  it.each([
+    ["id", "an auto-increment primary key"],
+    ["createdAt", "an onCreate hook"],
+    ["updatedAt", "an onUpdate hook"],
+    ["version", "an optimistic-lock version"],
+    ["computed", "a non-persisted property"],
+  ])("marks %s generated (%s)", (field) => {
+    expect(byName[field]).toMatchObject({ generated: true });
+  });
+
+  it.each(["name", "count", "status", "payload"])("leaves %s writable by the caller", (field) => {
+    expect(byName[field]).toMatchObject({ generated: false });
+  });
+});
+
+describe("buildEntityMetadata — embeddables", () => {
+  it("exposes the embeddable property and drops its inner columns", async () => {
+    @Embeddable()
+    class Address {
+      @Property({ type: "string" })
+      city!: string;
+
+      @Property({ type: "string" })
+      street!: string;
+    }
+
+    @Entity()
+    class Office {
+      @PrimaryKey({ type: "number" })
+      id!: number;
+
+      @Embedded(() => Address, { object: true })
+      address = new Address();
+
+      @Embedded(() => Address, { object: false, prefix: "billing_" })
+      billing = new Address();
+    }
+
+    const embedded = await newTestOrm([Office, Address]);
+    try {
+      const fields = buildEntityMetadata(embedded, Office).fields;
+      // The addressable properties only — never MikroORM's internal child
+      // names (`address~city`, `billing_city`), which would otherwise land in
+      // derived DTOs and allowlists as unusable wire fields.
+      expect(fields.map((field) => field.name)).toEqual(["id", "address", "billing"]);
+      expect(fields.filter((field) => field.name !== "id")).toMatchObject([{ kind: "json" }, { kind: "json" }]);
+    } finally {
+      await embedded.close();
+    }
+  });
+});
+
+describe("buildEntityMetadata — refusals", () => {
+  it("refuses a composite primary key", async () => {
+    @Entity()
+    class Membership {
+      @PrimaryKey({ type: "number" })
+      userId!: number;
+
+      @PrimaryKey({ type: "number" })
+      groupId!: number;
+
+      @Property({ type: "string" })
+      role!: string;
+    }
+
+    const composite = await newTestOrm([Membership]);
+    try {
+      expect(() => buildEntityMetadata(composite, Membership)).toThrowError(
+        /requires exactly one primary key; found 2/,
+      );
+    } finally {
+      await composite.close();
+    }
+  });
+});

--- a/packages/orms/mikroorm/tests/soft-delete.spec.ts
+++ b/packages/orms/mikroorm/tests/soft-delete.spec.ts
@@ -3,12 +3,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
 import {
   AlreadyDeletedException,
+  ConfigurationException,
   ConflictException,
   NotDeletedException,
   NotFoundException,
   type DefaultKavoService,
 } from "@kavo/core";
-import { buildEntityMetadata, createMikroOrmKavo } from "@kavo/mikroorm";
+import { buildEntityMetadata, createInfrastructure, createMikroOrmKavo } from "@kavo/mikroorm";
 import { clearDatabase, newTestOrm } from "./support/database.js";
 
 /**
@@ -80,6 +81,41 @@ describe("delete-marker detection", () => {
     // metadata seam to detect and `softDelete.field` must be configured.
     expect(buildEntityMetadata(orm, Ticket).softDeleteField).toBeNull();
     expect(buildEntityMetadata(orm, Invoice).softDeleteField).toBeNull();
+  });
+});
+
+describe("zero-config soft delete", () => {
+  it("is auto-enabled by a `deletedAt` property alone, with no config at all", async () => {
+    // `softDelete` defaults to `{ field: "deletedAt", strategy: "auto" }`, and
+    // `resolveSoftDelete` matches that name against the entity's own columns.
+    // So an adapter reporting `softDeleteField: null` does NOT mean "soft
+    // delete is off until configured" — the conventional column name turns it
+    // on by itself. That matters because the marker stays *writable* (nothing
+    // declares it, so it cannot be marked generated), which is what makes the
+    // DTO hardening in the note below load-bearing rather than optional.
+    const zeroConfig = createMikroOrmKavo(orm).createCrud(Ticket) as DefaultKavoService<Ticket>;
+    const created = (await zeroConfig.createOne({ reference: "T-zero", title: "x" } as never)) as Ticket;
+
+    await zeroConfig.deleteOne(created.id);
+
+    const raw = await orm.em.fork().findOne(Ticket, { id: created.id });
+    expect(raw).not.toBeNull(); // still there — soft, not hard
+    expect(raw?.deletedAt).toBeInstanceOf(Date);
+    expect((await zeroConfig.findMany()).total).toBe(0);
+  });
+
+  it("leaves the marker client-writable under derived DTOs", async () => {
+    // The consequence of the above, stated as a test so it cannot regress
+    // silently: with no `dto` block, `deletedAt` is an ordinary non-generated
+    // column and therefore in the writable projection. A plain patch stamps
+    // it, bypassing `deleteOne`'s already-deleted check. The mitigation is an
+    // explicit write DTO (see `examples/nest-mikroorm`'s OwnerController);
+    // the real fix belongs in core — see doc 17 §7.
+    const zeroConfig = createMikroOrmKavo(orm).createCrud(Ticket) as DefaultKavoService<Ticket>;
+    const created = (await zeroConfig.createOne({ reference: "T-writable", title: "x" } as never)) as Ticket;
+
+    await zeroConfig.patchOne(created.id, { deletedAt: new Date() } as never);
+    expect((await zeroConfig.findMany()).total).toBe(0);
   });
 });
 
@@ -228,11 +264,58 @@ describe("MikroOrmRepositoryAdapter — hard delete", () => {
     // Core catches this at `createCrud` rather than leaving the adapter to
     // fail per request — the adapter's own `requireSoftDelete` guard is the
     // second line, for a hand-built context.
-    expect(() =>
+    let thrown: unknown;
+    try {
       createMikroOrmKavo(orm).createCrud(Invoice, {
         softDelete: { strategy: "hard" },
         operations: { restoreOne: true },
-      }),
-    ).toThrowError(/hard delete strategy/);
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationException);
+    expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+    expect((thrown as Error).message).toMatch(/hard delete strategy/);
+  });
+
+  it("refuses restore at the adapter too, for a hand-built hard-delete context", async () => {
+    // The second line of defence the bootstrap check above makes unreachable
+    // through `createCrud` — a programmatic caller assembling its own context
+    // reaches the adapter directly, and must not silently no-op.
+    const created = (await invoices.createOne({ number: "INV-guard" } as never)) as Invoice;
+    const adapter = createInfrastructure(orm).adapterFor(Invoice);
+    const hardContext = {
+      entityName: "Invoice",
+      operation: "restoreOne",
+      config: { softDelete: { strategy: "hard" } },
+    };
+
+    let thrown: unknown;
+    try {
+      await adapter.restore(created.id, hardContext as never);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationException);
+    expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+  });
+
+  it("purges a hard-delete row outright, and 404s when it is already gone", async () => {
+    // Under a hard strategy `purge` skips the already-deleted check entirely
+    // and is just a delete. Core refuses to *enable* `purgeOne` on a
+    // hard-delete entity at bootstrap (same guard as `restoreOne`), so this
+    // branch is only reachable the way `requireSoftDelete`'s is: a
+    // programmatic caller assembling its own context.
+    const created = (await invoices.createOne({ number: "INV-purge" } as never)) as Invoice;
+    const adapter = createInfrastructure(orm).adapterFor(Invoice);
+    const hardContext = {
+      entityName: "Invoice",
+      operation: "purgeOne",
+      config: { softDelete: { strategy: "hard" } },
+    };
+
+    await adapter.purge(created.id, hardContext as never);
+    expect(await orm.em.fork().count(Invoice, {})).toBe(0);
+    await expect(adapter.purge(created.id, hardContext as never)).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/packages/orms/mikroorm/tests/soft-delete.spec.ts
+++ b/packages/orms/mikroorm/tests/soft-delete.spec.ts
@@ -1,0 +1,238 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Entity, MikroORM, PrimaryKey, Property } from "@mikro-orm/core";
+import {
+  AlreadyDeletedException,
+  ConflictException,
+  NotDeletedException,
+  NotFoundException,
+  type DefaultKavoService,
+} from "@kavo/core";
+import { buildEntityMetadata, createMikroOrmKavo } from "@kavo/mikroorm";
+import { clearDatabase, newTestOrm } from "./support/database.js";
+
+/**
+ * Soft delete over an ordinary nullable column. Unlike `@kavo/typeorm` there
+ * is only one shape to test: MikroORM declares no delete-date column of its
+ * own, so the marker is always an ordinary property and the strategy is
+ * always named in Kavo config.
+ */
+@Entity()
+class Ticket {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string", unique: true })
+  reference!: string;
+
+  @Property({ type: "string" })
+  title!: string;
+
+  @Property({ type: "Date", nullable: true })
+  deletedAt: Date | null = null;
+}
+
+@Entity()
+class Invoice {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "string" })
+  number!: string;
+
+  @Property({ type: "Date", nullable: true })
+  archivedAt: Date | null = null;
+}
+
+let orm: MikroORM;
+let tickets: DefaultKavoService<Ticket>;
+let invoices: DefaultKavoService<Invoice>;
+
+beforeAll(async () => {
+  orm = await newTestOrm([Ticket, Invoice]);
+  const kavo = createMikroOrmKavo(orm);
+  tickets = kavo.createCrud(Ticket, {
+    softDelete: { strategy: "soft", field: "deletedAt" },
+    operations: { purgeOne: true },
+  }) as DefaultKavoService<Ticket>;
+  invoices = kavo.createCrud(Invoice, {
+    softDelete: { strategy: "soft", field: "archivedAt" },
+  }) as DefaultKavoService<Invoice>;
+});
+
+afterAll(async () => {
+  await orm.close();
+});
+
+beforeEach(async () => {
+  await clearDatabase(orm);
+});
+
+async function newTicket(reference = "T-1"): Promise<number> {
+  const created = await tickets.createOne({ reference, title: "broken login" } as never);
+  return (created as Ticket).id;
+}
+
+describe("delete-marker detection", () => {
+  it("reports no ORM-declared delete column, because MikroORM declares none", () => {
+    // MikroORM's soft-delete pattern is a user-defined `@Filter`, a query
+    // concern rather than a column declaration — so there is nothing for the
+    // metadata seam to detect and `softDelete.field` must be configured.
+    expect(buildEntityMetadata(orm, Ticket).softDeleteField).toBeNull();
+    expect(buildEntityMetadata(orm, Invoice).softDeleteField).toBeNull();
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — soft delete", () => {
+  it("stamps the marker column and hides the row from every read", async () => {
+    const id = await newTicket();
+    await tickets.deleteOne(id);
+
+    const raw = await orm.em.fork().findOne(Ticket, { id });
+    expect(raw?.deletedAt).toBeInstanceOf(Date);
+
+    await expect(tickets.findOne(id)).rejects.toBeInstanceOf(NotFoundException);
+    expect((await tickets.findMany()).items).toHaveLength(0);
+    expect((await tickets.findMany()).total).toBe(0);
+  });
+
+  it("returns deleted rows under withDeleted", async () => {
+    const id = await newTicket();
+    await tickets.deleteOne(id);
+
+    const list = await tickets.findMany({ withDeleted: true });
+    expect(list.items).toHaveLength(1);
+    expect(list.total).toBe(1);
+    expect(await tickets.findOne(id, { withDeleted: true } as never)).toMatchObject({ id });
+  });
+
+  it("shows only deleted rows under onlyDeleted, live rows excluded", async () => {
+    const deletedId = await newTicket("T-deleted");
+    await newTicket("T-live");
+    await tickets.deleteOne(deletedId);
+
+    const list = await tickets.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ id: deletedId }]);
+    expect(list.total).toBe(1);
+    expect(await tickets.findOne(deletedId, { onlyDeleted: true } as never)).toMatchObject({ id: deletedId });
+  });
+
+  it("keeps the soft-delete scope alongside a filter rather than replacing it", async () => {
+    const deletedId = await newTicket("T-deleted");
+    await newTicket("T-live");
+    await tickets.deleteOne(deletedId);
+
+    // Both predicates must survive the AND: a filter that matches the deleted
+    // row must still not return it.
+    const list = await tickets.findMany({
+      filter: { kind: "condition", field: "reference", operator: "LIKE", value: "T-%" },
+    });
+    expect(list.items).toMatchObject([{ reference: "T-live" }]);
+  });
+
+  it("rejects withDeleted and onlyDeleted set together", async () => {
+    await expect(tickets.findMany({ withDeleted: true, onlyDeleted: true })).rejects.toMatchObject({
+      issues: [{ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }],
+    });
+  });
+
+  it("keeps updates away from deleted rows", async () => {
+    const id = await newTicket();
+    await tickets.deleteOne(id);
+    await expect(tickets.patchOne(id, { title: "resurrected" } as never)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("rejects a second delete with 409 already-deleted", async () => {
+    const id = await newTicket();
+    await tickets.deleteOne(id);
+    await expect(tickets.deleteOne(id)).rejects.toBeInstanceOf(AlreadyDeletedException);
+  });
+
+  it("restores a deleted row and refuses to restore a live one", async () => {
+    const id = await newTicket();
+    await tickets.deleteOne(id);
+
+    const restored = await tickets.restoreOne(id);
+    expect(restored).toMatchObject({ id, deletedAt: null });
+    expect((await tickets.findMany()).items).toHaveLength(1);
+    await expect(tickets.restoreOne(id)).rejects.toBeInstanceOf(NotDeletedException);
+  });
+
+  it("throws NotFound restoring a row that never existed", async () => {
+    await expect(tickets.restoreOne(4242)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("purges a deleted row for good, but never a live one", async () => {
+    const id = await newTicket();
+    await expect(tickets.purgeOne(id)).rejects.toBeInstanceOf(NotDeletedException);
+
+    await tickets.deleteOne(id);
+    await tickets.purgeOne(id);
+    expect(await orm.em.fork().count(Ticket, {})).toBe(0);
+  });
+
+  it("still conflicts on a unique index held by a deleted row", async () => {
+    // Documented adapter guidance: a soft-deleted row keeps its unique index
+    // entries, and the fix is a partial index — not a Kavo rewrite.
+    const id = await newTicket("T-dup");
+    await tickets.deleteOne(id);
+    await expect(tickets.createOne({ reference: "T-dup", title: "again" } as never)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — a differently named marker column", () => {
+  it("soft-deletes, excludes, and restores over an ordinary column", async () => {
+    const created = await invoices.createOne({ number: "INV-1" } as never);
+    const id = (created as Invoice).id;
+
+    await invoices.deleteOne(id);
+    const raw = await orm.em.fork().findOne(Invoice, { id });
+    expect(raw?.archivedAt).toBeInstanceOf(Date);
+    expect((await invoices.findMany()).items).toHaveLength(0);
+    expect((await invoices.findMany({ withDeleted: true })).items).toHaveLength(1);
+
+    expect(await invoices.restoreOne(id)).toMatchObject({ id, archivedAt: null });
+    expect((await invoices.findMany()).items).toHaveLength(1);
+  });
+
+  it("shows only deleted rows under onlyDeleted over an ordinary column", async () => {
+    const deleted = await invoices.createOne({ number: "INV-deleted" } as never);
+    await invoices.createOne({ number: "INV-live" } as never);
+    const deletedId = (deleted as Invoice).id;
+    await invoices.deleteOne(deletedId);
+
+    const list = await invoices.findMany({ onlyDeleted: true });
+    expect(list.items).toMatchObject([{ id: deletedId }]);
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — hard delete", () => {
+  it("removes the row outright and refuses a missing one", async () => {
+    const kavo = createMikroOrmKavo(orm);
+    const hard = kavo.createCrud(Invoice, {
+      softDelete: { strategy: "hard" },
+    }) as DefaultKavoService<Invoice>;
+
+    const created = (await hard.createOne({ number: "INV-hard" } as never)) as Invoice;
+    await hard.deleteOne(created.id);
+    expect(await orm.em.fork().count(Invoice, {})).toBe(0);
+    // `nativeDelete` reports zero affected rows for a row that is already
+    // gone, which is what turns a repeat delete into a 404 rather than a
+    // silent success.
+    await expect(hard.deleteOne(created.id)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("refuses to enable restoreOne on a hard-delete entity at bootstrap", () => {
+    // Core catches this at `createCrud` rather than leaving the adapter to
+    // fail per request — the adapter's own `requireSoftDelete` guard is the
+    // second line, for a hand-built context.
+    expect(() =>
+      createMikroOrmKavo(orm).createCrud(Invoice, {
+        softDelete: { strategy: "hard" },
+        operations: { restoreOne: true },
+      }),
+    ).toThrowError(/hard delete strategy/);
+  });
+});

--- a/packages/orms/mikroorm/tests/support/database.ts
+++ b/packages/orms/mikroorm/tests/support/database.ts
@@ -1,0 +1,32 @@
+import { MikroORM, type EntityClass } from "@mikro-orm/core";
+import { defineConfig } from "@mikro-orm/better-sqlite";
+
+/**
+ * One in-memory SQLite database per spec file, with the schema created from
+ * the entity metadata — the same "real driver, not mocks" posture the other
+ * adapters' suites take.
+ *
+ * `allowGlobalContext` stays off (its default): the adapter forks an
+ * `EntityManager` for every operation, and a test that reaches for `orm.em`
+ * directly instead of `orm.em.fork()` should fail loudly rather than share
+ * an identity map with the code under test.
+ */
+export async function newTestOrm(entities: readonly EntityClass<object>[]): Promise<MikroORM> {
+  const orm = await MikroORM.init(
+    defineConfig({
+      dbName: ":memory:",
+      entities: entities as EntityClass<object>[],
+    }),
+  );
+  await orm.schema.createSchema();
+  return orm;
+}
+
+/**
+ * Empty every table between tests. `clearDatabase` also resets MikroORM's
+ * identity map, which matters because the seeding helpers below fork their
+ * own `EntityManager`s.
+ */
+export async function clearDatabase(orm: MikroORM): Promise<void> {
+  await orm.schema.clearDatabase();
+}

--- a/packages/orms/mikroorm/tsconfig.json
+++ b/packages/orms/mikroorm/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/orms/mikroorm/tsconfig.tests.json
+++ b/packages/orms/mikroorm/tsconfig.tests.json
@@ -1,0 +1,20 @@
+{
+  // Typecheck-only project for `tests/` — see packages/core/tsconfig.tests.json.
+  // The decorator options are absent from this package's build config because
+  // `src` declares no entities; the tests do.
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "useDefineForClassFields": false,
+    "types": ["node"],
+    "paths": {
+      "@kavo/core": ["../../core/src/index.ts"],
+      "@kavo/mikroorm": ["./src/index.ts"]
+    }
+  },
+  "include": ["tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@mikro-orm/better-sqlite>better-sqlite3': ^13.0.2
+
 importers:
 
   .:
@@ -193,6 +196,22 @@ importers:
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
+
+  packages/orms/mikroorm:
+    dependencies:
+      '@kavo/core':
+        specifier: workspace:^
+        version: link:../../core
+    devDependencies:
+      '@mikro-orm/better-sqlite':
+        specifier: ^6.6.14
+        version: 6.6.14(@mikro-orm/core@6.6.16)
+      '@mikro-orm/core':
+        specifier: ^6.6.14
+        version: 6.6.16
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
 
   packages/orms/mongoose:
     dependencies:
@@ -733,6 +752,32 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@mikro-orm/better-sqlite@6.6.14':
+    resolution: {integrity: sha512-xe1mS9HWQfo8ODzuQbBANW/kLkuBMJ3aiOzPZo/hzQnoViFCzKwYRF93jXo+il5HRvme5ZXNR23RivtGDZ7tYw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+
+  '@mikro-orm/core@6.6.16':
+    resolution: {integrity: sha512-ym26fbhTti7Zh6oN1y74byoUoMEq1ahckiV7BZX5pHU/0OaUESiQA+Zar2Tv2ZFuZA9946XQ805F7/4NH6oDUQ==}
+    engines: {node: '>= 18.12.0'}
+
+  '@mikro-orm/knex@6.6.14':
+    resolution: {integrity: sha512-xQWq9+7TwE8LLul1RkhjB7/0/iCHMlkSmEToVpz+NNFoPj6M32DfY9mhNnM6qPZ/HF50WjpcVgCgi9ADrEBSFA==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+      better-sqlite3: '*'
+      libsql: '*'
+      mariadb: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      libsql:
+        optional: true
+      mariadb:
+        optional: true
+
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
@@ -829,6 +874,18 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@oxlint/binding-android-arm-eabi@1.76.0':
     resolution: {integrity: sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==}
@@ -1559,6 +1616,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -1655,6 +1716,10 @@ packages:
 
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
@@ -1754,12 +1819,19 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.19:
+    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
@@ -1846,8 +1918,20 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dataloader@2.2.3:
+    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
+
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
+  debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1903,6 +1987,10 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
   docker-compose@1.4.2:
     resolution: {integrity: sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==}
     engines: {node: '>= 6.0.0'}
@@ -1917,6 +2005,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -1999,6 +2091,15 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2055,11 +2156,18 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2073,6 +2181,10 @@ packages:
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -2121,6 +2233,10 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
+    engines: {node: '>=14.14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2144,6 +2260,10 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
   get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
@@ -2152,9 +2272,16 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  getopts@2.3.0:
+    resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
+
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -2164,6 +2291,10 @@ packages:
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2223,6 +2354,10 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   ignore@7.0.6:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
@@ -2233,6 +2368,10 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  interpret@2.2.0:
+    resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
+    engines: {node: '>= 0.10'}
 
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -2250,13 +2389,25 @@ packages:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-installed-globally@1.0.0:
     resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
     engines: {node: '>=18'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
@@ -2311,6 +2462,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   kareem@2.6.3:
     resolution: {integrity: sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==}
     engines: {node: '>=12.0.0'}
@@ -2318,6 +2472,37 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  knex@3.2.10:
+    resolution: {integrity: sha512-oypTHfrc9i72iyxaUQBKHOxhcr0xM65MPf6FpN02nimsftXwzXprIkLjfXdubvhbu4PMWLp023q8o8CYvHSuZw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '*'
+      mysql: '*'
+      mysql2: '*'
+      pg: '*'
+      pg-native: '*'
+      pg-query-stream: ^4.14.0
+      sqlite3: '*'
+      tedious: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      mysql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      sqlite3:
+        optional: true
+      tedious:
+        optional: true
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -2383,6 +2568,10 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
@@ -2401,6 +2590,14 @@ packages:
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mikro-orm@6.6.16:
+    resolution: {integrity: sha512-42bvve+XSzvBpOuZeZxJsM5aW4DQnDn23E5to4cvEjUdaPX7jg1bRh+l8f/8/WJJNzG1T05V5vHSe+SHzqN87A==}
+    engines: {node: '>= 18.12.0'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2529,6 +2726,9 @@ packages:
     resolution: {integrity: sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==}
     engines: {node: '>=14.0.0'}
 
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2653,6 +2853,10 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2667,6 +2871,9 @@ packages:
 
   pg-connection-string@2.14.0:
     resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-connection-string@2.6.2:
+    resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -2698,6 +2905,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -2800,6 +3011,9 @@ packages:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
@@ -2857,6 +3071,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
@@ -2865,6 +3083,10 @@ packages:
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -2877,6 +3099,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -2959,6 +3184,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2987,6 +3216,14 @@ packages:
   sql-highlight@6.1.0:
     resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
     engines: {node: '>=14'}
+
+  sqlstring-sqlite@0.1.1:
+    resolution: {integrity: sha512-9CAYUJ0lEUPYJrswqiqdINNSfq3jqWo/bFJ7tufdoNeSK0Fy+d1kFTxjqO9PIqza0Kri+ZtYMfPVf1aZaFOvrQ==}
+    engines: {node: '>= 0.6'}
+
+  sqlstring@2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
 
   ssh-remote-port-forward@1.0.4:
     resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
@@ -3096,6 +3333,10 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
+  tarn@3.1.2:
+    resolution: {integrity: sha512-3RTvqKZcK/17jnJ8rMKFXbyNogywTs1z0gVPPwFsJGX46rkmUHOdIaSQ/aVO1rS7nH+soiXiWk7rvUXxndm8Dg==}
+    engines: {node: '>=8.0.0'}
+
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
@@ -3104,6 +3345,10 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  tildify@2.0.0:
+    resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
+    engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3123,6 +3368,10 @@ packages:
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -3253,6 +3502,10 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -3873,6 +4126,53 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@mikro-orm/better-sqlite@6.6.14(@mikro-orm/core@6.6.16)':
+    dependencies:
+      '@mikro-orm/core': 6.6.16
+      '@mikro-orm/knex': 6.6.14(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)
+      better-sqlite3: 13.0.2
+      fs-extra: 11.3.3
+      sqlstring-sqlite: 0.1.1
+    transitivePeerDependencies:
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/core@6.6.16':
+    dependencies:
+      dataloader: 2.2.3
+      dotenv: 17.3.1
+      esprima: 4.0.1
+      fs-extra: 11.3.3
+      globby: 11.1.0
+      mikro-orm: 6.6.16
+      reflect-metadata: 0.2.2
+
+  '@mikro-orm/knex@6.6.14(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)':
+    dependencies:
+      '@mikro-orm/core': 6.6.16
+      fs-extra: 11.3.3
+      knex: 3.2.10(better-sqlite3@13.0.2)
+      sqlstring: 2.3.3
+    optionalDependencies:
+      better-sqlite3: 13.0.2
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.12.33)
@@ -3962,6 +4262,18 @@ snapshots:
       '@nestjs/platform-express': 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
 
   '@noble/hashes@1.8.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@oxlint/binding-android-arm-eabi@1.76.0':
     optional: true
@@ -4636,6 +4948,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  array-union@2.1.0: {}
+
   asap@2.0.6: {}
 
   asn1@0.2.6:
@@ -4724,6 +5038,10 @@ snapshots:
   brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   bson@6.10.4: {}
 
@@ -4822,11 +5140,15 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.19: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   commander@15.0.0: {}
 
@@ -4901,7 +5223,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dataloader@2.2.3: {}
+
   dayjs@1.11.21: {}
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
 
   debug@4.4.3:
     dependencies:
@@ -4953,6 +5281,10 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
   docker-compose@1.4.2:
     dependencies:
       yaml: 2.9.0
@@ -4978,6 +5310,8 @@ snapshots:
       - supports-color
 
   dotenv@16.6.1: {}
+
+  dotenv@17.3.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5093,6 +5427,10 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  esm@3.2.25: {}
+
+  esprima@4.0.1: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -5170,9 +5508,21 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.5: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -5186,6 +5536,10 @@ snapshots:
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -5242,6 +5596,12 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-extra@11.3.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -5268,12 +5628,16 @@ snapshots:
       hasown: 2.0.4
       math-intrinsics: 1.1.0
 
+  get-package-type@0.1.0: {}
+
   get-port@5.1.1: {}
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  getopts@2.3.0: {}
 
   giget@2.0.0:
     dependencies:
@@ -5283,6 +5647,10 @@ snapshots:
       node-fetch-native: 1.6.7
       nypm: 0.6.9
       pathe: 2.0.3
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@10.5.0:
     dependencies:
@@ -5296,6 +5664,15 @@ snapshots:
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
 
   gopd@1.2.0: {}
 
@@ -5360,11 +5737,15 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  ignore@5.3.2: {}
+
   ignore@7.0.6: {}
 
   inherits@2.0.4: {}
 
   ini@4.1.1: {}
+
+  interpret@2.2.0: {}
 
   interpret@3.1.1: {}
 
@@ -5376,12 +5757,20 @@ snapshots:
     dependencies:
       hasown: 2.0.4
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-installed-globally@1.0.0:
     dependencies:
       global-directory: 4.0.1
       is-path-inside: 4.0.0
+
+  is-number@7.0.0: {}
 
   is-path-inside@4.0.0: {}
 
@@ -5419,9 +5808,36 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   kareem@2.6.3: {}
 
   kleur@3.0.3: {}
+
+  knex@3.2.10(better-sqlite3@13.0.2):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.18.1
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.1.2
+      tildify: 2.0.0
+    optionalDependencies:
+      better-sqlite3: 13.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   lazystream@1.0.1:
     dependencies:
@@ -5477,6 +5893,8 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  merge2@1.4.1: {}
+
   methods@1.1.2: {}
 
   micromark-util-character@2.1.1:
@@ -5495,6 +5913,13 @@ snapshots:
   micromark-util-symbol@2.0.1: {}
 
   micromark-util-types@2.0.2: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mikro-orm@6.6.16: {}
 
   mime-db@1.52.0: {}
 
@@ -5618,6 +6043,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ms@2.1.2: {}
+
   ms@2.1.3: {}
 
   multer@2.2.0:
@@ -5739,6 +6166,8 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  path-type@4.0.0: {}
+
   pathe@2.0.3: {}
 
   pend@1.2.0: {}
@@ -5749,6 +6178,8 @@ snapshots:
     optional: true
 
   pg-connection-string@2.14.0: {}
+
+  pg-connection-string@2.6.2: {}
 
   pg-int8@1.0.1: {}
 
@@ -5781,6 +6212,8 @@ snapshots:
       split2: 4.2.0
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
 
@@ -5882,6 +6315,8 @@ snapshots:
       es-define-property: 1.0.1
       side-channel: 1.1.1
 
+  queue-microtask@1.2.3: {}
+
   range-parser@1.3.0: {}
 
   raw-body@3.0.2:
@@ -5948,6 +6383,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-from@5.0.0: {}
+
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
@@ -5956,6 +6393,8 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   retry@0.12.0: {}
+
+  reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
@@ -5999,6 +6438,10 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   rxjs@7.8.2:
     dependencies:
@@ -6102,6 +6545,8 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  slash@3.0.0: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
@@ -6119,6 +6564,10 @@ snapshots:
   sql-escaper@1.5.1: {}
 
   sql-highlight@6.1.0: {}
+
+  sqlstring-sqlite@0.1.1: {}
+
+  sqlstring@2.3.3: {}
 
   ssh-remote-port-forward@1.0.4:
     dependencies:
@@ -6278,6 +6727,8 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tarn@3.1.2: {}
+
   teex@1.0.1:
     dependencies:
       streamx: 2.28.0
@@ -6314,6 +6765,8 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  tildify@2.0.0: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -6326,6 +6779,10 @@ snapshots:
   tinyrainbow@3.1.1: {}
 
   tmp@0.2.7: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
@@ -6427,6 +6884,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,58 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
 
+  examples/nest-mikroorm:
+    dependencies:
+      '@kavo/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@kavo/mikroorm':
+        specifier: workspace:*
+        version: link:../../packages/orms/mikroorm
+      '@kavo/nest':
+        specifier: workspace:*
+        version: link:../../packages/frameworks/nest
+      '@mikro-orm/better-sqlite':
+        specifier: ^6.6.14
+        version: 6.6.14(@mikro-orm/core@6.6.16)(pg@8.20.0)
+      '@mikro-orm/core':
+        specifier: ^6.6.14
+        version: 6.6.16
+      '@mikro-orm/postgresql':
+        specifier: ^6.6.14
+        version: 6.6.16(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)
+      '@nestjs/common':
+        specifier: ^11.0.0
+        version: 11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.0.0
+        version: 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.28)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-express':
+        specifier: ^11.0.0
+        version: 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
+      '@nestjs/swagger':
+        specifier: ^11.0.0
+        version: 11.4.6(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+    devDependencies:
+      '@nestjs/testing':
+        specifier: ^11.0.0
+        version: 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.28)
+      '@testcontainers/postgresql':
+        specifier: ^12.0.4
+        version: 12.0.4
+      '@types/supertest':
+        specifier: ^7.2.1
+        version: 7.2.1
+      supertest:
+        specifier: ^7.0.0
+        version: 7.2.2
+
   examples/nest-mongoose:
     dependencies:
       '@kavo/core':
@@ -205,7 +257,7 @@ importers:
     devDependencies:
       '@mikro-orm/better-sqlite':
         specifier: ^6.6.14
-        version: 6.6.14(@mikro-orm/core@6.6.16)
+        version: 6.6.14(@mikro-orm/core@6.6.16)(pg@8.20.0)
       '@mikro-orm/core':
         specifier: ^6.6.14
         version: 6.6.16
@@ -777,6 +829,28 @@ packages:
         optional: true
       mariadb:
         optional: true
+
+  '@mikro-orm/knex@6.6.16':
+    resolution: {integrity: sha512-H0fYK4vSe2mtmfBDDNsOw5Z56JDYEzbaoIo24JhkzmoGna85ddwyYzYB289DMS8Ukn7qZKhfR2pn2kQDRSJiyw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
+      better-sqlite3: '*'
+      libsql: '*'
+      mariadb: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      libsql:
+        optional: true
+      mariadb:
+        optional: true
+
+  '@mikro-orm/postgresql@6.6.16':
+    resolution: {integrity: sha512-9MwmbnF+nuX5i/I4YClOLkYGoN2omY6Z5LA1rJHNs+5P3BDYSxR9dZk9kuPJ+g9GJXAx/gKKJzKgp7Wv4G65fA==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^6.0.0
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -2891,6 +2965,15 @@ packages:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
   pg@8.22.0:
     resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
     engines: {node: '>= 16.0.0'}
@@ -2933,6 +3016,10 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
   postgres-bytea@1.0.1:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
@@ -2941,9 +3028,17 @@ packages:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-interval@4.0.2:
+    resolution: {integrity: sha512-EMsphSQ1YkQqKZL2cuG0zHkmjCCzQqQ71l2GXITqRwjhRleCdv00bDk/ktaSi0LnlaPzAc3535KTrjXsTdtx7A==}
+    engines: {node: '>=12'}
 
   preact@10.29.7:
     resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
@@ -4126,10 +4221,10 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mikro-orm/better-sqlite@6.6.14(@mikro-orm/core@6.6.16)':
+  '@mikro-orm/better-sqlite@6.6.14(@mikro-orm/core@6.6.16)(pg@8.20.0)':
     dependencies:
       '@mikro-orm/core': 6.6.16
-      '@mikro-orm/knex': 6.6.14(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)
+      '@mikro-orm/knex': 6.6.14(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)(pg@8.20.0)
       better-sqlite3: 13.0.2
       fs-extra: 11.3.3
       sqlstring-sqlite: 0.1.1
@@ -4155,11 +4250,11 @@ snapshots:
       mikro-orm: 6.6.16
       reflect-metadata: 0.2.2
 
-  '@mikro-orm/knex@6.6.14(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)':
+  '@mikro-orm/knex@6.6.14(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)(pg@8.20.0)':
     dependencies:
       '@mikro-orm/core': 6.6.16
       fs-extra: 11.3.3
-      knex: 3.2.10(better-sqlite3@13.0.2)
+      knex: 3.2.10(better-sqlite3@13.0.2)(pg@8.20.0)
       sqlstring: 2.3.3
     optionalDependencies:
       better-sqlite3: 13.0.2
@@ -4167,6 +4262,44 @@ snapshots:
       - mysql
       - mysql2
       - pg
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/knex@6.6.16(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)(pg@8.20.0)':
+    dependencies:
+      '@mikro-orm/core': 6.6.16
+      fs-extra: 11.3.3
+      knex: 3.2.10(better-sqlite3@13.0.2)(pg@8.20.0)
+      sqlstring: 2.3.3
+    optionalDependencies:
+      better-sqlite3: 13.0.2
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - pg-query-stream
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)':
+    dependencies:
+      '@mikro-orm/core': 6.6.16
+      '@mikro-orm/knex': 6.6.16(@mikro-orm/core@6.6.16)(better-sqlite3@13.0.2)(pg@8.20.0)
+      pg: 8.20.0
+      postgres-array: 3.0.4
+      postgres-date: 2.1.0
+      postgres-interval: 4.0.2
+    transitivePeerDependencies:
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
       - pg-native
       - pg-query-stream
       - sqlite3
@@ -5818,7 +5951,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knex@3.2.10(better-sqlite3@13.0.2):
+  knex@3.2.10(better-sqlite3@13.0.2)(pg@8.20.0):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -5836,6 +5969,7 @@ snapshots:
       tildify: 2.0.0
     optionalDependencies:
       better-sqlite3: 13.0.2
+      pg: 8.20.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6183,6 +6317,10 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
+  pg-pool@3.14.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
   pg-pool@3.14.0(pg@8.22.0):
     dependencies:
       pg: 8.22.0
@@ -6196,6 +6334,16 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.20.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
 
   pg@8.22.0:
     dependencies:
@@ -6237,13 +6385,19 @@ snapshots:
 
   postgres-array@2.0.0: {}
 
+  postgres-array@3.0.4: {}
+
   postgres-bytea@1.0.1: {}
 
   postgres-date@1.0.7: {}
 
+  postgres-date@2.1.0: {}
+
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres-interval@4.0.2: {}
 
   preact@10.29.7: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "packages/protocols/graphql" },
     { "path": "packages/protocols/mcp" },
     { "path": "examples/nest-typeorm" },
-    { "path": "examples/nest-mongoose" }
+    { "path": "examples/nest-mongoose" },
+    { "path": "examples/nest-mikroorm" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "packages/orms/typeorm" },
     { "path": "packages/orms/prisma" },
     { "path": "packages/orms/mongoose" },
+    { "path": "packages/orms/mikroorm" },
     { "path": "packages/frameworks/nest" },
     { "path": "packages/protocols/graphql" },
     { "path": "packages/protocols/mcp" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       "@kavo/typeorm": new URL("./packages/orms/typeorm/src/index.ts", import.meta.url).pathname,
       "@kavo/prisma": new URL("./packages/orms/prisma/src/index.ts", import.meta.url).pathname,
       "@kavo/mongoose": new URL("./packages/orms/mongoose/src/index.ts", import.meta.url).pathname,
+      "@kavo/mikroorm": new URL("./packages/orms/mikroorm/src/index.ts", import.meta.url).pathname,
       "@kavo/nest": new URL("./packages/frameworks/nest/src/index.ts", import.meta.url).pathname,
       "@kavo/graphql": new URL("./packages/protocols/graphql/src/index.ts", import.meta.url).pathname,
       "@kavo/mcp": new URL("./packages/protocols/mcp/src/index.ts", import.meta.url).pathname,


### PR DESCRIPTION
## What

Adds `@kavo/mikroorm` (`packages/orms/mikroorm`), the fourth `orms/*` adapter: `RepositoryAdapter` over a MikroORM `EntityManager`, with the metadata seam fed from MikroORM's own `MetadataStorage`.

Closes #102

## Why this shape

MikroORM sits between the two existing SQL adapters — TypeORM's entity model (real decorated runtime classes carrying their own metadata) with Prisma's query surface (a declarative `FilterQuery` that nests relation paths natively). So the metadata seam mirrors `@kavo/typeorm` and the translation seam mirrors `@kavo/prisma`. No marker classes (ADR-0017), and no ADR of its own: the class passed to `createCrud` is the class MikroORM registered.

Four adapter-specific decisions, all documented in [doc 17](docs/internals/architecture/17-mikroorm-adapter.md):

- **Every operation forks its own `EntityManager`.** MikroORM is a Unit-of-Work ORM whose EM owns an identity map; sharing one across requests would serve stale rows. That is why `createInfrastructure` takes the `MikroORM` instance rather than an EM — it needs something to fork from.
- **Rows convert with `wrap().toObject()` at the boundary.** Required, not cosmetic: a to-many is a `Collection`, not an array, and core's `DefaultSerializer` branches on `Array.isArray` — a `Collection` would fall down the single-row path and serialize its internals. `@kavo/mongoose` converts at the same seam for the same reason.
- **`IncludeNode.strategy` is ignored**, as in `@kavo/prisma`. MikroORM resolves `populate` with its own queries and applies `limit`/`offset` to the root either way, so the join/batch split has nothing to control here.
- **`softDeleteField` is always `null`.** MikroORM's soft-delete pattern is a user-defined `@Filter` — a query concern, not a column declaration — so `softDelete.field` must be configured.

## Two calls worth a reviewer's eye

**`caseInsensitiveFilters` defaults to `false`**, where `@kavo/prisma`'s identically-named option defaults to `true`. `$ilike` is PostgreSQL-only and every other driver takes the token verbatim and fails with a syntax error, so the failure modes are not symmetric: off on Postgres costs case-insensitivity, on anywhere else makes *every* `ILIKE` query throw. On SQLite it isn't even a loss — its `LIKE` is already ASCII case-insensitive.

**Empty groups are spelled as an empty `$in` on the primary key.** MikroORM renders `$not: {}` as match-*everything*, the opposite of what an empty `NOT` group means, and rejects an empty `$and`/`$or` outright. An empty `$in` is the one portable contradiction. Verified against the real driver, not assumed.

## Public API impact

New package barrel only — `@kavo/core`'s barrel is untouched, and core has no changes at all. Exports: `MikroOrmRepositoryAdapter`, `buildEntityMetadata`, `mapDriverError`, `translateFilter` + `MikroWhere` + `FilterTranslatorOptions`, `createInfrastructure` / `createMikroOrmKavo` / `MikroOrmInfrastructureOptions`, and `toPlain` / `toPlainAll`.

That last pair is a deliberate call rather than an oversight: it has no consumer outside the package today, but it is the documented boundary conversion and belongs alongside the other seams an adopter may need to reimplement. Say the word if you'd rather it stayed internal.

## Deviations from the issue

- **Doc is `17-`, not `16-`** — `16-mcp-binding.md` already exists; the issue said "next available number."
- **Peer is `^6.0.0`, not `^6 || ^7`.** MikroORM v7 removed decorators entirely for `defineEntity`/`EntitySchema`, invalidating the premise the entity-identity design rests on. Not claimed until tested.
- **No transaction plumbing.** Parity here *is* absence: `@kavo/typeorm` never reads `context.transaction` either, and core's `TransactionManager` has no consumer. Building one would exceed "adapter parity only."

## Testing

`pnpm check` green: **63 files, 1054 tests**. `pnpm docs:links`, `pnpm docs:build`, `pnpm format:check` all green.

91 new tests across 5 spec files, on real SQLite rather than mocks, matching the other adapters' conventions: adapter CRUD/query behaviour, filter-translator units, error mapping, includes, soft delete, metadata derivation.

Two of them exist because the implementation found real problems:

- **Embeddable child properties leaked.** MikroORM exposes both the addressable parent and one child per inner column (`address~city`, `billing_city`); unfiltered they land in derived DTOs and allowlists as unusable wire fields. Now dropped, with a test.
- **Relation deep-write.** Core only narrows a relation to `{ id }` when the *target* is in its catalog, so a relation whose target was never `createCrud`-ed arrives as whatever the client sent. An object carrying no id now becomes `null` rather than reaching `em.create`, which would leave a nested write one cascade setting away from working (ADR-0014). Regression test included.

## Review notes

- **The depcruise change is more than the one new rule.** Besides `mikroorm-only-imports-core`, `mikroorm` joins the four `to:` alternations that guard *other* packages against importing an adapter. Without those, a bare `@kavo/mikroorm` specifier from core or a protocol would pass a green `depcruise` — exactly the gap CLAUDE.md warns about.
- **One tooling change.** `@mikro-orm/better-sqlite@6` pins `better-sqlite3@^11`, whose prebuilds stop before current Node, so install fails outright. The root manifest carries a **scoped** `pnpm.overrides` entry (`"@mikro-orm/better-sqlite>better-sqlite3"`) raising that dependency alone — `@kavo/typeorm`'s own SQLite resolution is untouched. Explained in CONTRIBUTING.
- **The docs sweep is deliberately wider than the issue asked.** Docs 01/02/06/11/12 carried claims an eighth package falsifies — notably "only `@kavo/typeorm` acts on the join/batch distinction" — and CLAUDE.md/CONTRIBUTING.md counted seven packages. `publish.yml` and `/publish`'s table also needed the new entry, which `tests/release-workflow.spec.ts` gates against the real workspace.
- **`ToolLogoStrip.vue` is untouched.** The homepage logo strip needs an SVG path I don't have, and fabricating a logo is worse than omitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
