### PR TITLE
feat(core,nest): error-message quality pass

### DIFF
--- a/docs/internals/architecture/06-error-handling.md
+++ b/docs/internals/architecture/06-error-handling.md
@@ -14,6 +14,7 @@ KavoException (abstract; implements the KavoExceptionShape contract)
 ├─ AlreadyDeletedException      soft delete of a deleted row → 409
 ├─ NotDeletedException          restore/purge of a live row → 409
 ├─ OperationDisabledException
+├─ OperationNotRegisteredException   registry miss, never "disabled"
 ├─ BulkOperationException       carries items[] (reserved)
 ├─ PersistenceException
 ├─ TransactionException         carries retryable: boolean
@@ -45,6 +46,7 @@ policy). Source of truth: `ERROR_CATALOG` in
 | `KAVO_ALREADY_DELETED`          | 409  | Soft-deleting an already-deleted row                                                             | —                                 |
 | `KAVO_NOT_DELETED`              | 409  | Restoring or purging a row that is not deleted                                                   | —                                 |
 | `KAVO_OPERATION_DISABLED`       | 405  | Programmatic call to a disabled registry entry (no route exists over HTTP)                       | —                                 |
+| `KAVO_OPERATION_NOT_REGISTERED` | 405  | Programmatic call naming an operation the registry has no entry for at all                       | —                                 |
 | `KAVO_BULK_FAILED`              | 422  | Atomic bulk failure (reserved — bulk is not built)                                               | `items[]` per-index issues        |
 | `KAVO_PERSISTENCE_FAILED`       | 500  | Unrecognized adapter/driver error                                                                | `cause` kept internally           |
 | `KAVO_TRANSACTION_FAILED`       | 500  | Deadlock/serialization failure                                                                   | `retryable` flag                  |

--- a/extensions/skills/error-handling/SKILL.md
+++ b/extensions/skills/error-handling/SKILL.md
@@ -19,6 +19,7 @@ KavoException (abstract; implements the KavoExceptionShape contract)
 ├─ AlreadyDeletedException      soft-deleting an already-deleted row → 409
 ├─ NotDeletedException          restoring/purging a live row → 409
 ├─ OperationDisabledException
+├─ OperationNotRegisteredException   registry miss, never "disabled"
 ├─ BulkOperationException       carries items[] (reserved — bulk not built)
 ├─ PersistenceException
 ├─ TransactionException         carries retryable: boolean
@@ -36,23 +37,24 @@ on framework exception types.
 
 Codes are API surface — renaming one is a breaking (semver) change.
 
-| Code                           | HTTP | Fires when                                                                      | Payload extensions                |
-| ------------------------------ | ---- | ------------------------------------------------------------------------------- | --------------------------------- |
-| `KAVO_QUERY_INVALID`           | 400  | Any query grammar/allowlist/limit violation (aggregate)                         | `errors[]` of the sub-codes below |
-| `KAVO_QUERY_INVALID_FIELD`     | 400  | Field not on the filter/sort/select allowlist                                   | issue-level                       |
-| `KAVO_QUERY_INVALID_OPERATOR`  | 400  | Unknown or misspelled wire operator                                             | issue-level                       |
-| `KAVO_QUERY_INVALID_VALUE`     | 400  | Coercion failure, malformed bounds, bad pagination value                        | issue-level                       |
-| `KAVO_QUERY_LIMIT_EXCEEDED`    | 400  | `maxFilterDepth` / `maxInValues` exceeded                                       | issue-level                       |
-| `KAVO_QUERY_UNSUPPORTED_PARAM` | 400  | `withDeleted` on a hard-delete entity; `include` with no include resolver wired | issue-level                       |
-| `KAVO_NOT_FOUND`               | 404  | Target row missing on `findOne`/`updateOne`/`patchOne`/`deleteOne`              | —                                 |
-| `KAVO_CONFLICT`                | 409  | Unique/FK violation mapped by the adapter                                       | —                                 |
-| `KAVO_ALREADY_DELETED`         | 409  | Soft-deleting an already-deleted row                                            | —                                 |
-| `KAVO_NOT_DELETED`             | 409  | Restoring or purging a row that is not deleted                                  | —                                 |
-| `KAVO_OPERATION_DISABLED`      | 405  | Programmatic/HTTP call to a disabled registry entry                             | —                                 |
-| `KAVO_BULK_FAILED`             | 422  | Atomic bulk failure (reserved — bulk is not built)                              | `items[]` per-index issues        |
-| `KAVO_PERSISTENCE_FAILED`      | 500  | Unrecognized adapter/driver error                                               | `cause` kept internally           |
-| `KAVO_TRANSACTION_FAILED`      | 500  | Deadlock/serialization failure                                                  | `retryable` flag                  |
-| `KAVO_CONFIG_INVALID`          | 500  | Bootstrap config error — fails startup, never a response                        | —                                 |
+| Code                            | HTTP | Fires when                                                                      | Payload extensions                |
+| ------------------------------- | ---- | ------------------------------------------------------------------------------- | --------------------------------- |
+| `KAVO_QUERY_INVALID`            | 400  | Any query grammar/allowlist/limit violation (aggregate)                         | `errors[]` of the sub-codes below |
+| `KAVO_QUERY_INVALID_FIELD`      | 400  | Field not on the filter/sort/select allowlist                                   | issue-level                       |
+| `KAVO_QUERY_INVALID_OPERATOR`   | 400  | Unknown or misspelled wire operator                                             | issue-level                       |
+| `KAVO_QUERY_INVALID_VALUE`      | 400  | Coercion failure, malformed bounds, bad pagination value                        | issue-level                       |
+| `KAVO_QUERY_LIMIT_EXCEEDED`     | 400  | `maxFilterDepth` / `maxInValues` exceeded                                       | issue-level                       |
+| `KAVO_QUERY_UNSUPPORTED_PARAM`  | 400  | `withDeleted` on a hard-delete entity; `include` with no include resolver wired | issue-level                       |
+| `KAVO_NOT_FOUND`                | 404  | Target row missing on `findOne`/`updateOne`/`patchOne`/`deleteOne`              | —                                 |
+| `KAVO_CONFLICT`                 | 409  | Unique/FK violation mapped by the adapter                                       | —                                 |
+| `KAVO_ALREADY_DELETED`          | 409  | Soft-deleting an already-deleted row                                            | —                                 |
+| `KAVO_NOT_DELETED`              | 409  | Restoring or purging a row that is not deleted                                  | —                                 |
+| `KAVO_OPERATION_DISABLED`       | 405  | Programmatic/HTTP call to a disabled registry entry                             | —                                 |
+| `KAVO_OPERATION_NOT_REGISTERED` | 405  | Programmatic call naming an operation the registry has no entry for at all      | —                                 |
+| `KAVO_BULK_FAILED`              | 422  | Atomic bulk failure (reserved — bulk is not built)                              | `items[]` per-index issues        |
+| `KAVO_PERSISTENCE_FAILED`       | 500  | Unrecognized adapter/driver error                                               | `cause` kept internally           |
+| `KAVO_TRANSACTION_FAILED`       | 500  | Deadlock/serialization failure                                                  | `retryable` flag                  |
+| `KAVO_CONFIG_INVALID`           | 500  | Bootstrap config error — fails startup, never a response                        | —                                 |
 
 ## Error context & message strategy
 

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -11,7 +11,11 @@ import type { OperationDescriptor, OperationRegistry } from "../operations/opera
 import type { StandardOperationId } from "../operations/operation.js";
 import type { ResolvedEntityConfig } from "../config/resolved-entity-config.js";
 import type { KavoSettings } from "../config/settings.js";
-import { OperationDisabledException, QueryValidationException } from "../errors/exceptions.js";
+import {
+  OperationDisabledException,
+  OperationNotRegisteredException,
+  QueryValidationException,
+} from "../errors/exceptions.js";
 import { QueryNormalizer } from "../query/query-normalizer.js";
 import { createKavoContext, randomUuid } from "../context/default-kavo-context.js";
 import { mergeSettings } from "../config/merge-settings.js";
@@ -100,13 +104,28 @@ export class KavoEngine<Entity extends object> {
     // Nothing is special-cased per verb — built-ins are ordinary registry
     // entries (ADR-0006).
     const descriptor = registry.get(request.operation);
-    if (descriptor === undefined || !descriptor.enabled) {
+    const errorContext = { entityName: config.entityName, operation: request.operation };
+    // A registry miss and a disabled entry are different mistakes with
+    // different fixes, so they get different codes (issue #7). Only the
+    // disabled branch is reachable over HTTP: route generation walks this
+    // same registry, so an unregistered id never gets a route.
+    if (descriptor === undefined) {
+      throw new OperationNotRegisteredException({
+        messageParams: {
+          operation: request.operation,
+          entity: config.entityName,
+          available: registeredIds(registry),
+        },
+        context: errorContext,
+      });
+    }
+    if (!descriptor.enabled) {
       throw new OperationDisabledException({
         messageParams: {
           operation: request.operation,
           entity: config.entityName,
         },
-        context: { entityName: config.entityName, operation: request.operation },
+        context: errorContext,
       });
     }
 
@@ -262,4 +281,21 @@ export class KavoEngine<Entity extends object> {
       list: null,
     };
   }
+}
+
+/**
+ * Every id the registry knows, sorted, for the not-registered message. The
+ * list is short (the standard table plus whatever was registered on top)
+ * and it answers "then what *can* I call?" — disabled entries included,
+ * since those are one config flag away from working and their own error
+ * says so.
+ */
+function registeredIds<Entity extends object>(registry: OperationRegistry<Entity>): string {
+  return (
+    registry
+      .all()
+      .map((descriptor) => descriptor.id)
+      .sort()
+      .join(", ") || "none"
+  );
 }

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -16,6 +16,7 @@ import {
   OperationNotRegisteredException,
   QueryValidationException,
 } from "../errors/exceptions.js";
+import { nameList } from "../errors/message-hints.js";
 import { QueryNormalizer } from "../query/query-normalizer.js";
 import { createKavoContext, randomUuid } from "../context/default-kavo-context.js";
 import { mergeSettings } from "../config/merge-settings.js";
@@ -291,11 +292,5 @@ export class KavoEngine<Entity extends object> {
  * says so.
  */
 function registeredIds<Entity extends object>(registry: OperationRegistry<Entity>): string {
-  return (
-    registry
-      .all()
-      .map((descriptor) => descriptor.id)
-      .sort()
-      .join(", ") || "none"
-  );
+  return nameList(registry.all().map((descriptor) => descriptor.id));
 }

--- a/packages/core/src/errors/error-catalog.ts
+++ b/packages/core/src/errors/error-catalog.ts
@@ -84,7 +84,23 @@ export const ERROR_CATALOG = {
   KAVO_OPERATION_DISABLED: {
     status: 405,
     title: "Operation disabled",
-    message: "Operation '{operation}' is disabled for {entity}.",
+    // `{operation}` twice is safe: `renderMessage` replaces globally, and
+    // the one throw site (`KavoEngine.run`) always supplies it. A
+    // placeholder for text a *caller* might omit would render verbatim —
+    // which is why the fix is baked into the template rather than passed
+    // in as a free-form hint.
+    message:
+      "Operation '{operation}' is disabled for {entity}. Enable it with 'operations.{operation}' in the entity config.",
+  },
+  KAVO_OPERATION_NOT_REGISTERED: {
+    status: 405,
+    title: "Operation not registered",
+    // Distinct from `KAVO_OPERATION_DISABLED` because `messageKey` *is* the
+    // code: a consumer localizing from key + params would otherwise
+    // re-render "is disabled" for an operation nobody ever disabled.
+    // `{available}` is the whole registry (eight standard entries), which
+    // subsumes a "did you mean" — the near miss is right there in the list.
+    message: "Operation '{operation}' is not registered for {entity}. Registered operations: {available}.",
   },
   KAVO_PERSISTENCE_FAILED: {
     status: 500,

--- a/packages/core/src/errors/error-catalog.ts
+++ b/packages/core/src/errors/error-catalog.ts
@@ -89,8 +89,19 @@ export const ERROR_CATALOG = {
     // placeholder for text a *caller* might omit would render verbatim —
     // which is why the fix is baked into the template rather than passed
     // in as a free-form hint.
+    //
+    // The parenthetical is unconditional for the same reason. The config
+    // key alone is not the whole fix for `restoreOne`/`purgeOne`: on an
+    // entity that resolves to hard delete, `requireSoftDeletable` rejects
+    // them at bootstrap (ADR-0013), so advertising `operations.restoreOne`
+    // on its own would send a developer from a 405 to an app that no longer
+    // starts. A conditional clause would have to arrive as a param, and a
+    // param this template can be rendered without is exactly the verbatim
+    // hazard above — so the caveat is carried by the template, where it is
+    // always true and always localizable.
     message:
-      "Operation '{operation}' is disabled for {entity}. Enable it with 'operations.{operation}' in the entity config.",
+      "Operation '{operation}' is disabled for {entity}. Enable it with 'operations.{operation}' in the entity config " +
+      "(restoreOne and purgeOne also need the entity to be soft-deletable).",
   },
   KAVO_OPERATION_NOT_REGISTERED: {
     status: 405,

--- a/packages/core/src/errors/exceptions.ts
+++ b/packages/core/src/errors/exceptions.ts
@@ -120,6 +120,24 @@ export class OperationDisabledException extends KavoException {
 }
 
 /**
+ * Calling an operation the registry has no entry for at all — a misspelled
+ * id, or a custom operation that was never registered. Distinct from
+ * {@link OperationDisabledException} at the same 405: "disabled" says the
+ * entry exists and can be switched on, which for a registry miss is simply
+ * untrue, and `messageKey` (= the code) is what a localizing consumer
+ * re-renders from.
+ *
+ * Unreachable over HTTP — route generation walks the same registry, so an
+ * unregistered id has no route — which is exactly why the falsehood
+ * survived: only programmatic callers ever saw it.
+ */
+export class OperationNotRegisteredException extends KavoException {
+  constructor(options: KavoExceptionOptions = {}) {
+    super("KAVO_OPERATION_NOT_REGISTERED", options);
+  }
+}
+
+/**
  * Bootstrap-time configuration error. Never a wire response — it fires
  * before the app serves traffic, and it must name the entity, the key
  * path, and the offending value (error quality bar).

--- a/packages/core/src/errors/message-hints.ts
+++ b/packages/core/src/errors/message-hints.ts
@@ -1,0 +1,121 @@
+/**
+ * Prose helpers for the actionable half of an error `detail`: the "did you
+ * mean" suggestion and the bounded list of names the client may actually
+ * use.
+ *
+ * Internal by design — not barrel-exported, and it appears in no public
+ * signature. `detail` text is not typed API (ADR-0009 fixes the document
+ * *shape*, and localization goes through `messageKey` + `messageParams`),
+ * so these strings stay free to improve.
+ *
+ * **Disclosure rule (normative).** Every caller passes candidates drawn
+ * only from the *permitted* set — includable relations, allowlisted
+ * filterable/sortable/selectable fields — never the full relation or field
+ * registry. That keeps what a rejection enumerates exactly equal to what
+ * the client is already allowed to ask for.
+ */
+
+/** Longest candidate list rendered in full before it is truncated. */
+const DEFAULT_LIST_CAP = 10;
+
+/**
+ * The closest candidate to `input`, or `undefined` when nothing is close
+ * enough to be worth guessing at.
+ *
+ * The threshold tightens for short names: at two edits, a three-letter
+ * input is within reach of most three-letter candidates, and a confidently
+ * wrong suggestion costs more than none at all.
+ */
+export function suggestName(input: string, candidates: readonly string[]): string | undefined {
+  const threshold = input.length <= 4 ? 1 : 2;
+  let best: string | undefined;
+  let bestDistance = threshold + 1;
+  for (const candidate of candidates) {
+    if (candidate === input) continue;
+    const distance = editDistance(input.toLowerCase(), candidate.toLowerCase(), threshold);
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+  return bestDistance <= threshold ? best : undefined;
+}
+
+/**
+ * Candidates as a sorted, comma-separated list — truncated with a total so
+ * a 200-field entity does not turn one rejection into a wall of text.
+ * `"none"` when there is nothing to offer, which is itself the answer on an
+ * entity whose `relations.edges` is still empty.
+ */
+export function nameList(candidates: readonly string[], cap: number = DEFAULT_LIST_CAP): string {
+  if (candidates.length === 0) return "none";
+  const sorted = [...candidates].sort();
+  if (sorted.length <= cap) return sorted.join(", ");
+  return `${sorted.slice(0, cap).join(", ")}, … (${sorted.length} total)`;
+}
+
+/** Which allowlist a rejected field belongs to, keyed by how it was used. */
+const ALLOWLIST_KEYS = Object.freeze({
+  filtering: "filterable",
+  sorting: "sortable",
+  selection: "selectable",
+} as const);
+
+/** How each usage reads as an adjective in front of "fields". */
+const ALLOWLIST_ADJECTIVES = Object.freeze({
+  filtering: "Filterable",
+  sorting: "Sortable",
+  selection: "Selectable",
+} as const);
+
+export type AllowlistUsage = keyof typeof ALLOWLIST_KEYS;
+
+/**
+ * The clause appended to an allowlist rejection, naming the near miss, the
+ * permitted set, and the config key that would permit the field. Callers
+ * own the leading sentence, which stays byte-identical to what it always
+ * was — this is purely additive text.
+ */
+export function allowlistHint(
+  field: string,
+  usage: AllowlistUsage,
+  entityName: string,
+  allowed: readonly string[],
+): string {
+  const suggestion = suggestName(field, allowed);
+  return (
+    (suggestion === undefined ? "" : ` Did you mean '${suggestion}'?`) +
+    ` ${ALLOWLIST_ADJECTIVES[usage]} fields on ${entityName}: ${nameList(allowed)}.` +
+    ` Add it to allowlists.${ALLOWLIST_KEYS[usage]} on the ${entityName} config to permit it.`
+  );
+}
+
+/**
+ * Optimal string alignment distance — Levenshtein plus adjacent
+ * transposition, because transposing two characters is the typo people
+ * actually make (`emial`, `nmae`) and plain Levenshtein charges it two
+ * edits, putting it out of reach of a short name's budget.
+ *
+ * Returns `ceiling + 1` for anything provably past the budget: the distance
+ * is never below the length difference, which settles most candidates
+ * without building the matrix at all.
+ */
+function editDistance(a: string, b: string, ceiling: number): number {
+  if (Math.abs(a.length - b.length) > ceiling) return ceiling + 1;
+  let twoBack: number[] = [];
+  let previous = Array.from({ length: b.length + 1 }, (_unused, index) => index);
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitution = previous[j - 1]! + (a[i - 1] === b[j - 1] ? 0 : 1);
+      let value = Math.min(current[j - 1]! + 1, previous[j]! + 1, substitution);
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        value = Math.min(value, twoBack[j - 2]! + 1);
+      }
+      current.push(value);
+    }
+    twoBack = previous;
+    previous = current;
+  }
+  return previous[b.length]!;
+}

--- a/packages/core/src/errors/message-hints.ts
+++ b/packages/core/src/errors/message-hints.ts
@@ -13,7 +13,18 @@
  * filterable/sortable/selectable fields — never the full relation or field
  * registry. That keeps what a rejection enumerates exactly equal to what
  * the client is already allowed to ask for.
+ *
+ * The rule's second half is about what a rejection must *not* confirm: a
+ * message may never differ according to whether the rejected name exists.
+ * Relation inclusion is opt-in and defaults to empty, so a message that
+ * said "exists but is not includable" for one name and "does not exist" for
+ * another would be an existence oracle for the very edges the config closed
+ * on purpose. Advice about names outside the permitted set is therefore
+ * phrased as a conditional ("if X has a 'y' relation"), which is equally
+ * actionable for the developer and answers nothing for a prober.
  */
+
+import type { QueryIssueDto } from "./problem-details.js";
 
 /** Longest candidate list rendered in full before it is truncated. */
 const DEFAULT_LIST_CAP = 10;
@@ -75,6 +86,13 @@ export type AllowlistUsage = keyof typeof ALLOWLIST_KEYS;
  * permitted set, and the config key that would permit the field. Callers
  * own the leading sentence, which stays byte-identical to what it always
  * was — this is purely additive text.
+ *
+ * The config-key advice is phrased as a conditional on purpose. An
+ * allowlist accepts whatever array the config declares — `resolveFieldSelector`
+ * never checks it against `EntityMetadata` — so telling a developer to
+ * allowlist a *typo* would trade this clear 400 for a 500 out of the driver
+ * on the next query. "If it is a column" is the honest form, and it says
+ * nothing about whether the column exists.
  */
 export function allowlistHint(
   field: string,
@@ -86,8 +104,46 @@ export function allowlistHint(
   return (
     (suggestion === undefined ? "" : ` Did you mean '${suggestion}'?`) +
     ` ${ALLOWLIST_ADJECTIVES[usage]} fields on ${entityName}: ${nameList(allowed)}.` +
-    ` Add it to allowlists.${ALLOWLIST_KEYS[usage]} on the ${entityName} config to permit it.`
+    ` If ${entityName} has a '${field}' column, add it to allowlists.${ALLOWLIST_KEYS[usage]}` +
+    ` on the ${entityName} config to permit it.`
   );
+}
+
+/**
+ * How many rejections in one request still carry the actionable clause.
+ *
+ * The hint is not free: `suggestName` walks the whole allowlist per rejected
+ * name, and the prose adds a few hundred bytes to each issue. A request
+ * naming five thousand fields (`?fields=a1,…,a5000` is a legal query string)
+ * would otherwise turn one 400 into a megabyte of text and an O(names ×
+ * allowlist) edit-distance sweep. Past a handful of problems the caller is
+ * not fixing a typo anyway, so the leading sentence carries on alone.
+ *
+ * The counter is the issue array itself, which may already hold unrelated
+ * problems — deliberately conservative: it errs toward dropping the hint.
+ */
+const MAX_HINTED_ISSUES = 5;
+
+/**
+ * Push one allowlist rejection. The single construction site for this
+ * message: the wire path (`DefaultFilterParser`) and the programmatic one
+ * (`QueryNormalizer`) both land here, so the two cannot word the same
+ * rejection differently.
+ */
+export function pushAllowlistIssue(
+  field: string,
+  usage: AllowlistUsage,
+  entityName: string,
+  allowed: readonly string[],
+  issues: QueryIssueDto[],
+): void {
+  issues.push({
+    field,
+    code: "KAVO_QUERY_INVALID_FIELD",
+    detail:
+      `Field '${field}' cannot be used for ${usage}.` +
+      (issues.length < MAX_HINTED_ISSUES ? allowlistHint(field, usage, entityName, allowed) : ""),
+  });
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,7 @@ export {
   NotDeletedException,
   NotFoundException,
   OperationDisabledException,
+  OperationNotRegisteredException,
   PersistenceException,
   QueryValidationException,
   TransactionException,

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -90,7 +90,9 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
           "infrastructure",
           "no metadata source: pass `infrastructure` to createKavo " +
             "(e.g. createInfrastructure(dataSource) from " +
-            "@kavo/typeorm) or `runtime.metadata` to createCrud",
+            "@kavo/typeorm) or `runtime.metadata` to createCrud — " +
+            "in a NestJS app that is KavoModule.forRoot({ infrastructure }) " +
+            "or forRootAsync({ useFactory })",
         );
       }
       const adapter = runtime?.adapter ?? options.infrastructure?.adapterFor(entity);
@@ -98,7 +100,9 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
         throw new ConfigurationException(
           metadata.name,
           "infrastructure",
-          "no repository adapter: pass `infrastructure` to createKavo or " + "`runtime.adapter` to createCrud",
+          "no repository adapter: pass `infrastructure` to createKavo or " +
+            "`runtime.adapter` to createCrud — in a NestJS app that is " +
+            "KavoModule.forRoot({ infrastructure }) or forRootAsync({ useFactory })",
         );
       }
 
@@ -111,6 +115,7 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
         config as EntityConfig<Entity> | undefined,
         builtInHandlers(adapter as unknown as RepositoryAdapter<Entity>),
         resolved.settings.operations,
+        resolved.entityName,
       );
       requireSoftDeletable(resolved, registry);
 

--- a/packages/core/src/operations/default-operation-registry.ts
+++ b/packages/core/src/operations/default-operation-registry.ts
@@ -4,9 +4,19 @@ import type { OperationHandler } from "./operation-handler.js";
 import type { EntityConfig } from "../config/entity-config.js";
 import { ConfigurationException } from "../errors/exceptions.js";
 
-/** Map-backed operation registry, insertion-ordered. */
+/**
+ * Map-backed operation registry, insertion-ordered.
+ *
+ * `entityName` exists purely so the configuration errors below can name the
+ * entity they came from. It defaults the way `DefaultRelationRegistry`'s
+ * does, and both real call sites (`createCrud`, `@Kavo`) supply the real
+ * name — a config error reading `entity 'unknown'` was issue #7's third
+ * finding.
+ */
 export class DefaultOperationRegistry<Entity = unknown> implements OperationRegistry<Entity> {
   private readonly entries = new Map<OperationId, OperationDescriptor<Entity>>();
+
+  constructor(private readonly entityName: string = "entity") {}
 
   get(id: OperationId): OperationDescriptor<Entity> | undefined {
     return this.entries.get(id);
@@ -28,9 +38,9 @@ export class DefaultOperationRegistry<Entity = unknown> implements OperationRegi
     const existing = this.entries.get(id);
     if (existing === undefined) {
       throw new ConfigurationException(
-        "unknown",
+        this.entityName,
         `operations.${id}`,
-        `cannot override '${id}': no such registered operation`,
+        `cannot override '${id}': no such registered operation (registered: ${this.idList()})`,
       );
     }
     this.entries.set(id, { ...existing, handler });
@@ -40,12 +50,16 @@ export class DefaultOperationRegistry<Entity = unknown> implements OperationRegi
     const existing = this.entries.get(id);
     if (existing === undefined) {
       throw new ConfigurationException(
-        "unknown",
+        this.entityName,
         `operations.${id}`,
-        `cannot disable '${id}': no such registered operation`,
+        `cannot disable '${id}': no such registered operation (registered: ${this.idList()})`,
       );
     }
     this.entries.set(id, { ...existing, enabled: false });
+  }
+
+  private idList(): string {
+    return [...this.entries.keys()].sort().join(", ") || "none";
   }
 }
 
@@ -85,10 +99,10 @@ export const STANDARD_OPERATIONS: Readonly<Record<StandardOperationId, StandardO
 /** Provides the handler for one standard operation id. */
 export type StandardHandlerFactory<Entity> = (id: StandardOperationId) => OperationHandler<Entity>;
 
-const unboundHandler = (id: OperationId): OperationHandler<unknown> => ({
+const unboundHandler = (id: OperationId, entityName: string): OperationHandler<unknown> => ({
   execute(): Promise<never> {
     throw new ConfigurationException(
-      "unknown",
+      entityName,
       `operations.${id}`,
       `operation '${id}' has no bound handler — this registry was built ` + `for inspection (route generation) only`,
     );
@@ -121,13 +135,20 @@ const unboundHandler = (id: OperationId): OperationHandler<unknown> => ({
  * config doesn't mention at all, sitting between the unconditional/soft-delete
  * default and the entity's own `operations.<id>` — which always wins when
  * present, boolean shorthand or long form alike.
+ *
+ * `entityName` is only ever read back out in a configuration error's text.
+ * It is a trailing optional rather than a leading one, and the three
+ * optionals were deliberately *not* consolidated into an options bag:
+ * this factory is a barrel export, so a bag would be a breaking change to
+ * public API bought for a nicer call at two internal sites.
  */
 export function createOperationRegistry<Entity extends object>(
   config: EntityConfig<Entity> | undefined,
   handlers?: StandardHandlerFactory<Entity>,
   globalOperations?: Readonly<Partial<Record<StandardOperationId, boolean>>>,
+  entityName?: string,
 ): OperationRegistry<Entity> {
-  const registry = new DefaultOperationRegistry<Entity>();
+  const registry = new DefaultOperationRegistry<Entity>(entityName);
   const operations = config?.operations ?? {};
   const softDeleteDeclared = declaresSoftDelete(config);
 
@@ -141,7 +162,10 @@ export function createOperationRegistry<Entity extends object>(
       kind: shape.kind,
       cardinality: shape.cardinality,
       enabled: typeof operationConfig === "boolean" ? operationConfig : (settings?.enabled ?? defaultForEntity),
-      handler: settings?.handler ?? handlers?.(id) ?? (unboundHandler(id) as unknown as OperationHandler<Entity>),
+      handler:
+        settings?.handler ??
+        handlers?.(id) ??
+        (unboundHandler(id, entityName ?? "entity") as unknown as OperationHandler<Entity>),
       input: null,
       output: null,
       meta: settings?.meta ?? {},

--- a/packages/core/src/query/default-filter-parser.ts
+++ b/packages/core/src/query/default-filter-parser.ts
@@ -5,6 +5,7 @@ import type { ResolvedEntityConfig } from "../config/resolved-entity-config.js";
 import type { EntityMetadata, FieldMetadata } from "../metadata/entity-metadata.js";
 import type { QueryIssueDto } from "../errors/problem-details.js";
 import { QueryValidationException } from "../errors/exceptions.js";
+import { allowlistHint } from "../errors/message-hints.js";
 import { coerceScalar, isIssue } from "./value-coercion.js";
 import { parseBracketKey } from "./bracket-notation.js";
 
@@ -225,11 +226,14 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
     issues: QueryIssueDto[],
     out: FilterExpression<Entity>[],
   ): void {
-    if (!(config.allowlists.filterable as readonly string[]).includes(field)) {
+    const filterable = config.allowlists.filterable as readonly string[];
+    if (!filterable.includes(field)) {
       issues.push({
         field,
         code: "KAVO_QUERY_INVALID_FIELD",
-        detail: `Field '${field}' cannot be used for filtering.`,
+        detail:
+          `Field '${field}' cannot be used for filtering.` +
+          allowlistHint(field, "filtering", config.entityName, filterable),
       });
       return;
     }

--- a/packages/core/src/query/default-filter-parser.ts
+++ b/packages/core/src/query/default-filter-parser.ts
@@ -5,7 +5,7 @@ import type { ResolvedEntityConfig } from "../config/resolved-entity-config.js";
 import type { EntityMetadata, FieldMetadata } from "../metadata/entity-metadata.js";
 import type { QueryIssueDto } from "../errors/problem-details.js";
 import { QueryValidationException } from "../errors/exceptions.js";
-import { allowlistHint } from "../errors/message-hints.js";
+import { pushAllowlistIssue } from "../errors/message-hints.js";
 import { coerceScalar, isIssue } from "./value-coercion.js";
 import { parseBracketKey } from "./bracket-notation.js";
 
@@ -228,13 +228,10 @@ export class DefaultFilterParser<Entity = unknown> implements FilterParser<Entit
   ): void {
     const filterable = config.allowlists.filterable as readonly string[];
     if (!filterable.includes(field)) {
-      issues.push({
-        field,
-        code: "KAVO_QUERY_INVALID_FIELD",
-        detail:
-          `Field '${field}' cannot be used for filtering.` +
-          allowlistHint(field, "filtering", config.entityName, filterable),
-      });
+      // Same construction site as the programmatic path's
+      // `requireAllowlisted`, so the two entry points cannot word one
+      // rejection differently.
+      pushAllowlistIssue(field, "filtering", config.entityName, filterable, issues);
       return;
     }
     if (typeof value !== "object" || value === null || Array.isArray(value)) {

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -9,7 +9,9 @@ import type { EntityMetadata } from "../metadata/entity-metadata.js";
 import type { QueryIssueDto } from "../errors/problem-details.js";
 import type { IncludeResolver } from "../relations/include-resolver.js";
 import type { IncludeTree } from "../relations/include-tree.js";
+import type { AllowlistUsage } from "../errors/message-hints.js";
 import { ConfigurationException, QueryValidationException } from "../errors/exceptions.js";
+import { allowlistHint } from "../errors/message-hints.js";
 import { DefaultFilterParser } from "./default-filter-parser.js";
 import { builtInPaginationStrategies } from "./pagination-strategies.js";
 import { parseBracketKey } from "./bracket-notation.js";
@@ -118,14 +120,14 @@ export class QueryNormalizer<Entity = unknown> {
 
     const clientSort = input.sort ?? [];
     for (const entry of clientSort) {
-      requireAllowlisted(entry.field as string, config.allowlists.sortable, "sorting", issues);
+      requireAllowlisted(entry.field as string, config, "sorting", issues);
     }
     const sort = clientSort.length > 0 ? clientSort : defaultSortOf(config);
 
     const { root: rootFields, relations: relationFields } = collapseFieldSelection<Entity>(input.fields, issues);
     if (rootFields != null) {
       for (const field of rootFields) {
-        requireAllowlisted(field as string, config.allowlists.selectable, "selection", issues);
+        requireAllowlisted(field as string, config, "selection", issues);
       }
     }
     const fields: FieldSelection<Entity> = {
@@ -317,7 +319,7 @@ function parseSort<Entity>(
     if (token === "") continue;
     const descending = token.startsWith("-");
     const field = descending ? token.slice(1) : token;
-    if (requireAllowlisted(field, config.allowlists.sortable, "sorting", issues)) {
+    if (requireAllowlisted(field, config, "sorting", issues)) {
       result.push({
         field: field as FieldPath<Entity>,
         direction: descending ? "desc" : "asc",
@@ -423,7 +425,7 @@ function parseFields<Entity>(
   const root: FieldPath<Entity, 1>[] = [];
   for (const field of raw.split(",")) {
     if (field === "") continue;
-    if (requireAllowlisted(field, config.allowlists.selectable, "selection", issues)) {
+    if (requireAllowlisted(field, config, "selection", issues)) {
       root.push(field as FieldPath<Entity, 1>);
     }
   }
@@ -445,7 +447,7 @@ function validateExpression<Entity>(
     return;
   }
   if (expression.kind === "condition") {
-    requireAllowlisted(expression.field as string, config.allowlists.filterable, "filtering", issues);
+    requireAllowlisted(expression.field as string, config, "filtering", issues);
     const value = expression.value;
     if (Array.isArray(value) && value.length > config.settings.query.maxInValues) {
       issues.push({
@@ -461,17 +463,31 @@ function validateExpression<Entity>(
   }
 }
 
-function requireAllowlisted(
+/** Which allowlist each usage reads, so the caller names only the usage. */
+const ALLOWLIST_FOR: Readonly<Record<AllowlistUsage, "filterable" | "sortable" | "selectable">> = Object.freeze({
+  filtering: "filterable",
+  sorting: "sortable",
+  selection: "selectable",
+});
+
+/**
+ * The single allowlist gate for the programmatic entry point and the wire
+ * one alike. On rejection the issue names the near miss, the permitted set,
+ * and the config key that would permit the field — the leading sentence is
+ * unchanged, everything actionable is appended.
+ */
+function requireAllowlisted<Entity>(
   field: string,
-  allowlist: readonly unknown[],
-  usage: "filtering" | "sorting" | "selection",
+  config: ResolvedEntityConfig<Entity>,
+  usage: AllowlistUsage,
   issues: QueryIssueDto[],
 ): boolean {
-  if ((allowlist as readonly string[]).includes(field)) return true;
+  const allowed = config.allowlists[ALLOWLIST_FOR[usage]] as readonly string[];
+  if (allowed.includes(field)) return true;
   issues.push({
     field,
     code: "KAVO_QUERY_INVALID_FIELD",
-    detail: `Field '${field}' cannot be used for ${usage}.`,
+    detail: `Field '${field}' cannot be used for ${usage}.` + allowlistHint(field, usage, config.entityName, allowed),
   });
   return false;
 }

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -11,7 +11,7 @@ import type { IncludeResolver } from "../relations/include-resolver.js";
 import type { IncludeTree } from "../relations/include-tree.js";
 import type { AllowlistUsage } from "../errors/message-hints.js";
 import { ConfigurationException, QueryValidationException } from "../errors/exceptions.js";
-import { allowlistHint } from "../errors/message-hints.js";
+import { pushAllowlistIssue } from "../errors/message-hints.js";
 import { DefaultFilterParser } from "./default-filter-parser.js";
 import { builtInPaginationStrategies } from "./pagination-strategies.js";
 import { parseBracketKey } from "./bracket-notation.js";
@@ -484,11 +484,7 @@ function requireAllowlisted<Entity>(
 ): boolean {
   const allowed = config.allowlists[ALLOWLIST_FOR[usage]] as readonly string[];
   if (allowed.includes(field)) return true;
-  issues.push({
-    field,
-    code: "KAVO_QUERY_INVALID_FIELD",
-    detail: `Field '${field}' cannot be used for ${usage}.` + allowlistHint(field, usage, config.entityName, allowed),
-  });
+  pushAllowlistIssue(field, usage, config.entityName, allowed, issues);
   return false;
 }
 

--- a/packages/core/src/relations/default-include-resolver.ts
+++ b/packages/core/src/relations/default-include-resolver.ts
@@ -86,30 +86,26 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
     const tree: Record<string, IncludeNode> = {};
     for (const draft of drafts.values()) {
       const relation = owner.relations.get(draft.name);
-      // Two different mistakes, and the fix differs: a name that is not a
-      // relation at all is a typo, while a relation the config never named
-      // in `relations.edges` is a permission the developer has to grant.
-      // The registry keeps every metadata relation and flips `includable`
-      // only for configured edges, so the two are already distinguishable
-      // here (they were reported identically until issue #7).
-      if (relation === undefined) {
+      // A name that is not a relation at all and a relation the config never
+      // opted in are the same rejection to the client, deliberately: the
+      // registry keeps every metadata relation and flips `includable` only
+      // for configured edges, so wording the two differently would confirm
+      // the existence of the edges `relations.edges` closed on purpose (the
+      // disclosure rule in `errors/message-hints.ts`). What issue #7 was
+      // actually about — the message never naming the config key that grants
+      // inclusion — is fixed without that split, by stating the key as a
+      // conditional the developer can act on and a prober learns nothing from.
+      if (relation === undefined || !relation.includable) {
+        const includable = includableNames(owner);
         issues.push({
           field: draft.path,
           code: "KAVO_QUERY_INVALID_FIELD",
           detail:
-            `Relation '${draft.name}' does not exist on ${owner.entityName}` +
-            `${inPath(draft)}.${suggestion(draft.name, includableNames(owner))}` +
-            ` Includable relations on ${owner.entityName}: ${nameList(includableNames(owner))}.`,
-        });
-        continue;
-      }
-      if (!relation.includable) {
-        issues.push({
-          field: draft.path,
-          code: "KAVO_QUERY_INVALID_FIELD",
-          detail:
-            `Relation '${draft.name}' on ${owner.entityName} is not includable${inPath(draft)}.` +
-            ` Opt in with relations.edges.${draft.name}.includable = true on the ${owner.entityName} config.`,
+            `Relation '${draft.name}' is not includable on ${owner.entityName}${inPath(draft)}.` +
+            `${suggestion(draft.name, includable)}` +
+            ` Includable relations on ${owner.entityName}: ${nameList(includable)}.` +
+            ` If ${owner.entityName} has a '${draft.name}' relation, opt in with` +
+            ` relations.edges.${draft.name}.includable = true on the ${owner.entityName} config.`,
         });
         continue;
       }

--- a/packages/core/src/relations/default-include-resolver.ts
+++ b/packages/core/src/relations/default-include-resolver.ts
@@ -5,6 +5,7 @@ import type { QueryIssueDto } from "../errors/problem-details.js";
 import type { RelationDescriptor } from "./relation-descriptor.js";
 import type { ResolvedEntityConfig } from "../config/resolved-entity-config.js";
 import { QueryValidationException } from "../errors/exceptions.js";
+import { allowlistHint, nameList, suggestName } from "../errors/message-hints.js";
 
 /** A pending node, before validation turns it into an `IncludeNode`. */
 interface DraftNode {
@@ -85,11 +86,30 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
     const tree: Record<string, IncludeNode> = {};
     for (const draft of drafts.values()) {
       const relation = owner.relations.get(draft.name);
-      if (relation === undefined || !relation.includable) {
+      // Two different mistakes, and the fix differs: a name that is not a
+      // relation at all is a typo, while a relation the config never named
+      // in `relations.edges` is a permission the developer has to grant.
+      // The registry keeps every metadata relation and flips `includable`
+      // only for configured edges, so the two are already distinguishable
+      // here (they were reported identically until issue #7).
+      if (relation === undefined) {
         issues.push({
           field: draft.path,
           code: "KAVO_QUERY_INVALID_FIELD",
-          detail: `Field '${draft.path}' cannot be used for inclusion.`,
+          detail:
+            `Relation '${draft.name}' does not exist on ${owner.entityName}` +
+            `${inPath(draft)}.${suggestion(draft.name, includableNames(owner))}` +
+            ` Includable relations on ${owner.entityName}: ${nameList(includableNames(owner))}.`,
+        });
+        continue;
+      }
+      if (!relation.includable) {
+        issues.push({
+          field: draft.path,
+          code: "KAVO_QUERY_INVALID_FIELD",
+          detail:
+            `Relation '${draft.name}' on ${owner.entityName} is not includable${inPath(draft)}.` +
+            ` Opt in with relations.edges.${draft.name}.includable = true on the ${owner.entityName} config.`,
         });
         continue;
       }
@@ -196,11 +216,42 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
       issues.push({
         field: `${draft.path}.${field}`,
         code: "KAVO_QUERY_INVALID_FIELD",
-        detail: `Field '${field}' cannot be used for selection on '${draft.path}'.`,
+        detail:
+          `Field '${field}' cannot be used for selection on '${draft.path}'.` +
+          // The allowlist that rejected it is the *target* entity's, so the
+          // config key the developer has to edit is the target's too.
+          allowlistHint(field, "selection", target.entityName, allowed),
       });
     }
     return fields;
   }
+}
+
+/**
+ * The relations a client is permitted to include on this entity — the only
+ * names a rejection may enumerate. `all()` also holds relations the config
+ * never opted in, and naming those would turn an error message into a
+ * schema dump (the disclosure rule in `errors/message-hints.ts`).
+ */
+function includableNames(owner: ResolvedEntityConfig<object>): readonly string[] {
+  return owner.relations
+    .all()
+    .filter((relation) => relation.includable)
+    .map((relation) => relation.name);
+}
+
+/**
+ * ` (in include path 'posts.comments')` — omitted at the top level, where
+ * the path and the relation name are the same string and repeating it adds
+ * nothing.
+ */
+function inPath(draft: DraftNode): string {
+  return draft.path === draft.name ? "" : ` (in include path '${draft.path}')`;
+}
+
+function suggestion(name: string, candidates: readonly string[]): string {
+  const match = suggestName(name, candidates);
+  return match === undefined ? "" : ` Did you mean '${match}'?`;
 }
 
 /** Merge one dot-path into the draft tree, sharing prefixes. */

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -114,6 +114,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "OperationConfig",
   "OperationDescriptor",
   "OperationDisabledException",
+  "OperationNotRegisteredException",
   "OperationDtoMap",
   "OperationHandler",
   "OperationId",

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BUILT_IN_DEFAULTS, ConfigurationException, mergeSettings, resolveEntityConfig } from "@kavo/core";
+import { BUILT_IN_DEFAULTS, ConfigurationException, createKavo, mergeSettings, resolveEntityConfig } from "@kavo/core";
 import { User, userMetadata } from "./support/user-fixture.js";
 
 describe("mergeSettings — merge algebra", () => {
@@ -199,5 +199,48 @@ describe("resolveEntityConfig — bootstrap", () => {
 describe("User fixture sanity", () => {
   it("has runtime shape (initialized fields)", () => {
     expect(Object.keys(new User())).toContain("email");
+  });
+});
+
+/**
+ * Issue #7: a bootstrap failure has to name the call that fixes it,
+ * including for the framework the developer is actually holding — the core
+ * message named only the core API, which is not what a Nest app wrote.
+ */
+describe("bootstrap wiring errors", () => {
+  const detailOf = (fn: () => unknown): string => {
+    try {
+      fn();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigurationException);
+      return (error as ConfigurationException).detail;
+    }
+    throw new Error("expected ConfigurationException");
+  };
+
+  it("names both the core and the NestJS entry point when metadata is missing", () => {
+    const detail = detailOf(() => createKavo().createCrud(User));
+    expect(detail).toContain("createKavo");
+    expect(detail).toContain("createInfrastructure(dataSource)");
+    expect(detail).toContain("KavoModule.forRoot({ infrastructure })");
+  });
+
+  it("names them again when only the adapter is missing", () => {
+    const detail = detailOf(() => createKavo().createCrud(User, undefined, { metadata: userMetadata }));
+    expect(detail).toContain("runtime.adapter");
+    expect(detail).toContain("KavoModule.forRoot({ infrastructure })");
+  });
+
+  it("never reports a configuration error against the entity named 'unknown'", () => {
+    // The registry used to hardcode that literal, so every config error it
+    // raised blamed an entity nobody had declared.
+    const detail = detailOf(() =>
+      createKavo().createCrud(User, { operations: { restoreOne: true } } as never, {
+        metadata: userMetadata,
+        adapter: {} as never,
+      }),
+    );
+    expect(detail).toContain("User");
+    expect(detail).not.toContain("'unknown'");
   });
 });

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -151,6 +151,15 @@ describe("KavoEngine pipeline", () => {
     await expect(crud.deleteOne(1)).rejects.toThrow("operations.deleteOne");
   });
 
+  it("does not send a restoreOne caller toward a config that fails to boot", async () => {
+    // `restoreOne` is disabled here because `User` is not soft-deletable,
+    // and `requireSoftDeletable` rejects `operations.restoreOne = true` on a
+    // hard-delete entity at bootstrap. Naming the flag without the
+    // prerequisite would turn a 405 into an app that no longer starts.
+    const { crud } = makeCrud();
+    await expect(crud.restoreOne(1)).rejects.toThrow("also need the entity to be soft-deletable");
+  });
+
   it("separates an unregistered operation from a disabled one (issue #7)", async () => {
     // Both are 405, but "disabled" is a lie about an id the registry never
     // had — and `messageKey` is the code, so a localizing consumer would

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -3,6 +3,7 @@ import {
   ConfigurationException,
   NotFoundException,
   OperationDisabledException,
+  OperationNotRegisteredException,
   createKavo,
   toProblemDetails,
 } from "@kavo/core";
@@ -17,6 +18,13 @@ function makeCrud(config?: Parameters<ReturnType<typeof createKavo>["createCrud"
   });
   return { crud, adapter, kavo };
 }
+
+/**
+ * A call naming an operation the registry has no entry for. Only reachable
+ * through the engine: the typed service surface has no such method, and
+ * route generation walks the same registry, so no route exists either.
+ */
+const unregisteredRequest = () => ({ operation: "findAll", id: null, body: null, query: null, options: null }) as never;
 
 describe("KavoEngine pipeline", () => {
   it("runs createOne → findOne → updateOne → patchOne → deleteOne", async () => {
@@ -132,6 +140,42 @@ describe("KavoEngine pipeline", () => {
   it("raises OperationDisabledException for config-disabled operations", async () => {
     const { crud } = makeCrud({ operations: { deleteOne: false } } as never);
     await expect(crud.deleteOne(1)).rejects.toBeInstanceOf(OperationDisabledException);
+  });
+
+  it("names the config key that would switch a disabled operation back on", async () => {
+    const { crud } = makeCrud({ operations: { deleteOne: false } } as never);
+    await expect(crud.deleteOne(1)).rejects.toMatchObject({
+      code: "KAVO_OPERATION_DISABLED",
+      messageParams: { operation: "deleteOne", entity: "User" },
+    });
+    await expect(crud.deleteOne(1)).rejects.toThrow("operations.deleteOne");
+  });
+
+  it("separates an unregistered operation from a disabled one (issue #7)", async () => {
+    // Both are 405, but "disabled" is a lie about an id the registry never
+    // had — and `messageKey` is the code, so a localizing consumer would
+    // re-render that lie. Unreachable over HTTP (no route is generated for
+    // an id the registry does not hold), so only this path can prove it.
+    const { crud } = makeCrud();
+    await expect(crud.engine.execute(unregisteredRequest())).rejects.toMatchObject({
+      code: "KAVO_OPERATION_NOT_REGISTERED",
+      status: 405,
+      context: { entityName: "User", operation: "findAll" },
+    });
+  });
+
+  it("lists what a caller could have called instead", async () => {
+    const { crud } = makeCrud();
+    try {
+      await crud.engine.execute(unregisteredRequest());
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(OperationNotRegisteredException);
+      const { detail } = error as OperationNotRegisteredException;
+      expect(detail).toContain("Registered operations:");
+      expect(detail).toContain("findMany");
+      expect(detail).not.toContain("disabled");
+    }
   });
 
   it("dispatches overridden handlers through the same pipeline", async () => {

--- a/packages/core/tests/errors.spec.ts
+++ b/packages/core/tests/errors.spec.ts
@@ -11,6 +11,7 @@ import {
   NotDeletedException,
   NotFoundException,
   OperationDisabledException,
+  OperationNotRegisteredException,
   PersistenceException,
   QueryValidationException,
   TransactionException,
@@ -39,6 +40,7 @@ const CATALOG: Readonly<Record<CatalogedErrorCode, { status: number; title: stri
   KAVO_ALREADY_DELETED: { status: 409, title: "Already deleted" },
   KAVO_NOT_DELETED: { status: 409, title: "Not deleted" },
   KAVO_OPERATION_DISABLED: { status: 405, title: "Operation disabled" },
+  KAVO_OPERATION_NOT_REGISTERED: { status: 405, title: "Operation not registered" },
   KAVO_PERSISTENCE_FAILED: { status: 500, title: "Persistence failure" },
   KAVO_TRANSACTION_FAILED: { status: 500, title: "Transaction failure" },
   KAVO_CONFIG_INVALID: { status: 500, title: "Invalid configuration" },
@@ -122,6 +124,7 @@ describe("exception hierarchy", () => {
     { exception: new AlreadyDeletedException(), code: "KAVO_ALREADY_DELETED", status: 409 },
     { exception: new NotDeletedException(), code: "KAVO_NOT_DELETED", status: 409 },
     { exception: new OperationDisabledException(), code: "KAVO_OPERATION_DISABLED", status: 405 },
+    { exception: new OperationNotRegisteredException(), code: "KAVO_OPERATION_NOT_REGISTERED", status: 405 },
     { exception: new PersistenceException(), code: "KAVO_PERSISTENCE_FAILED", status: 500 },
     { exception: new TransactionException(), code: "KAVO_TRANSACTION_FAILED", status: 500 },
     { exception: new QueryValidationException([]), code: "KAVO_QUERY_INVALID", status: 400 },
@@ -194,6 +197,31 @@ describe("exception hierarchy", () => {
   it("marks a transaction retryable only when told so", () => {
     expect(new TransactionException().retryable).toBe(false);
     expect(new TransactionException({ retryable: true }).retryable).toBe(true);
+  });
+
+  it("bakes the fix into the disabled-operation template, not into a caller-supplied hint", () => {
+    // Issue #7: `messageKey` *is* the code, so a consumer that localizes by
+    // re-rendering key + params has to get the actionable half too — it
+    // cannot live only in the English string a throw site pasted together.
+    const exception = new OperationDisabledException({
+      messageParams: { operation: "purgeOne", entity: "User" },
+    });
+    expect(exception.detail).toContain("Operation 'purgeOne' is disabled for User.");
+    expect(exception.detail).toContain("Enable it with 'operations.purgeOne' in the entity config.");
+    expect(renderMessage("KAVO_OPERATION_DISABLED", exception.messageParams)).toBe(exception.detail);
+  });
+
+  it("never calls an unregistered operation 'disabled'", () => {
+    const exception = new OperationNotRegisteredException({
+      messageParams: { operation: "findAll", entity: "User", available: "findMany, findOne" },
+    });
+    expect(exception.detail).toContain("is not registered for User");
+    expect(exception.detail).toContain("Registered operations: findMany, findOne.");
+    expect(exception.detail).not.toContain("disabled");
+    // The two share a status but never a code — the code is what a
+    // localizing consumer keys off.
+    expect(exception.status).toBe(new OperationDisabledException().status);
+    expect(exception.code).not.toBe("KAVO_OPERATION_DISABLED");
   });
 
   it("names the entity, key path, and problem on a configuration error", () => {

--- a/packages/core/tests/errors.spec.ts
+++ b/packages/core/tests/errors.spec.ts
@@ -207,7 +207,14 @@ describe("exception hierarchy", () => {
       messageParams: { operation: "purgeOne", entity: "User" },
     });
     expect(exception.detail).toContain("Operation 'purgeOne' is disabled for User.");
-    expect(exception.detail).toContain("Enable it with 'operations.purgeOne' in the entity config.");
+    expect(exception.detail).toContain("Enable it with 'operations.purgeOne' in the entity config");
+    // The caveat rides the template rather than a param, so it survives
+    // re-rendering and cannot leave a `{placeholder}` in a response when a
+    // caller constructs this exception without it. `purgeOne` is disabled by
+    // default on *every* entity, so the flag alone is the wrong advice more
+    // often than not.
+    expect(exception.detail).toContain("also need the entity to be soft-deletable");
+    expect(exception.detail).not.toContain("{");
     expect(renderMessage("KAVO_OPERATION_DISABLED", exception.messageParams)).toBe(exception.detail);
   });
 

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -349,6 +349,100 @@ describe("association by id (ADR-0014)", () => {
   });
 });
 
+/**
+ * Issue #7: the two ways an include can be rejected used to render the
+ * identical sentence, so the message could not tell a typo from a
+ * permission that was never granted. Assertions stay on the actionable
+ * clause (`toContain`), never on the whole string — the prose is meant to
+ * keep improving.
+ */
+describe("include rejection messages", () => {
+  const detailOf = async (fn: () => Promise<unknown>): Promise<string> => {
+    try {
+      await fn();
+    } catch (error) {
+      const issues = (error as QueryValidationException).issues;
+      expect(issues).toHaveLength(1);
+      return issues[0]!.detail;
+    }
+    throw new Error("expected QueryValidationException");
+  };
+
+  it("tells a relation that does not exist from one that was never opted in", async () => {
+    const { authors } = blog();
+    const unknown = await detailOf(() =>
+      authors.findMany({ include: ["ghosts"] as unknown as readonly IncludePath<Author>[] }),
+    );
+    const closed = await detailOf(() => authors.findMany({ include: ["posts"] }));
+    expect(unknown).not.toBe(closed);
+    expect(unknown).toContain("does not exist on Author");
+    expect(closed).toContain("is not includable");
+  });
+
+  it("names the config key that opts a real relation in", async () => {
+    const { authors } = blog();
+    const detail = await detailOf(() => authors.findMany({ include: ["posts"] }));
+    expect(detail).toContain("relations.edges.posts.includable = true");
+    expect(detail).toContain("on the Author config");
+  });
+
+  it("lists the includable relations, and says 'none' when the default empty config is why", async () => {
+    const { authors } = blog();
+    const detail = await detailOf(() =>
+      authors.findMany({ include: ["ghosts"] as unknown as readonly IncludePath<Author>[] }),
+    );
+    expect(detail).toContain("Includable relations on Author: none.");
+  });
+
+  it("suggests the near miss, drawn only from relations already opted in", async () => {
+    const { authors } = blog({ author: { relations: { edges: { posts: { includable: true } } } } });
+    const detail = await detailOf(() =>
+      authors.findMany({ include: ["postz"] as unknown as readonly IncludePath<Author>[] }),
+    );
+    expect(detail).toContain("Did you mean 'posts'?");
+  });
+
+  it("never enumerates a relation the config has not opted in", async () => {
+    // The disclosure rule: a rejection may name only what the client is
+    // already permitted to ask for. `Post.author` exists in metadata but no
+    // edge names it, so it must not appear.
+    const { authors } = blog({
+      author: { relations: { edges: { posts: { includable: true } } } },
+    });
+    const detail = await detailOf(() =>
+      authors.findMany({ include: ["posts.authr"] as unknown as readonly IncludePath<Author>[] }),
+    );
+    expect(detail).toContain("Includable relations on Post: none.");
+    expect(detail).not.toContain("'author'");
+  });
+
+  it("blames the entity that owns the failing segment, not the root", async () => {
+    const { authors } = blog({
+      author: { relations: { edges: { posts: { includable: true } } } },
+    });
+    const detail = await detailOf(() =>
+      authors.findMany({ include: ["posts.comments"] as unknown as readonly IncludePath<Author>[] }),
+    );
+    expect(detail).toContain("on Post is not includable");
+    expect(detail).toContain("(in include path 'posts.comments')");
+    expect(detail).toContain("on the Post config");
+    expect(detail).not.toContain("Author");
+  });
+
+  it("names the target entity's allowlist when a relation fieldset is rejected", async () => {
+    const { authors } = blog({
+      author: { relations: { edges: { posts: { includable: true } } } },
+      post: { allowlists: { selectable: ["id", "title"] } },
+    });
+    const detail = await detailOf(() =>
+      authors.findMany({ include: ["posts"], fields: { relations: { posts: ["titel"] } } }),
+    );
+    expect(detail).toContain("Did you mean 'title'?");
+    expect(detail).toContain("Selectable fields on Post: id, title.");
+    expect(detail).toContain("allowlists.selectable on the Post config");
+  });
+});
+
 /** The include tree the adapter last received — what resolution produced. */
 function includeTree<Entity extends object>(adapter: SeededAdapter<Entity>): Record<string, IncludeNode> {
   return (adapter.lastQuery?.include ?? {}) as Record<string, IncludeNode>;

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -368,15 +368,20 @@ describe("include rejection messages", () => {
     throw new Error("expected QueryValidationException");
   };
 
-  it("tells a relation that does not exist from one that was never opted in", async () => {
+  it("says the same thing for a relation that exists and one that does not", async () => {
+    // The oracle this closes: `Author.posts` is real but never opted in,
+    // `ghosts` is not a relation at all. Inclusion is opt-in and defaults to
+    // empty, so a message that distinguished them would confirm the
+    // existence of every edge the config deliberately closed — one guessed
+    // name per request. Both rejections differ only in the name echoed back.
     const { authors } = blog();
-    const unknown = await detailOf(() =>
+    const real = await detailOf(() => authors.findMany({ include: ["posts"] }));
+    const invented = await detailOf(() =>
       authors.findMany({ include: ["ghosts"] as unknown as readonly IncludePath<Author>[] }),
     );
-    const closed = await detailOf(() => authors.findMany({ include: ["posts"] }));
-    expect(unknown).not.toBe(closed);
-    expect(unknown).toContain("does not exist on Author");
-    expect(closed).toContain("is not includable");
+    expect(real.replace(/posts/g, "X")).toBe(invented.replace(/ghosts/g, "X"));
+    expect(real).toContain("is not includable on Author");
+    expect(invented).toContain("is not includable on Author");
   });
 
   it("names the config key that opts a real relation in", async () => {
@@ -423,7 +428,7 @@ describe("include rejection messages", () => {
     const detail = await detailOf(() =>
       authors.findMany({ include: ["posts.comments"] as unknown as readonly IncludePath<Author>[] }),
     );
-    expect(detail).toContain("on Post is not includable");
+    expect(detail).toContain("is not includable on Post");
     expect(detail).toContain("(in include path 'posts.comments')");
     expect(detail).toContain("on the Post config");
     expect(detail).not.toContain("Author");

--- a/packages/core/tests/message-hints.spec.ts
+++ b/packages/core/tests/message-hints.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+// Deliberately a deep import: `message-hints` is internal, kept off the
+// barrel because `detail` prose is not public API (ADR-0009 fixes the
+// document shape, not its English). A test may reach its own package's src.
+import { allowlistHint, nameList, suggestName } from "../src/errors/message-hints.js";
+
+describe("suggestName", () => {
+  const fields = ["email", "id", "name", "createdAt"];
+
+  it("suggests the candidate one edit away", () => {
+    expect(suggestName("emai", fields)).toBe("email");
+    expect(suggestName("names", fields)).toBe("name");
+  });
+
+  it("treats a transposition as the single typo it is, even on a short name", () => {
+    // Plain Levenshtein charges a swap two edits, which puts it outside a
+    // four-letter name's budget — and a swap is the typo people make.
+    expect(suggestName("nmae", fields)).toBe("name");
+    expect(suggestName("emial", fields)).toBe("email");
+  });
+
+  it("suggests across a case difference", () => {
+    expect(suggestName("Email", fields)).toBe("email");
+  });
+
+  it("suggests nothing for an unrelated name", () => {
+    expect(suggestName("password", fields)).toBeUndefined();
+  });
+
+  it("suggests nothing when there are no candidates", () => {
+    expect(suggestName("email", [])).toBeUndefined();
+  });
+
+  it("never suggests the input back to itself", () => {
+    expect(suggestName("email", fields)).toBeUndefined();
+  });
+
+  it("holds short names to one edit, so 'id' does not become 'at'", () => {
+    // At two edits every three-letter name reaches every other one, and a
+    // confidently wrong suggestion is worse than none.
+    expect(suggestName("idx", ["at", "on"])).toBeUndefined();
+    expect(suggestName("idx", ["id"])).toBe("id");
+  });
+
+  it("picks the closest candidate when several are within reach", () => {
+    expect(suggestName("titl", ["title", "titles"])).toBe("title");
+  });
+
+  it("tolerates two edits once the name is long enough", () => {
+    expect(suggestName("creatdAtt", fields)).toBe("createdAt");
+  });
+});
+
+describe("nameList", () => {
+  it("renders a short list in sorted order", () => {
+    expect(nameList(["name", "email", "id"])).toBe("email, id, name");
+  });
+
+  it("says 'none' for an empty set — the answer on an entity with no edges", () => {
+    expect(nameList([])).toBe("none");
+  });
+
+  it("truncates a long list and reports the true total", () => {
+    const many = Array.from({ length: 200 }, (_unused, index) => `f${String(index).padStart(3, "0")}`);
+    const rendered = nameList(many);
+    expect(rendered).toContain("(200 total)");
+    expect(rendered.split(", ")).toHaveLength(11); // 10 names + the "… (200 total)" tail
+    expect(rendered).not.toContain("f011");
+  });
+
+  it("renders exactly at the cap without truncating", () => {
+    const ten = Array.from({ length: 10 }, (_unused, index) => `f${index}`);
+    expect(nameList(ten)).not.toContain("total");
+  });
+});
+
+describe("allowlistHint", () => {
+  it("names the near miss, the permitted set, and the config key", () => {
+    const hint = allowlistHint("emial", "filtering", "User", ["email", "id"]);
+    expect(hint).toContain("Did you mean 'email'?");
+    expect(hint).toContain("Filterable fields on User: email, id.");
+    expect(hint).toContain("Add it to allowlists.filterable on the User config");
+  });
+
+  it("omits the suggestion when nothing is close", () => {
+    expect(allowlistHint("password", "filtering", "User", ["email", "id"])).not.toContain("Did you mean");
+  });
+
+  it("names the allowlist key matching the usage", () => {
+    expect(allowlistHint("x", "sorting", "User", ["id"])).toContain("allowlists.sortable");
+    expect(allowlistHint("x", "selection", "User", ["id"])).toContain("allowlists.selectable");
+    expect(allowlistHint("x", "sorting", "User", ["id"])).toContain("Sortable fields on User");
+    expect(allowlistHint("x", "selection", "User", ["id"])).toContain("Selectable fields on User");
+  });
+});

--- a/packages/core/tests/message-hints.spec.ts
+++ b/packages/core/tests/message-hints.spec.ts
@@ -79,7 +79,15 @@ describe("allowlistHint", () => {
     const hint = allowlistHint("emial", "filtering", "User", ["email", "id"]);
     expect(hint).toContain("Did you mean 'email'?");
     expect(hint).toContain("Filterable fields on User: email, id.");
-    expect(hint).toContain("Add it to allowlists.filterable on the User config");
+    expect(hint).toContain("add it to allowlists.filterable on the User config");
+  });
+
+  it("makes the allowlist advice conditional on the field being a real column", () => {
+    // An allowlist accepts whatever the config declares — nothing checks it
+    // against `EntityMetadata` — so "add it to allowlists.sortable" stated
+    // flatly would trade this 400 for a 500 out of the driver the next time
+    // the developer sorts by their typo.
+    expect(allowlistHint("nmae", "sorting", "User", ["name", "id"])).toContain("If User has a 'nmae' column");
   });
 
   it("omits the suggestion when nothing is close", () => {

--- a/packages/core/tests/operation-registry.spec.ts
+++ b/packages/core/tests/operation-registry.spec.ts
@@ -109,6 +109,23 @@ describe("DefaultOperationRegistry — the operation table (ADR-0006)", () => {
       }
     }
   });
+
+  it("names the entity it was built for, never the literal 'unknown' (issue #7)", () => {
+    const registry = new DefaultOperationRegistry<User>("User");
+    registry.register(descriptor());
+    try {
+      registry.disable("ghost");
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "KAVO_CONFIG_INVALID",
+        messageParams: { entity: "User" },
+        context: { entityName: "User" },
+      });
+      // …and says what *is* registered, so the typo is visible.
+      expect((error as ConfigurationException).detail).toContain("registered: activate");
+    }
+  });
 });
 
 describe("STANDARD_OPERATIONS — the default table", () => {
@@ -182,6 +199,14 @@ describe("createOperationRegistry — inspection-only mode (ADR-0012)", () => {
       messageParams: { path: "operations.createOne" },
     });
     await expect(async () => handler?.execute({}, contextStub())).rejects.toBeInstanceOf(ConfigurationException);
+  });
+
+  it("threads the entity name through to the unbound handler's error", async () => {
+    const registry = createOperationRegistry<User>(undefined, undefined, undefined, "User");
+    const handler = registry.get("createOne")?.handler;
+    await expect(async () => handler?.execute({}, contextStub())).rejects.toMatchObject({
+      messageParams: { entity: "User" },
+    });
   });
 });
 

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -437,3 +437,64 @@ describe("QueryNormalizer — the three fields spellings", () => {
     });
   });
 });
+
+/**
+ * Issue #7: an allowlist rejection named what was refused and stopped
+ * there, leaving the developer to guess which config key would permit it.
+ * The leading sentence is unchanged; everything actionable is appended, so
+ * these assert the appended clause and never the whole string.
+ */
+describe("allowlist rejection messages", () => {
+  it("names the near miss, the permitted set, and the config key for a filter field", () => {
+    const detail = issuesOf(() => normalizer.normalizeWire({ "filter[emial][eq]": "a" }, config))[0]!.detail;
+    expect(detail).toContain("Field 'emial' cannot be used for filtering.");
+    expect(detail).toContain("Did you mean 'email'?");
+    expect(detail).toContain("Filterable fields on User:");
+    expect(detail).toContain("Add it to allowlists.filterable on the User config to permit it.");
+  });
+
+  it("names allowlists.sortable for a sort field", () => {
+    const detail = issuesOf(() => normalizer.normalizeWire({ sort: "-emial" }, config))[0]!.detail;
+    expect(detail).toContain("Did you mean 'email'?");
+    expect(detail).toContain("allowlists.sortable on the User config");
+  });
+
+  it("names allowlists.selectable for a selected field", () => {
+    const detail = issuesOf(() => normalizer.normalizeWire({ fields: "emial" }, config))[0]!.detail;
+    expect(detail).toContain("Did you mean 'email'?");
+    expect(detail).toContain("allowlists.selectable on the User config");
+  });
+
+  it("names the same key for a programmatic filter expression", () => {
+    const detail = issuesOf(() =>
+      normalizer.normalizeInput(
+        { filter: { kind: "condition", field: "emial", operator: "EQ", value: "a" } } as never,
+        config,
+      ),
+    )[0]!.detail;
+    expect(detail).toContain("Did you mean 'email'?");
+    expect(detail).toContain("allowlists.filterable on the User config");
+  });
+
+  it("says the same thing through the programmatic entry point", () => {
+    // The two entry points share one gate, so the security posture and the
+    // message quality cannot diverge between them.
+    const wire = issuesOf(() => normalizer.normalizeWire({ sort: "emial" }, config))[0]!.detail;
+    const programmatic = issuesOf(() =>
+      normalizer.normalizeInput({ sort: [{ field: "emial", direction: "asc" }] } as never, config),
+    )[0]!.detail;
+    expect(programmatic).toBe(wire);
+  });
+
+  it("offers no suggestion when nothing is close, and still names the fix", () => {
+    const detail = issuesOf(() => normalizer.normalizeWire({ sort: "passwordHash" }, config))[0]!.detail;
+    expect(detail).not.toContain("Did you mean");
+    expect(detail).toContain("allowlists.sortable");
+  });
+
+  it("collects every rejection into one round trip", () => {
+    const issues = issuesOf(() => normalizer.normalizeWire({ sort: "emial", fields: "nmae" }, config));
+    expect(issues).toHaveLength(2);
+    expect(issues.every((issue) => issue.detail.includes("Did you mean"))).toBe(true);
+  });
+});

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -450,7 +450,21 @@ describe("allowlist rejection messages", () => {
     expect(detail).toContain("Field 'emial' cannot be used for filtering.");
     expect(detail).toContain("Did you mean 'email'?");
     expect(detail).toContain("Filterable fields on User:");
-    expect(detail).toContain("Add it to allowlists.filterable on the User config to permit it.");
+    expect(detail).toContain("add it to allowlists.filterable on the User config to permit it.");
+  });
+
+  it("stops appending the hint once a request is past a handful of problems", () => {
+    // `?fields=a1,…,a5000` is a legal query string, and the hint is not
+    // free: it walks the whole allowlist per rejected name and adds a few
+    // hundred bytes per issue. Uncapped, one request becomes a megabyte of
+    // prose and an O(names × allowlist) sweep. The leading sentence — the
+    // part that says what was refused — is never dropped.
+    const many = Array.from({ length: 200 }, (_unused, index) => `bad${index}`).join(",");
+    const issues = issuesOf(() => normalizer.normalizeWire({ fields: many }, config));
+    expect(issues).toHaveLength(200);
+    expect(issues.every((issue) => issue.detail.includes("cannot be used for selection"))).toBe(true);
+    expect(issues.filter((issue) => issue.detail.includes("allowlists.selectable"))).toHaveLength(5);
+    expect(issues[199]!.detail).toBe("Field 'bad199' cannot be used for selection.");
   });
 
   it("names allowlists.sortable for a sort field", () => {

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -169,7 +169,7 @@ export function Kavo<
     Reflect.defineMetadata(KAVO_CONTROLLER_METADATA, metadata, target);
     registeredKavoControllers.set(target, metadata);
 
-    const registry = createOperationRegistry(erasedConfig);
+    const registry = createOperationRegistry(erasedConfig, undefined, undefined, entity.name);
     const overrides = collectOverrides(controller.prototype, entity.name, registry);
 
     for (const descriptor of registry.all()) {

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -208,11 +208,7 @@ export class KavoModule {
             "KavoModule.forFeature only accepts @Kavo controllers",
         );
       }
-      return {
-        provide: getKavoServiceToken(metadata.entity),
-        useFactory: (kavo: KavoInstance) => kavo.createCrud(metadata.entity, metadata.config),
-        inject: [KAVO_INSTANCE],
-      };
+      return serviceProvider(metadata);
     });
     return {
       module: KavoModule,
@@ -238,13 +234,37 @@ function providersFromRegistry(): Provider[] {
       );
     }
     ownerByEntity.set(metadata.entity, controller);
-    providers.push({
-      provide: getKavoServiceToken(metadata.entity),
-      useFactory: (kavo: KavoInstance) => kavo.createCrud(metadata.entity, metadata.config),
-      inject: [KAVO_INSTANCE],
-    });
+    providers.push(serviceProvider(metadata));
   }
   return providers;
+}
+
+/**
+ * One entity's `KavoService`, resolved from the root instance.
+ *
+ * `KAVO_INSTANCE` is injected **optionally** so that a module graph with a
+ * `forFeature` but no `forRoot`/`forRootAsync` fails with a
+ * `ConfigurationException` naming the missing call, instead of Nest's
+ * "can't resolve dependencies (?)" — which names an internal token the
+ * developer never wrote and gives no clue what to add (issue #7).
+ */
+function serviceProvider(metadata: KavoControllerMetadata): Provider {
+  return {
+    provide: getKavoServiceToken(metadata.entity),
+    useFactory: (kavo: KavoInstance | undefined) => {
+      if (kavo === undefined) {
+        throw new ConfigurationException(
+          metadata.entity.name,
+          "forFeature",
+          "the Kavo root instance is not in this module graph — " +
+            "KavoModule.forFeature only provides per-entity services and needs it; " +
+            "add KavoModule.forRoot({ infrastructure }) (or forRootAsync) to your root module's imports",
+        );
+      }
+      return kavo.createCrud(metadata.entity, metadata.config);
+    },
+    inject: [{ token: KAVO_INSTANCE, optional: true }],
+  };
 }
 
 /**

--- a/packages/frameworks/nest/tests/for-feature-without-for-root.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/for-feature-without-for-root.e2e.spec.ts
@@ -1,0 +1,60 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { Controller } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { ConfigurationException } from "@kavo/core";
+import { Kavo, KavoModule } from "@kavo/nest";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+
+/**
+ * Issue #7: `forFeature` provides per-entity services out of the root
+ * instance, so without `forRoot`/`forRootAsync` in the graph its factory
+ * has nothing to build from. That used to surface as Nest's own
+ * "Nest can't resolve dependencies of the KAVO_INSTANCE (?)" — a token the
+ * developer never typed, with no hint of the call that was missing.
+ *
+ * Its own file for the same reason `for-feature-registry.e2e.spec.ts` has
+ * one: the `@Kavo` registry is a process-wide singleton, and a suite that
+ * decorates one class per file is the only place the no-arg form is
+ * unambiguous.
+ */
+
+@Kavo(Todo)
+@Controller("todos")
+class LonelyTodoController {}
+
+describe("KavoModule.forFeature without forRoot", () => {
+  const compileFeatureOnly = (): Promise<unknown> =>
+    Test.createTestingModule({ imports: [KavoModule.forFeature([LonelyTodoController])] }).compile();
+
+  it("fails with a ConfigurationException naming the call that is missing", async () => {
+    await expect(compileFeatureOnly()).rejects.toBeInstanceOf(ConfigurationException);
+    const error = (await compileFeatureOnly().catch((thrown: unknown) => thrown)) as ConfigurationException;
+    expect(error.code).toBe("KAVO_CONFIG_INVALID");
+    expect(error.context.entityName).toBe("Todo");
+    expect(error.detail).toContain("KavoModule.forRoot({ infrastructure })");
+    expect(error.detail).toContain("forRootAsync");
+    // The point of the change: the message no longer leads with an internal
+    // DI token nobody wrote.
+    expect(error.detail).not.toContain("KAVO_INSTANCE");
+  });
+
+  it("says the same thing for the no-argument, registry-driven form", async () => {
+    await expect(Test.createTestingModule({ imports: [KavoModule.forFeature()] }).compile()).rejects.toBeInstanceOf(
+      ConfigurationException,
+    );
+  });
+
+  it("still resolves normally once forRoot is in the graph", async () => {
+    // The optional injection must not turn a real wiring bug into a silent
+    // success, nor break the wiring that always worked.
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        KavoModule.forRoot({ infrastructure: fakeInfrastructure(new InMemoryTodoAdapter()) }),
+        KavoModule.forFeature([LonelyTodoController]),
+      ],
+    }).compile();
+    await expect(moduleRef.init()).resolves.toBeDefined();
+    await moduleRef.close();
+  });
+});


### PR DESCRIPTION
Closes #7

## What and why

The errors a developer hit when they got something wrong named *what* was rejected but never *what to change*, and three of them were actively misleading. This is the error-message quality pass, delivered as the three independent slices the issue lays out — one commit each.

The two facts that set the priority: **inclusion is opt-in and ships `edges: {}`**, so "no relation is includable" is the *default* state of every entity and its message was the framework's highest-traffic dead end; and **`@kavo/mcp` hands `detail` straight to an LLM** (`tools.ts:73`), which makes message quality functional rather than cosmetic — a tool-calling model that gets `Field 'emial' cannot be used for filtering.` has nothing to correct against and loops.

**Slice 1 — query-path messages.** New dependency-free `errors/message-hints.ts` (internal, not barrel-exported) supplies `suggestName` / `nameList` / `allowlistHint`. Every allowlist rejection now appends the near miss, the permitted set, and the config key; the include resolver splits its one collapsed branch into "does not exist on Post" versus "on Post is not includable — opt in with `relations.edges.comments.includable = true`". Suggestions use optimal string alignment rather than plain Levenshtein, so a transposition (`emial`, `nmae`) costs one edit and stays in reach of a short name's budget.

**Slice 2 — operation resolution.** `descriptor === undefined || !descriptor.enabled` was one branch, so an operation the registry never had was reported as *disabled*. `messageKey` **is** the code, so a consumer localizing from key + params re-rendered that falsehood on the channel ADR-0009 designates as authoritative — fixing only the English string would have left it in place. Adds `KAVO_OPERATION_NOT_REGISTERED` (405) and bakes the enabling config key into the `KAVO_OPERATION_DISABLED` template.

**Slice 3 — bootstrap wiring.** The registry's three `"unknown"` entity literals now carry the real name; `forFeature` without `forRoot` raises a `ConfigurationException` naming the missing call instead of Nest's `can't resolve dependencies of KAVO_INSTANCE (?)`; core's infrastructure errors name the Nest entry point as well as the core one.

## Disclosure rule (normative, enforced by tests)

Hints reach the wire, deliberately: `errors.exposeInternals` is scoped to **driver internals** (`problem-details-serializer.ts:33` gates `cause` alone) and defaults to `false`, so gating would hide the whole feature from the audience it is for. But suggestion candidates and listed names are drawn **only from the permitted set** — includable relations, allowlisted filterable/sortable/selectable fields — never the full registry, so a rejection enumerates exactly what the client may already ask for. `includes.spec.ts` pins this: `Post.author` exists in metadata but is not opted in, and must not appear.

## Public API impact

- **Added** (non-breaking): `OperationNotRegisteredException` and its `KAVO_OPERATION_NOT_REGISTERED` catalog entry, both on the core barrel; manifest and `CATALOG` mirror updated.
- **Added** (non-breaking): a trailing optional 4th param `entityName` on `createOperationRegistry`, and an optional constructor param on `DefaultOperationRegistry` (matching `DefaultRelationRegistry`'s existing shape). The issue left "4th positional vs. options bag" open — positional, because a bag is a **breaking** change to a barrel export bought for a nicer call at two internal sites.
- **Not added:** the `hint?: string` on `KavoExceptionOptions`/`KavoException` the original design proposed. Auditing every throw site, query-path issues are inline `QueryIssueDto` literals that never build an exception and `ConfigurationException` already takes a free-form `problem` — it would have been public API on eleven classes serving one caller.
- **No** wire-shape change: `ProblemDetailsDto` and `QueryIssueDto` are untouched, `Object.keys(issue)` still `["code","detail","field"]`, no existing code changed status, title, or meaning.
- Error `detail` strings changed. Not typed API, and every new assertion is `toContain` on the actionable clause, never full-string equality.

## Testing

`pnpm check` **green** — 72 files, 1409 tests, `depcruise` 0 violations (301 modules / 1083 dependencies), `oxlint` clean. `pnpm docs:links`, `pnpm docs:build`, and `pnpm format:check` also run and green, since none of the three is part of `check`.

New: `packages/core/tests/message-hints.spec.ts` (16 cases — transposition, short-name threshold, truncation at 200 candidates, empty sets) and `packages/frameworks/nest/tests/for-feature-without-for-root.e2e.spec.ts` (its own file, because the `@Kavo` registry is a process-wide singleton). Extended: `includes.spec.ts` (unknown vs non-includable are distinct; the *owning* entity is blamed at depth 2, not the root; the disclosure rule), `query-normalizer.spec.ts` (wire and programmatic entry points produce byte-identical details), `errors.spec.ts`, `engine.spec.ts`, `config.spec.ts`, `operation-registry.spec.ts`.

## Review notes

- **The new code is the load-bearing decision.** The issue originally self-imposed "no new codes"; that constraint was dropped, and the reasoning is in the slice-2 commit body. Worth agreeing with before merge, since codes are API surface.
- **Optional DI injection** (`inject: [{ token, optional: true }]`) is verified against the installed `@nestjs/common` 11.1.28; `OptionalFactoryDependency` has existed since Nest 9.3, so it is safe across the `^10 || ^11` peer range. The third test in that file pins that normal wiring still resolves — the guard must not turn a real bug into a silent success.
- **Deliberately left out**, per the issue's own scoping: the soft-delete-prerequisite variant (unreachable at request time — it is a bootstrap error via `requireSoftDeletable`), and the two adjacent findings recorded in #7 — `06-error-handling.md` documenting `KAVO_BULK_FAILED`, which is not in `ERROR_CATALOG`, and `kavo.ts:164` naming TypeORM's `@DeleteDateColumn` in a message core now serves four ORMs with.
