### PR TITLE
fix(core,typeorm,prisma,mongoose,mikroorm): five query-grammar correctness bugs

### DIFF
--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -28,6 +28,18 @@ aliases (`GTE`/`Gte` are 400s). Logical operators: `AND`, `OR`, `NOT`
 registry mapping tokens to AST factories is a natural extension point but
 is deliberately not built in v6.
 
+**`NOT` is variadic and means `NOT(AND(children))`.** All three logical
+operators take a child list — `FilterGroup.children` is
+`readonly FilterExpression[]` for every operator — so `NOT` needed an
+arity answer rather than an assumption. The wire parser only ever builds
+the unary shape (`convertLogical` wraps exactly one converted node), but a
+programmatic caller hand-builds the AST and `QueryNormalizer` validates
+allowlists and limits, not arity. Conjoining is what makes the unary case
+a special case of the general one instead of the only legal one, and it
+gives the degenerate group below its meaning for free. Reading
+`children[0]` and dropping the rest — which `@kavo/typeorm` and
+`@kavo/prisma` used to do — returned rows the caller asked to exclude.
+
 ## 2. Reference example
 
 ```
@@ -59,7 +71,19 @@ fields:     root: [id, name, email]
   AND (`filter[age][gte]=18&filter[age][lt]=65`).
 - **Multi-value operators** (`in`, `notIn`): comma-separated by default;
   the repeated-key form `filter[status][in][]=a&filter[status][in][]=b`
-  is also accepted.
+  is also accepted. A **bare empty operand** — `filter[status][in]=`, or
+  its repeated-key spelling `filter[status][in][]=` — is a
+  `KAVO_QUERY_INVALID_VALUE` **400 on every column kind**. It is neither
+  "no filter" nor "the empty set": a client that wants no filter omits the
+  parameter. Left to coercion the two column kinds disagreed — string
+  coercion accepts `""`, so `filter[name][in]=` built a live `IN ('')`
+  (a search for the empty string, usually zero rows and no error), while
+  `filter[age][in]=` was already a 400. A UI that submits a cleared
+  multi-select now gets an error it can see rather than a silently empty
+  page. An _interior_ empty element (`in=a,,b`) is a different question
+  and keeps its per-element coercion behavior. The genuinely empty array a
+  programmatic caller can pass (`value: []`) is unaffected — that is the
+  empty set, and it round-trips as one.
 - **`between`:** exactly two comma-separated bounds, in the order given —
   the pair is never sorted, so `between=65,18` is an empty range rather
   than a silently corrected one.
@@ -75,11 +99,39 @@ fields:     root: [id, name, email]
   escape character, Postgres does not — so a parameter is the portable
   spelling). `ilike` is translated portably (`LOWER(col) LIKE
 LOWER(:v)`), identical on every driver. Both operators apply to string
-  columns only.
+  columns only. Two adapters cannot honor the whole pattern language:
+  `@kavo/prisma` has no raw pattern operator, so an interior `%` and any
+  `_` are **rejected with a 400** rather than mistranslated (doc 14 §6),
+  and `@kavo/mikroorm` cannot attach an `ESCAPE` clause, so the backslash
+  escape there is driver-dependent (doc 17 §7).
 - **Relation-path filtering:** dot notation
   (`filter[profile.city][eq]=Helsinki`), permitted only for paths on the
   filterable allowlist. Relation-path filters **restrict root rows** (a
   non-selecting join); they never load or filter the included collection.
+  On a **to-many** segment that reads as "at least one" — SQL gets it from
+  a `LEFT JOIN` plus a `WHERE`, and the declarative adapters spell it as
+  Prisma's `some` / MikroORM's nested list match.
+- **Degenerate empty groups.** A group with **zero** children is
+  unreachable from the wire (the parser only emits a group once a child
+  converted), but a programmatic caller hand-builds the AST and
+  `QueryNormalizer` checks allowlists and limits, not arity — so every
+  adapter has to answer for it, and **all four agree**:
+
+  | AST      | Matches       | Why                                           |
+  | -------- | ------------- | --------------------------------------------- |
+  | `AND []` | **every row** | `true` is the identity of conjunction         |
+  | `OR []`  | **no row**    | `false` is the identity of disjunction        |
+  | `NOT []` | **no row**    | `NOT(AND [])` — the negation of the tautology |
+
+  Each adapter emits a **real predicate** for these, never an omitted one:
+  an omitted predicate is exactly how an empty `OR` silently widened to
+  every row in `@kavo/typeorm`. The spellings differ because the targets
+  do — `1 = 0` in SQL, `$nor: [{}]` in MongoDB, an empty `$in` on the
+  primary key in MikroORM, `{ OR: [] }` in Prisma (whose `NOT` over an
+  empty operand is dropped rather than honored, doc 14 §2) — but the
+  result sets do not, and each adapter's translator spec pins its own row
+  of this table.
+
 - **Nested boolean trees:** `filter` also accepts one JSON-encoded value
   — `?filter={"or":[{"name":{"eq":"admin"}},{"not":{"status":{"eq":"x"}}}]}` —
   parsed into the same AST. Bracket notation is sugar for the common flat

--- a/docs/internals/architecture/14-prisma-adapter.md
+++ b/docs/internals/architecture/14-prisma-adapter.md
@@ -45,6 +45,37 @@ of adding a join. `LIKE`/`ILIKE` map onto `startsWith`/`endsWith`/
 `contains`/`equals` by wildcard position, since Prisma has no raw pattern
 operator.
 
+Two of those translations need more than the AST to be correct, which is
+why `FilterTranslatorOptions` carries the queried `model` and a
+`PrismaRelationGraph` alongside the connector setting:
+
+**Relation-path cardinality.** Prisma accepts the bare nested form only on
+a **to-one** relation; on a list it requires a `some`/`every`/`none`
+wrapper and rejects the bare shape with `Unknown argument`. The grammar
+already implies which one: doc 05 §3 defines a relation-path filter as
+restricting _root_ rows, so a to-many segment nests under `some` —
+`filter[posts.title][eq]=x` is `{ posts: { some: { title: … } } }`, the
+same semantics `@kavo/typeorm` gets for free from a `LEFT JOIN` plus a
+`WHERE` on the joined column. Each segment of a multi-hop path is
+classified independently (`author.posts.title` wraps only the second),
+which is why the graph covers the whole datamodel rather than one entity:
+`EntityMetadata.relations` describes the queried entity alone, and the
+second hop belongs to another model. The graph is derived once from the
+DMMF at bootstrap (`buildRelationGraph`, called by `createInfrastructure`)
+and passed as plain data, so `translateFilter` stays a pure function. A
+segment that resolves to no relation raises
+`KAVO_QUERY_UNSUPPORTED_PARAM` (400) rather than emitting a `where` the
+engine will reject — core's default allowlists hold scalars only, so
+reaching it means a relation path was allowlisted by hand.
+
+**The empty `NOT` group.** `NOT` is variadic and means `NOT(AND(children))`
+(doc 05 §1), but the zero-child case cannot be spelled that way here:
+Prisma **drops** a `NOT` whose operand carries no condition, so
+`{ NOT: { AND: [] } }` matches every row instead of none. The empty
+disjunction `{ OR: [] }` is the contradiction Prisma does honor, and is
+what the translator emits — verified against a real engine in
+`tests/adapter.spec.ts`, which pins all three degenerate groups.
+
 **`ILIKE` and connector support.** Prisma's case-insensitive filter
 (`mode: "insensitive"`) is Postgres/MongoDB-only; MySQL, SQLite, and SQL
 Server reject the argument. There is no reliable way to detect the
@@ -94,7 +125,36 @@ per-database code lists. The original error always travels as `cause`:
 | `P2034` transaction conflict  | `TransactionException` (`retryable: true`) |
 | anything else                 | `PersistenceException` with `cause`        |
 
-## 6. Attachment points for later work
+## 6. Adapter-specific caveats
+
+**`LIKE` cannot express an interior `%`, and has no `_` at all.** Prisma's
+`where` has no raw pattern operator — only `equals`, `startsWith`,
+`endsWith`, and `contains` — so exactly four pattern shapes translate:
+
+| wire pattern | Prisma filter    |
+| ------------ | ---------------- |
+| `john`       | `equals: "john"` |
+| `A%`         | `startsWith: A`  |
+| `%son`       | `endsWith: son`  |
+| `%j%`        | `contains: j`    |
+
+Anything else — an interior wildcard (`a%b`), or any use of the
+single-character wildcard `_`, which Prisma has no equivalent for — is
+**rejected with `KAVO_QUERY_UNSUPPORTED_PARAM` (400)**. It is not
+downgraded to `equals` on the raw pattern: that returned a silently
+different result set from the other three adapters for the same wire
+request, with no error on either side. Escape a literal `%`/`_` with a
+backslash to sidestep the limit, or reach for a raw query. Doc 05 §3
+cross-references this from the grammar side.
+
+The grammar's backslash escape itself _is_ honored: `\%` and `\_` are
+resolved to literal text before the wildcard positions are read, so
+`filter[name][like]=100\%` is `{ equals: "100%" }` — matching what
+`@kavo/typeorm` gets from its bound `ESCAPE` clause and `@kavo/mongoose`
+from `likeToRegExpSource`. `@kavo/mikroorm` is the adapter with the weaker
+escape story here (doc 17 §7).
+
+## 7. Attachment points for later work
 
 - **Transactions:** same unbuilt seam as `@kavo/typeorm` (doc 09 §6) —
   `TransactionManager` has no consumer in this build.
@@ -104,7 +164,7 @@ per-database code lists. The original error always travels as `cause`:
   of (Prisma manages the join table itself). See the package README for
   the escape hatch (a custom operation handler against the raw client).
 
-## 7. Performance posture
+## 8. Performance posture
 
 Filters translate to Prisma's own indexed-field filter operators — no
 raw SQL, no function-wrapping. No N+1: Prisma's `include` already

--- a/packages/core/src/query/default-filter-parser.ts
+++ b/packages/core/src/query/default-filter-parser.ts
@@ -287,6 +287,22 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
       case "IN":
       case "NOT_IN": {
         const parts = splitMultiValue(raw);
+        if (isBareEmptyOperand(parts)) {
+          // `filter[status][in]=` is neither "no filter" nor "the empty set".
+          // Left alone it splits to `[""]`, which string coercion accepts, so
+          // on a string column it became a live `IN ('')` — a search for the
+          // empty string — while a typed column 400'd on coercion. One answer
+          // for every column kind, and the loud one: a UI that submits a
+          // cleared multi-select gets an error it can see rather than a
+          // silently empty page. Omitting the parameter is how a caller says
+          // "no filter". See doc 05 §3.
+          issues.push({
+            field,
+            code: "KAVO_QUERY_INVALID_VALUE",
+            detail: `'${token}' takes at least one value; '${field}' was given an empty one. Omit the parameter to apply no filter.`,
+          });
+          return null;
+        }
         const max = config.settings.query.maxInValues;
         if (parts.length > max) {
           issues.push({
@@ -371,6 +387,21 @@ function splitMultiValue(raw: unknown): readonly unknown[] {
   if (Array.isArray(raw)) return raw;
   if (typeof raw === "string") return raw.split(",");
   return [raw];
+}
+
+/**
+ * Whether a multi-value operand is the *bare* empty spelling — `in=` or
+ * `in[]=`, which both split to a single empty string.
+ *
+ * Deliberately not "contains an empty element": `in=a,,b` is a different
+ * question (a malformed list rather than an absent one) and keeps its
+ * existing per-element coercion behavior. The genuinely empty array a
+ * programmatic caller can build (`value: []`) never reaches here either —
+ * `filter[status][in][]` with no values arrives as `[]`, length zero, which
+ * is the empty set and round-trips as one.
+ */
+function isBareEmptyOperand(parts: readonly unknown[]): boolean {
+  return parts.length === 1 && parts[0] === "";
 }
 
 function expressionDepth(expression: FilterExpression<unknown>): number {

--- a/packages/core/tests/filter-parser.spec.ts
+++ b/packages/core/tests/filter-parser.spec.ts
@@ -240,17 +240,37 @@ describe("DefaultFilterParser — IN / NOT_IN value lists", () => {
     expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" });
   });
 
-  it("reads a bare empty value on a string column as a one-element list", () => {
-    // Current behavior, pinned so a change is visible rather than silent:
-    // string coercion accepts "", so `filter[name][in]=` is `IN ('')` — a
-    // live filter for the empty string, not the empty set and not a 400. A
-    // UI submitting an empty multi-select gets rows named "" rather than
-    // either of the two things it might have meant. Tracked in #113.
-    expect(parse({ "filter[name][in]": "" }).root).toEqual({
+  it("rejects a bare empty value on a string column too, not just a typed one", () => {
+    // The decision recorded in doc 05 §3 (#113). Left to coercion the two
+    // column kinds disagreed: string coercion accepts "", so
+    // `filter[name][in]=` used to build a live `IN ('')` — a search for the
+    // empty string — while `filter[age][in]=` was a 400. A cleared
+    // multi-select must not silently become "rows whose value is ''".
+    for (const [key, field] of [
+      ["filter[name][in]", "name"],
+      ["filter[name][notIn]", "name"],
+    ] as const) {
+      const issues = issuesOf(() => parse({ [key]: "" }));
+      expect(issues[0]).toMatchObject({ field, code: "KAVO_QUERY_INVALID_VALUE" });
+    }
+  });
+
+  it("rejects the bare empty value in the repeated-key spelling as well", () => {
+    // `filter[name][in][]=` arrives as `[""]`, the same absent operand in a
+    // different spelling — one answer for both.
+    const issues = issuesOf(() => parse({ "filter[name][in][]": [""] }));
+    expect(issues[0]).toMatchObject({ field: "name", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("still admits an interior empty element, which is a different question", () => {
+    // `in=a,,b` is a malformed list rather than an absent one; #113 scoped
+    // itself to the bare spelling, so this keeps its per-element coercion
+    // behavior rather than being swept up by the new check.
+    expect(parse({ "filter[name][in]": "a,,b" }).root).toEqual({
       kind: "condition",
       field: "name",
       operator: "IN",
-      value: [""],
+      value: ["a", "", "b"],
     });
   });
 });

--- a/packages/orms/mikroorm/src/filter-translator.ts
+++ b/packages/orms/mikroorm/src/filter-translator.ts
@@ -80,9 +80,12 @@ function translateExpression(expression: FilterExpression, options: FilterTransl
   const children = expression.children.map((child) => translateExpression(child, options));
 
   if (expression.operator === "NOT") {
-    // Core's parser gives a NOT group exactly one child. With no child there
-    // is nothing to negate, and "not (anything)" matches nothing.
-    return children.length === 0 ? matchesNothing(options.idField) : { $not: children[0]! };
+    // `NOT` is variadic and means `NOT(AND(children))` (doc 05 §1), so more
+    // than one child is conjoined first rather than having everything past
+    // `children[0]` dropped. Core's wire parser only ever builds the unary
+    // shape; this guards a hand-built AST.
+    if (children.length === 0) return matchesNothing(options.idField);
+    return { $not: children.length === 1 ? children[0]! : { $and: children } };
   }
 
   // The parser enforces arity, so the empty cases only guard hand-built ASTs

--- a/packages/orms/mikroorm/tests/filter-translator.spec.ts
+++ b/packages/orms/mikroorm/tests/filter-translator.spec.ts
@@ -93,6 +93,14 @@ describe("translateFilter — groups", () => {
     });
   });
 
+  it("conjoins a multi-child NOT rather than dropping every child past the first", () => {
+    // `NOT` means `NOT(AND(children))` (doc 05 §1, #115). Negating only
+    // `children[0]` returned rows the caller asked to exclude.
+    expect(translate({ kind: "group", operator: "NOT", children: [left, right] } as FilterExpression)).toEqual({
+      $not: { $and: [{ name: { $eq: "Ada" } }, { age: { $gt: 30 } }] },
+    });
+  });
+
   it("nests groups without losing precedence", () => {
     const nested = {
       kind: "group",

--- a/packages/orms/mongoose/src/filter-translator.ts
+++ b/packages/orms/mongoose/src/filter-translator.ts
@@ -57,10 +57,13 @@ function translateExpression(expression: FilterExpression, options: FilterTransl
   const children = expression.children.map((child) => translateExpression(child, options));
 
   if (expression.operator === "NOT") {
-    // Core's parser gives a NOT group exactly one child. `$nor` over that
-    // child is MongoDB's negation; with no child there is nothing to
-    // negate, and "not (anything)" matches nothing.
-    return children.length === 0 ? MATCHES_NOTHING : { $nor: children };
+    // `NOT` is variadic and means `NOT(AND(children))` (doc 05 §1). `$nor`
+    // is MongoDB's negation, but `$nor: [a, b]` is `NOT(a OR b)` — so more
+    // than one child is conjoined *first* and the conjunction negated,
+    // rather than handed to `$nor` as siblings. Core's wire parser only
+    // ever builds the unary shape; this guards a hand-built AST.
+    if (children.length === 0) return MATCHES_NOTHING;
+    return { $nor: [children.length === 1 ? children[0]! : { $and: children }] };
   }
 
   // MongoDB rejects an empty `$and`/`$or` outright, so the identity for

--- a/packages/orms/mongoose/tests/filter-translator.spec.ts
+++ b/packages/orms/mongoose/tests/filter-translator.spec.ts
@@ -74,6 +74,16 @@ describe("translateFilter — logical groups", () => {
     });
   });
 
+  it("conjoins a multi-child NOT before negating it, rather than $nor-ing the children", () => {
+    // `NOT` means `NOT(AND(children))` (doc 05 §1, #115). `$nor: [a, b]`
+    // would be `NOT(a OR b)` — a *narrower* set than asked for, and the
+    // mirror of the widening the other two adapters had.
+    const children = [condition("a", "EQ", 1), condition("b", "EQ", 2)];
+    expect(translate({ kind: "group", operator: "NOT", children } as FilterExpression)).toEqual({
+      $nor: [{ $and: [{ a: { $eq: 1 } }, { b: { $eq: 2 } }] }],
+    });
+  });
+
   it("spells the identity of an empty group rather than emitting one MongoDB rejects", () => {
     // MongoDB errors outright on `{ $and: [] }` / `{ $or: [] }`. The parser
     // enforces arity, so this only guards hand-built ASTs.

--- a/packages/orms/prisma/src/filter-translator.ts
+++ b/packages/orms/prisma/src/filter-translator.ts
@@ -1,22 +1,35 @@
 import type { Filter, FilterCondition, FilterExpression, FilterScalar } from "@kavo/core";
-import { assertNever } from "@kavo/core";
+import { assertNever, QueryValidationException } from "@kavo/core";
+import type { PrismaRelationEdge, PrismaRelationGraph } from "./metadata.js";
 
 /** A Prisma `where` input, built structurally — no generated type is required to build one. */
 export type PrismaWhere = Record<string, unknown>;
 
-/**
- * Whether the target connector supports Prisma's `mode: "insensitive"`
- * string filter — Postgres and MongoDB do; MySQL, SQLite, and SQL Server
- * reject the argument outright. There is no reliable way to detect this
- * from the DMMF at runtime, so it is an explicit, caller-declared setting
- * (see `PrismaInfrastructureOptions.caseInsensitiveFilters`) rather than a
- * guess. On an unsupported connector, `ILIKE` degrades to the same
- * translation as `LIKE` — on SQLite in particular this is not a loss of
- * behavior, since SQLite's own `LIKE` is already ASCII case-insensitive.
- */
 export interface FilterTranslatorOptions {
+  /**
+   * Whether the target connector supports Prisma's `mode: "insensitive"`
+   * string filter — Postgres and MongoDB do; MySQL, SQLite, and SQL Server
+   * reject the argument outright. There is no reliable way to detect this
+   * from the DMMF at runtime, so it is an explicit, caller-declared setting
+   * (see `PrismaInfrastructureOptions.caseInsensitiveFilters`) rather than a
+   * guess. On an unsupported connector, `ILIKE` degrades to the same
+   * translation as `LIKE` — on SQLite in particular this is not a loss of
+   * behavior, since SQLite's own `LIKE` is already ASCII case-insensitive.
+   */
   readonly caseInsensitiveFilters: boolean;
+  /** The model a relation path starts walking from — the entity being queried. */
+  readonly model: string;
+  /** The whole datamodel's relation edges, so a path's cardinality is knowable. */
+  readonly relations: PrismaRelationGraph;
 }
+
+/**
+ * A predicate that matches no row: the empty disjunction, which is `false`
+ * by definition. Spelled this way rather than against the primary key
+ * (`@kavo/mikroorm`'s `{ id: { $in: [] } }`) because it needs no metadata,
+ * and unlike an empty `NOT` Prisma does honor it.
+ */
+const MATCHES_NOTHING: PrismaWhere = { OR: [] };
 
 /**
  * Filter AST → Prisma `where` object.
@@ -24,8 +37,9 @@ export interface FilterTranslatorOptions {
  * Unlike `@kavo/typeorm`'s translator, this needs no query-builder state
  * (no join aliases, no parameter numbering): Prisma's `where` already
  * nests relation paths natively (`{ author: { name: { equals: "Ada" } } }`),
- * so a relation-path field (`author.name`) simply nests the same
- * translation one level deeper instead of adding a join.
+ * so a relation-path field (`author.name`) nests the same translation one
+ * level deeper instead of adding a join. A *to-many* segment takes a `some`
+ * wrapper on the way down — see {@link nest}.
  */
 export function translateFilter<Entity>(
   filter: Filter<Entity>,
@@ -41,17 +55,76 @@ function translateExpression(expression: FilterExpression, options: FilterTransl
     return translateCondition(expression, options);
   }
   if (expression.operator === "NOT") {
-    const child = expression.children[0];
-    return { NOT: child === undefined ? {} : translateExpression(child, options) };
+    // `NOT` is variadic and means `NOT(AND(children))` (doc 05 §1), so no
+    // child past the first is dropped (#115).
+    //
+    // The empty case cannot be spelled that way, though: Prisma drops a
+    // `NOT` whose operand carries no condition, so `{ NOT: { AND: [] } }`
+    // matches *every* row rather than none — the same silent widening #111
+    // fixed in `@kavo/typeorm`, verified against a real engine in
+    // `adapter.spec.ts`. `MATCHES_NOTHING` is the contradiction Prisma does
+    // honor.
+    if (expression.children.length === 0) return MATCHES_NOTHING;
+    return { NOT: conjunction(expression.children, options) };
   }
   const key = expression.operator === "OR" ? "OR" : "AND";
   return { [key]: expression.children.map((child) => translateExpression(child, options)) };
 }
 
-/** Nest `condition.field` (`"author.name"`) into Prisma's native relation-path shape. */
-function nest(field: string, leaf: Record<string, unknown>): PrismaWhere {
+/**
+ * `AND` over `children`, as the thing `NOT` negates. A single child is
+ * returned unwrapped so the common unary `NOT` keeps its exact shape.
+ */
+function conjunction(children: readonly FilterExpression[], options: FilterTranslatorOptions): PrismaWhere {
+  if (children.length === 1) return translateExpression(children[0]!, options);
+  return { AND: children.map((child) => translateExpression(child, options)) };
+}
+
+/**
+ * Nest `condition.field` (`"author.name"`) into Prisma's native
+ * relation-path shape.
+ *
+ * Cardinality decides the shape, which is why the translator needs the
+ * relation graph at all. Prisma accepts a bare nested object only on a
+ * to-one relation; on a list it requires `some`/`every`/`none` and rejects
+ * the bare form with `Unknown argument`. `some` is the right one: doc 05 §3
+ * defines a relation-path filter as restricting *root* rows — "a user with
+ * at least one post titled x" — which is exactly what `@kavo/typeorm` gets
+ * from a `LEFT JOIN` plus a `WHERE` on the joined column.
+ */
+function nest(field: string, leaf: Record<string, unknown>, options: FilterTranslatorOptions): PrismaWhere {
   const segments = field.split(".");
-  return segments.reduceRight<Record<string, unknown>>((inner, segment) => ({ [segment]: inner }), leaf);
+  if (segments.length === 1) return { [field]: leaf };
+
+  // Walk the path first, so an unresolvable segment raises a Kavo 400
+  // instead of building a `where` Prisma will reject at runtime.
+  const edges: PrismaRelationEdge[] = [];
+  let model = options.model;
+  for (const segment of segments.slice(0, -1)) {
+    const edge = options.relations.get(model)?.get(segment);
+    if (edge === undefined) throw unknownRelationSegment(field, segment, model);
+    edges.push(edge);
+    model = edge.target;
+  }
+
+  // Then build outwards from the leaf, wrapping each to-many hop in `some`.
+  let nested: Record<string, unknown> = { [segments[segments.length - 1]!]: leaf };
+  for (let index = edges.length - 1; index >= 0; index -= 1) {
+    const inner = edges[index]!.cardinality === "many" ? { some: nested } : nested;
+    nested = { [segments[index]!]: inner };
+  }
+  return nested;
+}
+
+function unknownRelationSegment(field: string, segment: string, model: string): QueryValidationException {
+  return QueryValidationException.single({
+    field,
+    code: "KAVO_QUERY_UNSUPPORTED_PARAM",
+    detail:
+      `Query parameter '${field}' is not supported: '${segment}' is not a relation on Prisma model ` +
+      `'${model}', so @kavo/prisma cannot tell whether to nest it as a to-one or a to-many filter. ` +
+      `Remove '${field}' from the allowlist, or correct the path.`,
+  });
 }
 
 function translateCondition(condition: FilterCondition, options: FilterTranslatorOptions): PrismaWhere {
@@ -60,36 +133,40 @@ function translateCondition(condition: FilterCondition, options: FilterTranslato
 
   switch (condition.operator) {
     case "EQ":
-      return nest(field, { equals: value as FilterScalar });
+      return nest(field, { equals: value as FilterScalar }, options);
     case "NE":
-      return nest(field, { not: value as FilterScalar });
+      return nest(field, { not: value as FilterScalar }, options);
     case "GT":
-      return nest(field, { gt: value });
+      return nest(field, { gt: value }, options);
     case "GTE":
-      return nest(field, { gte: value });
+      return nest(field, { gte: value }, options);
     case "LT":
-      return nest(field, { lt: value });
+      return nest(field, { lt: value }, options);
     case "LTE":
-      return nest(field, { lte: value });
+      return nest(field, { lte: value }, options);
     case "IN":
-      return nest(field, { in: value as readonly FilterScalar[] });
+      return nest(field, { in: value as readonly FilterScalar[] }, options);
     case "NOT_IN":
-      return nest(field, { notIn: value as readonly FilterScalar[] });
+      return nest(field, { notIn: value as readonly FilterScalar[] }, options);
     case "LIKE":
-      return nest(field, likeToPrismaStringFilter(value as string));
+      return nest(field, likeToPrismaStringFilter(value as string, field), options);
     case "ILIKE":
-      return nest(field, {
-        ...likeToPrismaStringFilter(value as string),
-        ...(options.caseInsensitiveFilters && { mode: "insensitive" }),
-      });
+      return nest(
+        field,
+        {
+          ...likeToPrismaStringFilter(value as string, field),
+          ...(options.caseInsensitiveFilters && { mode: "insensitive" }),
+        },
+        options,
+      );
     case "BETWEEN": {
       const [low, high] = value as readonly FilterScalar[];
-      return nest(field, { gte: low, lte: high });
+      return nest(field, { gte: low, lte: high }, options);
     }
     case "IS_NULL":
-      return nest(field, { equals: null });
+      return nest(field, { equals: null }, options);
     case "IS_NOT_NULL":
-      return nest(field, { not: null });
+      return nest(field, { not: null }, options);
     default:
       // Every AST operator must translate to a predicate — proven total
       // here at build time, same guarantee as `@kavo/typeorm`'s translator.
@@ -97,20 +174,108 @@ function translateCondition(condition: FilterCondition, options: FilterTranslato
   }
 }
 
+/** One piece of a `LIKE` pattern: literal text, `%` (any run), or `_` (exactly one). */
+type LikeToken =
+  { readonly kind: "literal"; readonly text: string } | { readonly kind: "any" } | { readonly kind: "one" };
+
 /**
- * `LIKE`/`ILIKE` carry SQL wildcard syntax (`%prefix%`, `A%`, `%suffix`)
- * from the parser; Prisma has no raw pattern operator, only
- * `contains`/`startsWith`/`endsWith`/`equals`. The wildcard *position*
- * decides which one — `A%` is a prefix match (`startsWith`), not "contains
- * A somewhere", so the two ends are checked independently rather than
- * always falling back to `contains`.
+ * Split a `LIKE` pattern into tokens, honoring the grammar's backslash
+ * escape (doc 05 §3): `\%` and `\_` are literal text, not wildcards.
+ *
+ * Consecutive `%` collapse into one — `a%%` and `a%` mean the same thing —
+ * so the shape check downstream is about structure rather than spelling.
+ * A trailing lone backslash escapes nothing and is treated as a literal,
+ * matching `@kavo/mongoose`'s `likeToRegExpSource`.
  */
-function likeToPrismaStringFilter(pattern: string): Record<string, unknown> {
-  const leading = pattern.startsWith("%");
-  const trailing = pattern.endsWith("%") && pattern.length > 1;
-  const stripped = pattern.slice(leading ? 1 : 0, trailing ? -1 : undefined);
-  if (leading && trailing) return { contains: stripped };
-  if (trailing) return { startsWith: stripped };
-  if (leading) return { endsWith: stripped };
-  return { equals: stripped };
+function tokenizeLike(pattern: string): readonly LikeToken[] {
+  const tokens: LikeToken[] = [];
+  let literal = "";
+  const flush = (): void => {
+    if (literal !== "") {
+      tokens.push({ kind: "literal", text: literal });
+      literal = "";
+    }
+  };
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index]!;
+    if (character === "\\") {
+      const escaped = pattern[index + 1];
+      if (escaped === undefined) {
+        literal += "\\";
+        break;
+      }
+      literal += escaped;
+      index += 1;
+      continue;
+    }
+    if (character === "%") {
+      flush();
+      if (tokens[tokens.length - 1]?.kind !== "any") tokens.push({ kind: "any" });
+      continue;
+    }
+    if (character === "_") {
+      flush();
+      tokens.push({ kind: "one" });
+      continue;
+    }
+    literal += character;
+  }
+  flush();
+  return tokens;
+}
+
+/**
+ * `LIKE`/`ILIKE` → a Prisma string filter.
+ *
+ * Prisma's `where` has no raw pattern operator — only
+ * `equals`/`startsWith`/`endsWith`/`contains` — so exactly four pattern
+ * shapes are expressible, distinguished by where the wildcards sit:
+ *
+ * | pattern | filter        |
+ * | ------- | ------------- |
+ * | `john`  | `equals`      |
+ * | `A%`    | `startsWith`  |
+ * | `%son`  | `endsWith`    |
+ * | `%j%`   | `contains`    |
+ *
+ * Everything else — an interior `%` (`a%b`), or any `_` at all, which
+ * Prisma has no single-character wildcard for — is **rejected with a 400**
+ * rather than silently downgraded. The rejected forms used to fall through
+ * to `equals` on the raw pattern (#114), so the same wire request returned
+ * one result set on TypeORM/Mongoose/MikroORM and a different one here,
+ * with no error on either side. A 400 makes the limitation visible; see
+ * `docs/internals/architecture/14-prisma-adapter.md`.
+ *
+ * The backslash escape is applied first, so `100\%` is the literal text
+ * `100%` (an `equals`), not a `startsWith` on `100\` — matching the
+ * `ESCAPE` clause `@kavo/typeorm` binds and the regex `@kavo/mongoose`
+ * builds.
+ */
+function likeToPrismaStringFilter(pattern: string, field: string): Record<string, unknown> {
+  const tokens = tokenizeLike(pattern);
+  const literals = tokens.filter((token) => token.kind === "literal");
+  const text = literals.length === 1 ? (literals[0] as { text: string }).text : "";
+
+  if (!tokens.some((token) => token.kind === "one") && literals.length <= 1) {
+    const leading = tokens[0]?.kind === "any";
+    const trailing = tokens.length > 1 && tokens[tokens.length - 1]?.kind === "any";
+    // `%` alone is one `any` token: leading with no literal, which reads as
+    // `contains: ""` — every non-null value, the same set SQL `LIKE '%'` has.
+    if (tokens.length === 1 && leading) return { contains: "" };
+    if (leading && trailing) return { contains: text };
+    if (trailing) return { startsWith: text };
+    if (leading) return { endsWith: text };
+    return { equals: text };
+  }
+
+  throw QueryValidationException.single({
+    field,
+    code: "KAVO_QUERY_UNSUPPORTED_PARAM",
+    detail:
+      `Query parameter '${field}' is not supported: @kavo/prisma cannot express the pattern ` +
+      `'${pattern}'. Prisma's 'where' has no raw pattern operator, so only a leading and/or ` +
+      `trailing '%' is supported ('john', 'A%', '%son', '%j%'); an interior '%' and the ` +
+      `single-character wildcard '_' have no equivalent. Escape a literal '%' or '_' with a ` +
+      `backslash, or move the pattern to a raw query.`,
+  });
 }

--- a/packages/orms/prisma/src/index.ts
+++ b/packages/orms/prisma/src/index.ts
@@ -1,6 +1,14 @@
-export { buildEntityMetadata } from "./metadata.js";
+export {
+  buildEntityMetadata,
+  buildRelationGraph,
+  type PrismaRelationEdge,
+  type PrismaRelationGraph,
+} from "./metadata.js";
 export { mapDriverError } from "./error-mapping.js";
-export { translateFilter, type PrismaWhere } from "./filter-translator.js";
+// `FilterTranslatorOptions` is named here for the same reason `@kavo/mongoose`
+// and `@kavo/mikroorm` name theirs: `PrismaRepositoryAdapter` is public, and
+// constructing one means constructing its filter options.
+export { translateFilter, type FilterTranslatorOptions, type PrismaWhere } from "./filter-translator.js";
 export { PrismaRepositoryAdapter } from "./prisma-repository-adapter.js";
 export { createInfrastructure, createPrismaKavo, type PrismaInfrastructureOptions } from "./infrastructure.js";
 export { delegateName, type PrismaClientLike, type PrismaModelDelegate } from "./prisma-client-like.js";

--- a/packages/orms/prisma/src/infrastructure.ts
+++ b/packages/orms/prisma/src/infrastructure.ts
@@ -8,7 +8,7 @@ import type {
 } from "@kavo/core";
 import { createKavo } from "@kavo/core";
 import type { PrismaDatamodel } from "./datamodel.js";
-import { buildEntityMetadata } from "./metadata.js";
+import { buildEntityMetadata, buildRelationGraph } from "./metadata.js";
 import type { PrismaClientLike } from "./prisma-client-like.js";
 import { PrismaRepositoryAdapter } from "./prisma-repository-adapter.js";
 
@@ -52,6 +52,11 @@ export function createInfrastructure(
   const byName = new Map(options.entities.map((entity) => [entity.name, entity]));
   const metadataCache = new Map<ClassRef, EntityMetadata>();
   const adapterCache = new Map<ClassRef, RepositoryAdapter>();
+  // Derived once for the whole datamodel, not per entity: a relation-path
+  // filter walks models the queried entity's own metadata cannot describe
+  // (`author.posts.title` needs Author's edges too). Bootstrap work, like
+  // metadata derivation and adapter construction.
+  const relations = buildRelationGraph(options.datamodel);
 
   function metadataFor<Entity extends object>(entity: ClassRef<Entity>): EntityMetadata<Entity> {
     let metadata = metadataCache.get(entity);
@@ -69,6 +74,7 @@ export function createInfrastructure(
       if (adapter === undefined) {
         adapter = new PrismaRepositoryAdapter(prismaClient, metadataFor(entity), {
           caseInsensitiveFilters: options.caseInsensitiveFilters ?? true,
+          relations,
         }) as RepositoryAdapter;
         adapterCache.set(entity, adapter);
       }

--- a/packages/orms/prisma/src/metadata.ts
+++ b/packages/orms/prisma/src/metadata.ts
@@ -115,6 +115,45 @@ export function buildEntityMetadata<Entity extends object>(
   };
 }
 
+/**
+ * One relation edge, as the filter translator needs to see it: which
+ * Prisma model it lands on, and whether it is a list.
+ */
+export interface PrismaRelationEdge {
+  readonly cardinality: "one" | "many";
+  /** Target model name — the key to look up for the next path segment. */
+  readonly target: string;
+}
+
+/**
+ * Model name → relation property name → edge, for the whole datamodel.
+ *
+ * `EntityMetadata.relations` describes one entity, which is enough for
+ * include resolution but not for a filter path: `author.posts.title` walks
+ * two models, and only the second hop knows whether `posts` is a list. The
+ * graph is derived once at bootstrap (`createInfrastructure`) and handed to
+ * the translator as plain data, which is what keeps `translateFilter` a
+ * pure function rather than something that reaches for a client.
+ */
+export type PrismaRelationGraph = ReadonlyMap<string, ReadonlyMap<string, PrismaRelationEdge>>;
+
+/** Derive {@link PrismaRelationGraph} from Prisma's DMMF. */
+export function buildRelationGraph(datamodel: PrismaDatamodel): PrismaRelationGraph {
+  return new Map(
+    datamodel.models.map((model) => [
+      model.name,
+      new Map(
+        model.fields
+          .filter((field) => field.kind === "object")
+          .map((field): [string, PrismaRelationEdge] => [
+            field.name,
+            { cardinality: field.isList ? "many" : "one", target: field.type },
+          ]),
+      ),
+    ]),
+  );
+}
+
 function relationDescriptor(
   field: PrismaField,
   ownerModelName: string,

--- a/packages/orms/prisma/src/prisma-repository-adapter.ts
+++ b/packages/orms/prisma/src/prisma-repository-adapter.ts
@@ -30,12 +30,17 @@ import { delegateName, type PrismaClientLike, type PrismaModelDelegate } from ".
 export class PrismaRepositoryAdapter<Entity extends object> implements RepositoryAdapter<Entity> {
   private readonly delegate: PrismaModelDelegate;
   private readonly idField: string;
+  private readonly filterOptions: FilterTranslatorOptions;
 
   constructor(
     private readonly prismaClient: PrismaClientLike,
     private readonly metadata: EntityMetadata<Entity>,
-    private readonly filterOptions: FilterTranslatorOptions = { caseInsensitiveFilters: true },
+    // `model` is not the caller's to supply — it is the entity this adapter
+    // already describes, and a mismatched one would nest relation paths
+    // against the wrong model's edges.
+    filterOptions: Omit<FilterTranslatorOptions, "model">,
   ) {
+    this.filterOptions = { ...filterOptions, model: metadata.name };
     const name = delegateName(metadata.name);
     const delegate = prismaClient[name];
     if (delegate === undefined) {

--- a/packages/orms/prisma/tests/adapter.spec.ts
+++ b/packages/orms/prisma/tests/adapter.spec.ts
@@ -253,6 +253,28 @@ describe("PrismaRepositoryAdapter — query translation", () => {
     expect(list.items.map((b) => (b as Book).title)).toEqual(["Notes"]);
   });
 
+  it("filters on a to-many relation path, restricting root rows rather than 500ing", async () => {
+    // Prisma requires `some`/`every`/`none` on a list relation and rejects
+    // the bare nested form with `Unknown argument`, which reached the client
+    // as a 500 (#116). doc 05 §3 defines a relation-path filter as
+    // restricting root rows — "an author with at least one book titled X" —
+    // which is `some`.
+    const scoped = kavo.createCrud(Author, {
+      allowlists: { filterable: ["name", "books.title" as never] },
+    }) as DefaultKavoService<Author>;
+    await seed();
+    const all = (await authors.findMany()).items.map((a) => a as Author);
+    const ada = all.find((a) => a.name === "Ada")!;
+    const grace = all.find((a) => a.name === "Grace")!;
+    await client.book.create({ data: { title: "Notes", authorId: ada.id } });
+    await client.book.create({ data: { title: "Other", authorId: grace.id } });
+
+    const list = await scoped.findMany({
+      filter: { kind: "condition", field: "books.title" as never, operator: "EQ", value: "Notes" },
+    });
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Ada"]);
+  });
+
   it("associates a relation by writing its scalar foreign-key field (ADR-0014)", async () => {
     const books = kavo.createCrud(Book, {
       relations: { edges: { author: { includable: true } } },
@@ -264,5 +286,62 @@ describe("PrismaRepositoryAdapter — query translation", () => {
 
     const fetched = await books.findOne(created.id, { include: ["author"] } as never);
     expect(fetched).toMatchObject({ author: { id: author.id, name: "Assoc" } });
+  });
+});
+
+/**
+ * The corners of the grammar that only a real engine can settle: what
+ * Prisma actually does with the degenerate empty groups (#111 left the
+ * `NOT []` cell of the cross-adapter table unverified), and whether the
+ * translated `LIKE` filters match the rows SQL `LIKE` would.
+ */
+describe("PrismaRepositoryAdapter — grammar corners against a real engine", () => {
+  const empty = (operator: "AND" | "OR" | "NOT") =>
+    authors.findMany({ filter: { kind: "group", operator, children: [] } as never });
+
+  it("agrees with the other three adapters on every degenerate empty group", async () => {
+    await seed(); // four rows
+    // Identity of conjunction is `true`, of disjunction `false`; `NOT []` is
+    // `NOT(AND [])`, so it negates the tautology. doc 05 §3.
+    expect((await empty("AND")).items).toHaveLength(4);
+    expect((await empty("OR")).items).toHaveLength(0);
+    expect((await empty("NOT")).items).toHaveLength(0);
+  });
+
+  it("excludes rows matching every child of a multi-child NOT", async () => {
+    // `NOT(AND(children))` (doc 05 §1). Negating only `children[0]` would
+    // have kept Ada out on her name alone and let the second condition go.
+    await seed();
+    const list = await authors.findMany({
+      filter: {
+        kind: "group",
+        operator: "NOT",
+        children: [
+          { kind: "condition", field: "name", operator: "EQ", value: "Ada" },
+          { kind: "condition", field: "age", operator: "EQ", value: 36 },
+        ],
+      } as never,
+    });
+    // Only Ada is both named Ada and 36, so only Ada is excluded.
+    expect(list.items.map((a) => (a as Author).name).sort()).toEqual(["Alan", "Grace", "Joan"]);
+  });
+
+  it("matches a literal % through the backslash escape, not rows beginning with a backslash", async () => {
+    // The grammar's `\%` escape (doc 05 §3) is what the other three adapters
+    // honor; Prisma used to leave the backslash in the operand (#114).
+    await authors.createOne({ email: "pct@x.io", name: "100%", age: 1 } as never);
+    await authors.createOne({ email: "plain@x.io", name: "1000", age: 1 } as never);
+
+    const list = await authors.findMany({
+      filter: { kind: "condition", field: "name", operator: "LIKE", value: "100\\%" },
+    });
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["100%"]);
+  });
+
+  it("rejects a pattern Prisma cannot express with a 400, not a driver error", async () => {
+    await seed();
+    await expect(
+      authors.findMany({ filter: { kind: "condition", field: "name", operator: "LIKE", value: "A%a" } }),
+    ).rejects.toBeInstanceOf(QueryValidationException);
   });
 });

--- a/packages/orms/prisma/tests/filter-translator.spec.ts
+++ b/packages/orms/prisma/tests/filter-translator.spec.ts
@@ -1,10 +1,31 @@
 import { describe, expect, it } from "vitest";
-import type { Filter, FilterExpression } from "@kavo/core";
-import { translateFilter } from "@kavo/prisma";
+import { QueryValidationException, type Filter, type FilterExpression } from "@kavo/core";
+import { translateFilter, type FilterTranslatorOptions, type PrismaRelationGraph } from "@kavo/prisma";
+
+/**
+ * A synthetic relation graph, so the translator is exercised on its own
+ * terms rather than against whatever `prisma/schema.prisma` happens to
+ * declare: `Book.author` is to-one, `Author.books` is to-many, and
+ * `Author.city` gives a second to-one hop for the multi-segment cases.
+ * `adapter.spec.ts` covers the same shapes against a real Prisma engine.
+ */
+const relations: PrismaRelationGraph = new Map([
+  ["Book", new Map([["author", { cardinality: "one", target: "Author" } as const]])],
+  [
+    "Author",
+    new Map([
+      ["books", { cardinality: "many", target: "Book" } as const],
+      ["city", { cardinality: "one", target: "City" } as const],
+    ]),
+  ],
+  ["City", new Map()],
+]);
 
 /** The connector setting only reaches `ILIKE`; everything else is invariant. */
-const options = { caseInsensitiveFilters: false };
-const insensitive = { caseInsensitiveFilters: true };
+const options: FilterTranslatorOptions = { caseInsensitiveFilters: false, model: "Book", relations };
+const insensitive: FilterTranslatorOptions = { ...options, caseInsensitiveFilters: true };
+/** Rooted at the other side of the to-one/to-many pair. */
+const fromAuthor: FilterTranslatorOptions = { ...options, model: "Author" };
 
 function condition(field: string, operator: string, value: unknown): FilterExpression {
   return { kind: "condition", field, operator, value } as FilterExpression;
@@ -54,12 +75,6 @@ describe("translateFilter — operators", () => {
  * `%` picks which one is emitted. Collapsing everything to `contains` would
  * turn `A%` ("starts with A") into "has an A somewhere", which is a wider
  * result set than the caller asked for.
- *
- * These four are the patterns the mapping handles, and *only* those:
- * `likeToPrismaStringFilter` inspects the two ends and nothing else, so an
- * interior `%`, any `_`, and the backslash escape doc 05 §3 promises are all
- * mistranslated today — see #114. Those cases are deliberately not asserted
- * here, because pinning the current output would bless it as the contract.
  */
 describe("translateFilter — LIKE wildcard positions", () => {
   it.each([
@@ -67,8 +82,74 @@ describe("translateFilter — LIKE wildcard positions", () => {
     ["A%", { startsWith: "A" }],
     ["%son", { endsWith: "son" }],
     ["john", { equals: "john" }],
+    // `%` on its own is "any non-null value", the same set SQL `LIKE '%'` has.
+    ["%", { contains: "" }],
+    // Repeated wildcards are the same pattern spelled differently.
+    ["A%%", { startsWith: "A" }],
+    // An empty pattern is `LIKE ''` — only the empty string, not everything.
+    ["", { equals: "" }],
   ])("reads the pattern %s by where its wildcards sit", (pattern, expected) => {
     expect(translate(condition("name", "LIKE", pattern))).toEqual({ name: expected });
+  });
+});
+
+/**
+ * The backslash escape is a **grammar-level** contract (doc 05 §3), not an
+ * adapter's option: `@kavo/typeorm` binds a real `ESCAPE` clause and
+ * `@kavo/mongoose`'s `likeToRegExpSource("100\\%")` returns `^100%`. Prisma
+ * used to leave the backslash in the operand and read only the two ends of
+ * the pattern, so `100\%` became `{ startsWith: "100\\" }` — the same wire
+ * request returning a different result set here than on the other three
+ * adapters, with no error on either side (#114).
+ */
+describe("translateFilter — the LIKE backslash escape", () => {
+  it.each([
+    ["100\\%", { equals: "100%" }],
+    ["a\\_b", { equals: "a_b" }],
+    // Escaped wildcards are literal *text*, so a real leading `%` still
+    // decides the filter around them.
+    ["%50\\%", { endsWith: "50%" }],
+    // A trailing lone backslash escapes nothing and stays literal, matching
+    // `@kavo/mongoose`.
+    ["a\\", { equals: "a\\" }],
+  ])("reads %s as literal text rather than as a wildcard", (pattern, expected) => {
+    expect(translate(condition("name", "LIKE", pattern))).toEqual({ name: expected });
+  });
+});
+
+/**
+ * Prisma's four string filters cannot express an interior `%` or the
+ * single-character wildcard `_` at all. Those used to fall through to
+ * `equals` on the raw pattern — a silently wrong result set. A 400 is the
+ * documented answer (doc 14, "Adapter-specific caveats"): the limitation is
+ * visible to the caller instead of being absorbed.
+ */
+describe("translateFilter — patterns Prisma cannot express", () => {
+  it.each([
+    ["a%b", "an interior wildcard"],
+    ["%a%b%", "two interior literals"],
+    ["a_c", "the single-character wildcard"],
+    ["%j_hn%", "a single-character wildcard inside a contains"],
+    ["_", "a bare single-character wildcard"],
+  ])("rejects %s (%s) rather than downgrading it to equals", (pattern) => {
+    expect(() => translate(condition("name", "LIKE", pattern))).toThrowError(QueryValidationException);
+  });
+
+  it("reports the rejection as a field-level 400 naming the field", () => {
+    try {
+      translate(condition("name", "LIKE", "a%b"));
+      expect.unreachable("an inexpressible pattern must raise");
+    } catch (error) {
+      expect(error).toBeInstanceOf(QueryValidationException);
+      expect((error as QueryValidationException).issues[0]).toMatchObject({
+        field: "name",
+        code: "KAVO_QUERY_UNSUPPORTED_PARAM",
+      });
+    }
+  });
+
+  it("rejects the same patterns under ILIKE, not just LIKE", () => {
+    expect(() => translate(condition("name", "ILIKE", "a_c"), insensitive)).toThrowError(QueryValidationException);
   });
 });
 
@@ -112,9 +193,17 @@ describe("translateFilter — logical groups", () => {
     });
   });
 
-  // Single child only — see the note in the typeorm spec and #115.
   it("maps a NOT group onto NOT over its single child", () => {
     expect(translate(group("NOT", [left]))).toEqual({ NOT: { name: { equals: "Ada" } } });
+  });
+
+  it("conjoins a multi-child NOT rather than dropping every child past the first", () => {
+    // `NOT` means `NOT(AND(children))` (doc 05 §1, #115). Reading
+    // `children[0]` and discarding the rest returned rows the caller asked
+    // to exclude.
+    expect(translate(group("NOT", [left, right]))).toEqual({
+      NOT: { AND: [{ name: { equals: "Ada" } }, { age: { gt: 30 } }] },
+    });
   });
 
   it("nests groups without losing precedence", () => {
@@ -123,13 +212,89 @@ describe("translateFilter — logical groups", () => {
       AND: [{ name: { equals: "Ada" } }, { OR: [{ age: { gt: 30 } }, { age: { lt: 10 } }] }],
     });
   });
+
+  /**
+   * The degenerate zero-child groups, unreachable from the wire but
+   * buildable by a programmatic caller. All four adapters agree on the
+   * answers, stated once in doc 05 §3: `AND []` matches every row, `OR []`
+   * none, and `NOT []` — being `NOT(AND [])` — none either. `adapter.spec.ts`
+   * confirms these against a real Prisma engine, which is what #111 asked
+   * for; this pins the shape they are spelled as.
+   */
+  it("spells the degenerate empty groups from the identity of each connective", () => {
+    expect(translate(group("AND", []))).toEqual({ AND: [] });
+    expect(translate(group("OR", []))).toEqual({ OR: [] });
+    // Not `{ NOT: { AND: [] } }`: Prisma drops a `NOT` whose operand carries
+    // no condition, so that spelling matches every row. The empty
+    // disjunction is the contradiction it does honor.
+    expect(translate(group("NOT", []))).toEqual({ OR: [] });
+  });
 });
 
 /**
  * Prisma's `where` nests relation paths natively, so unlike `@kavo/typeorm`
  * this translator adds no join — a dotted field simply nests the same leaf
- * one level deeper.
+ * one level deeper. **Cardinality decides the shape**: Prisma accepts a bare
+ * nested object only on a to-one relation and requires `some`/`every`/`none`
+ * on a list, rejecting the bare form with `Unknown argument` — which is why
+ * a to-many path used to be a 500 rather than filtered rows (#116).
  */
+describe("translateFilter — relation-path cardinality", () => {
+  it("wraps a to-many path in `some`, per the restrict-root-rows semantics", () => {
+    // doc 05 §3: a relation-path filter restricts *root* rows — "an author
+    // with at least one book titled Dune" — which is exactly `some`, and
+    // exactly what `@kavo/typeorm` gets from a LEFT JOIN plus a WHERE.
+    expect(translate(condition("books.title", "EQ", "Dune"), fromAuthor)).toEqual({
+      books: { some: { title: { equals: "Dune" } } },
+    });
+  });
+
+  it("leaves a to-one path bare, the shape Prisma wants there", () => {
+    expect(translate(condition("author.name", "EQ", "Ada"))).toEqual({
+      author: { name: { equals: "Ada" } },
+    });
+  });
+
+  it("classifies each segment of a mixed multi-segment path independently", () => {
+    // `author` is to-one and `books` is to-many, so only the second hop
+    // takes a wrapper — a path-wide answer would be wrong at one end.
+    expect(translate(condition("author.books.title", "EQ", "Dune"))).toEqual({
+      author: { books: { some: { title: { equals: "Dune" } } } },
+    });
+  });
+
+  it("carries the cardinality onto every operator's leaf, not just equality", () => {
+    expect(translate(condition("books.title", "IN", ["Dune", "Emma"]), fromAuthor)).toEqual({
+      books: { some: { title: { in: ["Dune", "Emma"] } } },
+    });
+    expect(translate(condition("books.title", "IS_NULL", true), fromAuthor)).toEqual({
+      books: { some: { title: { equals: null } } },
+    });
+  });
+
+  it("raises a Kavo 400 for a path it cannot classify, rather than a shape Prisma will reject", () => {
+    // A raw `PrismaClientValidationError` surfaces as a 500 with a driver
+    // message; a segment that is not a relation is a configuration mistake
+    // (core's default allowlists hold scalars only) and says so.
+    try {
+      translate(condition("nonsense.title", "EQ", "x"));
+      expect.unreachable("an unclassifiable relation path must raise");
+    } catch (error) {
+      expect(error).toBeInstanceOf(QueryValidationException);
+      expect((error as QueryValidationException).issues[0]).toMatchObject({
+        field: "nonsense.title",
+        code: "KAVO_QUERY_UNSUPPORTED_PARAM",
+      });
+    }
+  });
+
+  it("raises when a later segment of a multi-segment path is unknown", () => {
+    // The walk must not stop at the first hop: `author` resolves, `nope`
+    // does not, and the failure has to be the whole path's.
+    expect(() => translate(condition("author.nope.title", "EQ", "x"))).toThrowError(QueryValidationException);
+  });
+});
+
 describe("translateFilter — relation paths", () => {
   it("nests a dotted path into Prisma's relation shape", () => {
     expect(translate(condition("author.name", "EQ", "Ada"))).toEqual({

--- a/packages/orms/typeorm/src/filter-translator.ts
+++ b/packages/orms/typeorm/src/filter-translator.ts
@@ -65,17 +65,51 @@ export class FilterTranslator<Entity extends ObjectLiteral> implements FilterBui
     if (expression.kind === "condition") {
       return new Brackets((where) => this.applyCondition(where, expression));
     }
+    const children = expression.children;
+
     if (expression.operator === "NOT") {
-      const child = expression.children[0];
+      // `NOT` is variadic and means `NOT(AND(children))` (doc 05 §1), so no
+      // child past the first is dropped. The empty case falls out of the
+      // same rule rather than needing one: the empty conjunction is `true`,
+      // and `NOT(true)` matches nothing.
+      const negated = this.conjunction(children);
       return new NotBrackets((where) => {
-        if (child !== undefined) where.where(this.toBrackets(child));
+        where.where(negated);
       });
     }
+
+    if (children.length === 0) {
+      // The identity of the connective, spelled as a *real* predicate.
+      // Emitting nothing would drop the `Brackets` entirely — TypeORM
+      // discards one whose callback added no condition — which silently
+      // widened an empty `OR` from "matches nothing" to every row (#111).
+      return new Brackets((where) => {
+        where.where(expression.operator === "OR" ? "1 = 0" : "1 = 1");
+      });
+    }
+
     const connect = expression.operator === "OR" ? "orWhere" : "andWhere";
-    const children = expression.children;
     return new Brackets((where) => {
       for (const child of children) {
         where[connect](this.toBrackets(child));
+      }
+    });
+  }
+
+  /**
+   * `AND` over `children`, as the thing `NOT` negates. A single child is
+   * returned unwrapped so the common unary `NOT` keeps its exact SQL, and
+   * the empty conjunction is the tautology `1 = 1`.
+   */
+  private conjunction(children: readonly FilterExpression<Entity>[]): Brackets {
+    if (children.length === 1) return this.toBrackets(children[0]!);
+    return new Brackets((where) => {
+      if (children.length === 0) {
+        where.where("1 = 1");
+        return;
+      }
+      for (const child of children) {
+        where.andWhere(this.toBrackets(child));
       }
     });
   }

--- a/packages/orms/typeorm/tests/filter-translator.spec.ts
+++ b/packages/orms/typeorm/tests/filter-translator.spec.ts
@@ -199,10 +199,15 @@ describe("FilterTranslator — logical groups", () => {
     expect(whereOf(group("OR", [left, right]))).toBe(`(("root"."title" = :p0) OR ("root"."pages" > :p1))`);
   });
 
-  // Single child only: a multi-child NOT silently drops everything past
-  // children[0] today, which is #115 rather than a contract to pin here.
   it("wraps a NOT group in SQL NOT over its single child", () => {
     expect(whereOf(group("NOT", [left]))).toBe(`NOT(("root"."title" = :p0))`);
+  });
+
+  it("negates every child of a multi-child NOT, not just the first", () => {
+    // `NOT` is variadic and means `NOT(AND(children))` (doc 05 §1). Reading
+    // `children[0]` and discarding the rest returned rows the caller asked
+    // to exclude — a silent widening, #115.
+    expect(whereOf(group("NOT", [left, right]))).toBe(`NOT((("root"."title" = :p0) AND ("root"."pages" > :p1)))`);
   });
 
   it("keeps precedence when an OR nests inside an AND", () => {
@@ -221,6 +226,43 @@ describe("FilterTranslator — logical groups", () => {
     // A dropped predicate widens the result set silently, which is the one
     // failure mode a filter must never have.
     expect(() => whereOf(condition("title", "SOUNDS_LIKE", "x"))).toThrowError(/filter operator/);
+  });
+});
+
+/**
+ * The degenerate zero-child groups, which the wire grammar cannot produce
+ * (`convertLogical` only emits a group once a child converted) but a
+ * programmatic caller hand-building the AST can. All four adapters agree on
+ * the answers, stated once in `docs/internals/architecture/05-query-grammar.md` §3:
+ * `AND []` is the identity of conjunction (every row), `OR []` the identity
+ * of disjunction (no row), and `NOT []` is `NOT(AND [])` — no row.
+ *
+ * The whole predicate is asserted, never a substring: the bug being pinned
+ * here (#111) was an *omitted* predicate, and an omission is exactly what a
+ * `toContain` cannot see.
+ */
+describe("FilterTranslator — degenerate empty groups", () => {
+  it("spells an empty OR as a contradiction, not as no predicate at all", () => {
+    // TypeORM drops a `Brackets` whose callback added no condition, so the
+    // predicate vanished and the empty OR matched *every* row — the silent
+    // widening in #111.
+    expect(whereOf(group("OR", []))).toBe("(1 = 0)");
+  });
+
+  it("keeps an empty AND matching every row, as a real predicate", () => {
+    expect(whereOf(group("AND", []))).toBe("(1 = 1)");
+  });
+
+  it("keeps an empty NOT matching no row", () => {
+    expect(whereOf(group("NOT", []))).toBe("NOT((1 = 1))");
+  });
+
+  it("does not let an empty group leak its identity into its parent", () => {
+    // The identity must scope to its own brackets: an unbracketed `1 = 0`
+    // OR-ed into the parent would empty an unrelated conjunct.
+    expect(whereOf(group("AND", [condition("title", "EQ", "Dune"), group("OR", [])]))).toBe(
+      `(("root"."title" = :p0) AND (1 = 0))`,
+    );
   });
 });
 


### PR DESCRIPTION
Five query-grammar correctness bugs, fixed together because they are one
cluster: every one of them is an adapter or the parser silently disagreeing
with `docs/internals/architecture/05-query-grammar.md`, and four of the five
needed the *same* missing decision written down before they could be fixed
consistently.

Closes #111
Closes #113
Closes #114
Closes #115
Closes #116

## The two decisions this had to make first

Three issues (#111, #113, #115) explicitly asked for a recorded decision
rather than a particular fix. Both are now in doc 05, and every adapter
implements them:

**`NOT` is variadic and means `NOT(AND(children))`** (doc 05 §1). The AST
type gives every logical operator a child list and `QueryNormalizer` checks
allowlists and limits, not arity — so `NOT` needed an answer. Conjoining
beats "reject anything non-unary" because it makes the unary case a special
case of the general one, and because it gives the degenerate group its
meaning for free: `NOT []` is `NOT(AND [])`, the negation of the tautology,
which is exactly the "matches nothing" three adapters already spelled by
hand. Nothing has to be rejected.

**A bare `in=` / `notIn=` is a 400 on every column kind** (doc 05 §3), the
third of the options #113 listed. The other two were defensible, but "the
client sees an empty page and no error" is the complaint in the issue, and a
400 is the only answer that surfaces it. It also matches what typed columns
already did.

Both are now stated once and cross-referenced from the adapters that
implement them.

## Per issue

**#111 — empty `OR` matched every row (`@kavo/typeorm`).** `Brackets` whose
callback adds no condition is dropped by TypeORM, so the predicate vanished
rather than becoming a contradiction. Each connective's identity is now a
real predicate (`1 = 0` / `1 = 1`), mirroring the empty-`IN` handling in the
same translator. The cross-adapter table the issue asked for is in doc 05 §3,
and each adapter's spec pins its own row.

The issue's open cell — Prisma's `NOT []` — was verified against a real
engine, and the answer was *not* the assumed one: **Prisma drops a `NOT`
whose operand carries no condition**, so `{ NOT: { AND: [] } }` matches every
row. The e2e test caught this on first run. `{ OR: [] }` is the contradiction
Prisma honors and is what the translator emits now;
`packages/orms/prisma/tests/adapter.spec.ts` pins all three degenerate groups
against the engine.

**#113 — bare `in=`.** Rejected in `DefaultFilterParser` before coercion, so
the answer no longer depends on whether string coercion happens to accept
`""`. Interior empties (`in=a,,b`) are out of scope and unchanged; the
genuinely empty array (`value: []`) still round-trips.

**#114 — Prisma `LIKE`.** The pattern is now tokenized with the backslash
escape resolved *first*, so `100\%` is the literal text `100%` (an `equals`)
rather than `startsWith: "100\"`. The four shapes Prisma's string filters can
express translate; an interior `%` or any `_` — which Prisma has no
equivalent for — is a **400** rather than a silent downgrade to `equals` on
the raw pattern. Documented as an adapter caveat in doc 14 §6, mirroring how
doc 17 §7 documents MikroORM's weaker escape story, and cross-referenced from
doc 05 §3.

**#115 — multi-child `NOT`.** Fixed in all four adapters, not just the two
named: `@kavo/mongoose` had the mirror-image bug (`$nor: [a, b]` is
`NOT(a OR b)`, which is *narrower* than asked for) and `@kavo/mikroorm`
dropped children the same way `@kavo/typeorm` did. No rejection in
`validateExpression` was needed given the semantics chosen above.

**#116 — to-many relation-path filter 500'd.** Cardinality now decides the
nesting: a list segment goes under `some` — the "restrict root rows"
semantics doc 05 §3 already specifies, and what `@kavo/typeorm` gets for free
from a `LEFT JOIN` plus a `WHERE`. Each segment of a multi-hop path is
classified independently (`author.posts.title` wraps only the second), which
is why the translator needs the whole datamodel's edges rather than the
queried entity's `EntityMetadata.relations`: the second hop belongs to
another model. `buildRelationGraph` derives them once at bootstrap and passes
them as plain data, so `translateFilter` stays the pure function the issue
asked it to remain. A segment that resolves to no relation raises
`KAVO_QUERY_UNSUPPORTED_PARAM` (400) instead of a raw
`PrismaClientValidationError`.

## Public API

`@kavo/prisma` names three new types on its barrel —
`FilterTranslatorOptions`, `PrismaRelationGraph`, `PrismaRelationEdge` — plus
`buildRelationGraph`. `PrismaRepositoryAdapter` is public and constructing one
now means supplying a relation graph, so the options type has to be nameable;
`@kavo/mongoose` and `@kavo/mikroorm` already export theirs, so this closes an
asymmetry rather than opening one.

**Breaking for direct constructors:** `new PrismaRepositoryAdapter(...)`'s
third argument is now required and carries `relations`. It had a
`{ caseInsensitiveFilters: true }` default, which cannot survive — the adapter
is not correct without the graph, and a silent fallback would reinstate the
#116 shape. `createInfrastructure` / `createPrismaKavo` callers are unaffected.

## Verification

`pnpm check` green — 1366 tests, 70 files, build + typecheck + depcruise +
lint. `pnpm docs:build` and `pnpm docs:links` green too (neither is in
`check`). Every fix has a failing-first test; the Prisma work additionally has
end-to-end coverage against a real Prisma engine on SQLite.

## Deliberately not done

- **A single cross-adapter agreement test.** #111 and #114 both asked for the
  agreement to be asserted somewhere. It is stated once in doc 05 §3 — the
  home #111 named — and each adapter's translator spec pins its own row of
  that table, so a divergence does fail a test. A *single* test asserting all
  four at once would have to live in the repo-level `tests/` directory and
  would drag `typeorm`, `mongoose`, `@mikro-orm/core` and `@prisma/client`
  into the root `package.json` as devDependencies. Worth doing, but it is a
  dependency-topology change that deserves its own review rather than riding
  along here.
- **`@kavo/mikroorm`'s relation-path nesting**, which #116 explicitly scoped
  out as a separate issue if it diverges.
- **Prisma `orderBy` on a to-many path**, which has the same cardinality
  question as #116 but is a sort, not a filter, and no issue covers it.
