### PR TITLE
ci: split the gate into build and test jobs, and badge the README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,17 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# `pnpm check` runs the whole gate as one command locally. CI splits it in
+# two — `build` (compile, types, boundaries, lint) and `test` — because a
+# status badge can only report a job, never a step: one combined job can say
+# "CI failing" but never "the build is fine, a test regressed". The halves
+# are disjoint and their union is exactly `pnpm check`, which
+# `tests/ci-workflow.spec.ts` asserts against this file so a step added to
+# the gate cannot silently stop running here. They also run in parallel, so
+# the split costs no wall-clock.
 jobs:
-  check:
-    name: check (node ${{ matrix.node }})
+  build:
+    name: build (node ${{ matrix.node }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -39,9 +47,40 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # build + depcruise + test — the same gate as local `pnpm check`.
-      - name: Check
-        run: pnpm check
+      # `generate` first: the Prisma client it emits is what `build` and
+      # `typecheck` compile @kavo/prisma against.
+      - name: Build
+        run: pnpm run generate && pnpm run build && pnpm run typecheck && pnpm run depcruise && pnpm run lint
+
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["lts/-1", "lts/*", "current"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # No `build` step: vitest aliases every `@kavo/*` specifier straight to
+      # package `src/` (see vitest.config.ts), so the suite never reads
+      # `dist/`. `generate` is still required — it emits the Prisma client and
+      # pushes the SQLite fixture schema the @kavo/prisma specs run against.
+      - name: Test
+        run: pnpm run generate && pnpm run test
 
   format:
     name: format

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
   GraphQL CRUD API with filtering, sorting, pagination, and generated routes.
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@kavo/core"><img src="https://img.shields.io/npm/v/%40kavo%2Fcore?label=npm" alt="Latest version on npm" /></a>
+  <a href="https://github.com/kavo-labs/kavo/actions/workflows/ci.yml"><img src="https://img.shields.io/github/check-runs/kavo-labs/kavo/main?nameFilter=build%20(node%20lts%2F*)&label=build" alt="Build status on main" /></a>
+  <a href="https://github.com/kavo-labs/kavo/actions/workflows/ci.yml"><img src="https://img.shields.io/github/check-runs/kavo-labs/kavo/main?nameFilter=test%20(node%20lts%2F*)&label=tests" alt="Test status on main" /></a>
+  <a href="https://github.com/kavo-labs/kavo/blob/main/LICENSE"><img src="https://img.shields.io/github/license/kavo-labs/kavo?label=license" alt="Apache-2.0 licensed" /></a>
+  <a href="https://www.npmjs.com/package/@kavo/core"><img src="https://img.shields.io/npm/dm/%40kavo%2Fcore?label=downloads" alt="Downloads per month on npm" /></a>
+  <a href="https://kavo.js.org"><img src="https://img.shields.io/badge/docs-kavo.js.org-1f6feb" alt="Documentation" /></a>
+</p>
+
 # Kavo
 
 Define an entity once, add one decorator, and Kavo generates the rest: create,

--- a/tests/ci-workflow.spec.ts
+++ b/tests/ci-workflow.spec.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The CI split, and the README badges that report it, as assertions.
+ *
+ * `pnpm check` is the gate and is never worked around, but CI cannot run it
+ * as one job and still say anything useful on a badge: a status badge reports
+ * a job, never a step, so a single combined job can only ever say "CI
+ * failing". `ci.yml` therefore splits the gate into `build` and `test`, and
+ * the README badges each point at one of them by check-run name.
+ *
+ * That buys two ways to drift silently, which is what these tests close:
+ *
+ *   1. A step added to `pnpm check` that nobody adds to either CI job. The
+ *      gate would still be green locally while CI quietly stopped running it.
+ *   2. A job renamed in `ci.yml`. Shields matches a check run by exact name,
+ *      so the badge does not go red — it goes blank ("check run not found"),
+ *      which reads as "no signal" rather than "broken".
+ *
+ * Both files are read as text on purpose: they are the artifacts under test,
+ * and a test that reimplemented their contents would pass while the real
+ * pipeline drifted. That is the same reasoning as
+ * `tests/release-workflow.spec.ts`.
+ */
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const WORKFLOW_PATH = resolve(REPO_ROOT, ".github/workflows/ci.yml");
+const README_PATH = resolve(REPO_ROOT, "README.md");
+const MANIFEST_PATH = resolve(REPO_ROOT, "package.json");
+
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+const readme = readFileSync(README_PATH, "utf8");
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8")) as { scripts?: Record<string, string | undefined> };
+
+/** The node versions `ci.yml` fans its matrix jobs out over. */
+const NODE_MATRIX = ["lts/-1", "lts/*", "current"];
+
+const PNPM_RUN = /pnpm run ([\w:-]+)/g;
+
+/** Every first capture group of `pattern` across `source`. */
+function captures(source: string, pattern: RegExp): string[] {
+  const found: string[] = [];
+  for (const [, capture] of source.matchAll(pattern)) {
+    if (capture !== undefined) found.push(capture);
+  }
+  return found;
+}
+
+/** The script names `pnpm check` chains, in order: `pnpm run x && pnpm run y`. */
+function gateSteps(): string[] {
+  return captures(manifest.scripts?.check ?? "", PNPM_RUN);
+}
+
+/** The `pnpm run x && …` chain a named job executes, flattened to script names. */
+function jobSteps(jobName: string): string[] {
+  // Each job body runs from its own `jobs:` key to the next one (two-space
+  // indent at column 0), which keeps this from swallowing the whole file.
+  const body = new RegExp(`\\n  ${jobName}:\\n([\\s\\S]*?)(?=\\n  \\w[\\w-]*:\\n|$)`).exec(workflow)?.[1];
+  expect(body, `ci.yml declares a \`${jobName}\` job`).toBeDefined();
+  return captures(body ?? "", PNPM_RUN);
+}
+
+/** Every check-run name `ci.yml` can produce, with the node matrix expanded. */
+function checkRunNames(): string[] {
+  return captures(workflow, /^ {4}name: (.+)$/gm).flatMap((jobName) =>
+    jobName.includes("${{ matrix.node }}")
+      ? NODE_MATRIX.map((node) => jobName.replace("${{ matrix.node }}", node))
+      : [jobName],
+  );
+}
+
+/** The check-run name every shields.io badge in the README filters on. */
+function badgedCheckRunNames(): string[] {
+  return captures(readme, /img\.shields\.io\/github\/check-runs\/[^"\s]*?nameFilter=([^&"\s]+)/g).map((name) =>
+    decodeURIComponent(name),
+  );
+}
+
+describe("the CI split covers the whole gate", () => {
+  const steps = gateSteps();
+  const build = jobSteps("build");
+  const test = jobSteps("test");
+
+  it("runs every step of `pnpm check` in at least one job", () => {
+    expect(steps.length).toBeGreaterThan(0);
+    for (const step of steps) {
+      expect([...build, ...test], `\`pnpm run ${step}\` is part of the gate but no CI job runs it`).toContain(step);
+    }
+  });
+
+  it("adds no step to CI that the gate does not run", () => {
+    for (const step of new Set([...build, ...test])) {
+      expect(steps, `CI runs \`pnpm run ${step}\`, which is not part of \`pnpm check\``).toContain(step);
+    }
+  });
+
+  it("runs the test suite only in the `test` job, so its badge means tests", () => {
+    expect(test).toContain("test");
+    expect(build).not.toContain("test");
+  });
+
+  it("runs compilation, boundaries and lint only in the `build` job", () => {
+    for (const step of ["build", "typecheck", "depcruise", "lint"]) {
+      expect(build).toContain(step);
+      expect(test).not.toContain(step);
+    }
+  });
+
+  it("generates the Prisma client in both jobs, since neither can compile or run without it", () => {
+    expect(build).toContain("generate");
+    expect(test).toContain("generate");
+  });
+});
+
+describe("the README status badges point at real check runs", () => {
+  it("filters on a check-run name ci.yml actually produces", () => {
+    const badged = badgedCheckRunNames();
+    const produced = checkRunNames();
+
+    expect(badged.length, "README carries at least one per-job status badge").toBeGreaterThan(0);
+    for (const name of badged) {
+      expect(produced, `README badges the check run "${name}", which ci.yml never produces`).toContain(name);
+    }
+  });
+
+  it("badges both halves of the gate", () => {
+    const badged = badgedCheckRunNames();
+    expect(badged.some((name) => name.startsWith("build ("))).toBe(true);
+    expect(badged.some((name) => name.startsWith("test ("))).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds status/metadata badges to the README, and restructures CI so the build and test badges can mean something distinct.

## Badges

Six, in a centered row under the hero:

| Badge | Source |
| --- | --- |
| npm version | `@kavo/core` — the hub, lockstep-versioned with the other seven |
| build | `build (node lts/*)` check run on `main` |
| tests | `test (node lts/*)` check run on `main` |
| license | the repo `LICENSE` |
| downloads | `@kavo/core` monthly |
| docs | static link to kavo.js.org |

**The license badge reads GitHub, not npm, on purpose.** The `v0.6.0` tag was cut at 15:16 on 2026-08-01; the Apache-2.0 relicense (`094dfd4`) landed at 22:14 the same day. So `@kavo/core@0.6.0` on npm still declares MIT, and an `npm/l` badge would advertise the wrong license until the next release. The GitHub badge correctly reads Apache-2.0 today.

## Why CI had to change

A GitHub status badge can report a *job*, never a *step*. With `build`, `typecheck`, `depcruise`, `lint` and `test` all inside one `check` job, there was no way to render "build passing / tests failing" — only "CI failing".

So `check` is now two jobs:

- **`build`** — `generate && build && typecheck && depcruise && lint`
- **`test`** — `generate && test`

Disjoint apart from `generate`, which both need (it emits the Prisma client the build compiles against, and pushes the SQLite fixture schema the `@kavo/prisma` specs use). Their union is exactly `pnpm check`, which stays the single local gate, unchanged.

`test` deliberately skips `build`: `vitest.config.ts` aliases every `@kavo/*` specifier straight to package `src/`, so the suite never reads `dist/`. The jobs run in parallel, so the split costs no wall-clock — it should shave some.

## Guarding the drift

`tests/ci-workflow.spec.ts` (repo-level, same rationale as `tests/release-workflow.spec.ts` — the workflow file *is* the artifact under test, so it is read as text) pins two things that would otherwise rot silently:

1. Every step of `pnpm check` still runs in at least one CI job, and CI runs nothing the gate does not. Add a step to `check` without wiring it into CI and this goes red.
2. Every README badge filters on a check-run name `ci.yml` actually produces. This matters more than it looks: shields matches a check run by *exact* name, so renaming a job does **not** turn the badge red — it blanks it to "no check runs", which reads as *no signal* rather than *broken*.

Verified the second test has teeth by renaming a filter to `tests (node lts/*)` and confirming it fails.

## Verification

- `pnpm check` — green (73 files, 1419 tests)
- `pnpm format:check` — green
- `pnpm docs:links` — green
- Every badge URL fetched against shields.io; all render. The `build`/`tests` badges read "no check runs" until this merges and the renamed jobs first run on `main` — expected.

> [!NOTE]
> `main` is currently red, unrelated to this PR: run 30949071015 failed on three testcontainers suites because Docker Hub returned HTTP 500 on manifest fetches. A re-run should clear it. Worth doing before merge so the new badges land green.