### PR TITLE
fix(core): stop a __proto__ bracket segment polluting Object.prototype, and cover the query grammar

### DIFF
--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -60,7 +60,9 @@ fields:     root: [id, name, email]
 - **Multi-value operators** (`in`, `notIn`): comma-separated by default;
   the repeated-key form `filter[status][in][]=a&filter[status][in][]=b`
   is also accepted.
-- **`between`:** exactly two comma-separated bounds.
+- **`between`:** exactly two comma-separated bounds, in the order given —
+  the pair is never sorted, so `between=65,18` is an empty range rather
+  than a silently corrected one.
 - **`isNull` / `isNotNull`:** boolean-valued. `false` flips to the
   complementary operator (`isNull=false` ≡ `isNotNull=true`), so both
   spellings mean what they read as.
@@ -104,10 +106,15 @@ LOWER(:v)`), identical on every driver. Both operators apply to string
   pass `FieldSelectionInput`, whose three spellings mirror these wire forms
   and collapse to the same normalized selection (doc 03).
 - **Soft delete:** `withDeleted=true` includes soft-deleted rows, which
-  are otherwise excluded from every read (doc 11). On an entity
-  that is not soft-deletable it is rejected with
+  are otherwise excluded from every read (doc 11); `onlyDeleted=true`
+  narrows a read to _only_ those rows — the trash view — and applies to
+  single-row reads as well as lists. On an entity
+  that is not soft-deletable either is rejected with
   `KAVO_QUERY_UNSUPPORTED_PARAM`, not ignored; a non-boolean value is a
-  field-level 400.
+  field-level 400. The two are contradictory ("everything" vs. "only the
+  deleted"), so sending both is `KAVO_QUERY_CONFLICTING_PARAMS`. Neither
+  flag changes include resolution: a trash-view read resolves `include=`
+  exactly as a live one does.
 - **Includes:** `include=posts.comments,profile` — comma-separated
   dot-paths, merged into one validated tree (doc 12). A
   relation that is not on the entity's inclusion allowlist is a 400, never
@@ -140,6 +147,15 @@ LOWER(:v)`), identical on every driver. Both operators apply to string
   in that map and passes through as a string. Include resolution and
   fieldset validation wire in the target entity's config (doc 12), but
   filter-value coercion does not.
+- **Reserved keys:** the bracket tree is built from attacker-controlled
+  segments **before** any allowlist check, so it is built on
+  prototype-less objects. `filter[__proto__][x]=v` therefore assigns an
+  ordinary own key and is rejected as a non-allowlisted field
+  (`KAVO_QUERY_INVALID_FIELD`) rather than writing through to
+  `Object.prototype`. The same applies to `fields[__proto__]`, and the
+  deserializer reads request bodies with an own-property check, so a
+  prototype polluted by anything else in the host application still cannot
+  add a writable field to a request that omitted it.
 - **One exception, all issues:** every violation across filter, sort,
   fields, and pagination is collected into a single
   `QueryValidationException`, so a client fixes its request in one round
@@ -153,7 +169,8 @@ raw query string (flat bracket keys)
   → sort / fields parsing (allowlists)
   → PaginationStrategy    (defaultLimit / maxLimit / 400s)
   → NormalizedQueryContext  { filter, sort, pagination, fields,
-                              include: {}, withDeleted: false, count }
+                              include: {}, withDeleted: false,
+                              onlyDeleted: false, count }
 ```
 
 `QueryNormalizer.normalizeWire` runs the whole pipeline for HTTP input

--- a/packages/core/src/query/default-filter-parser.ts
+++ b/packages/core/src/query/default-filter-parser.ts
@@ -112,7 +112,10 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
 
   /** Fold every `filter[...]` param into one nested node tree. */
   private collectBracketTree(rawParams: Readonly<Record<string, unknown>>): Record<string, unknown> | null {
-    const tree: Record<string, unknown> = {};
+    // Null-prototype: segments are attacker-controlled, and on a plain `{}`
+    // the segment `__proto__` resolves to `Object.prototype` — `assignPath`
+    // would then walk into it and write there. See {@link emptyNode}.
+    const tree = emptyNode();
     let found = false;
     for (const [key, value] of Object.entries(rawParams)) {
       const segments = parseBracketKey(key, "filter");
@@ -381,6 +384,27 @@ function expressionDepth(expression: FilterExpression<unknown>): number {
 }
 
 /**
+ * A tree node with **no prototype**, which is what makes the bracket grammar
+ * safe to build from untrusted keys.
+ *
+ * On an ordinary `{}`, reading the key `__proto__` yields `Object.prototype`
+ * rather than `undefined`, so `filter[__proto__][withDeleted]=true` would
+ * have `assignPath` walk into the prototype and assign there — polluting
+ * every object in the process. The pollution then rides the prototype chain
+ * into `rawParams["withDeleted"]`, `rawParams["limit"]` and the `key in
+ * source` check in the deserializer, so one anonymous request could hand
+ * every later request a filter, a soft-delete flag, or an extra body field.
+ *
+ * With no prototype there is nothing to walk into: `__proto__` becomes an
+ * ordinary own key and fails the filterable allowlist like any other unknown
+ * field — a 400, not a silent drop and not a write. `Object.entries`,
+ * `typeof`, and the rest of this file behave identically on these objects.
+ */
+function emptyNode(): Record<string, unknown> {
+  return Object.create(null) as Record<string, unknown>;
+}
+
+/**
  * Set `value` at `segments` in a nested record. A trailing empty segment
  * (the repeated-key form `filter[status][in][]=a&filter[status][in][]=b`)
  * appends into an array at the parent key instead.
@@ -397,7 +421,7 @@ function assignPath(tree: Record<string, unknown>, segments: readonly string[], 
     if (typeof existing === "object" && existing !== null && !Array.isArray(existing)) {
       node = existing as Record<string, unknown>;
     } else {
-      const next: Record<string, unknown> = {};
+      const next = emptyNode();
       node[segment] = next;
       node = next;
     }

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -387,7 +387,12 @@ function parseFields<Entity>(
   // `fields[posts.comments]=id,body` — the key is the relation path. The
   // include resolver validates it against the *target* entity's allowlist,
   // so nothing beyond shape is checked here.
-  const relations: Record<string, readonly string[]> = {};
+  //
+  // Null-prototype, for the same reason the filter parser builds its tree
+  // that way: the key is attacker-controlled, and `relations["__proto__"] =
+  // [...]` on an ordinary object invokes the prototype setter — the fieldset
+  // silently vanishes instead of reaching the resolver and being rejected.
+  const relations: Record<string, readonly string[]> = Object.create(null);
   for (const key of Object.keys(rawParams)) {
     const segments = parseBracketKey(key, "fields");
     if (segments === null || segments.length !== 1 || segments[0] === "") continue;

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -160,7 +160,13 @@ export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entit
     const source = raw as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const key of allowed) {
-      if (!(key in source)) continue;
+      // Own properties only. `raw` is a wire body, so an inherited key is
+      // never something the client sent — but it *is* something a polluted
+      // `Object.prototype` would supply, silently adding a writable field to
+      // every request that omits it. Defence in depth: the filter parser no
+      // longer offers a way to pollute (see `emptyNode` there), and this
+      // keeps a pollution introduced anywhere else out of writes.
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
       const idField = this.relationIdFields.get(key)?.();
       result[key] = idField === undefined ? source[key] : associate(source[key], idField);
     }

--- a/packages/core/tests/filter-parser.spec.ts
+++ b/packages/core/tests/filter-parser.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { FilterCondition, FilterGroup } from "@kavo/core";
 import { DefaultFilterParser, resolveEntityConfig } from "@kavo/core";
 import { userMetadata } from "./support/user-fixture.js";
@@ -283,6 +283,61 @@ describe("DefaultFilterParser — malformed bracket keys", () => {
     const issues = issuesOf(() => parse({ [key]: value }));
     expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_OPERATOR" });
     expect(issues[0]?.detail).toContain("filter[age][operator]=value");
+  });
+
+  /**
+   * Regression: `filter[__proto__][x]=v` used to walk into `Object.prototype`
+   * and assign there, because on an ordinary `{}` the key `__proto__` reads
+   * back as the prototype rather than `undefined`. One anonymous GET then
+   * handed every later request in the process a soft-delete flag, a filter,
+   * a pagination limit, or an extra writable body field — the parser's tree
+   * is built before any allowlist check, so the segment never had to be
+   * filterable to get there.
+   */
+  describe("reserved prototype keys", () => {
+    const reserved = ["__proto__", "constructor", "prototype"];
+
+    afterEach(() => {
+      // A leak here would silently arm every later test in the run, so the
+      // guard is unconditional rather than part of one assertion.
+      for (const key of ["withDeleted", "limit", "polluted"]) {
+        delete (Object.prototype as Record<string, unknown>)[key];
+      }
+    });
+
+    it.each(reserved)("does not write through a '%s' segment", (segment) => {
+      issuesOf(() => parse({ [`filter[${segment}][withDeleted]`]: "true" }));
+      expect(Object.prototype.hasOwnProperty.call(Object.prototype, "withDeleted")).toBe(false);
+      expect(({} as Record<string, unknown>)["withDeleted"]).toBeUndefined();
+    });
+
+    it.each(reserved)("rejects a '%s' segment as a non-allowlisted field", (segment) => {
+      // Fail closed and loudly: it is an unknown field like any other, not a
+      // silently dropped key.
+      const issues = issuesOf(() => parse({ [`filter[${segment}][eq]`]: "x" }));
+      expect(issues[0]).toMatchObject({ field: segment, code: "KAVO_QUERY_INVALID_FIELD" });
+    });
+
+    it("does not write through the JSON escape hatch either", () => {
+      // Written as a literal, not via `JSON.stringify({ __proto__: … })` —
+      // in an object literal that key *sets* the prototype, so stringify
+      // would emit `{}` and the test would pass vacuously. `JSON.parse` is
+      // the safe direction (it defines an own property), and the own key
+      // then meets the allowlist like any other unknown field.
+      const issues = issuesOf(() => parse({ filter: String.raw`{"__proto__":{"polluted":{"eq":"x"}}}` }));
+      expect(issues[0]).toMatchObject({ field: "__proto__", code: "KAVO_QUERY_INVALID_FIELD" });
+      expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+    });
+
+    it("keeps a legitimately nested path working", () => {
+      // The guard must not cost the ordinary nested case anything.
+      const root = parse({
+        "filter[or][0][name][eq]": "admin",
+        "filter[or][1][age][gte]": "18",
+      }).root as FilterGroup;
+      expect(root.operator).toBe("OR");
+      expect(root.children).toHaveLength(2);
+    });
   });
 
   it("reports a malformed logical group under its bracketed wire key", () => {

--- a/packages/core/tests/filter-parser.spec.ts
+++ b/packages/core/tests/filter-parser.spec.ts
@@ -75,15 +75,8 @@ describe("DefaultFilterParser — isNull / isNotNull symmetry", () => {
 });
 
 describe("DefaultFilterParser — bracket grammar", () => {
-  it("parses a single comparison with coercion", () => {
-    const filter = parse({ "filter[age][gte]": "18" });
-    expect(filter.root).toEqual({
-      kind: "condition",
-      field: "age",
-      operator: "GTE",
-      value: 18,
-    });
-  });
+  // The single-comparison case is the `gte` row of the operator table above;
+  // repeating it here would mean two tests to update for one contract.
 
   it("ANDs multiple filter params implicitly", () => {
     const filter = parse({
@@ -111,14 +104,6 @@ describe("DefaultFilterParser — bracket grammar", () => {
       (child): child is FilterCondition => child.kind === "condition" && child.operator === "IN",
     );
     expect(inCondition?.value).toEqual(["active", "pending"]);
-  });
-
-  it("accepts the repeated-key form for IN", () => {
-    const filter = parse({ "filter[status][in][]": ["active", "pending"] });
-    expect(filter.root).toMatchObject({
-      operator: "IN",
-      value: ["active", "pending"],
-    });
   });
 
   it("builds NOT groups with a single child", () => {
@@ -232,10 +217,11 @@ describe("DefaultFilterParser — IN / NOT_IN value lists", () => {
   });
 
   it("carries an empty value list through as an empty array", () => {
-    // The repeated-key form is the only spelling that can produce one (a
-    // bare `in=` splits to `[""]`, which fails coercion). Adapters spell the
-    // empty set as a contradiction/tautology rather than emitting `IN ()`,
-    // so the AST has to reach them able to say "no values" at all.
+    // No wire spelling produces one — `in=` splits to `[""]` and `in[]=` to
+    // `[""]` too — so this shape reaches the parser only from a
+    // programmatic caller. It still has to survive: adapters spell the empty
+    // set as a contradiction/tautology rather than emitting `IN ()`, so the
+    // AST must be able to say "no values" at all.
     for (const [token, operator] of [
       ["in", "IN"],
       ["notIn", "NOT_IN"],
@@ -249,9 +235,23 @@ describe("DefaultFilterParser — IN / NOT_IN value lists", () => {
     }
   });
 
-  it("rejects a bare empty value rather than reading it as the empty set", () => {
+  it("rejects a bare empty value on a typed column", () => {
     const issues = issuesOf(() => parse({ "filter[age][in]": "" }));
     expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("reads a bare empty value on a string column as a one-element list", () => {
+    // Current behavior, pinned so a change is visible rather than silent:
+    // string coercion accepts "", so `filter[name][in]=` is `IN ('')` — a
+    // live filter for the empty string, not the empty set and not a 400. A
+    // UI submitting an empty multi-select gets rows named "" rather than
+    // either of the two things it might have meant. Tracked in #113.
+    expect(parse({ "filter[name][in]": "" }).root).toEqual({
+      kind: "condition",
+      field: "name",
+      operator: "IN",
+      value: [""],
+    });
   });
 });
 
@@ -271,14 +271,29 @@ describe("DefaultFilterParser — malformed bracket keys", () => {
     expect(filter.root).toEqual({ kind: "condition", field: "age", operator: "GTE", value: 18 });
   });
 
-  it("rejects an empty operator segment as an unknown operator", () => {
-    const issues = issuesOf(() => parse({ "filter[age][]": "18" }));
+  // Both spellings below fail the *shape* check in `convertConditions` — the
+  // value is not an operator map — rather than the unknown-token branch in
+  // `buildCondition` (covered separately under "security posture"). They
+  // share `KAVO_QUERY_INVALID_OPERATOR`, so the `detail` is what tells the
+  // two branches apart and is asserted here for that reason.
+  it.each([
+    ["an empty operator segment", "filter[age][]", ["18"]],
+    ["no operator segment at all", "filter[age]", "18"],
+  ])("rejects %s as not an operator map", (_label, key, value) => {
+    const issues = issuesOf(() => parse({ [key]: value }));
     expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_OPERATOR" });
+    expect(issues[0]?.detail).toContain("filter[age][operator]=value");
   });
 
-  it("rejects a field with no operator segment at all", () => {
-    const issues = issuesOf(() => parse({ "filter[age]": "18" }));
-    expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_OPERATOR" });
+  it("reports a malformed logical group under its bracketed wire key", () => {
+    // The one issue shape whose `field` is a bracketed key rather than a
+    // bare column name — worth pinning, since a client parses these.
+    const notAGroup = issuesOf(() => parse({ "filter[or]": "banned" }));
+    expect(notAGroup[0]).toMatchObject({ field: "filter[or]", code: "KAVO_QUERY_INVALID_VALUE" });
+
+    const badBranch = issuesOf(() => parse({ filter: JSON.stringify({ or: ["x"] }) }));
+    expect(badBranch[0]).toMatchObject({ field: "filter[or]", code: "KAVO_QUERY_INVALID_VALUE" });
+    expect(badBranch[0]?.detail).toContain("branch");
   });
 });
 
@@ -351,6 +366,24 @@ describe("DefaultFilterParser — JSON escape hatch", () => {
     const issues = issuesOf(() => parse({ filter: "{nope" }));
     expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
   });
+
+  it("ANDs the two forms together when a request carries both", () => {
+    // Doc 05 §3 promises this explicitly, and it is the only place the two
+    // parse paths meet — `collectBracketTree` and `parseJsonFilter` each
+    // contribute a root, which `parse` folds into one AND.
+    const filter = parse({
+      "filter[age][gte]": "18",
+      filter: JSON.stringify({ status: { eq: "active" } }),
+    });
+    expect(filter.root).toEqual({
+      kind: "group",
+      operator: "AND",
+      children: [
+        { kind: "condition", field: "age", operator: "GTE", value: 18 },
+        { kind: "condition", field: "status", operator: "EQ", value: "active" },
+      ],
+    });
+  });
 });
 
 describe("DefaultFilterParser — security posture", () => {
@@ -405,8 +438,8 @@ describe("DefaultFilterParser — security posture", () => {
     expect(issues).toHaveLength(2);
   });
 
-  it("restricts LIKE to string columns", () => {
-    const issues = issuesOf(() => parse({ "filter[age][like]": "%1%" }));
-    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
+  it.each(["like", "ilike"])("restricts '%s' to string columns", (token) => {
+    const issues = issuesOf(() => parse({ [`filter[age][${token}]`]: "%1%" }));
+    expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" });
   });
 });

--- a/packages/core/tests/filter-parser.spec.ts
+++ b/packages/core/tests/filter-parser.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { FilterCondition, FilterGroup } from "@kavo/core";
 import { DefaultFilterParser, resolveEntityConfig } from "@kavo/core";
 import { userMetadata } from "./support/user-fixture.js";
+import { postMetadata } from "./support/blog-fixture.js";
 import { issuesOf } from "./support/query-issues.js";
 
 const config = resolveEntityConfig(userMetadata, undefined, undefined);
@@ -10,6 +11,68 @@ const parser = new DefaultFilterParser(userMetadata);
 function parse(params: Record<string, unknown>) {
   return parser.parse(params, config);
 }
+
+/**
+ * The operator table in `docs/internals/architecture/05-query-grammar.md` §1
+ * is the single source of truth for the wire-token ⇄ AST-enum mapping, and
+ * `OPERATOR_TOKENS` is proven *total* over `FilterOperator` at build time.
+ * Totality is not reachability, though: a token can be spelled wrong and
+ * still typecheck, so every row is exercised here through `parse()` — one
+ * case per row, in the doc's order.
+ */
+describe("DefaultFilterParser — the operator table", () => {
+  it.each([
+    ["eq", "status", "active", "EQ", "active"],
+    ["ne", "status", "banned", "NE", "banned"],
+    ["gt", "age", "18", "GT", 18],
+    ["gte", "age", "18", "GTE", 18],
+    ["lt", "age", "65", "LT", 65],
+    ["lte", "age", "65", "LTE", 65],
+    ["in", "status", "active,pending", "IN", ["active", "pending"]],
+    ["notIn", "status", "banned,pending", "NOT_IN", ["banned", "pending"]],
+    ["like", "name", "%john%", "LIKE", "%john%"],
+    ["ilike", "name", "%john%", "ILIKE", "%john%"],
+    ["between", "age", "18,65", "BETWEEN", [18, 65]],
+    ["isNull", "name", "true", "IS_NULL", true],
+    ["isNotNull", "name", "true", "IS_NOT_NULL", true],
+  ])("maps the wire token '%s' onto its AST operator", (token, field, raw, operator, value) => {
+    expect(parse({ [`filter[${field}][${token}]`]: raw }).root).toEqual({
+      kind: "condition",
+      field,
+      operator,
+      value,
+    });
+  });
+});
+
+/**
+ * `isNull` / `isNotNull` are boolean-valued, and `false` flips to the
+ * complementary operator rather than dropping the condition — so both
+ * spellings mean what they read as (doc 05 §3). All four combinations, since
+ * only asserting the `isNull` half would let the `isNotNull` flip regress.
+ */
+describe("DefaultFilterParser — isNull / isNotNull symmetry", () => {
+  it.each([
+    ["isNull", "true", "IS_NULL"],
+    ["isNull", "false", "IS_NOT_NULL"],
+    ["isNotNull", "true", "IS_NOT_NULL"],
+    ["isNotNull", "false", "IS_NULL"],
+  ])("reads %s=%s as %s", (token, flag, operator) => {
+    expect(parse({ [`filter[name][${token}]`]: flag }).root).toEqual({
+      kind: "condition",
+      field: "name",
+      operator,
+      value: true,
+    });
+  });
+
+  it("rejects a non-boolean value on either spelling", () => {
+    for (const token of ["isNull", "isNotNull"]) {
+      const issues = issuesOf(() => parse({ [`filter[name][${token}]`]: "yes" }));
+      expect(issues[0]).toMatchObject({ field: "name", code: "KAVO_QUERY_INVALID_VALUE" });
+    }
+  });
+});
 
 describe("DefaultFilterParser — bracket grammar", () => {
   it("parses a single comparison with coercion", () => {
@@ -65,19 +128,208 @@ describe("DefaultFilterParser — bracket grammar", () => {
     expect(root.children).toHaveLength(1);
   });
 
-  it("coerces dates and booleans; flips isNull=false", () => {
+  it("coerces a raw wire value against the column's metadata", () => {
     const date = parse({ "filter[createdAt][gte]": "2026-01-01" }).root as FilterCondition;
     expect(date.value).toBeInstanceOf(Date);
-
-    const flipped = parse({ "filter[name][isNull]": "false" }).root as FilterCondition;
-    expect(flipped.operator).toBe("IS_NOT_NULL");
   });
 
-  it("parses BETWEEN with exactly two bounds", () => {
+  it("builds an explicit top-level AND group, bracket and JSON alike", () => {
+    // Implicit AND (two `filter[...]` params) and `or`/`not` are covered
+    // above; the explicit `and` token is its own branch of `convertLogical`
+    // and would otherwise never be exercised.
+    const bracket = parse({
+      "filter[and][0][name][eq]": "admin",
+      "filter[and][1][age][gte]": "18",
+    });
+    const root = bracket.root as FilterGroup;
+    expect(root.operator).toBe("AND");
+    expect(root.children).toEqual([
+      { kind: "condition", field: "name", operator: "EQ", value: "admin" },
+      { kind: "condition", field: "age", operator: "GTE", value: 18 },
+    ]);
+
+    const json = parse({
+      filter: JSON.stringify({ and: [{ name: { eq: "admin" } }, { age: { gte: 18 } }] }),
+    });
+    expect(json).toEqual(bracket);
+  });
+});
+
+describe("DefaultFilterParser — BETWEEN bounds", () => {
+  it("parses exactly two bounds and rejects any other arity", () => {
     const filter = parse({ "filter[age][between]": "18,65" }).root as FilterCondition;
     expect(filter.value).toEqual([18, 65]);
-    const issues = issuesOf(() => parse({ "filter[age][between]": "1,2,3" }));
-    expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
+    for (const raw of ["1,2,3", "18"]) {
+      const issues = issuesOf(() => parse({ "filter[age][between]": raw }));
+      expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_VALUE");
+    }
+  });
+
+  it("coerces date bounds through the same column metadata", () => {
+    const filter = parse({
+      "filter[createdAt][between]": "2026-01-01,2026-06-01",
+    }).root as FilterCondition;
+    const [low, high] = filter.value as [Date, Date];
+    expect(low.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    expect(high.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("rejects a bound that fails coercion, on either side", () => {
+    for (const raw of ["abc,65", "18,abc"]) {
+      const issues = issuesOf(() => parse({ "filter[age][between]": raw }));
+      expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" });
+    }
+    const dates = issuesOf(() => parse({ "filter[createdAt][between]": "2026-01-01,not-a-date" }));
+    expect(dates[0]).toMatchObject({ field: "createdAt", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("keeps out-of-order bounds in wire order rather than swapping them", () => {
+    // The grammar promises two bounds, not a sorted pair. Silently swapping
+    // would make `between=65,18` — a range that matches nothing in SQL —
+    // quietly return rows the caller never asked for.
+    const filter = parse({ "filter[age][between]": "65,18" }).root as FilterCondition;
+    expect(filter.value).toEqual([65, 18]);
+  });
+});
+
+/**
+ * `like`/`ilike` are pure passthrough at this layer: no auto-wrapped
+ * wildcards, and the documented backslash escape for a literal `%`/`_`
+ * survives verbatim so the adapter can emit the matching `ESCAPE` clause
+ * (doc 05 §3). Each translator tests what it *does* with the pattern; this
+ * pins down that it receives the caller's pattern unaltered.
+ */
+describe("DefaultFilterParser — LIKE / ILIKE passthrough", () => {
+  it.each(["like", "ilike"])("never wraps a '%s' pattern in wildcards", (token) => {
+    const filter = parse({ [`filter[name][${token}]`]: "john" }).root as FilterCondition;
+    expect(filter.value).toBe("john");
+  });
+
+  it.each(["like", "ilike"])("passes the backslash escape for a literal %% or _ through '%s'", (token) => {
+    // The wire value is `100\%` / `a\_b`: a backslash the parser must not
+    // consume, unescape, or double.
+    expect((parse({ [`filter[name][${token}]`]: "100\\%" }).root as FilterCondition).value).toBe("100\\%");
+    expect((parse({ [`filter[name][${token}]`]: "a\\_b" }).root as FilterCondition).value).toBe("a\\_b");
+    expect((parse({ [`filter[name][${token}]`]: "a\\\\b" }).root as FilterCondition).value).toBe("a\\\\b");
+  });
+});
+
+describe("DefaultFilterParser — IN / NOT_IN value lists", () => {
+  it("accepts both wire spellings for either operator", () => {
+    for (const [token, operator] of [
+      ["in", "IN"],
+      ["notIn", "NOT_IN"],
+    ] as const) {
+      expect(parse({ [`filter[status][${token}]`]: "active,pending" }).root).toMatchObject({
+        operator,
+        value: ["active", "pending"],
+      });
+      expect(parse({ [`filter[status][${token}][]`]: ["active", "pending"] }).root).toMatchObject({
+        operator,
+        value: ["active", "pending"],
+      });
+    }
+  });
+
+  it("carries an empty value list through as an empty array", () => {
+    // The repeated-key form is the only spelling that can produce one (a
+    // bare `in=` splits to `[""]`, which fails coercion). Adapters spell the
+    // empty set as a contradiction/tautology rather than emitting `IN ()`,
+    // so the AST has to reach them able to say "no values" at all.
+    for (const [token, operator] of [
+      ["in", "IN"],
+      ["notIn", "NOT_IN"],
+    ] as const) {
+      expect(parse({ [`filter[status][${token}][]`]: [] }).root).toEqual({
+        kind: "condition",
+        field: "status",
+        operator,
+        value: [],
+      });
+    }
+  });
+
+  it("rejects a bare empty value rather than reading it as the empty set", () => {
+    const issues = issuesOf(() => parse({ "filter[age][in]": "" }));
+    expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+});
+
+describe("DefaultFilterParser — malformed bracket keys", () => {
+  it("treats a key that is not a well-formed filter path as no filter at all", () => {
+    // `parseBracketKey` returns null for each of these, so nothing is
+    // collected — the request carries no filter rather than a half-parsed
+    // one. Unit-tested on the key parser; asserted here through `parse()`,
+    // where the consequence (a `null` root, not a thrown error) lives.
+    for (const key of ["filter[age", "filter[age][gte]x", "filter[a]]", "filter[a]b[c]"]) {
+      expect(parse({ [key]: "18" })).toEqual({ root: null });
+    }
+  });
+
+  it("still parses the well-formed params alongside a malformed one", () => {
+    const filter = parse({ "filter[age": "1", "filter[age][gte]": "18" });
+    expect(filter.root).toEqual({ kind: "condition", field: "age", operator: "GTE", value: 18 });
+  });
+
+  it("rejects an empty operator segment as an unknown operator", () => {
+    const issues = issuesOf(() => parse({ "filter[age][]": "18" }));
+    expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_OPERATOR" });
+  });
+
+  it("rejects a field with no operator segment at all", () => {
+    const issues = issuesOf(() => parse({ "filter[age]": "18" }));
+    expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_OPERATOR" });
+  });
+});
+
+/**
+ * Relation-path filtering (`filter[author.name][eq]=Ada`) is allowlist-gated
+ * like everything else, and its value is *not* coerced: coercion consults
+ * the root entity's column metadata only, where a dotted path has no entry
+ * (doc 05 §4). Both halves are asserted through the real `parse()` path —
+ * `coerceScalar`/`parseBracketKey` are unit-tested in isolation elsewhere,
+ * which cannot show that the parser wires them together this way.
+ */
+describe("DefaultFilterParser — relation paths", () => {
+  const relationConfig = resolveEntityConfig(
+    postMetadata,
+    { allowlists: { filterable: ["title", "author.name"] } },
+    undefined,
+  );
+  const relationParser = new DefaultFilterParser(postMetadata);
+  const parseRelation = (params: Record<string, unknown>) => relationParser.parse(params, relationConfig);
+
+  it("keeps the dotted path as one field and leaves the value a string", () => {
+    expect(parseRelation({ "filter[author.name][eq]": "Ada" }).root).toEqual({
+      kind: "condition",
+      field: "author.name",
+      operator: "EQ",
+      value: "Ada",
+    });
+  });
+
+  it("passes a numeric-looking relation value through uncoerced", () => {
+    // `Post.id` is a number column, but `author.id` is not in this entity's
+    // column map — so the string reaches the adapter and the database
+    // compares it.
+    const relaxed = resolveEntityConfig(postMetadata, { allowlists: { filterable: ["author.id"] } }, undefined);
+    expect(relationParser.parse({ "filter[author.id][eq]": "7" }, relaxed).root).toMatchObject({ value: "7" });
+  });
+
+  it("rejects a relation path nobody allowlisted, exactly like a scalar column", () => {
+    // Allowlists default to the entity's own scalar columns, so a relation
+    // path is never filterable implicitly.
+    const issues = issuesOf(() => parseRelation({ "filter[comments.body][eq]": "x" }));
+    expect(issues[0]).toMatchObject({ field: "comments.body", code: "KAVO_QUERY_INVALID_FIELD" });
+  });
+
+  it("carries a relation path into a logical group unchanged", () => {
+    const root = parseRelation({
+      "filter[or][0][author.name][eq]": "Ada",
+      "filter[or][1][title][eq]": "First",
+    }).root as FilterGroup;
+    expect(root.operator).toBe("OR");
+    expect(root.children[0]).toMatchObject({ field: "author.name", value: "Ada" });
   });
 });
 

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -20,8 +20,8 @@ const softDeletableNormalizer = new QueryNormalizer(accountMetadata);
  * soft-delete flags — can meet in a single normalized request.
  */
 const postCatalog = new DefaultEntityCatalog((entity: ClassRef) => {
-  if ((entity as ClassRef) === Comment) return commentMetadata as unknown as EntityMetadata<object>;
-  if ((entity as ClassRef) === Author) return authorMetadata as unknown as EntityMetadata<object>;
+  if (entity === Comment) return commentMetadata as unknown as EntityMetadata<object>;
+  if (entity === Author) return authorMetadata as unknown as EntityMetadata<object>;
   return undefined;
 });
 const postConfig = resolveEntityConfig(
@@ -259,17 +259,21 @@ describe("QueryNormalizer — the whole grammar in one request", () => {
   });
 
   it("still collects issues from every section when they are combined", () => {
+    // Distinct bad names per section on purpose: with one shared name the
+    // three `KAVO_QUERY_INVALID_FIELD` issues are indistinguishable, so a
+    // regression where one section double-reported while another stopped
+    // reporting would produce the same multiset and pass.
     const issues = issuesOf(() =>
       postNormalizer.normalizeWire(
-        { ...wire, "filter[secret][eq]": "x", sort: "-secret", fields: "secret", limit: "abc" },
+        { ...wire, "filter[secretA][eq]": "x", sort: "-secretB", fields: "secretC", limit: "abc" },
         postConfig,
       ),
     );
-    expect(issues.map((issue) => issue.code).sort()).toEqual([
-      "KAVO_QUERY_INVALID_FIELD",
-      "KAVO_QUERY_INVALID_FIELD",
-      "KAVO_QUERY_INVALID_FIELD",
-      "KAVO_QUERY_INVALID_VALUE",
+    expect(issues).toEqual([
+      expect.objectContaining({ field: "secretA", code: "KAVO_QUERY_INVALID_FIELD" }),
+      expect.objectContaining({ field: "secretB", code: "KAVO_QUERY_INVALID_FIELD" }),
+      expect.objectContaining({ field: "secretC", code: "KAVO_QUERY_INVALID_FIELD" }),
+      expect.objectContaining({ field: "limit", code: "KAVO_QUERY_INVALID_VALUE" }),
     ]);
   });
 });

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { QueryNormalizer, resolveEntityConfig } from "@kavo/core";
+import type { ClassRef, EntityMetadata } from "@kavo/core";
+import { DefaultEntityCatalog, DefaultIncludeResolver, QueryNormalizer, resolveEntityConfig } from "@kavo/core";
 import { userMetadata } from "./support/user-fixture.js";
 import { accountMetadata } from "./support/account-fixture.js";
+import type { Post } from "./support/blog-fixture.js";
+import { Author, Comment, authorMetadata, commentMetadata, postMetadata } from "./support/blog-fixture.js";
 import { issuesOf } from "./support/query-issues.js";
 
 const config = resolveEntityConfig(userMetadata, undefined, undefined);
@@ -9,6 +12,24 @@ const normalizer = new QueryNormalizer(userMetadata);
 
 const softDeletableConfig = resolveEntityConfig(accountMetadata, undefined, undefined);
 const softDeletableNormalizer = new QueryNormalizer(accountMetadata);
+
+/**
+ * `Post` is the one fixture that is both soft-deletable (`deletedAt`) and
+ * relation-bearing, so it is the only place the whole grammar — filter,
+ * sort, pagination, root and relation fieldsets, includes, and the
+ * soft-delete flags — can meet in a single normalized request.
+ */
+const postCatalog = new DefaultEntityCatalog((entity: ClassRef) => {
+  if ((entity as ClassRef) === Comment) return commentMetadata as unknown as EntityMetadata<object>;
+  if ((entity as ClassRef) === Author) return authorMetadata as unknown as EntityMetadata<object>;
+  return undefined;
+});
+const postConfig = resolveEntityConfig(
+  postMetadata,
+  { relations: { edges: { comments: { includable: true } } } },
+  undefined,
+);
+const postNormalizer = new QueryNormalizer<Post>(postMetadata, [], new DefaultIncludeResolver<Post>(postCatalog));
 
 describe("QueryNormalizer — wire params", () => {
   it("normalizes the full reference query", () => {
@@ -182,6 +203,106 @@ describe("QueryNormalizer — onlyDeleted", () => {
   it("rejects a non-boolean onlyDeleted value", () => {
     const issues = issuesOf(() => softDeletableNormalizer.normalizeWire({ onlyDeleted: "yes" }, softDeletableConfig));
     expect(issues[0]).toMatchObject({ field: "onlyDeleted", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+});
+
+/**
+ * Every feature below is individually covered above; what these pin down is
+ * that they compose. Each section of the pipeline writes into one shared
+ * issue list and one shared result, so a regression that lets one section
+ * clobber another's output — or short-circuit the sections after it — is
+ * invisible to any single-feature test.
+ */
+describe("QueryNormalizer — the whole grammar in one request", () => {
+  const wire = {
+    "filter[title][like]": "%draft%",
+    "filter[authorId][eq]": "7",
+    sort: "-id,title",
+    limit: "5",
+    offset: "10",
+    fields: "id,title",
+    "fields[comments]": "id,body",
+    include: "comments",
+    onlyDeleted: "true",
+  };
+
+  it("normalizes filter, sort, pagination, fields, include and onlyDeleted together", () => {
+    const query = postNormalizer.normalizeWire(wire, postConfig);
+
+    expect(query.filter.root).toMatchObject({
+      kind: "group",
+      operator: "AND",
+      children: [
+        { field: "title", operator: "LIKE", value: "%draft%" },
+        { field: "authorId", operator: "EQ", value: 7 },
+      ],
+    });
+    expect(query.sort).toEqual([
+      { field: "id", direction: "desc" },
+      { field: "title", direction: "asc" },
+    ]);
+    expect(query.pagination).toEqual({ limit: 5, offset: 10 });
+    expect(query.fields).toEqual({ root: ["id", "title"], relations: { comments: ["id", "body"] } });
+    expect(query.onlyDeleted).toBe(true);
+    expect(query.withDeleted).toBe(false);
+    expect(query.count).toBe(true);
+  });
+
+  it("resolves the include tree in the same pass, fieldset attached", () => {
+    const query = postNormalizer.normalizeWire(wire, postConfig);
+    expect(Object.keys(query.include)).toEqual(["comments"]);
+    expect(query.include["comments"]).toMatchObject({
+      path: "comments",
+      fields: ["id", "body"],
+      strategy: "batch",
+    });
+  });
+
+  it("still collects issues from every section when they are combined", () => {
+    const issues = issuesOf(() =>
+      postNormalizer.normalizeWire(
+        { ...wire, "filter[secret][eq]": "x", sort: "-secret", fields: "secret", limit: "abc" },
+        postConfig,
+      ),
+    );
+    expect(issues.map((issue) => issue.code).sort()).toEqual([
+      "KAVO_QUERY_INVALID_FIELD",
+      "KAVO_QUERY_INVALID_FIELD",
+      "KAVO_QUERY_INVALID_FIELD",
+      "KAVO_QUERY_INVALID_VALUE",
+    ]);
+  });
+});
+
+/**
+ * A trash view is still a read: narrowing the root to soft-deleted rows must
+ * not change what `include=` resolves to. The flags and the include resolver
+ * are separate branches of `normalizeWire`, and the include branch runs
+ * before pagination — so a flag that short-circuited would silently strip
+ * relations from exactly the view that needs them most.
+ */
+describe("QueryNormalizer — include under the soft-delete flags", () => {
+  it("resolves the same include tree for a live, withDeleted, and onlyDeleted read", () => {
+    const live = postNormalizer.normalizeWire({ include: "comments" }, postConfig);
+    const withDeleted = postNormalizer.normalizeWire({ include: "comments", withDeleted: "true" }, postConfig);
+    const onlyDeleted = postNormalizer.normalizeWire({ include: "comments", onlyDeleted: "true" }, postConfig);
+
+    expect(Object.keys(live.include)).toEqual(["comments"]);
+    expect(withDeleted.include).toEqual(live.include);
+    expect(onlyDeleted.include).toEqual(live.include);
+    expect([live.withDeleted, live.onlyDeleted]).toEqual([false, false]);
+    expect([withDeleted.withDeleted, withDeleted.onlyDeleted]).toEqual([true, false]);
+    expect([onlyDeleted.withDeleted, onlyDeleted.onlyDeleted]).toEqual([false, true]);
+  });
+
+  it("reports the include failure and the flag conflict in one exception", () => {
+    const issues = issuesOf(() =>
+      postNormalizer.normalizeWire({ include: "ghosts", withDeleted: "true", onlyDeleted: "true" }, postConfig),
+    );
+    expect(issues).toContainEqual(expect.objectContaining({ field: "ghosts", code: "KAVO_QUERY_INVALID_FIELD" }));
+    expect(issues).toContainEqual(
+      expect.objectContaining({ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }),
+    );
   });
 });
 

--- a/packages/frameworks/nest/src/flatten-query.ts
+++ b/packages/frameworks/nest/src/flatten-query.ts
@@ -22,8 +22,14 @@ import { WireQuery } from "@kavo/core";
  * sorting, or field selection.
  */
 export function flattenQuery(query: Readonly<Record<string, unknown>>): Record<string, unknown> {
-  if (query instanceof WireQuery) return { ...query.params };
-  const flat: Record<string, unknown> = {};
+  // Null-prototype throughout: the normalizer reads single params straight
+  // off this object (`rawParams["withDeleted"]`, `rawParams["limit"]`), so
+  // on an ordinary object a polluted `Object.prototype` would be
+  // indistinguishable from a client-supplied param. It also makes
+  // `flat["__proto__"] = …` an ordinary assignment rather than a call into
+  // the prototype setter.
+  const flat = Object.create(null) as Record<string, unknown>;
+  if (query instanceof WireQuery) return Object.assign(flat, query.params);
   for (const [key, value] of Object.entries(query)) {
     flattenInto(flat, key, value);
   }

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -761,6 +761,17 @@ describe("@Kavo soft-delete routes", () => {
     expect(live.body.items).toEqual([expect.objectContaining({ id: 2, title: "still here" })]);
   });
 
+  it("applies onlyDeleted to a single-row read too", async () => {
+    // The list and the by-id path resolve visibility separately, in every
+    // real adapter as well as this fake, so the trash view has to be
+    // asserted on both — a by-id read that ignored the flag would 404 the
+    // row the list just handed the client.
+    await request(server()).delete("/todos/1").expect(204);
+    await request(server()).get("/todos/1").expect(404);
+    const trashed = await request(server()).get("/todos/1?onlyDeleted=true").expect(200);
+    expect(trashed.body).toMatchObject({ id: 1, title: "x" });
+  });
+
   it("maps withDeleted+onlyDeleted together to a 400 problem-details document", async () => {
     const response = await request(server())
       .get("/todos?withDeleted=true&onlyDeleted=true")
@@ -893,7 +904,11 @@ describe("@Kavo relation includes", () => {
     expect(Object.keys(adapter.lastQuery?.include ?? {})).toEqual(["list"]);
 
     // The envelope mirrors the request, and the included relation is still
-    // embedded on every item of the page.
+    // embedded on every item of the page. `total: 3` is not evidence the
+    // filter ran — this fake's `count()` ignores the filter, and all three
+    // rows match it anyway. The load-bearing assertions are the
+    // `adapter.lastQuery` ones above; filter *evaluation* belongs to the
+    // real adapters.
     expect(response.body).toMatchObject({ limit: 2, offset: 1, total: 3 });
     expect(response.body.items).toHaveLength(2);
     for (const item of response.body.items) {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -743,6 +743,48 @@ describe("@Kavo soft-delete routes", () => {
     expect(response.body.items).toHaveLength(1);
   });
 
+  it("narrows the list to the trash for onlyDeleted=true", async () => {
+    // The flag is unit-tested in core; what this pins down is that it
+    // survives the wire — the binding hands the engine flat query params,
+    // and a flag that never reached the normalizer would read as a
+    // plain live listing instead of a 400.
+    await request(server()).post("/todos").send({ title: "still here" }).expect(201);
+    await request(server()).delete("/todos/1").expect(204);
+
+    const trash = await request(server()).get("/todos?onlyDeleted=true").expect(200);
+    expect(trash.body).toMatchObject({ total: 1 });
+    expect(trash.body.items).toEqual([expect.objectContaining({ id: 1, title: "x" })]);
+    expect(adapter.lastQuery).toMatchObject({ onlyDeleted: true, withDeleted: false });
+
+    // …and the default view is still its complement.
+    const live = await request(server()).get("/todos").expect(200);
+    expect(live.body.items).toEqual([expect.objectContaining({ id: 2, title: "still here" })]);
+  });
+
+  it("maps withDeleted+onlyDeleted together to a 400 problem-details document", async () => {
+    const response = await request(server())
+      .get("/todos?withDeleted=true&onlyDeleted=true")
+      .expect(400)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body).toMatchObject({ status: 400, code: "KAVO_QUERY_INVALID" });
+    expect(response.body.errors).toContainEqual(
+      expect.objectContaining({ field: "onlyDeleted", code: "KAVO_QUERY_CONFLICTING_PARAMS" }),
+    );
+  });
+
+  it("rejects onlyDeleted on an entity that is not soft-deletable", async () => {
+    @Kavo(Todo, { softDelete: { strategy: "hard" } })
+    @Controller("todos")
+    class HardDeleteController {}
+
+    await app.close();
+    await bootstrap(HardDeleteController);
+    const response = await request(server()).get("/todos?onlyDeleted=true").expect(400);
+    expect(response.body.errors).toContainEqual(
+      expect.objectContaining({ field: "onlyDeleted", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+    );
+  });
+
   it("restores through PATCH /:id/restore, returning the item", async () => {
     await request(server()).delete("/todos/1").expect(204);
     const restored = await request(server()).patch("/todos/1/restore").expect(200);
@@ -817,6 +859,46 @@ describe("@Kavo relation includes", () => {
       code: "KAVO_QUERY_INVALID",
       errors: [{ field: "list", code: "KAVO_QUERY_INVALID_FIELD" }],
     });
+  });
+
+  it("carries filter, sort, include and pagination through one request", async () => {
+    // Each of these is covered on its own above; what a single request adds
+    // is that they survive *together* — one query string, one flatten, one
+    // normalization pass. A regression where one section's parse consumed or
+    // clobbered another's params is invisible to any single-feature test.
+    for (let i = 1; i <= 3; i++) {
+      await request(server())
+        .post("/todos")
+        .send({ title: `t${i}`, priority: i, list: 7 })
+        .expect(201);
+    }
+
+    const response = await request(server())
+      .get("/todos?filter[done][eq]=false&filter[priority][gte]=1&sort=-priority,title&include=list&limit=2&offset=1")
+      .expect(200);
+
+    expect(adapter.lastQuery?.filter.root).toMatchObject({
+      kind: "group",
+      operator: "AND",
+      children: [
+        { field: "done", operator: "EQ", value: false },
+        { field: "priority", operator: "GTE", value: 1 },
+      ],
+    });
+    expect(adapter.lastQuery?.sort).toEqual([
+      { field: "priority", direction: "desc" },
+      { field: "title", direction: "asc" },
+    ]);
+    expect(adapter.lastQuery?.pagination).toEqual({ limit: 2, offset: 1 });
+    expect(Object.keys(adapter.lastQuery?.include ?? {})).toEqual(["list"]);
+
+    // The envelope mirrors the request, and the included relation is still
+    // embedded on every item of the page.
+    expect(response.body).toMatchObject({ limit: 2, offset: 1, total: 3 });
+    expect(response.body.items).toHaveLength(2);
+    for (const item of response.body.items) {
+      expect(item).toMatchObject({ list: { id: 7 } });
+    }
   });
 
   it("documents include and fields[relation] in the OpenAPI schema", async () => {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -169,6 +169,80 @@ describe("@Kavo route generation", () => {
   });
 });
 
+/**
+ * Regression, over real HTTP because that is where the damage was: a single
+ * anonymous GET whose query string carried a `__proto__` bracket segment used
+ * to write into `Object.prototype`, and the write then leaked into every
+ * later request in the process through the plain-object reads in the
+ * normalizer and the deserializer. Unit coverage lives in
+ * `packages/core/tests/filter-parser.spec.ts`; what this file adds is the
+ * amplification path — victim requests that never touch the attacking one.
+ */
+describe("@Kavo prototype pollution over the wire", () => {
+  @Kavo(Todo, { softDelete: { strategy: "soft" } })
+  @Controller("todos")
+  class PollutionController {}
+
+  const POLLUTED = ["withDeleted", "onlyDeleted", "limit", "done", "priority", "include"];
+
+  beforeEach(async () => {
+    await bootstrap(PollutionController);
+  });
+
+  afterEach(() => {
+    for (const key of POLLUTED) delete (Object.prototype as Record<string, unknown>)[key];
+  });
+
+  async function attack(segment: string, value: string): Promise<void> {
+    // The attacking request itself is allowed to 400 — what matters is that
+    // it leaves nothing behind.
+    await request(server()).get(`/todos?filter[__proto__][${segment}]=${value}`);
+    expect(Object.prototype.hasOwnProperty.call(Object.prototype, segment)).toBe(false);
+  }
+
+  it("cannot hand a later reader the soft-deleted rows", async () => {
+    await request(server()).post("/todos").send({ title: "live" }).expect(201);
+    await request(server()).post("/todos").send({ title: "deleted" }).expect(201);
+    await request(server()).delete("/todos/2").expect(204);
+
+    await attack("withDeleted", "true");
+
+    const victim = await request(server()).get("/todos").expect(200);
+    expect(victim.body.total).toBe(1);
+    expect(victim.body.items).toEqual([expect.objectContaining({ title: "live" })]);
+  });
+
+  it("cannot smuggle a field into a later writer's body", async () => {
+    // The nastiest amplification: `done` is on the create DTO, so a polluted
+    // prototype used to satisfy the deserializer's `key in source` check and
+    // append itself to bodies that never mentioned it.
+    await attack("done", "true");
+
+    const created = await request(server()).post("/todos").send({ title: "innocent" }).expect(201);
+    expect(created.body).toMatchObject({ title: "innocent", done: false });
+  });
+
+  it("cannot cap or break a later reader's pagination", async () => {
+    for (let i = 1; i <= 3; i++) {
+      await request(server())
+        .post("/todos")
+        .send({ title: `t${i}` })
+        .expect(201);
+    }
+    await attack("limit", "1");
+
+    const victim = await request(server()).get("/todos").expect(200);
+    expect(victim.body.items).toHaveLength(3);
+  });
+
+  it("cannot poison a later reader into a permanent 400", async () => {
+    // `include` on an entity with nothing includable is a 400. Inherited off
+    // the prototype it would make every read fail for every client, forever.
+    await attack("include", "list");
+    await request(server()).get("/todos").expect(200);
+  });
+});
+
 describe("@Kavo page pagination over the wire", () => {
   @Kavo(Todo, { pagination: { strategy: "page", defaultLimit: 2, maxLimit: 3 } })
   @Controller("todos")

--- a/packages/frameworks/nest/tests/support/fake-infrastructure.ts
+++ b/packages/frameworks/nest/tests/support/fake-infrastructure.ts
@@ -116,7 +116,7 @@ export class InMemoryTodoAdapter implements RepositoryAdapter<Todo> {
   ): Promise<Todo | null> {
     const row = this.rows.find((candidate) => candidate.id === Number(id)) ?? null;
     if (row === null) return null;
-    return this.visible(row, context, query?.withDeleted ?? false) ? row : null;
+    return this.visible(row, context, query?.withDeleted ?? false, query?.onlyDeleted ?? false) ? row : null;
   }
 
   async findOne(query: NormalizedQueryContext<Todo>, context: KavoContext<Todo>): Promise<Todo | null> {
@@ -194,11 +194,17 @@ export class InMemoryTodoAdapter implements RepositoryAdapter<Todo> {
   }
 
   private live(query: NormalizedQueryContext<Todo>, context: KavoContext<Todo>): readonly Todo[] {
-    return this.rows.filter((row) => this.visible(row, context, query.withDeleted));
+    return this.rows.filter((row) => this.visible(row, context, query.withDeleted, query.onlyDeleted));
   }
 
-  private visible(row: Todo, context: KavoContext<Todo>, withDeleted: boolean): boolean {
+  /**
+   * The three soft-delete views a read can ask for: live rows (the
+   * default), everything (`withDeleted`), and the trash (`onlyDeleted`).
+   * Driven by the resolved strategy rather than this fake's own opinion.
+   */
+  private visible(row: Todo, context: KavoContext<Todo>, withDeleted: boolean, onlyDeleted = false): boolean {
     if (context.config.softDelete.strategy !== "soft") return true;
+    if (onlyDeleted) return row.deletedAt !== null;
     return withDeleted || row.deletedAt === null;
   }
 

--- a/packages/frameworks/nest/tests/support/fake-infrastructure.ts
+++ b/packages/frameworks/nest/tests/support/fake-infrastructure.ts
@@ -202,7 +202,7 @@ export class InMemoryTodoAdapter implements RepositoryAdapter<Todo> {
    * default), everything (`withDeleted`), and the trash (`onlyDeleted`).
    * Driven by the resolved strategy rather than this fake's own opinion.
    */
-  private visible(row: Todo, context: KavoContext<Todo>, withDeleted: boolean, onlyDeleted = false): boolean {
+  private visible(row: Todo, context: KavoContext<Todo>, withDeleted: boolean, onlyDeleted: boolean): boolean {
     if (context.config.softDelete.strategy !== "soft") return true;
     if (onlyDeleted) return row.deletedAt !== null;
     return withDeleted || row.deletedAt === null;

--- a/packages/orms/prisma/tests/filter-translator.spec.ts
+++ b/packages/orms/prisma/tests/filter-translator.spec.ts
@@ -18,10 +18,6 @@ function translate(root: FilterExpression | null, opts = options): unknown {
   return translateFilter({ root } as Filter, opts);
 }
 
-function ilikeFilter(value: string): Filter {
-  return { root: { kind: "condition", field: "name", operator: "ILIKE", value } };
-}
-
 describe("translateFilter — shape", () => {
   it("returns undefined for an empty filter, so no `where` is sent at all", () => {
     expect(translate(null)).toBeUndefined();
@@ -54,10 +50,16 @@ describe("translateFilter — operators", () => {
 
 /**
  * Prisma has no raw pattern operator — only
- * `contains`/`startsWith`/`endsWith`/`equals` — so the wildcard *position*
- * in the caller's SQL pattern decides which one is emitted. Collapsing
- * everything to `contains` would turn `A%` ("starts with A") into "has an A
- * somewhere", which is a wider result set than the caller asked for.
+ * `contains`/`startsWith`/`endsWith`/`equals` — so a leading and/or trailing
+ * `%` picks which one is emitted. Collapsing everything to `contains` would
+ * turn `A%` ("starts with A") into "has an A somewhere", which is a wider
+ * result set than the caller asked for.
+ *
+ * These four are the patterns the mapping handles, and *only* those:
+ * `likeToPrismaStringFilter` inspects the two ends and nothing else, so an
+ * interior `%`, any `_`, and the backslash escape doc 05 §3 promises are all
+ * mistranslated today — see #114. Those cases are deliberately not asserted
+ * here, because pinning the current output would bless it as the contract.
  */
 describe("translateFilter — LIKE wildcard positions", () => {
   it.each([
@@ -72,19 +74,19 @@ describe("translateFilter — LIKE wildcard positions", () => {
 
 describe("translateFilter — caseInsensitiveFilters", () => {
   it("adds Prisma's mode: 'insensitive' for ILIKE when the connector supports it (default)", () => {
-    const where = translateFilter(ilikeFilter("a%"), { caseInsensitiveFilters: true });
-    expect(where).toEqual({ name: { startsWith: "a", mode: "insensitive" } });
+    expect(translate(condition("name", "ILIKE", "a%"), insensitive)).toEqual({
+      name: { startsWith: "a", mode: "insensitive" },
+    });
   });
 
   it("omits mode entirely when the connector doesn't support it (e.g. SQLite)", () => {
-    const where = translateFilter(ilikeFilter("a%"), { caseInsensitiveFilters: false });
-    expect(where).toEqual({ name: { startsWith: "a" } });
+    expect(translate(condition("name", "ILIKE", "a%"), options)).toEqual({ name: { startsWith: "a" } });
   });
 
   it("leaves plain LIKE untouched by the setting either way", () => {
-    const filter: Filter = { root: { kind: "condition", field: "name", operator: "LIKE", value: "a%" } };
-    expect(translateFilter(filter, { caseInsensitiveFilters: true })).toEqual({ name: { startsWith: "a" } });
-    expect(translateFilter(filter, { caseInsensitiveFilters: false })).toEqual({ name: { startsWith: "a" } });
+    for (const opts of [insensitive, options]) {
+      expect(translate(condition("name", "LIKE", "a%"), opts)).toEqual({ name: { startsWith: "a" } });
+    }
   });
 
   it("carries the mode onto every ILIKE wildcard position, not just the prefix one", () => {
@@ -110,6 +112,7 @@ describe("translateFilter — logical groups", () => {
     });
   });
 
+  // Single child only — see the note in the typeorm spec and #115.
   it("maps a NOT group onto NOT over its single child", () => {
     expect(translate(group("NOT", [left]))).toEqual({ NOT: { name: { equals: "Ada" } } });
   });

--- a/packages/orms/prisma/tests/filter-translator.spec.ts
+++ b/packages/orms/prisma/tests/filter-translator.spec.ts
@@ -1,10 +1,74 @@
 import { describe, expect, it } from "vitest";
-import type { Filter } from "@kavo/core";
+import type { Filter, FilterExpression } from "@kavo/core";
 import { translateFilter } from "@kavo/prisma";
+
+/** The connector setting only reaches `ILIKE`; everything else is invariant. */
+const options = { caseInsensitiveFilters: false };
+const insensitive = { caseInsensitiveFilters: true };
+
+function condition(field: string, operator: string, value: unknown): FilterExpression {
+  return { kind: "condition", field, operator, value } as FilterExpression;
+}
+
+function group(operator: "AND" | "OR" | "NOT", children: FilterExpression[]): FilterExpression {
+  return { kind: "group", operator, children } as FilterExpression;
+}
+
+function translate(root: FilterExpression | null, opts = options): unknown {
+  return translateFilter({ root } as Filter, opts);
+}
 
 function ilikeFilter(value: string): Filter {
   return { root: { kind: "condition", field: "name", operator: "ILIKE", value } };
 }
+
+describe("translateFilter — shape", () => {
+  it("returns undefined for an empty filter, so no `where` is sent at all", () => {
+    expect(translate(null)).toBeUndefined();
+  });
+});
+
+describe("translateFilter — operators", () => {
+  it.each([
+    ["EQ", "Ada", { name: { equals: "Ada" } }],
+    ["NE", "Ada", { name: { not: "Ada" } }],
+    ["GT", 30, { name: { gt: 30 } }],
+    ["GTE", 30, { name: { gte: 30 } }],
+    ["LT", 30, { name: { lt: 30 } }],
+    ["LTE", 30, { name: { lte: 30 } }],
+    ["IN", ["a", "b"], { name: { in: ["a", "b"] } }],
+    ["NOT_IN", ["a", "b"], { name: { notIn: ["a", "b"] } }],
+    ["BETWEEN", [1, 9], { name: { gte: 1, lte: 9 } }],
+    ["IS_NULL", true, { name: { equals: null } }],
+    ["IS_NOT_NULL", true, { name: { not: null } }],
+  ])("maps %s onto its Prisma filter", (operator, value, expected) => {
+    expect(translate(condition("name", operator, value))).toEqual(expected);
+  });
+
+  it("throws rather than dropping an operator outside the AST enum", () => {
+    // Prisma ignores unknown keys in a `where`, so a dropped predicate would
+    // silently widen the result set instead of erroring.
+    expect(() => translate(condition("name", "SOUNDS_LIKE", "x"))).toThrowError(/filter operator/);
+  });
+});
+
+/**
+ * Prisma has no raw pattern operator — only
+ * `contains`/`startsWith`/`endsWith`/`equals` — so the wildcard *position*
+ * in the caller's SQL pattern decides which one is emitted. Collapsing
+ * everything to `contains` would turn `A%` ("starts with A") into "has an A
+ * somewhere", which is a wider result set than the caller asked for.
+ */
+describe("translateFilter — LIKE wildcard positions", () => {
+  it.each([
+    ["%john%", { contains: "john" }],
+    ["A%", { startsWith: "A" }],
+    ["%son", { endsWith: "son" }],
+    ["john", { equals: "john" }],
+  ])("reads the pattern %s by where its wildcards sit", (pattern, expected) => {
+    expect(translate(condition("name", "LIKE", pattern))).toEqual({ name: expected });
+  });
+});
 
 describe("translateFilter — caseInsensitiveFilters", () => {
   it("adds Prisma's mode: 'insensitive' for ILIKE when the connector supports it (default)", () => {
@@ -21,5 +85,78 @@ describe("translateFilter — caseInsensitiveFilters", () => {
     const filter: Filter = { root: { kind: "condition", field: "name", operator: "LIKE", value: "a%" } };
     expect(translateFilter(filter, { caseInsensitiveFilters: true })).toEqual({ name: { startsWith: "a" } });
     expect(translateFilter(filter, { caseInsensitiveFilters: false })).toEqual({ name: { startsWith: "a" } });
+  });
+
+  it("carries the mode onto every ILIKE wildcard position, not just the prefix one", () => {
+    expect(translate(condition("name", "ILIKE", "%a%"), insensitive)).toEqual({
+      name: { contains: "a", mode: "insensitive" },
+    });
+    expect(translate(condition("name", "ILIKE", "a"), insensitive)).toEqual({
+      name: { equals: "a", mode: "insensitive" },
+    });
+  });
+});
+
+describe("translateFilter — logical groups", () => {
+  const left = condition("name", "EQ", "Ada");
+  const right = condition("age", "GT", 30);
+
+  it("maps AND and OR onto Prisma's own combinators", () => {
+    expect(translate(group("AND", [left, right]))).toEqual({
+      AND: [{ name: { equals: "Ada" } }, { age: { gt: 30 } }],
+    });
+    expect(translate(group("OR", [left, right]))).toEqual({
+      OR: [{ name: { equals: "Ada" } }, { age: { gt: 30 } }],
+    });
+  });
+
+  it("maps a NOT group onto NOT over its single child", () => {
+    expect(translate(group("NOT", [left]))).toEqual({ NOT: { name: { equals: "Ada" } } });
+  });
+
+  it("nests groups without losing precedence", () => {
+    const nested = group("AND", [left, group("OR", [right, condition("age", "LT", 10)])]);
+    expect(translate(nested)).toEqual({
+      AND: [{ name: { equals: "Ada" } }, { OR: [{ age: { gt: 30 } }, { age: { lt: 10 } }] }],
+    });
+  });
+});
+
+/**
+ * Prisma's `where` nests relation paths natively, so unlike `@kavo/typeorm`
+ * this translator adds no join — a dotted field simply nests the same leaf
+ * one level deeper.
+ */
+describe("translateFilter — relation paths", () => {
+  it("nests a dotted path into Prisma's relation shape", () => {
+    expect(translate(condition("author.name", "EQ", "Ada"))).toEqual({
+      author: { name: { equals: "Ada" } },
+    });
+  });
+
+  it("nests a multi-segment path all the way down", () => {
+    expect(translate(condition("author.city.name", "EQ", "Paris"))).toEqual({
+      author: { city: { name: { equals: "Paris" } } },
+    });
+  });
+
+  it("nests every operator's leaf, not just equality", () => {
+    expect(translate(condition("author.age", "GTE", 18))).toEqual({ author: { age: { gte: 18 } } });
+    expect(translate(condition("author.name", "IN", ["Ada", "Grace"]))).toEqual({
+      author: { name: { in: ["Ada", "Grace"] } },
+    });
+    expect(translate(condition("author.name", "ILIKE", "a%"), insensitive)).toEqual({
+      author: { name: { startsWith: "a", mode: "insensitive" } },
+    });
+  });
+
+  it("leaves an undotted field at the top level", () => {
+    expect(translate(condition("author", "EQ", "abc"))).toEqual({ author: { equals: "abc" } });
+  });
+
+  it("nests a relation path the same way inside a logical group", () => {
+    expect(translate(group("OR", [condition("author.name", "EQ", "Ada"), condition("title", "EQ", "x")]))).toEqual({
+      OR: [{ author: { name: { equals: "Ada" } } }, { title: { equals: "x" } }],
+    });
   });
 });

--- a/packages/orms/typeorm/tests/filter-translator.spec.ts
+++ b/packages/orms/typeorm/tests/filter-translator.spec.ts
@@ -52,11 +52,13 @@ class Book {
 let dataSource: DataSource;
 
 beforeAll(async () => {
+  // No `synchronize` — this spec builds SQL and never executes it, so the
+  // tables need not exist. The DataSource is here for its metadata and its
+  // driver-accurate identifier quoting.
   dataSource = new DataSource({
     type: "better-sqlite3",
     database: ":memory:",
     entities: [Author, Book],
-    synchronize: true,
   });
   await dataSource.initialize();
 });
@@ -90,9 +92,12 @@ function builderFor() {
 }
 
 /** Just the predicate — the SELECT list is the driver's business, not ours. */
-function whereOf(root: FilterExpression | null): string {
-  const { sql } = translate(root);
+function predicateOf(sql: string): string {
   return sql.split(" WHERE ")[1] ?? "";
+}
+
+function whereOf(root: FilterExpression | null): string {
+  return predicateOf(translate(root).sql);
 }
 
 describe("FilterTranslator — comparison operators", () => {
@@ -104,25 +109,28 @@ describe("FilterTranslator — comparison operators", () => {
     ["LT", "pages", 100, `("root"."pages" < :p0)`, 100],
     ["LTE", "pages", 100, `("root"."pages" <= :p0)`, 100],
   ])("maps %s onto its SQL comparison with a bound parameter", (operator, field, value, sql, bound) => {
-    const { parameters } = translate(condition(field, operator, value));
-    expect(whereOf(condition(field, operator, value))).toBe(sql);
+    const { sql: generated, parameters } = translate(condition(field, operator, value));
+    expect(predicateOf(generated)).toBe(sql);
     expect(parameters["p0"]).toBe(bound);
   });
 
+  // `toBe` on the whole predicate throughout, not `toContain`: an extra
+  // clause emitted alongside the expected one (a leaked `1 = 0`, a doubled
+  // ESCAPE) would satisfy a substring match while quietly emptying the page.
   it("maps IN and NOT_IN onto a spread parameter list", () => {
     const inSet = translate(condition("title", "IN", ["Dune", "Emma"]));
-    expect(inSet.sql).toContain(`("root"."title" IN (:...p0))`);
+    expect(predicateOf(inSet.sql)).toBe(`("root"."title" IN (:...p0))`);
     expect(inSet.parameters["p0"]).toEqual(["Dune", "Emma"]);
 
     const notIn = translate(condition("title", "NOT_IN", ["Dune"]));
-    expect(notIn.sql).toContain(`("root"."title" NOT IN (:...p0))`);
+    expect(predicateOf(notIn.sql)).toBe(`("root"."title" NOT IN (:...p0))`);
     expect(notIn.parameters["p0"]).toEqual(["Dune"]);
   });
 
   it("maps BETWEEN onto two independently named bound parameters", () => {
     const { sql, parameters } = translate(condition("pages", "BETWEEN", [100, 200]));
-    expect(sql).toContain(`("root"."pages" BETWEEN :p0_lo AND :p0_hi)`);
-    expect(parameters).toMatchObject({ p0_lo: 100, p0_hi: 200 });
+    expect(predicateOf(sql)).toBe(`("root"."pages" BETWEEN :p0_lo AND :p0_hi)`);
+    expect(parameters).toEqual({ p0_lo: 100, p0_hi: 200 });
   });
 
   it("maps IS_NULL and IS_NOT_NULL onto SQL null tests with no parameter", () => {
@@ -167,13 +175,13 @@ describe("FilterTranslator — LIKE and ILIKE", () => {
     // default sql_mode treats it as an escape character, Postgres does not),
     // so `ESCAPE '\'` is not portable — a bound parameter is.
     const { sql, parameters } = translate(condition("title", "LIKE", "100\\%"));
-    expect(sql).toContain(`("root"."title" LIKE :p0 ESCAPE :p0Escape)`);
+    expect(predicateOf(sql)).toBe(`("root"."title" LIKE :p0 ESCAPE :p0Escape)`);
     expect(parameters).toEqual({ p0: "100\\%", p0Escape: "\\" });
   });
 
   it("translates ILIKE portably as LOWER() LIKE LOWER(), with the same escape", () => {
     const { sql, parameters } = translate(condition("title", "ILIKE", "a%"));
-    expect(sql).toContain(`(LOWER("root"."title") LIKE LOWER(:p0) ESCAPE :p0Escape)`);
+    expect(predicateOf(sql)).toBe(`(LOWER("root"."title") LIKE LOWER(:p0) ESCAPE :p0Escape)`);
     expect(parameters).toEqual({ p0: "a%", p0Escape: "\\" });
   });
 
@@ -191,6 +199,8 @@ describe("FilterTranslator — logical groups", () => {
     expect(whereOf(group("OR", [left, right]))).toBe(`(("root"."title" = :p0) OR ("root"."pages" > :p1))`);
   });
 
+  // Single child only: a multi-child NOT silently drops everything past
+  // children[0] today, which is #115 rather than a contract to pin here.
   it("wraps a NOT group in SQL NOT over its single child", () => {
     expect(whereOf(group("NOT", [left]))).toBe(`NOT(("root"."title" = :p0))`);
   });
@@ -220,8 +230,10 @@ describe("FilterTranslator — relation paths", () => {
     expect(sql).toContain(`LEFT JOIN "author" "root__author"`);
     expect(sql).toContain(`("root__author"."name" = :p0)`);
     // Non-selecting: the join restricts root rows, it never loads the
-    // relation — that is what `include=` is for.
-    expect(sql).not.toContain(`"root__author"."name" AS`);
+    // relation — that is what `include=` is for. Asserted over the whole
+    // select list rather than one column, so a join projecting only the id
+    // cannot slip through.
+    expect(sql.split(" FROM ")[0]).not.toContain("root__author");
   });
 
   it("chains a join per segment of a multi-segment path", () => {
@@ -242,10 +254,14 @@ describe("FilterTranslator — relation paths", () => {
   });
 
   it("reuses a join someone else registered rather than duplicating it", () => {
-    // An include join selects its relation; a filter join only restricts. If
-    // both were added under the same alias the query would be invalid, and
-    // if the filter's non-selecting join won, the include would come back
-    // empty.
+    // An include join selects its relation; a filter join only restricts.
+    // TypeORM does not deduplicate aliases itself — adding both emits two
+    // LEFT JOINs and duplicates the select columns, which fails at execution
+    // ("ambiguous column name" on SQLite, "table name specified more than
+    // once" on Postgres). `registerJoin` is what prevents that, and the
+    // adapter joins includes before applying filters
+    // (typeorm-repository-adapter.ts) so the selecting join is the one in
+    // place by the time the translator looks.
     const { sql } = translate(condition("author.name", "EQ", "Ada"), (translator, qb) => {
       qb.leftJoinAndSelect("root.author", "root__author");
       translator.registerJoin("root__author");
@@ -253,6 +269,23 @@ describe("FilterTranslator — relation paths", () => {
     expect(sql.match(/LEFT JOIN/g)).toHaveLength(1);
     expect(sql).toContain(`"root__author"."name" AS "root__author_name"`);
     expect(sql).toContain(`("root__author"."name" = :p0)`);
+  });
+
+  it("shares one join between a filter and a sort on the same path", () => {
+    // `columnRef` has two callers: `applyCondition` here, and the adapter's
+    // `addOrderBy` for a sort on an allowlisted relation path. Only the
+    // filter side goes through `apply()`, so scoping the join cache per
+    // `apply()` call would leave every other test in this file green while
+    // the sort re-joined the relation under a second alias — k² raw rows per
+    // parent, invisible after `getMany()` dedupes entities.
+    const qb = builderFor();
+    const translator = new FilterTranslator<Book>(qb, "root");
+    translator.apply({ root: condition("author.name", "EQ", "Ada") } as Filter<Book>);
+    qb.addOrderBy(translator.columnRef("author.name"), "DESC");
+
+    const sql = qb.getQuery();
+    expect(sql.match(/LEFT JOIN/g)).toHaveLength(1);
+    expect(sql).toContain(`ORDER BY "root__author"."name" DESC`);
   });
 
   it("leaves an undotted field on the root alias", () => {

--- a/packages/orms/typeorm/tests/filter-translator.spec.ts
+++ b/packages/orms/typeorm/tests/filter-translator.spec.ts
@@ -1,0 +1,263 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Column, DataSource, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import type { ObjectLiteral } from "typeorm";
+import type { Filter, FilterExpression } from "@kavo/core";
+import { FilterTranslator } from "@kavo/typeorm";
+
+/**
+ * The mirror of `@kavo/mongoose`'s and `@kavo/mikroorm`'s translator specs:
+ * every row of the operator table in
+ * `docs/internals/architecture/05-query-grammar.md` §1, the logical
+ * combinators, and relation-path handling — asserted on what actually
+ * reaches the database.
+ *
+ * The other three adapters translate to a plain object, so their specs
+ * assert one. This one mutates a `SelectQueryBuilder`, so the observable
+ * output is the generated SQL plus its bound parameters; a real (in-memory
+ * SQLite) `DataSource` supplies the builder rather than a fake, because the
+ * identifier quoting and join clauses under test are the driver's work.
+ */
+
+@Entity()
+class Author {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  name!: string;
+
+  @OneToMany(() => Book, (book) => book.author)
+  books!: Book[];
+}
+
+@Entity()
+class Book {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  title!: string;
+
+  @Column("int")
+  pages!: number;
+
+  @Column("varchar", { nullable: true })
+  blurb!: string | null;
+
+  @ManyToOne(() => Author, (author) => author.books)
+  author!: Author;
+}
+
+let dataSource: DataSource;
+
+beforeAll(async () => {
+  dataSource = new DataSource({
+    type: "better-sqlite3",
+    database: ":memory:",
+    entities: [Author, Book],
+    synchronize: true,
+  });
+  await dataSource.initialize();
+});
+
+afterAll(async () => {
+  await dataSource.destroy();
+});
+
+function condition(field: string, operator: string, value: unknown): FilterExpression {
+  return { kind: "condition", field, operator, value } as FilterExpression;
+}
+
+function group(operator: "AND" | "OR" | "NOT", children: FilterExpression[]): FilterExpression {
+  return { kind: "group", operator, children } as FilterExpression;
+}
+
+/** Translate `root` against a fresh builder and report the whole statement. */
+function translate(
+  root: FilterExpression | null,
+  prepare: (translator: FilterTranslator<Book>, qb: ReturnType<typeof builderFor>) => void = () => {},
+): { sql: string; parameters: ObjectLiteral } {
+  const qb = builderFor();
+  const translator = new FilterTranslator<Book>(qb, "root");
+  prepare(translator, qb);
+  translator.apply({ root } as Filter<Book>);
+  return { sql: qb.getQuery(), parameters: qb.getParameters() };
+}
+
+function builderFor() {
+  return dataSource.createQueryBuilder(Book, "root");
+}
+
+/** Just the predicate — the SELECT list is the driver's business, not ours. */
+function whereOf(root: FilterExpression | null): string {
+  const { sql } = translate(root);
+  return sql.split(" WHERE ")[1] ?? "";
+}
+
+describe("FilterTranslator — comparison operators", () => {
+  it.each([
+    ["EQ", "title", "Dune", `("root"."title" = :p0)`, "Dune"],
+    ["NE", "title", "Dune", `("root"."title" != :p0)`, "Dune"],
+    ["GT", "pages", 100, `("root"."pages" > :p0)`, 100],
+    ["GTE", "pages", 100, `("root"."pages" >= :p0)`, 100],
+    ["LT", "pages", 100, `("root"."pages" < :p0)`, 100],
+    ["LTE", "pages", 100, `("root"."pages" <= :p0)`, 100],
+  ])("maps %s onto its SQL comparison with a bound parameter", (operator, field, value, sql, bound) => {
+    const { parameters } = translate(condition(field, operator, value));
+    expect(whereOf(condition(field, operator, value))).toBe(sql);
+    expect(parameters["p0"]).toBe(bound);
+  });
+
+  it("maps IN and NOT_IN onto a spread parameter list", () => {
+    const inSet = translate(condition("title", "IN", ["Dune", "Emma"]));
+    expect(inSet.sql).toContain(`("root"."title" IN (:...p0))`);
+    expect(inSet.parameters["p0"]).toEqual(["Dune", "Emma"]);
+
+    const notIn = translate(condition("title", "NOT_IN", ["Dune"]));
+    expect(notIn.sql).toContain(`("root"."title" NOT IN (:...p0))`);
+    expect(notIn.parameters["p0"]).toEqual(["Dune"]);
+  });
+
+  it("maps BETWEEN onto two independently named bound parameters", () => {
+    const { sql, parameters } = translate(condition("pages", "BETWEEN", [100, 200]));
+    expect(sql).toContain(`("root"."pages" BETWEEN :p0_lo AND :p0_hi)`);
+    expect(parameters).toMatchObject({ p0_lo: 100, p0_hi: 200 });
+  });
+
+  it("maps IS_NULL and IS_NOT_NULL onto SQL null tests with no parameter", () => {
+    expect(whereOf(condition("blurb", "IS_NULL", true))).toBe(`("root"."blurb" IS NULL)`);
+    expect(whereOf(condition("blurb", "IS_NOT_NULL", true))).toBe(`("root"."blurb" IS NOT NULL)`);
+    expect(translate(condition("blurb", "IS_NULL", true)).parameters).toEqual({});
+  });
+
+  it("emits no WHERE clause at all for a filter with no root", () => {
+    expect(translate(null).sql).not.toContain("WHERE");
+  });
+});
+
+/**
+ * `= NULL` is never true in SQL, so an `EQ null` that translated literally
+ * would silently match nothing — and `!= NULL` would silently match nothing
+ * where the caller asked for "anything but null".
+ */
+describe("FilterTranslator — null-valued equality", () => {
+  it("rewrites EQ null and NE null as null tests", () => {
+    expect(whereOf(condition("blurb", "EQ", null))).toBe(`("root"."blurb" IS NULL)`);
+    expect(whereOf(condition("blurb", "NE", null))).toBe(`("root"."blurb" IS NOT NULL)`);
+  });
+});
+
+/**
+ * SQL has no `IN ()`: emitting one is a syntax error, so the empty set is
+ * spelled as the constant it means. `NOT IN ()` is the tautology, which is
+ * the case a naive "skip the predicate" would get right by accident and
+ * `IN ()` would get catastrophically wrong.
+ */
+describe("FilterTranslator — the empty value set", () => {
+  it("spells an empty IN as a contradiction and an empty NOT_IN as a tautology", () => {
+    expect(whereOf(condition("title", "IN", []))).toBe("(1 = 0)");
+    expect(whereOf(condition("title", "NOT_IN", []))).toBe("(1 = 1)");
+  });
+});
+
+describe("FilterTranslator — LIKE and ILIKE", () => {
+  it("binds the backslash escape character as a parameter, never as a literal", () => {
+    // Drivers disagree about backslash inside a string literal (MySQL's
+    // default sql_mode treats it as an escape character, Postgres does not),
+    // so `ESCAPE '\'` is not portable — a bound parameter is.
+    const { sql, parameters } = translate(condition("title", "LIKE", "100\\%"));
+    expect(sql).toContain(`("root"."title" LIKE :p0 ESCAPE :p0Escape)`);
+    expect(parameters).toEqual({ p0: "100\\%", p0Escape: "\\" });
+  });
+
+  it("translates ILIKE portably as LOWER() LIKE LOWER(), with the same escape", () => {
+    const { sql, parameters } = translate(condition("title", "ILIKE", "a%"));
+    expect(sql).toContain(`(LOWER("root"."title") LIKE LOWER(:p0) ESCAPE :p0Escape)`);
+    expect(parameters).toEqual({ p0: "a%", p0Escape: "\\" });
+  });
+
+  it("passes the caller's pattern through unaltered — no wildcards are added", () => {
+    expect(translate(condition("title", "LIKE", "john")).parameters["p0"]).toBe("john");
+  });
+});
+
+describe("FilterTranslator — logical groups", () => {
+  const left = condition("title", "EQ", "Dune");
+  const right = condition("pages", "GT", 100);
+
+  it("joins AND and OR children with explicit parentheses", () => {
+    expect(whereOf(group("AND", [left, right]))).toBe(`(("root"."title" = :p0) AND ("root"."pages" > :p1))`);
+    expect(whereOf(group("OR", [left, right]))).toBe(`(("root"."title" = :p0) OR ("root"."pages" > :p1))`);
+  });
+
+  it("wraps a NOT group in SQL NOT over its single child", () => {
+    expect(whereOf(group("NOT", [left]))).toBe(`NOT(("root"."title" = :p0))`);
+  });
+
+  it("keeps precedence when an OR nests inside an AND", () => {
+    // Parentheses, not operator-order luck: without the inner brackets this
+    // would read as `a AND b OR c` and match rows the caller excluded.
+    const nested = group("AND", [left, group("OR", [right, condition("pages", "LT", 10)])]);
+    expect(whereOf(nested)).toBe(`(("root"."title" = :p0) AND (("root"."pages" > :p1) OR ("root"."pages" < :p2)))`);
+  });
+
+  it("numbers parameters globally, so repeated conditions on one field cannot collide", () => {
+    const { parameters } = translate(group("AND", [condition("pages", "GTE", 100), condition("pages", "LT", 200)]));
+    expect(parameters).toEqual({ p0: 100, p1: 200 });
+  });
+
+  it("refuses an operator outside the AST enum rather than dropping the predicate", () => {
+    // A dropped predicate widens the result set silently, which is the one
+    // failure mode a filter must never have.
+    expect(() => whereOf(condition("title", "SOUNDS_LIKE", "x"))).toThrowError(/filter operator/);
+  });
+});
+
+describe("FilterTranslator — relation paths", () => {
+  it("adds one non-selecting left join per segment, under a deterministic alias", () => {
+    const { sql } = translate(condition("author.name", "EQ", "Ada"));
+    expect(sql).toContain(`LEFT JOIN "author" "root__author"`);
+    expect(sql).toContain(`("root__author"."name" = :p0)`);
+    // Non-selecting: the join restricts root rows, it never loads the
+    // relation — that is what `include=` is for.
+    expect(sql).not.toContain(`"root__author"."name" AS`);
+  });
+
+  it("chains a join per segment of a multi-segment path", () => {
+    // TypeORM nests the second join inside the first, so the aliases — not
+    // the clause order — are what identifies the chain.
+    const { sql } = translate(condition("author.books.title", "EQ", "Dune"));
+    expect(sql.match(/LEFT JOIN/g)).toHaveLength(2);
+    expect(sql).toContain(`"author" "root__author"`);
+    expect(sql).toContain(`LEFT JOIN "book" "root__author__books"`);
+    expect(sql).toContain(`("root__author__books"."title" = :p0)`);
+  });
+
+  it("reuses one join for repeated references to the same path", () => {
+    const { sql } = translate(group("AND", [condition("author.name", "EQ", "Ada"), condition("author.id", "GT", 1)]));
+    expect(sql.match(/LEFT JOIN/g)).toHaveLength(1);
+    expect(sql).toContain(`("root__author"."name" = :p0)`);
+    expect(sql).toContain(`("root__author"."id" > :p1)`);
+  });
+
+  it("reuses a join someone else registered rather than duplicating it", () => {
+    // An include join selects its relation; a filter join only restricts. If
+    // both were added under the same alias the query would be invalid, and
+    // if the filter's non-selecting join won, the include would come back
+    // empty.
+    const { sql } = translate(condition("author.name", "EQ", "Ada"), (translator, qb) => {
+      qb.leftJoinAndSelect("root.author", "root__author");
+      translator.registerJoin("root__author");
+    });
+    expect(sql.match(/LEFT JOIN/g)).toHaveLength(1);
+    expect(sql).toContain(`"root__author"."name" AS "root__author_name"`);
+    expect(sql).toContain(`("root__author"."name" = :p0)`);
+  });
+
+  it("leaves an undotted field on the root alias", () => {
+    const { sql } = translate(condition("title", "EQ", "Dune"));
+    expect(sql).not.toContain("LEFT JOIN");
+    expect(sql).toContain(`("root"."title" = :p0)`);
+  });
+});


### PR DESCRIPTION
Closes #74

## Security fix (added after review — this PR is no longer test-only)

Review found a **wire-reachable prototype-pollution vulnerability** in `@kavo/core`, and it is fixed here.

`DefaultFilterParser` built its bracket tree on ordinary objects, where reading the key `__proto__` yields `Object.prototype` rather than `undefined`. `assignPath` walked into it and assigned there — and the tree is built in `collectBracketTree` **before any allowlist check**, so the segment never had to be filterable to get there.

One anonymous request, verified end to end over real HTTP through the Nest binding:

```
GET /todos?filter[__proto__][withDeleted]=true   -> 200, filter.root: null, no error, no log
                                                    Object.prototype.withDeleted = "true"
GET /todos            (a different, anonymous, empty-query request)
   before: total=1     after: total=2, returns the soft-deleted row
POST /todos {"title":"innocent"}   -> created {title:"innocent", done:true}
```

Three amplifications, all confirmed, all persistent for the life of the process and across every entity and client:

- **Trash disclosure** — `query-normalizer.ts` reads `rawParams["withDeleted"]` off a plain object, so it inherits the polluted value.
- **Mass assignment into other clients' writes** — `DefaultDeserializer` used `key in source`, which walks the prototype chain, so a polluted DTO key appended itself to bodies that never mentioned it.
- **Persistent DoS** — on a non-soft-deletable entity the inherited flag makes every subsequent read 400 forever.

Reachable on the **default** stack Kavo targets: Express 5 / Nest 11's "simple" query parser preserves the flat key verbatim. Express 4's `qs` "extended" parser strips `__proto__` and masks it.

**The fix.** Build the bracket tree — and the `fields[...]` map, which had the same flaw in a quieter form — on prototype-less objects. `__proto__` then becomes an ordinary own key and fails the filterable allowlist like any other unknown field: a **400**, not a silent drop and not a write. Defence in depth on top: the deserializer reads own properties only, and `flattenQuery` hands the normalizer a prototype-less object, so a prototype polluted by anything *else* in the host application still cannot reach a request.

Six regression tests, verified to fail against the previous code — two at the parser and four over real HTTP, since the damage was to requests that never touched the attacking one.

## What and why (the original scope)

The query grammar in `docs/internals/architecture/05-query-grammar.md` is the
single source of truth for the operator set, the logical combinators, and the
cross-cutting read features — but test coverage of it was uneven. Several
operators had no parser-level case at all, adapter-level translator coverage
ranged from thorough (mongoose) to nonexistent (typeorm), and features that
are each well covered on their own were never exercised in the same request.
This closes those gaps, test-only: no production code changed.

Two themes run through it. First, **totality is not reachability** —
`OPERATOR_TOKENS` is proven total over `FilterOperator` at build time, so a
missing operator fails the build, but a *misspelled* wire token still
typechecks and becomes silently unreachable from HTTP. Every row of the
operator table is now exercised through `parse()`. Second, **composition** —
each section of `QueryNormalizer` writes into one shared issue list and one
shared result, and a regression where one section clobbers or short-circuits
another is invisible to any single-feature test, so filter + sort + pagination
+ fields + include + the soft-delete flags now meet in one normalized request
(core) and one HTTP request (nest).

## Public API impact

**No barrel changes**, and no signature changes. One **behavior** change, deliberate and documented: `filter[__proto__][...]` / `fields[__proto__]` now return `400 KAVO_QUERY_INVALID_FIELD` instead of being silently ignored. Nothing legitimate relied on that. Doc 05 §4 records it, and §3/§5 pick up `onlyDeleted` and `between`'s bound ordering, which the tests now pin but the reference never stated.

## Testing

`pnpm check` green (70 files, **1330 tests** — 113 new, measured against the branch point), plus `pnpm docs:links`, `pnpm docs:build` and `pnpm format:check` all green.

The six security regressions were confirmed red against the unfixed source before being fixed — reverting each guard individually fails exactly them and nothing else.

- **`@kavo/core` — `filter-parser.spec.ts`**: one case per operator-table row
  (adding `NE`, `LT`, `LTE`, `NOT_IN`, `ILIKE`); the `isNull`/`isNotNull` flip
  in all four spellings; the explicit top-level `and` token in both bracket and
  JSON form, asserted identical; `BETWEEN` bound coercion, per-side coercion
  failure, and wire order preserved rather than sorted; `LIKE`/`ILIKE` backslash
  passthrough for a literal `%`/`_`; empty and repeated-key `IN`/`NOT_IN` lists;
  malformed bracket keys driven through `parse()` rather than only through
  `parseBracketKey`; and relation-path filtering end to end, including that a
  dotted path is *not* coerced and is not filterable implicitly.
- **`@kavo/core` — `query-normalizer.spec.ts`**: the whole grammar in one
  request over the `Post` fixture (the only one that is both soft-deletable and
  relation-bearing), and an include tree that resolves identically for a live,
  `withDeleted`, and `onlyDeleted` read.
- **`@kavo/typeorm` — `filter-translator.spec.ts` (new)**: the package had no
  translator spec. Mirrors the mongoose and mikroorm ones, but asserts the
  generated SQL plus its bound parameters, since this translator mutates a
  `SelectQueryBuilder` rather than returning an object. Covers every operator,
  `EQ`/`NE` against `null`, the empty value set, the portable
  `ESCAPE`-as-parameter binding, group precedence, global parameter numbering,
  and the non-selecting relation joins — chained, deduplicated, and yielding to
  an include join registered under the same alias.
- **`@kavo/prisma` — `filter-translator.spec.ts`**: extended past `ILIKE` to the
  full operator set, the four `LIKE` wildcard positions that decide which Prisma
  string filter is emitted, the logical groups, and native relation-path nesting.
- **`@kavo/nest` — `binding.e2e.spec.ts`**: `onlyDeleted` over the wire (trash
  view, `withDeleted`+`onlyDeleted` conflict, rejection on a non-soft-deletable
  entity), plus one request combining `filter[...]`, `sort`, `include` and
  pagination.

## Review notes

- **The security fix is the thing to review hardest.** Specifically: whether prototype-less objects break any consumer that expects a plain object. I checked `Object.entries`/`Object.keys`/`typeof` use throughout the parser and normalizer, and there is no `toStrictEqual` anywhere in the suite (which *is* prototype-sensitive, unlike `toEqual`). I left `DefaultSerializer.project`'s `key in source` alone on purpose — its source is a hydrated entity, where a prototype getter could be a legitimate computed field; only `deserialize`, whose source is an untrusted wire body, moved to an own-property check.
- **Five defects found by review are deliberately *not* fixed here**, each filed instead, because fixing production behavior in a test-scoped PR is what #74's own constraint forbids. None is asserted as correct behavior anywhere; where a test sits next to one, it carries a pointer.
  - **#111** — an empty `OR` group makes `@kavo/typeorm` return every row.
  - **#113** — a bare `in=` is a 400 on a typed column and a live `IN ('')` on a string one.
  - **#114** — `@kavo/prisma`'s `LIKE` ignores the documented `\%`/`\_` escape and any interior wildcard, so the same wire request returns different rows per adapter.
  - **#115** — a multi-child `NOT` silently drops every child past the first, on both TypeORM and Prisma.
  - **#116** — a to-many relation-path filter emits a `where` Prisma rejects, so the client gets a 500.
- **Original note, still accurate.** An empty `OR`
  group makes `@kavo/typeorm` return **every row** — TypeORM drops a `Brackets`
  whose callback added no condition, so the predicate vanishes instead of
  becoming a contradiction. `@kavo/mongoose` and `@kavo/mikroorm` both make the
  same AST match nothing, with comments and tests. It is unreachable from the
  wire (the parser never emits an empty group) but reachable from a hand-built
  programmatic AST. Per #74's constraint I filed it as **#111** rather than
  patching it under a `type:test` issue, and left the degenerate-group cases out
  of the new typeorm spec rather than asserting the wrong behaviour as correct.
  #111 also carries the unverified `@kavo/prisma` `NOT []` → `{ NOT: {} }` case.
- The typeorm spec asserts exact SQL strings, which is the most brittle thing
  here. It is deliberate: identifier quoting, the `ESCAPE` parameter binding and
  the bracket placement are the contract with the driver, and `toContain` would
  not catch a lost paren. A real in-memory SQLite `DataSource` supplies the
  builder, so the assertions are against the driver's real output.
- The `NOT` group rendering (`NOT((…))`) and TypeORM's *nested* multi-segment
  join clause are both quirks of TypeORM's builder, discovered empirically and
  noted in comments — worth a second look if you think either is worth
  normalising instead of asserting.
- `filter-parser.spec.ts`'s existing "coerces dates and booleans; flips
  isNull=false" case was narrowed to the date half, since the flip is now
  covered symmetrically in its own block.
