### PR TITLE
feat(nest-typeorm): add CockroachDB flavour to the example app

### DIFF
--- a/examples/nest-mikroorm/README.md
+++ b/examples/nest-mikroorm/README.md
@@ -26,6 +26,15 @@ docker run --rm -e POSTGRES_PASSWORD=kavo -p 5432:5432 postgres:18-alpine
 pnpm build && PGDATABASE=postgres PGPASSWORD=kavo pnpm --filter @kavo/example-nest-mikroorm start
 ```
 
+Unlike `nest-typeorm`, this app has no CockroachDB flavour: MikroORM has no
+dedicated CockroachDB driver, and pointing `@mikro-orm/postgresql` (which
+runs on `knex`) at Cockroach's Postgres-wire-compatible port doesn't work —
+`knex`'s Postgres dialect runs `SELECT version()` on every new connection
+and regex-parses the result to detect the server version; CockroachDB's
+version string doesn't match that pattern, so the parse returns `null` and
+the connection pool throws on every acquire. That's a `knex`/CockroachDB
+incompatibility, not something this app's wiring can work around.
+
 ## What differs from `nest-typeorm`
 
 **Soft delete is declared, not inferred.** `Owner` is soft-deletable in both

--- a/examples/nest-typeorm/README.md
+++ b/examples/nest-typeorm/README.md
@@ -35,7 +35,7 @@ pnpm build && pnpm --filter @kavo/example-nest-typeorm start:postgres
 The e2e suite (`tests/app-postgres.e2e.spec.ts`) needs none of this set up
 by hand — it self-provisions a Postgres container via Testcontainers and
 passes that container's connection options straight to
-`AppModule.forRoot(...)`, so `pnpm check`/`pnpm test` exercises all three
+`AppModule.forRoot(...)`, so `pnpm check`/`pnpm test` exercises all four
 databases with no manual step. This does require a running Docker daemon
 wherever those commands run.
 
@@ -52,6 +52,22 @@ pnpm build && pnpm --filter @kavo/example-nest-typeorm start:mariadb
 
 The e2e suite (`tests/app-mariadb.e2e.spec.ts`) self-provisions a MariaDB
 container via Testcontainers the same way the Postgres suite does — no
+manual setup, just a running Docker daemon.
+
+## CockroachDB
+
+`main-cockroach.ts` boots the same app against a real CockroachDB instance,
+with connection settings hardcoded to match a single local container:
+
+```bash
+docker run --rm -e COCKROACH_DATABASE=kavo -e COCKROACH_USER=root -p 26257:26257 cockroachdb/cockroach:v25.2.22 start-single-node --insecure
+pnpm build && pnpm --filter @kavo/example-nest-typeorm start:cockroach
+# → http://localhost:3000/cats   (Swagger at /docs)
+```
+
+`--insecure` mode has no password, unlike the Postgres and MariaDB flavours.
+The e2e suite (`tests/app-cockroach.e2e.spec.ts`) self-provisions a
+CockroachDB container via Testcontainers the same way the other two do — no
 manual setup, just a running Docker daemon.
 
 Try it:
@@ -75,10 +91,11 @@ POST   /cats                     {"name":"Kit","age":1,"owner":1}   # associate 
 
 The e2e suite in `tests/` is the executable form of the behavior spec.
 `crud-e2e.suite.ts` holds the shared assertions; `app.e2e.spec.ts`,
-`app-postgres.e2e.spec.ts`, and `app-mariadb.e2e.spec.ts` each boot the app
-against their own database and run the same suite against it — one
-behavioral spec, three drivers. This app grows into a fuller reference
-application (`User`, `Project`, `Task`, `Comment`, `Tag`).
+`app-postgres.e2e.spec.ts`, `app-mariadb.e2e.spec.ts`, and
+`app-cockroach.e2e.spec.ts` each boot the app against their own database and
+run the same suite against it — one behavioral spec, four drivers. This app
+grows into a fuller reference application (`User`, `Project`, `Task`,
+`Comment`, `Tag`).
 
 The app consumes only public package APIs — if it ever needs a deep
 import, that is an API-surface bug in the package, not the app.

--- a/examples/nest-typeorm/package.json
+++ b/examples/nest-typeorm/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -b",
     "start": "node dist/main.js",
     "start:postgres": "node dist/main-postgres.js",
-    "start:mariadb": "node dist/main-mariadb.js"
+    "start:mariadb": "node dist/main-mariadb.js",
+    "start:cockroach": "node dist/main-cockroach.js"
   },
   "dependencies": {
     "@kavo/core": "workspace:*",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^11.0.0",
+    "@testcontainers/cockroachdb": "^12.0.4",
     "@testcontainers/mariadb": "^12.0.4",
     "@testcontainers/postgresql": "^12.0.4",
     "@types/supertest": "^7.2.1",

--- a/examples/nest-typeorm/src/database.module.ts
+++ b/examples/nest-typeorm/src/database.module.ts
@@ -27,17 +27,28 @@ export interface MariaDbOptions extends ConnectionOptions {
   type: "mariadb";
 }
 
+/**
+ * CockroachDB's default `--insecure` mode (used locally and in the e2e
+ * container) has no password, so unlike the other two drivers it is
+ * optional here.
+ */
+export interface CockroachDbOptions extends Omit<ConnectionOptions, "password"> {
+  type: "cockroachdb";
+  password?: string;
+}
+
 /** The driver a real (non-SQLite) `forRoot(...)` call picks. */
-export type SqlOptions = PostgresOptions | MariaDbOptions;
+export type SqlOptions = PostgresOptions | MariaDbOptions | CockroachDbOptions;
 
 /**
  * One `DataSource` for the whole app. `forRoot()` (no argument) defaults to
  * an in-memory SQLite database, keeping the demo (and its e2e suite)
- * dependency-free; `forRoot(sql)` switches the same app to a real Postgres
- * or MariaDB instance instead, picked by `sql.type` — see
+ * dependency-free; `forRoot(sql)` switches the same app to a real Postgres,
+ * MariaDB, or CockroachDB instance instead, picked by `sql.type` — see
  * `examples/nest-typeorm/README.md` for the `docker run` used locally for
  * each, and `tests/app-postgres.e2e.spec.ts` / `tests/app-mariadb.e2e.spec.ts`
- * for how the e2e suite self-provisions one via Testcontainers.
+ * / `tests/app-cockroach.e2e.spec.ts` for how the e2e suite self-provisions
+ * one via Testcontainers.
  *
  * Global so `DATA_SOURCE` is injectable straight into any `@Kavo`
  * controller (e.g. `AddressController`'s `@Override`'d methods), not just
@@ -55,11 +66,11 @@ export class DatabaseModule {
           provide: DATA_SOURCE,
           useFactory: async (): Promise<DataSource> => {
             const dataSource = sql
-              ? new DataSource({
-                  ...sql,
-                  entities,
-                  synchronize: true,
-                })
+              ? new DataSource(
+                  sql.type === "cockroachdb"
+                    ? { ...sql, entities, synchronize: true, timeTravelQueries: false }
+                    : { ...sql, entities, synchronize: true },
+                )
               : new DataSource({
                   type: "better-sqlite3",
                   database: ":memory:",

--- a/examples/nest-typeorm/src/main-cockroach.ts
+++ b/examples/nest-typeorm/src/main-cockroach.ts
@@ -1,0 +1,37 @@
+import "reflect-metadata";
+import { NestFactory } from "@nestjs/core";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { AppModule } from "./app.module.js";
+
+// Matches the `docker run` command in examples/nest-typeorm/README.md.
+const COCKROACHDB_OPTIONS = {
+  type: "cockroachdb",
+  host: "localhost",
+  port: 26257,
+  username: "root",
+  database: "kavo",
+} as const;
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule.forRoot(COCKROACHDB_OPTIONS));
+
+  const document = SwaggerModule.createDocument(
+    app,
+    new DocumentBuilder()
+      .setTitle("Kavo — Pet example (CockroachDB)")
+      .setDescription(
+        "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
+          "sorting, pagination, layered config, and RFC 9457 problem-details " +
+          "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
+          "model the schema, with opt-in relation includes " +
+          "(`?include=owner`, `?include=pets`) and soft delete on owners.",
+      )
+      .setVersion("0.0.0")
+      .build(),
+  );
+  SwaggerModule.setup("docs", app, document);
+
+  await app.listen(3000);
+}
+
+void bootstrap();

--- a/examples/nest-typeorm/tests/app-cockroach.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/app-cockroach.e2e.spec.ts
@@ -1,0 +1,46 @@
+import "reflect-metadata";
+import { afterAll, beforeAll } from "vitest";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { CockroachDbContainer, type StartedCockroachDbContainer } from "@testcontainers/cockroachdb";
+import { AppModule } from "../src/app.module.js";
+import { registerCrudE2eSuite } from "./crud-e2e.suite.js";
+import { listen } from "./support/listen.js";
+
+/**
+ * Same suite as `app.e2e.spec.ts`, run against a real CockroachDB instead of
+ * in-memory SQLite. `AppModule.forRoot(cockroach)` takes the connection
+ * options directly — no manual CockroachDB setup needed to run `pnpm check`,
+ * since the options come from a container this test provisions itself.
+ *
+ * CockroachDB's `--insecure` mode (what the container and
+ * `main-cockroach.ts` both run) has no password, unlike the Postgres and
+ * MariaDB flavours.
+ */
+let container: StartedCockroachDbContainer;
+let app: INestApplication;
+
+beforeAll(async () => {
+  container = await new CockroachDbContainer("cockroachdb/cockroach:v25.2.22").start();
+
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      AppModule.forRoot({
+        type: "cockroachdb",
+        host: container.getHost(),
+        port: container.getPort(),
+        username: container.getUsername(),
+        database: container.getDatabase(),
+      }),
+    ],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  await listen(app);
+}, 240_000);
+
+afterAll(async () => {
+  if (app !== undefined) await app.close();
+  if (container !== undefined) await container.stop();
+}, 30_000);
+
+registerCrudE2eSuite(() => app);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@nestjs/testing':
         specifier: ^11.0.0
         version: 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.28)
+      '@testcontainers/cockroachdb':
+        specifier: ^12.0.4
+        version: 12.0.4
       '@testcontainers/mariadb':
         specifier: ^12.0.4
         version: 12.0.4
@@ -1392,6 +1395,9 @@ packages:
 
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
+
+  '@testcontainers/cockroachdb@12.0.4':
+    resolution: {integrity: sha512-IKM3p9w2+jxyE5tVXonOVQtzECPyMf/yO3snHOrzEX2lvLyVMVUrB8Tn7RwCIPB1jQhGwBbr0H+ZUjmEsRXdIQ==}
 
   '@testcontainers/mariadb@12.0.4':
     resolution: {integrity: sha512-AdMFF4VfzBq2brV5Ol9OAx4CSrK5u0kRromNv0pSsp6LTK0JEBGyj5JysRo9CMHnsbG5X4I2jkfhAZsonUoBWw==}
@@ -4715,6 +4721,15 @@ snapshots:
   '@swc/types@0.1.28':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@testcontainers/cockroachdb@12.0.4':
+    dependencies:
+      testcontainers: 12.0.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   '@testcontainers/mariadb@12.0.4':
     dependencies:


### PR DESCRIPTION
## What & why

Adds a CockroachDB flavour to the `nest-typeorm` reference app, mirroring the existing Postgres and MariaDB flavours: `main-cockroach.ts`, a `start:cockroach` script, `CockroachDbOptions` in `DatabaseModule`, and an e2e suite (`tests/app-cockroach.e2e.spec.ts`) that self-provisions a container via Testcontainers and runs the same shared CRUD assertions as the other three drivers. TypeORM ships a native `cockroachdb` driver over the existing `pg` peer dependency, so no new runtime deps were needed — only the `@testcontainers/cockroachdb` devDependency for the e2e suite.

`nest-mikroorm` was investigated too, but not extended: MikroORM has no dedicated CockroachDB driver, and reusing `@mikro-orm/postgresql` against Cockroach's Postgres-wire-compatible port doesn't work — verified by spiking it against a live container. `knex`'s Postgres dialect runs `SELECT version()` on every new connection and regex-parses the result; CockroachDB's version string doesn't match that pattern, so the parse returns `null` and the connection pool throws on every acquire. That's a `knex`/CockroachDB incompatibility, not something fixable from this app's wiring, so the `nest-mikroorm` README documents it as a known limitation instead.

## Public API impact

None — example-app-only change, no `@kavo/*` package touched.

## Testing

- New: `examples/nest-typeorm/tests/app-cockroach.e2e.spec.ts` — self-provisions `cockroachdb/cockroach:v25.2.22` via Testcontainers and runs the full shared `crud-e2e.suite.ts` (50 assertions) against it.
- Manually verified the README's `docker run` command (`-e COCKROACH_DATABASE=kavo -e COCKROACH_USER=root ... start-single-node --insecure`) against a live container and confirmed `main-cockroach.ts`'s hardcoded connection options connect successfully.
- `pnpm check`: green — 67 test files, 1185 tests passing.
- `pnpm docs:links`: green.

## Review notes

- `DatabaseModule.forRoot` branches on `sql.type === "cockroachdb"` to add TypeORM's required `timeTravelQueries: false` option — that field only exists on `CockroachDataSourceOptions`, so it can't be spread unconditionally into the union without breaking the Postgres/MariaDB variants.
- CockroachDB's `--insecure` mode has no password, so `CockroachDbOptions` makes `password` optional unlike the other two driver option types.