### PR TITLE
feat(core): add computed/virtual fields to entity responses

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -191,6 +191,10 @@ const config = defineConfig({
                 text: "0018 — Mongoose models are entity identities",
                 link: "/internals/adr/0018-mongoose-models-are-entity-identities",
               },
+              {
+                text: "0019 — Computed fields are serializer-evaluated",
+                link: "/internals/adr/0019-computed-fields-are-serializer-evaluated",
+              },
             ],
           },
         ],

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -180,12 +180,20 @@ Response fields with no backing column, derived from an entity that has already 
 
 | Field        | Type                                        | What it does                                                                                         |
 | ------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `resolve`    | `(entity, context: KavoContext) => unknown` | Derives the value. Called once per served item, **synchronously** — see the N+1 caveat below.        |
-| `selectable` | `boolean` (default `true`)                  | Whether `fields=` may name the field. `false` keeps it always-present and never individually chosen. |
+| `resolve`    | `(entity, context: KavoContext) => unknown` | Derives the value. Called once per served item, **synchronously** — see the caveats below.           |
+| `selectable` | `boolean` (default `true`)                  | Whether `fields=` may name the field. `false` makes naming it a 400 — read the note below carefully. |
 
 A declared computed field is in the default `item`/`list` projection with no DTO registration, and in the `selectable` allowlist by default. It is **never** filterable, sortable, or writable — naming one in `allowlists.filterable`/`sortable` is both a type error and a bootstrap `ConfigurationException`, and a value for one in a request body is stripped even if a registered `create`/`update` DTO declares the key.
 
-Keep `resolve` a pure function of the entity (plus `context.principal` where a field has to vary by caller). It runs per row, so a resolver that queries the database or calls out over the network reintroduces exactly the N+1 that batched includes exist to avoid.
+`resolve` returning `undefined` omits the key; `null` emits it — the same distinction a column draws.
+
+**What `selectable: false` does and does not mean.** It removes the name from the allowlist, so `?fields=auditNote` is a 400. It does **not** pin the field into every response: selection narrows the projection uniformly, so any request that sends `fields=` at all still drops it, and the client has no way to ask for it back. Read it as "not individually selectable", not "always present". An explicit `allowlists.selectable` list naming the field overrides the flag — an explicit list is always the deliberate answer.
+
+Keep `resolve` a pure function of the entity (plus `context.principal` where a field has to vary by caller). It runs per row, so a resolver that queries the database or calls out over the network reintroduces exactly the N+1 that batched includes exist to avoid. Declaring it `async` is a bootstrap error rather than a slow success: the serializer never awaits, so the promise would be emitted as-is and serialize to `{}`.
+
+On an **included relation target**, `resolve` receives the _root_ request's `KavoContext` — serving `GET /posts/1?include=author` hands an `Author` computed field a context whose `entityName`, `operation`, `config` and `query` describe Post. Only `principal`, `correlationId`, `transaction` and `state` mean what they say from a relation target.
+
+Pass the config inline to `@Kavo(...)` (or use `satisfies`) rather than annotating it `EntityConfig<Book>`: the computed-key type parameter is inferred at the call site, and an explicit `EntityConfig<Book>` annotation fixes it to `never` — which erases `computed`'s value types and leaves `resolve`'s parameter implicitly `any`.
 
 See [ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated) for the reasoning and [DTO system §7](/internals/architecture/04-dto-system) for how it interacts with DTO narrowing and field selection.
 

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -163,7 +163,7 @@ What a request may filter, sort, and select on — including relation paths. Any
 | `sortable`   | same shape                                                    | Fields usable in `sort=`.       |
 | `selectable` | same shape                                                    | Fields usable in `fields=`.     |
 
-`{ exclude: [...] }` means "every own column except these", resolved against entity metadata at bootstrap. Omit a key entirely and it derives from the `query` DTO or entity metadata instead.
+`{ exclude: [...] }` means "every own column (plus, for `selectable`, every selectable computed field) except these", resolved at bootstrap against exactly the base set that key's plain default uses. Omit a key entirely and it derives from the `query` DTO or entity metadata instead.
 
 ### `computed`
 
@@ -172,7 +172,7 @@ Response fields with no backing column, derived from an entity that has already 
 ```ts
 @Kavo(Book, {
   computed: {
-    displayTitle: { resolve: (book) => `${book.title} (${book.year})` },
+    displayTitle: { resolve: (book) => (book.title === null ? null : `${book.title} (${book.year})`) },
     canEdit: { resolve: (book, context) => book.ownerId === (context.principal as User)?.id },
   },
 })
@@ -183,17 +183,23 @@ Response fields with no backing column, derived from an entity that has already 
 | `resolve`    | `(entity, context: KavoContext) => unknown` | Derives the value. Called once per served item, **synchronously** — see the caveats below.           |
 | `selectable` | `boolean` (default `true`)                  | Whether `fields=` may name the field. `false` makes naming it a 400 — read the note below carefully. |
 
-A declared computed field is in the default `item`/`list` projection with no DTO registration, and in the `selectable` allowlist by default. It is **never** filterable, sortable, or writable — naming one in `allowlists.filterable`/`sortable` is both a type error and a bootstrap `ConfigurationException`, and a value for one in a request body is stripped even if a registered `create`/`update` DTO declares the key.
+A declared computed field is in the default `item`/`list` projection with no DTO registration, and in the `selectable` allowlist by default. It is **never** filterable, sortable, or writable — naming one in `allowlists.filterable`/`sortable` is both a type error and a bootstrap `ConfigurationException`, and so is naming one in a registered `create`/`update`/`patch` DTO. (A raw body key is still just dropped, like any other unknown key; the DTO case is a declaration, and every other computed misdeclaration fails at bootstrap too. It also has a wire consequence a silent drop cannot reach: `@ApiBody` is built from the DTO's runtime shape, so OpenAPI would advertise a property the engine unconditionally discards.)
 
 `resolve` returning `undefined` omits the key; `null` emits it — the same distinction a column draws.
 
-**What `selectable: false` does and does not mean.** It removes the name from the allowlist, so `?fields=auditNote` is a 400. It does **not** pin the field into every response: selection narrows the projection uniformly, so any request that sends `fields=` at all still drops it, and the client has no way to ask for it back. Read it as "not individually selectable", not "always present". An explicit `allowlists.selectable` list naming the field overrides the flag — an explicit list is always the deliberate answer.
+**`resolve` must be total, not merely pure.** It runs once per served item and nothing catches it, so **one** row whose resolver throws turns the whole collection endpoint into a 500 — not for that row, for every caller, until the row is fixed. Write it against everything the column can actually hold, including `null`: `resolve: (todo) => todo.title?.toLowerCase() ?? null`, never `todo.title.toLowerCase()` on a nullable column. A `POST` that sets `title: null` succeeds (computed fields are stripped from the payload; `title` is an ordinary column), and `GET /todos` is dead from then on. A throwing resolver surfaces as a 500 `KAVO_PERSISTENCE_FAILED` with the cause attached and the message not leaked.
 
-Keep `resolve` a pure function of the entity (plus `context.principal` where a field has to vary by caller). It runs per row, so a resolver that queries the database or calls out over the network reintroduces exactly the N+1 that batched includes exist to avoid. Declaring it `async` is a bootstrap error rather than a slow success: the serializer never awaits, so the promise would be emitted as-is and serialize to `{}`.
+Keep it a pure function of the entity as well (plus `context.principal` where a field has to vary by caller). It runs per row, so a resolver that queries the database or calls out over the network reintroduces exactly the N+1 that batched includes exist to avoid. Declaring it `async` is a bootstrap error rather than a slow success: the serializer never awaits, so the promise would be emitted as-is and serialize to `{}`.
+
+**`resolve` receives the full fetched row**, not the projected object — selection is "kept internally, stripped late", so every column is present regardless of `fields=` or the registered `item` DTO. A computed field can therefore surface a value a narrowed DTO or `selectable` list deliberately hides. That is deliberate (`resolve` is server-authored code, the same trust level as `exposeInternals`), but it makes the resolver part of the exposure decision: narrowing the DTO does not narrow what the resolver can see.
+
+**What `selectable: false` does and does not mean.** It removes the name from the allowlist, so `?fields=auditNote` is a 400. It does **not** pin the field into every response: selection narrows the projection uniformly, so any request that sends `fields=` at all still drops it, and the client has no way to ask for it back. Read it as "not individually selectable", not "always present". An explicit `allowlists.selectable` list naming the field overrides the flag — an explicit list is always the deliberate answer.
 
 On an **included relation target**, `resolve` receives the _root_ request's `KavoContext` — serving `GET /posts/1?include=author` hands an `Author` computed field a context whose `entityName`, `operation`, `config` and `query` describe Post. Only `principal`, `correlationId`, `transaction` and `state` mean what they say from a relation target.
 
-Pass the config inline to `@Kavo(...)` (or use `satisfies`) rather than annotating it `EntityConfig<Book>`: the computed-key type parameter is inferred at the call site, and an explicit `EntityConfig<Book>` annotation fixes it to `never` — which erases `computed`'s value types and leaves `resolve`'s parameter implicitly `any`.
+**The generated OpenAPI response schema does not mention a computed field** when no `item`/`list` DTO is registered: the schema falls back to the entity class, whose columns are all the reflection can see, while the runtime response carries the computed key. Registering an `item`/`list` DTO naming the field fixes the document and the static response type in one move — the same escape hatch, for both consequences.
+
+Let the computed-key type parameter be inferred at the call site: pass the config inline to `@Kavo(...)` (or use `satisfies`), and pin neither an `EntityConfig<Book>` annotation on the config nor explicit type arguments on the call (`@Kavo<Todo, CreateTodoDto>(...)`, `createCrud<Book, CreateBookDto>(...)` — the likelier spelling once an entity has custom DTOs). Either fixes `Computed` to `never`, which erases `computed`'s value types and leaves `resolve`'s parameter implicitly `any`.
 
 See [ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated) for the reasoning and [DTO system §7](/internals/architecture/04-dto-system) for how it interacts with DTO narrowing and field selection.
 

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -115,7 +115,7 @@ An entity's own `operations.<id>` (below) always wins over this global map.
 
 ## `@Kavo(Entity, config)` — entity-scope config
 
-Every field above (`pagination`, `query`, `errors`, `relations`, `softDelete`) can also be set here, one level above global. In addition, `@Kavo`'s config carries three fields that only make sense per entity:
+Every field above (`pagination`, `query`, `errors`, `relations`, `softDelete`) can also be set here, one level above global. In addition, `@Kavo`'s config carries four fields that only make sense per entity:
 
 ### `dto`
 
@@ -164,6 +164,30 @@ What a request may filter, sort, and select on — including relation paths. Any
 | `selectable` | same shape                                                    | Fields usable in `fields=`.     |
 
 `{ exclude: [...] }` means "every own column except these", resolved against entity metadata at bootstrap. Omit a key entirely and it derives from the `query` DTO or entity metadata instead.
+
+### `computed`
+
+Response fields with no backing column, derived from an entity that has already been fetched:
+
+```ts
+@Kavo(Book, {
+  computed: {
+    displayTitle: { resolve: (book) => `${book.title} (${book.year})` },
+    canEdit: { resolve: (book, context) => book.ownerId === (context.principal as User)?.id },
+  },
+})
+```
+
+| Field        | Type                                        | What it does                                                                                         |
+| ------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `resolve`    | `(entity, context: KavoContext) => unknown` | Derives the value. Called once per served item, **synchronously** — see the N+1 caveat below.        |
+| `selectable` | `boolean` (default `true`)                  | Whether `fields=` may name the field. `false` keeps it always-present and never individually chosen. |
+
+A declared computed field is in the default `item`/`list` projection with no DTO registration, and in the `selectable` allowlist by default. It is **never** filterable, sortable, or writable — naming one in `allowlists.filterable`/`sortable` is both a type error and a bootstrap `ConfigurationException`, and a value for one in a request body is stripped even if a registered `create`/`update` DTO declares the key.
+
+Keep `resolve` a pure function of the entity (plus `context.principal` where a field has to vary by caller). It runs per row, so a resolver that queries the database or calls out over the network reintroduces exactly the N+1 that batched includes exist to avoid.
+
+See [ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated) for the reasoning and [DTO system §7](/internals/architecture/04-dto-system) for how it interacts with DTO narrowing and field selection.
 
 ### `operations`
 

--- a/docs/internals/adr/0019-computed-fields-are-serializer-evaluated.md
+++ b/docs/internals/adr/0019-computed-fields-are-serializer-evaluated.md
@@ -1,0 +1,119 @@
+# ADR-0019 — Computed fields are serializer-evaluated, and never filterable, sortable, or writable
+
+**Status:** accepted
+
+## Context
+
+Every projection Kavo derives comes from the metadata seam (ADR-0011),
+which describes **columns**. A field with no backing column — `fullName`
+from `firstName`/`lastName`, a formatted total, a caller-dependent flag —
+therefore has nowhere to live. The workaround that appeared to work was
+registering an `item` DTO naming a property that the entity class happens
+to expose as a getter: `DefaultSerializer` copied it because `key in
+source` was true. That is an accident of TypeORM handing the engine class
+instances. `@kavo/prisma`, `@kavo/mongoose`, and any adapter returning
+plain rows carry no getter, so the same config silently emitted nothing —
+and no ORM's rows made the field reachable through `fields=`, because the
+`selectable` allowlist derives from columns alone.
+
+Making such a field first-class raises one question with a wrong obvious
+answer. A field the client can _see_ looks like a field the client should
+be able to filter and sort on, and every other selectable path is. But
+filtering and sorting are pushed down to the database: the filter
+translators turn a path into `WHERE`/`ORDER BY` against a column that must
+exist. Honoring `filter[fullName][eq]` would mean fetching rows and
+evaluating the predicate in memory — which silently breaks pagination
+(`limit`/`offset` are applied by the database, before the predicate),
+`total`, and every performance property the query grammar is built on.
+The alternative, "just add the field to `selectable` and hope nobody
+filters", is exactly the fail-open posture `resolveAllowlists` exists to
+prevent.
+
+Where the field is evaluated is the other half. Nothing in the pipeline
+before response mapping can produce it: the adapter fetches columns, the
+query normalizer validates paths, the handlers move rows. Response
+mapping is also the one stage that already sees the fully-hydrated entity
+and the request context together.
+
+## Decision
+
+An entity may declare **computed fields** — `EntityConfig.computed`, a
+record of `ComputedFieldDescriptor<Entity>` keyed by the name each
+serializes as — and they are governed by four rules.
+
+**1. Serializer-evaluated, post-fetch.** `DefaultSerializer` produces a
+computed key by calling the descriptor's `resolve(entity, context)`,
+never by reading it off the row. That is the only stage involved, which
+is what makes computed fields behave identically for a TypeORM class
+instance and a Prisma/Mongoose plain object, and why **no ORM adapter
+changes**: no adapter consumes `query.fields` (selection is "kept
+internally, stripped late"), so every row arrives fully hydrated and a
+computed field's source columns are always present, even under
+`fields=fullName`. There is no dependency declaration and none is needed.
+
+`resolve` is **synchronous** and runs once per served item. An
+async or database-hitting resolver is not offered: it would reintroduce
+per-row N+1 at exactly the stage the include resolver exists to batch.
+
+**2. Present by default, narrowed like any other field.** A declared
+computed field joins the entity-derived `item`/`list` projection with no
+DTO registration, and joins the `selectable` allowlist unless the
+descriptor sets `selectable: false`. Both narrowing mechanisms then apply
+unchanged: an explicit `item`/`list` DTO that omits it hides it, and
+`fields=` narrows it away. The normative order is untouched — DTO mapping
+first, then field selection; selection never widens.
+
+**3. Never filterable, never sortable.** Not deferred — rejected. A
+computed field never joins the derived `filterable`/`sortable` allowlists,
+and naming one in a configured `allowlists.filterable`/`sortable` is a
+bootstrap `ConfigurationException`. In-memory post-fetch filtering is not
+a future option here; a caller who needs to filter or sort on a derived
+value wants a real generated column, which every supported ORM already
+offers.
+
+**4. Never writable.** `DefaultDeserializer` strips computed names from
+every write payload. Keeping them out of the derived writable projection
+is _not_ sufficient on its own: a registered `create`/`update` DTO
+replaces that projection wholesale (`dtoShapeKeys(dto) ??
+this.writableProjection`), so a DTO class declaring the field for
+documentation would otherwise pass the key through to the adapter as if it
+were a column. The strip is explicit and applies whichever projection is
+in force.
+
+Two further declarations are bootstrap errors, for the same
+fail-fast-with-the-key-path reason: a computed name colliding with a real
+column or relation (the shadowed value would silently vanish from every
+response), and a descriptor with no `resolve` function.
+
+`computed` carries functions, so — like `dto` and `relations` — it is
+**entity-scope structural config, outside the settings precedence chain**:
+it is absent from `SETTINGS_KEYS`, never merged global → entity →
+operation, and unreachable from a per-call `KavoCallOptions.settings`
+override.
+
+At the type level, `EntityConfig` takes an eighth parameter, `Computed`,
+inferred from the keys of `computed`. It widens `allowlists.selectable`
+to `FieldPath<Entity> | Computed` so an explicit selectable list can name
+a computed field without a cast — and, deliberately, widens nothing else,
+so rule 3 is a compile error before it is a bootstrap error.
+
+## Consequences
+
+- A computed field on a relation **target** works with no extra machinery:
+  the serializer already resolves an included node's projection from the
+  target's own `ResolvedEntityConfig` through the `EntityCatalog`, and
+  that config now carries `computed`. A relation still cannot widen what
+  its target exposes.
+- `ResolvedEntityConfig` gains a required `computed` member. It is
+  produced by Kavo and read by the serializer/deserializer; anything
+  constructing one by hand has to supply it.
+- Static typing of the _response_ is unchanged: the entity-derived
+  `ItemDto` does not grow the computed key. A caller wanting the field
+  statically typed registers an `item`/`list` DTO naming it, exactly as
+  for any other narrowing today. Deriving it automatically was considered
+  and left out — it would mean synthesizing a response type from a config
+  value, which every other DTO slot deliberately does not do.
+- The extension point, if a later version wants derived values the
+  database can filter on: that is a generated column, declared through
+  the ORM and surfaced by the metadata seam as an ordinary field — not a
+  second mode of this feature.

--- a/docs/internals/adr/0019-computed-fields-are-serializer-evaluated.md
+++ b/docs/internals/adr/0019-computed-fields-are-serializer-evaluated.md
@@ -59,6 +59,29 @@ the serializer emits the return value unawaited and the response would
 silently carry `{}`. Returning `undefined` omits the key and `null` emits
 it, the same distinction the column branch draws.
 
+`resolve` must also be **total**, which is a stronger requirement than
+pure and the one that actually bites. `serializeList` is an unguarded
+`entities.map(...)` and nothing downstream catches a resolver, so a
+single row the resolver cannot handle takes down the whole collection
+response — for every caller, not just that row, until the row is
+repaired. `todo.title.toLowerCase()` against a nullable column is
+therefore a latent outage, not a style issue: a client may `POST`
+`title: null` (the computed key is stripped from the payload, `title` is
+an ordinary column, the write succeeds) and `GET /todos` answers 500
+from then on. Resolvers are written defensively —
+`todo.title?.toLowerCase() ?? null`. The serializer deliberately does
+**not** swallow the throw: everything else in the pipeline fails loudly,
+and a caught resolver would turn a config bug into a field that is
+sometimes silently absent.
+
+Because selection is "kept internally, stripped late", `resolve` receives
+the **fully hydrated row**, not the projected object. A computed field
+can therefore surface a column that a narrowed `item` DTO or `selectable`
+list hides. That is intended rather than a leak — `resolve` is
+server-authored code at the same trust level as `exposeInternals` — but
+it means the resolver, not just the DTO, is part of the exposure
+decision.
+
 **2. Present by default, narrowed like any other field.** A declared
 computed field joins the entity-derived `item`/`list` projection with no
 DTO registration, and joins the `selectable` allowlist unless the
@@ -75,21 +98,36 @@ a future option here; a caller who needs to filter or sort on a derived
 value wants a real generated column, which every supported ORM already
 offers.
 
-**4. Never writable.** `DefaultDeserializer` strips computed names from
-every write payload. Keeping them out of the derived writable projection
-is _not_ sufficient on its own: a registered `create`/`update` DTO
-replaces that projection wholesale (`dtoShapeKeys(dto) ??
-this.writableProjection`), so a DTO class declaring the field for
-documentation would otherwise pass the key through to the adapter as if it
-were a column. The strip is explicit and applies whichever projection is
-in force.
+**4. Never writable**, in two layers. A registered
+`create`/`update`/`patch` DTO naming a computed field is a **bootstrap
+`ConfigurationException`**, like every other computed misdeclaration: the
+declaration is judgeable once, at `createCrud`, and a silent per-request
+drop is the wrong report for it. It also has a wire consequence no
+runtime strip can reach — `@kavo/nest` builds `@ApiBody` from the DTO's
+runtime shape, so OpenAPI would advertise a property the engine
+unconditionally discards. (A raw body key naming a computed field is
+still just dropped; that is an unknown key, not a declaration.)
+
+Underneath, `DefaultDeserializer` strips computed names from every write
+payload regardless. Keeping them out of the derived writable projection
+is _not_ sufficient on its own — a registered DTO replaces that
+projection wholesale (`dtoShapeKeys(dto) ?? this.writableProjection`) —
+and `DefaultDeserializer` is exported, so its contract is "a computed
+name never reaches the adapter" on its own terms, not "the config
+resolver checked first". Through `createCrud` the bootstrap error makes
+the strip unreachable; it stays as the guarantee for a deserializer
+constructed directly.
 
 Further declarations are bootstrap errors for the same
 fail-fast-with-the-key-path reason: a computed name colliding with a real
 column or relation (the shadowed value would silently vanish from every
 response), a descriptor with no `resolve` function, and the name
 `__proto__`, which is not an ordinary object key and would disappear from
-the resolved map without a word.
+the resolved map without a word. `__proto__` has to be caught twice: the
+computed-key spelling (`{ ["__proto__"]: … }`) creates an own key and is
+rejected by name, while the object-literal spelling (`{ __proto__: … }`)
+invokes the prototype setter and never reaches `Object.keys` at all — it
+is detected by checking the declared record's prototype.
 
 `computed` carries functions, so — like `dto` and `relations` — it is
 **entity-scope structural config, outside the settings precedence chain**:
@@ -135,6 +173,23 @@ so rule 3 is a compile error before it is a bootstrap error.
   for any other narrowing today. Deriving it automatically was considered
   and left out — it would mean synthesizing a response type from a config
   value, which every other DTO slot deliberately does not do.
+- The **generated OpenAPI response schema** has the same gap for the same
+  reason. `@kavo/nest`'s `successBodyFor` falls back to the entity class
+  when no `item`/`list` DTO is registered, so `GET /todos/1` returns the
+  computed field at runtime while the document does not mention it.
+  Registering an `item`/`list` DTO naming the field is the one escape
+  hatch for both consequences at once.
+- **A throwing resolver is a 500 labelled `KAVO_PERSISTENCE_FAILED`.**
+  Nothing in core catches `resolve`, so it takes the engine's ordinary
+  untranslated-error path: the original error is preserved as `cause` and
+  its message is never leaked into the problem-details body. The code is
+  the existing catch-all rather than a truthful one — "persistence
+  failed" is a poor label for caller code running at response mapping,
+  and a dedicated code was not worth a new entry in the stable catalog
+  for a case the cause already identifies. Note where in the lifecycle
+  this lands: response mapping runs **after** the handler, so on
+  `createOne` the row is already committed when the 500 goes out. A
+  client that retries duplicates it.
 - The extension point, if a later version wants derived values the
   database can filter on: that is a generated column, declared through
   the ORM and surfaced by the metadata seam as an ordinary field — not a

--- a/docs/internals/adr/0019-computed-fields-are-serializer-evaluated.md
+++ b/docs/internals/adr/0019-computed-fields-are-serializer-evaluated.md
@@ -53,7 +53,11 @@ computed field's source columns are always present, even under
 
 `resolve` is **synchronous** and runs once per served item. An
 async or database-hitting resolver is not offered: it would reintroduce
-per-row N+1 at exactly the stage the include resolver exists to batch.
+per-row N+1 at exactly the stage the include resolver exists to batch. An
+`async resolve` is a bootstrap error rather than a slow success, because
+the serializer emits the return value unawaited and the response would
+silently carry `{}`. Returning `undefined` omits the key and `null` emits
+it, the same distinction the column branch draws.
 
 **2. Present by default, narrowed like any other field.** A declared
 computed field joins the entity-derived `item`/`list` projection with no
@@ -80,10 +84,12 @@ documentation would otherwise pass the key through to the adapter as if it
 were a column. The strip is explicit and applies whichever projection is
 in force.
 
-Two further declarations are bootstrap errors, for the same
+Further declarations are bootstrap errors for the same
 fail-fast-with-the-key-path reason: a computed name colliding with a real
 column or relation (the shadowed value would silently vanish from every
-response), and a descriptor with no `resolve` function.
+response), a descriptor with no `resolve` function, and the name
+`__proto__`, which is not an ordinary object key and would disappear from
+the resolved map without a word.
 
 `computed` carries functions, so — like `dto` and `relations` — it is
 **entity-scope structural config, outside the settings precedence chain**:
@@ -104,6 +110,22 @@ so rule 3 is a compile error before it is a bootstrap error.
   target's own `ResolvedEntityConfig` through the `EntityCatalog`, and
   that config now carries `computed`. A relation still cannot widen what
   its target exposes.
+- What that composition does **not** give it is a context of its own. One
+  response is one request, and `KavoContext` describes that request, so a
+  target's resolver is handed the _root_ operation's context:
+  `GET /posts/1?include=author` gives an `Author` computed field a context
+  whose `entityName`, `operation`, `config` and `query` are Post's. Only
+  the request-scoped members — `principal`, `correlationId`,
+  `transaction`, `state` — are meaningful from a relation target. A
+  per-target context was rejected as a worse lie: it would have to invent
+  an `operation` that no caller issued and a `query` that was never
+  normalized against that entity.
+- `selectable: false` narrows the allowlist, not the projection. The field
+  stays in the default response and its name becomes a 400 in `fields=`;
+  a request that sends any fieldset still drops it, with no way to ask for
+  it back. That follows from rule 2 rather than contradicting it —
+  selection narrows uniformly — but it is the one place the flag's name
+  reads as a stronger promise than it makes.
 - `ResolvedEntityConfig` gains a required `computed` member. It is
   produced by Kavo and read by the serializer/deserializer; anything
   constructing one by hand has to supply it.

--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -90,7 +90,7 @@ faked through a DTO class:
 ```ts
 createCrud(User, {
   computed: {
-    fullName: { resolve: (user) => `${user.firstName} ${user.lastName}` },
+    fullName: { resolve: (user) => [user.firstName, user.lastName].filter(Boolean).join(" ") },
   },
 });
 ```
@@ -98,21 +98,26 @@ createCrud(User, {
 `DefaultSerializer` **evaluates** a computed key by calling `resolve`,
 never by reading it off the row — which is what makes it behave the same
 over a TypeORM class instance and a Prisma/Mongoose plain object, and why
-no ORM adapter is involved at all. `resolve` also receives the request's
+no ORM adapter is involved at all. It evaluates it even when the row
+_does_ carry that key (a class getter, or a column outside the metadata
+seam): resolving beats reading, or the feature would collapse back into
+the accident it replaced. `resolve` also receives the request's
 `KavoContext`, so a field may vary by `principal`; it is synchronous by
-design, because it runs once per served item.
+design, because it runs once per served item — and must be **total**, not
+just pure, because one throwing row fails the entire list response
+([ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated)).
 
 The rules, all governed by
 [ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated):
 
-| Aspect                  | Behavior                                                                                  |
-| ----------------------- | ----------------------------------------------------------------------------------------- |
-| Default projection      | Included in `item`/`list` automatically — no DTO registration needed                      |
-| Explicit DTO            | Narrows it like any other field (omit it to hide it; name it to keep it, still evaluated) |
-| `selectable`            | Joined by default, so `fields=fullName` works; `selectable: false` opts out               |
-| `filterable`/`sortable` | **Never** — naming one is a bootstrap `ConfigurationException`, and a type error besides  |
-| Write payloads          | Always stripped, even when a registered `create`/`update` DTO declares the key            |
-| Precedence chain        | Outside it: structural entity config like `dto`, resolved once at `createCrud`            |
+| Aspect                  | Behavior                                                                                                                         |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Default projection      | Included in `item`/`list` automatically — no DTO registration needed                                                             |
+| Explicit DTO            | Narrows it like any other field (omit it to hide it; name it to keep it, still evaluated)                                        |
+| `selectable`            | Joined by default, so `fields=fullName` works; `selectable: false` opts out                                                      |
+| `filterable`/`sortable` | **Never** — naming one is a bootstrap `ConfigurationException`, and a type error besides                                         |
+| Write payloads          | Never writable — a `create`/`update`/`patch` DTO naming one is a bootstrap error, and the deserializer strips the key regardless |
+| Precedence chain        | Outside it: structural entity config like `dto`, resolved once at `createCrud`                                                   |
 
 The serialization order of §5 is unchanged: a computed field is subject to
 "selection narrows, never widens" exactly like a column.
@@ -123,5 +128,7 @@ from the target's own resolved config through the `EntityCatalog` (§6), so
 this composes with no extra machinery.
 
 Static typing of the response is unaffected: the entity-derived `ItemDto`
-does not grow the key. Registering an `item`/`list` DTO that names it is
-how a caller gets it statically typed, as for any other narrowing.
+does not grow the key, and neither does the generated OpenAPI response
+schema, which falls back to the entity class when no `item`/`list` slot is
+registered. Registering an `item`/`list` DTO that names it is how a caller
+gets it statically typed — and documented — as for any other narrowing.

--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -33,9 +33,12 @@ type level and the runtime never disagree about which slot follows which.
 The metadata seam (`EntityMetadata`, doc 09 §1) supplies the field list
 the defaults derive from:
 
-- **Readable projection** (`item`/`list` default): every scalar column.
-  Relation properties are excluded unless the request includes them
-  deliberately; getters/methods never appear (they are not columns).
+- **Readable projection** (`item`/`list` default): every scalar column,
+  plus every computed field the entity declares (§7). Relation properties
+  are excluded unless the request includes them deliberately; a class
+  getter or method never appears on its own — it is not a column, and an
+  entity-class getter that seems to work is an accident of the ORM handing
+  the engine class instances ([ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated)).
 - **Writable projection** (`create`/`update`/`patch` default): every
   scalar column with `generated: false`. Generated columns (auto ids,
   `@CreateDateColumn`, versions) can never be written from a request
@@ -78,3 +81,47 @@ When a response embeds an included relation, the node's shape resolves
 from the **target entity's own registered `item`/`list` DTOs** when that
 entity has a Kavo config, else its entity-derived default. There is no
 per-include DTO slot — the related resource owns its own contract.
+
+## 7. Computed fields
+
+A field with no backing column is declared on the entity config, not
+faked through a DTO class:
+
+```ts
+createCrud(User, {
+  computed: {
+    fullName: { resolve: (user) => `${user.firstName} ${user.lastName}` },
+  },
+});
+```
+
+`DefaultSerializer` **evaluates** a computed key by calling `resolve`,
+never by reading it off the row — which is what makes it behave the same
+over a TypeORM class instance and a Prisma/Mongoose plain object, and why
+no ORM adapter is involved at all. `resolve` also receives the request's
+`KavoContext`, so a field may vary by `principal`; it is synchronous by
+design, because it runs once per served item.
+
+The rules, all governed by
+[ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated):
+
+| Aspect                  | Behavior                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| Default projection      | Included in `item`/`list` automatically — no DTO registration needed                      |
+| Explicit DTO            | Narrows it like any other field (omit it to hide it; name it to keep it, still evaluated) |
+| `selectable`            | Joined by default, so `fields=fullName` works; `selectable: false` opts out               |
+| `filterable`/`sortable` | **Never** — naming one is a bootstrap `ConfigurationException`, and a type error besides  |
+| Write payloads          | Always stripped, even when a registered `create`/`update` DTO declares the key            |
+| Precedence chain        | Outside it: structural entity config like `dto`, resolved once at `createCrud`            |
+
+The serialization order of §5 is unchanged: a computed field is subject to
+"selection narrows, never widens" exactly like a column.
+
+A computed field declared on a **relation target** resolves when that
+relation is included — the serializer reads the included node's projection
+from the target's own resolved config through the `EntityCatalog` (§6), so
+this composes with no extra machinery.
+
+Static typing of the response is unaffected: the entity-derived `ItemDto`
+does not grow the key. Registering an `item`/`list` DTO that names it is
+how a caller gets it statically typed, as for any other narrowing.

--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -189,10 +189,11 @@ LOWER(:v)`), identical on every driver. Both operators apply to string
   ([ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated)).
 - **Excluding instead of enumerating:** each allowlist key also accepts
   `{ exclude: [...] }` instead of an explicit array — resolved at
-  bootstrap to every own column except the ones named, so hiding one
-  column (e.g. a soft-delete marker) doesn't require re-listing every
-  other one. Resolution still starts from the same own-columns default,
-  so the result stays fail-closed like the plain array form.
+  bootstrap to every own column (plus, for `selectable`, every selectable
+  computed field) except the ones named, so hiding one column (e.g. a
+  soft-delete marker) doesn't require re-listing every other one.
+  Resolution starts from exactly the base set that key's plain default
+  uses, so the result stays fail-closed like the plain array form.
 - **Limits** (configurable per scope, doc 8): `query.maxFilterDepth`
   (default 3) on the built AST, `query.maxInValues` (default 100) on
   `in`/`notIn` arrays, `pagination.maxLimit` (default 100) on page size.

--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -181,6 +181,12 @@ LOWER(:v)`), identical on every driver. Both operators apply to string
   (`KAVO_QUERY_INVALID_FIELD`), never a silent drop. Programmatic
   callers (`findMany({ filter })`) pass through the **same** allowlist
   and limit checks — typed input skips coercion, not security.
+- **Computed fields are selectable only:** a declared computed field
+  (doc 04 §7) joins the _selectable_ default and never the filterable or
+  sortable one — it has no column to translate to `WHERE`/`ORDER BY`, so
+  naming it in either is a bootstrap `ConfigurationException` rather than
+  an in-memory fallback
+  ([ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated)).
 - **Excluding instead of enumerating:** each allowlist key also accepts
   `{ exclude: [...] }` instead of an explicit array — resolved at
   bootstrap to every own column except the ones named, so hiding one

--- a/docs/internals/architecture/08-configuration.md
+++ b/docs/internals/architecture/08-configuration.md
@@ -41,8 +41,10 @@ Implemented in `mergeSettings` (`merge-settings.ts`):
 - Arrays replace wholesale. `undefined` scopes are skipped.
 
 An `EntityConfig` mixes settings keys with structural keys (`dto`,
-`allowlists`, `operations`); only the settings subset participates in
-the merge.
+`allowlists`, `computed`, `operations`); only the settings subset
+participates in the merge. `computed` carries functions, so like `dto` it
+is entity-scope-only and never merges through the chain — see
+[ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated).
 
 **`operations` is a special case, at two different scopes.** At _global_
 scope, `KavoSettings.operations` is a plain boolean map
@@ -67,8 +69,9 @@ ADR-0015 for what this global default can and cannot reach in
 All merging happens **once at bootstrap** (`resolveEntityConfig`) into a
 deep-frozen `ResolvedEntityConfig`: entity-scope settings, precomputed
 per-operation views behind `settingsFor(operation)`, resolved allowlists
-(explicit or derived from own scalar columns), the cached `DtoResolver`,
-and the relation registry. There is no runtime mutation API — per-call
+(explicit, or derived from own scalar columns plus any selectable computed
+fields), the cached `DtoResolver`, the validated `computed` map, and the
+relation registry. There is no runtime mutation API — per-call
 overrides (`KavoCallOptions.settings`) are merged as _parameters_ onto
 the operation view inside the engine, validated, and discarded with the
 request.
@@ -81,6 +84,22 @@ request.
 expected a positive integer, got -1`). The same bar applies to unknown
 pagination strategies, missing infrastructure, non-`@Kavo` controllers in
 `forFeature`, and custom-operation id collisions.
+
+### `computed`
+
+Every way a computed-field declaration can be structurally wrong fails at
+bootstrap rather than as a surprising response later
+([ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated)):
+
+- a name that collides with a real column or relation — the shadowed value
+  would silently vanish from every response;
+- a descriptor with no `resolve` function;
+- an `async` `resolve`, whose promise the serializer would emit unawaited;
+- the name `__proto__`, which is not an ordinary object key and would
+  disappear from the resolved map without a word;
+- a computed name in a configured `allowlists.filterable`/`sortable` —
+  there is no column to translate to `WHERE`/`ORDER BY`, and in-memory
+  post-fetch filtering is rejected rather than deferred.
 
 ### `query.defaultSort`
 
@@ -110,5 +129,6 @@ route concerns via the `OperationMetadata` augmentation (ADR-0007).
 ## 6. Debug dump
 
 `kavo.describe(entityName)` (backed by `describeResolvedConfig`) returns
-the frozen result for one entity — settings, allowlists, relations, and
-every per-operation view — as a plain printable object.
+the frozen result for one entity — settings, allowlists, the declared
+computed-field names, relations, and every per-operation view — as a plain
+printable object.

--- a/docs/internals/architecture/08-configuration.md
+++ b/docs/internals/architecture/08-configuration.md
@@ -96,10 +96,17 @@ bootstrap rather than as a surprising response later
 - a descriptor with no `resolve` function;
 - an `async` `resolve`, whose promise the serializer would emit unawaited;
 - the name `__proto__`, which is not an ordinary object key and would
-  disappear from the resolved map without a word;
+  disappear from the resolved map without a word — caught in both of its
+  spellings, by name for `{ ["__proto__"]: … }` and by inspecting the
+  declared record's prototype for the object-literal `{ __proto__: … }`,
+  which invokes the prototype setter and never reaches `Object.keys`;
 - a computed name in a configured `allowlists.filterable`/`sortable` —
   there is no column to translate to `WHERE`/`ORDER BY`, and in-memory
-  post-fetch filtering is rejected rather than deferred.
+  post-fetch filtering is rejected rather than deferred;
+- a computed name declared by a registered `create`/`update`/`patch` DTO
+  class — the value could only ever be discarded, and the DTO's runtime
+  shape is what `@kavo/nest` builds `@ApiBody` from, so OpenAPI would
+  advertise a property the engine unconditionally drops.
 
 ### `query.defaultSort`
 

--- a/docs/using-the-api.md
+++ b/docs/using-the-api.md
@@ -94,7 +94,7 @@ A response can carry fields that have no database column behind them — a `full
 ```ts
 @Kavo(Book, {
   computed: {
-    displayTitle: { resolve: (book) => `${book.title} (${book.year})` },
+    displayTitle: { resolve: (book) => (book.title === null ? null : `${book.title} (${book.year})`) },
   },
 })
 ```
@@ -107,8 +107,10 @@ GET /books?fields=id,displayTitle
 From a client's point of view a computed field is an ordinary field: it is in the default response, it can be selected with `fields=`, and it can be narrowed away by an `item`/`list` DTO. Three things it is not:
 
 - **not filterable or sortable** — `filter[displayTitle][eq]=…` and `sort=displayTitle` are a 400, because there is no column to translate to `WHERE`/`ORDER BY`. Filter and sort on the underlying columns instead (`sort=title`);
-- **not writable** — sending one in a `POST`/`PUT`/`PATCH` body is silently ignored, like any other non-writable key;
+- **not writable** — sending one in a `POST`/`PUT`/`PATCH` body is silently ignored, like any other non-writable key (a server-side `create`/`update`/`patch` DTO that _declares_ one is a startup error rather than a silent drop);
 - **not database-side** — it is evaluated after the row is fetched, so it costs no extra query but also cannot make one cheaper.
+
+The one thing worth knowing on the server side: `resolve` must handle every value its columns can hold. It runs per served row with nothing catching it, so a single row it cannot handle turns a whole list response into a 500 — write `book.title?.toUpperCase() ?? null`, not `book.title.toUpperCase()`, against a nullable column.
 
 A computed field declared on a related entity shows up when that relation is included (`?include=author`), resolved from the related entity's own config. See [Configuration](/integrations/nest/configuration#computed) for the descriptor's options and [ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated) for why the three limits are permanent rather than pending.
 

--- a/docs/using-the-api.md
+++ b/docs/using-the-api.md
@@ -87,6 +87,31 @@ GET /books?fields=id,title
 
 Sparse fieldset for the root resource, validated against the `selectable` allowlist. Narrow an included relation the same way: `fields[author]=id,name`.
 
+## Computed fields
+
+A response can carry fields that have no database column behind them — a `fullName` built from two columns, a formatted total, a flag that depends on who is asking. They are declared once on the entity's config:
+
+```ts
+@Kavo(Book, {
+  computed: {
+    displayTitle: { resolve: (book) => `${book.title} (${book.year})` },
+  },
+})
+```
+
+```
+GET /books/1     → { "id": 1, "title": "Dune", "year": 1965, "displayTitle": "Dune (1965)" }
+GET /books?fields=id,displayTitle
+```
+
+From a client's point of view a computed field is an ordinary field: it is in the default response, it can be selected with `fields=`, and it can be narrowed away by an `item`/`list` DTO. Three things it is not:
+
+- **not filterable or sortable** — `filter[displayTitle][eq]=…` and `sort=displayTitle` are a 400, because there is no column to translate to `WHERE`/`ORDER BY`. Filter and sort on the underlying columns instead (`sort=title`);
+- **not writable** — sending one in a `POST`/`PUT`/`PATCH` body is silently ignored, like any other non-writable key;
+- **not database-side** — it is evaluated after the row is fetched, so it costs no extra query but also cannot make one cheaper.
+
+A computed field declared on a related entity shows up when that relation is included (`?include=author`), resolved from the related entity's own config. See [Configuration](/integrations/nest/configuration#computed) for the descriptor's options and [ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated) for why the three limits are permanent rather than pending.
+
 ## Includes
 
 ```

--- a/packages/core/src/config/computed-field.ts
+++ b/packages/core/src/config/computed-field.ts
@@ -24,17 +24,34 @@ import type { KavoContext } from "../context/kavo-context.js";
 export interface ComputedFieldDescriptor<Entity = unknown> {
   /**
    * Derive the field's value for one entity. Called once per served item,
-   * **synchronously** — the return value is emitted as-is, never awaited.
-   * Keep it a pure function of `entity` (plus, where a field has to vary by
-   * caller, `context.principal`): a resolver that hits the database or the
-   * network runs once per row and reintroduces exactly the N+1 the include
-   * resolver exists to avoid.
+   * **synchronously** — the return value is emitted as-is, never awaited
+   * (declaring `resolve` `async` is a bootstrap error). Returning
+   * `undefined` omits the key; `null` emits it, the same distinction a
+   * column draws. Keep it a pure function of `entity` (plus, where a field
+   * has to vary by caller, `context.principal`): a resolver that hits the
+   * database or the network runs once per row and reintroduces exactly the
+   * N+1 the include resolver exists to avoid.
+   *
+   * **On an included relation target, `context` is the *root* request's.**
+   * One response is one request, and `KavoContext` describes that request:
+   * serving `GET /posts/1?include=author` hands an `Author` computed field
+   * a context whose `entityName`, `operation`, `config` and `query` are
+   * Post's. Only the request-scoped members — `principal`, `correlationId`,
+   * `transaction`, `state` — mean what they say from a relation target
+   * (ADR-0019).
    */
   resolve(entity: Entity, context: KavoContext<Entity>): unknown;
   /**
    * Whether the field joins the `selectable` allowlist, so `fields=` can
-   * name it. Defaults to `true`; set `false` for a field that should always
-   * be present and never individually selectable.
+   * name it. Defaults to `true`; `false` keeps the field in the default
+   * projection while making its name a 400 in `fields=`.
+   *
+   * Note what that does *not* buy: a request that sends any `fields=` at
+   * all still drops the field, because selection narrows the projection
+   * uniformly and there is no way to ask for it back. `false` means "not
+   * individually selectable", not "always present". An explicit
+   * `allowlists.selectable` list naming the field overrides this — an
+   * explicit list is always the deliberate answer.
    */
   readonly selectable?: boolean;
 }

--- a/packages/core/src/config/computed-field.ts
+++ b/packages/core/src/config/computed-field.ts
@@ -16,7 +16,7 @@ import type { KavoContext } from "../context/kavo-context.js";
  * ```ts
  * createCrud(User, {
  *   computed: {
- *     fullName: { resolve: (user) => `${user.firstName} ${user.lastName}` },
+ *     fullName: { resolve: (user) => [user.firstName, user.lastName].filter(Boolean).join(" ") },
  *   },
  * });
  * ```
@@ -31,6 +31,19 @@ export interface ComputedFieldDescriptor<Entity = unknown> {
    * has to vary by caller, `context.principal`): a resolver that hits the
    * database or the network runs once per row and reintroduces exactly the
    * N+1 the include resolver exists to avoid.
+   *
+   * It must also be **total** over anything the columns can hold, which is
+   * the stronger requirement. `serializeList` maps it over every row and
+   * nothing catches it, so one row the resolver cannot handle fails the
+   * whole collection response for every caller —
+   * `user.firstName?.trim() ?? null`, never `user.firstName.trim()` on a
+   * nullable column.
+   *
+   * It receives the **fully hydrated row**, not the projected object
+   * (selection is "kept internally, stripped late"), so a computed field
+   * can surface a column a narrowed `item` DTO hides. That is deliberate —
+   * `resolve` is server-authored code — but it makes the resolver part of
+   * the exposure decision.
    *
    * **On an included relation target, `context` is the *root* request's.**
    * One response is one request, and `KavoContext` describes that request:

--- a/packages/core/src/config/computed-field.ts
+++ b/packages/core/src/config/computed-field.ts
@@ -1,0 +1,43 @@
+import type { KavoContext } from "../context/kavo-context.js";
+
+/**
+ * One computed (virtual) field: a response-only value derived from an
+ * entity that has **already been fetched** (ADR-0019).
+ *
+ * A computed field has no backing column, so it exists at exactly one
+ * stage of the pipeline — response mapping. `DefaultSerializer` calls
+ * `resolve` for every served item instead of reading the key off the row,
+ * which is what makes it behave identically for a TypeORM class instance
+ * and a Prisma/Mongoose plain object. The three invariants that follow
+ * from having no column are enforced at bootstrap, not at request time:
+ * a computed field is never filterable, never sortable, and never
+ * writable.
+ *
+ * ```ts
+ * createCrud(User, {
+ *   computed: {
+ *     fullName: { resolve: (user) => `${user.firstName} ${user.lastName}` },
+ *   },
+ * });
+ * ```
+ */
+export interface ComputedFieldDescriptor<Entity = unknown> {
+  /**
+   * Derive the field's value for one entity. Called once per served item,
+   * **synchronously** — the return value is emitted as-is, never awaited.
+   * Keep it a pure function of `entity` (plus, where a field has to vary by
+   * caller, `context.principal`): a resolver that hits the database or the
+   * network runs once per row and reintroduces exactly the N+1 the include
+   * resolver exists to avoid.
+   */
+  resolve(entity: Entity, context: KavoContext<Entity>): unknown;
+  /**
+   * Whether the field joins the `selectable` allowlist, so `fields=` can
+   * name it. Defaults to `true`; set `false` for a field that should always
+   * be present and never individually selectable.
+   */
+  readonly selectable?: boolean;
+}
+
+/** A declared set of computed fields, keyed by the name they serialize as. */
+export type ComputedFieldMap<Entity = unknown> = Readonly<Record<string, ComputedFieldDescriptor<Entity>>>;

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -6,6 +6,7 @@ import type { OperationDtoMap } from "../dto/dto.js";
 import type { EntityInput } from "../types/utility.js";
 import type { OperationHandler, OperationMetadata } from "../operations/operation-handler.js";
 import type { StandardOperationId } from "../operations/operation.js";
+import type { ComputedFieldDescriptor } from "./computed-field.js";
 
 /**
  * One allowlist key's raw configuration: either the explicit set of paths
@@ -14,9 +15,13 @@ import type { StandardOperationId } from "../operations/operation.js";
  * (`resolveAllowlists`), never evaluated eagerly here — the `@Kavo(...)`
  * config object is built at class-decoration time, before any ORM metadata
  * exists (ADR-0013), so there is nothing to resolve `exclude` against yet.
+ *
+ * `Extra` widens both forms with names that are not paths on the entity —
+ * only ever the entity's declared computed-field names, and only on
+ * `selectable` (ADR-0019).
  */
-export type QueryFieldSelector<Entity> =
-  readonly FieldPath<Entity>[] | { readonly exclude: readonly FieldPath<Entity>[] };
+export type QueryFieldSelector<Entity, Extra extends string = never> =
+  readonly (FieldPath<Entity> | Extra)[] | { readonly exclude: readonly (FieldPath<Entity> | Extra)[] };
 
 /**
  * Security allowlists: what a request may filter, sort, and
@@ -24,11 +29,17 @@ export type QueryFieldSelector<Entity> =
  * rejected with a 400 (`QueryValidationException`), never silently
  * dropped. When omitted, the allowlists derive from the `query` DTO or
  * entity metadata at bootstrap.
+ *
+ * `selectable` is the only key computed-field names may appear in:
+ * `filterable`/`sortable` stay typed to real paths, because a computed
+ * field has no column to translate to `WHERE`/`ORDER BY` (ADR-0019). The
+ * bootstrap check in `resolveAllowlists` catches the same mistake from an
+ * erased or cast config, where the type is not there to help.
  */
-export interface QueryAllowlists<Entity = unknown> {
+export interface QueryAllowlists<Entity = unknown, Computed extends string = never> {
   readonly filterable?: QueryFieldSelector<Entity>;
   readonly sortable?: QueryFieldSelector<Entity>;
-  readonly selectable?: QueryFieldSelector<Entity>;
+  readonly selectable?: QueryFieldSelector<Entity, Computed>;
 }
 
 /**
@@ -54,6 +65,10 @@ export interface OperationConfig<Entity = unknown> extends Omit<DeepPartial<Kavo
  * Raw entity-scope configuration — the second argument to `createCrud`.
  * Settings keys (inherited from `DeepPartial<KavoSettings>`) override
  * global scope for this entity.
+ *
+ * `Computed` is inferred from the keys of `computed` and exists so an
+ * explicit `allowlists.selectable` list can name a computed field without
+ * a cast; every other position stays typed to real entity paths.
  */
 export interface EntityConfig<
   Entity,
@@ -63,9 +78,19 @@ export interface EntityConfig<
   QueryDto = QueryContext<Entity>,
   ItemDto = Entity,
   ListDto = ItemDto,
+  Computed extends string = never,
 > extends Omit<DeepPartial<KavoSettings>, "operations"> {
   readonly dto?: OperationDtoMap<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>;
-  readonly allowlists?: QueryAllowlists<Entity>;
+  /**
+   * Computed (virtual) response fields, keyed by the name each serializes
+   * as — structural entity-scope config like `dto`, deliberately outside
+   * the settings precedence chain because it carries functions (ADR-0019).
+   * Declared fields join the entity-derived `item`/`list` projection and
+   * the `selectable` allowlist automatically; they are never filterable,
+   * sortable, or writable.
+   */
+  readonly computed?: Readonly<Record<Computed, ComputedFieldDescriptor<Entity>>>;
+  readonly allowlists?: QueryAllowlists<Entity, NoInfer<Computed>>;
   /**
    * Per-operation overrides. `false` disables the operation; `true`
    * enables one that is off by default (`purgeOne`, `restoreOne`).

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -3,12 +3,14 @@ import type { DeepPartial } from "../types/utility.js";
 import type { ComputedFieldDescriptor, ComputedFieldMap } from "./computed-field.js";
 import type { EntityConfig, OperationConfig, QueryFieldSelector } from "./entity-config.js";
 import type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./resolved-entity-config.js";
+import type { DtoClass } from "../dto/dto.js";
 import type { EntityMetadata } from "../metadata/entity-metadata.js";
 import type { FieldPath } from "../types/field-path.js";
 import type { OperationId, StandardOperationId } from "../operations/operation.js";
 import { BUILT_IN_DEFAULTS } from "./defaults.js";
 import { deepFreeze, mergeSettings } from "./merge-settings.js";
 import { validateSettings } from "./validate-settings.js";
+import { dtoShapeKeys } from "../dto/dto-shape.js";
 import { DefaultDtoResolver } from "../dto/default-dto-resolver.js";
 import { DefaultRelationRegistry } from "../relations/default-relation-registry.js";
 import { resolveSoftDelete } from "../persistence/soft-delete.js";
@@ -62,6 +64,7 @@ export function resolveEntityConfig<Entity extends object>(
 ): ResolvedEntityConfig<Entity> {
   const entityName = metadata.name;
   const computed = resolveComputedFields(metadata, entityConfig);
+  rejectComputedWriteDtoKeys(entityName, entityConfig, computed);
   const allowlists = resolveAllowlists(metadata, entityConfig, computed);
   const entitySettings = mergeSettings(
     BUILT_IN_DEFAULTS,
@@ -113,6 +116,13 @@ export function resolveEntityConfig<Entity extends object>(
 /** Assignable to `ComputedFieldMap<Entity>` for every `Entity`. */
 const NO_COMPUTED_FIELDS: Readonly<Record<string, never>> = Object.freeze({});
 
+const PROTO_NOT_A_NAME =
+  `'__proto__' cannot name a computed field — it is not an ordinary object key, ` +
+  `so the declaration would silently disappear instead of producing a response field`;
+
+/** The DTO slots whose classes describe a **write** payload (ADR-0019 §4). */
+const WRITE_DTO_SLOTS = ["create", "update", "patch"] as const;
+
 /**
  * Computed-field resolution (ADR-0019). `computed` carries functions, so
  * like `dto` it sits outside `SETTINGS_KEYS` and never merges through the
@@ -139,18 +149,25 @@ function resolveComputedFields<Entity extends object>(
   const declared = (entityConfig as { readonly computed?: ComputedFieldMap<Entity> } | undefined)?.computed;
   if (declared === undefined) return NO_COMPUTED_FIELDS;
 
+  // `__proto__` has two spellings and only one of them is a key. The
+  // computed form (`{ ["__proto__"]: … }`) creates an own key and is caught
+  // in the loop below; the literal form (`{ __proto__: … }`) invokes the
+  // prototype *setter* instead, so it never reaches `Object.keys` — the
+  // declaration would register nothing and throw nothing, which is exactly
+  // the outcome the message promises to prevent. A non-standard prototype
+  // on the declared record is that spelling's only observable trace.
+  const prototype = Object.getPrototypeOf(declared) as object | null;
+  if (prototype !== null && prototype !== Object.prototype) {
+    throw new ConfigurationException(entityName, "computed.__proto__", PROTO_NOT_A_NAME);
+  }
+
   const columns = new Set(metadata.fields.map((field) => field.name));
   const relations = new Set(metadata.relations.map((relation) => relation.name));
   const resolved: Record<string, ComputedFieldDescriptor<Entity>> = {};
   for (const name of Object.keys(declared)) {
     const descriptor = declared[name];
     if (name === "__proto__") {
-      throw new ConfigurationException(
-        entityName,
-        `computed.${name}`,
-        `'__proto__' cannot name a computed field — it is not an ordinary object key, ` +
-          `so the declaration would silently disappear instead of producing a response field`,
-      );
+      throw new ConfigurationException(entityName, `computed.${name}`, PROTO_NOT_A_NAME);
     }
     if (typeof descriptor?.resolve !== "function") {
       throw new ConfigurationException(
@@ -187,6 +204,45 @@ function resolveComputedFields<Entity extends object>(
     resolved[name] = descriptor;
   }
   return Object.freeze(resolved);
+}
+
+/**
+ * A registered `create`/`update`/`patch` DTO naming a computed field is a
+ * bootstrap error, like every other computed misconfiguration (ADR-0019).
+ *
+ * `DefaultDeserializer` would strip the key anyway — that strip stays, as
+ * the defence for anyone constructing a deserializer directly — but a
+ * silent per-request drop is the wrong report for a declaration that can
+ * be judged wrong once, at the moment it is made. It also has a wire
+ * consequence the strip cannot reach: `@kavo/nest` builds `@ApiBody` from
+ * the DTO's runtime shape, so OpenAPI would advertise a property the
+ * engine unconditionally discards.
+ *
+ * Only classes with a runtime shape are checkable; a purely declarative
+ * DTO yields `null` from `dtoShapeKeys` and falls back to the derived
+ * writable projection, which never contains a computed name.
+ */
+function rejectComputedWriteDtoKeys<Entity extends object>(
+  entityName: string,
+  entityConfig: EntityConfig<Entity> | undefined,
+  computed: ComputedFieldMap<Entity>,
+): void {
+  const names = new Set(Object.keys(computed));
+  if (names.size === 0) return;
+  const dto = entityConfig?.dto as Readonly<Record<string, DtoClass | undefined>> | undefined;
+  if (dto === undefined) return;
+  for (const slot of WRITE_DTO_SLOTS) {
+    const declared = dtoShapeKeys(dto[slot] ?? null)?.find((key) => names.has(key));
+    if (declared === undefined) continue;
+    throw new ConfigurationException(
+      entityName,
+      `dto.${slot}`,
+      `the '${slot}' DTO declares '${declared}', which is a computed field on '${entityName}' — ` +
+        `a computed field has no column behind it, so the value is stripped from every write ` +
+        `payload while the generated OpenAPI body still advertises the property; drop it from the ` +
+        `DTO, or make it a real column if it is meant to be written`,
+    );
+  }
 }
 
 /**
@@ -257,19 +313,21 @@ export function validateDefaultSort<Entity>(
 }
 
 /**
- * Resolves one allowlist key's raw selector against the entity's own
- * columns: an explicit array is used as-is; `{ exclude }` resolves to
- * `ownColumns` minus the named paths, so a column outside `ownColumns` can
- * never appear via `exclude` and stays fail-closed like the plain default.
+ * Resolves one allowlist key's raw selector against that key's **base
+ * set** — own columns for `filterable`/`sortable`, own columns plus the
+ * selectable computed fields for `selectable`. An explicit array is used
+ * as-is; `{ exclude }` resolves to `base` minus the named paths, so a path
+ * outside `base` can never appear via `exclude` and stays fail-closed like
+ * the plain default.
  */
 function resolveFieldSelector<Entity>(
-  ownColumns: readonly FieldPath<Entity>[],
+  base: readonly FieldPath<Entity>[],
   selector: QueryFieldSelector<Entity> | undefined,
 ): readonly FieldPath<Entity>[] {
-  if (selector === undefined) return ownColumns;
+  if (selector === undefined) return base;
   if (!("exclude" in selector)) return selector;
   const excluded = new Set(selector.exclude);
-  return ownColumns.filter((column) => !excluded.has(column));
+  return base.filter((path) => !excluded.has(path));
 }
 
 /**

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -119,10 +119,14 @@ const NO_COMPUTED_FIELDS: Readonly<Record<string, never>> = Object.freeze({});
  * precedence chain — an entity's declaration is the whole story, resolved
  * once here.
  *
- * Both ways a declaration can be structurally wrong fail at bootstrap
+ * The ways a declaration can be structurally wrong all fail at bootstrap
  * rather than as a surprising response later: a name that shadows a real
  * column or relation (the shadowed value would silently disappear from
- * every response), and a descriptor with no `resolve` function.
+ * every response), a descriptor with no `resolve` function, and the one
+ * name that is not a key at all — `__proto__`, which would set this
+ * accumulator's prototype instead of adding an entry and so vanish
+ * without a word (the same class of hazard as the bracket-segment fix in
+ * the filter parser).
  */
 function resolveComputedFields<Entity extends object>(
   metadata: EntityMetadata<Entity>,
@@ -140,6 +144,14 @@ function resolveComputedFields<Entity extends object>(
   const resolved: Record<string, ComputedFieldDescriptor<Entity>> = {};
   for (const name of Object.keys(declared)) {
     const descriptor = declared[name];
+    if (name === "__proto__") {
+      throw new ConfigurationException(
+        entityName,
+        `computed.${name}`,
+        `'__proto__' cannot name a computed field — it is not an ordinary object key, ` +
+          `so the declaration would silently disappear instead of producing a response field`,
+      );
+    }
     if (typeof descriptor?.resolve !== "function") {
       throw new ConfigurationException(
         entityName,
@@ -155,6 +167,21 @@ function resolveComputedFields<Entity extends object>(
         `computed.${name}`,
         `computed field '${name}' collides with an existing ${kind} on '${entityName}' — ` +
           `a computed field must have a name of its own, or the ${kind} would never reach a response`,
+      );
+    }
+    // The serializer emits `resolve`'s return value as-is and never awaits
+    // it (ADR-0019), so an `async` resolver would put a pending promise in
+    // the response — `{}` once serialized to JSON. Catching the shape
+    // people actually write turns a silently wrong body into a bootstrap
+    // failure; a plain function that happens to return a promise still
+    // gets through, which is the limit of what is detectable here.
+    if (descriptor.resolve.constructor?.name === "AsyncFunction") {
+      throw new ConfigurationException(
+        entityName,
+        `computed.${name}`,
+        `computed field '${name}' has an async 'resolve' — computed fields are resolved ` +
+          `synchronously per served item and the promise would be emitted unawaited; ` +
+          `fetch what it needs before serialization (a custom handler, or an eager relation)`,
       );
     }
     resolved[name] = descriptor;

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -1,5 +1,6 @@
 import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
+import type { ComputedFieldDescriptor, ComputedFieldMap } from "./computed-field.js";
 import type { EntityConfig, OperationConfig, QueryFieldSelector } from "./entity-config.js";
 import type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./resolved-entity-config.js";
 import type { EntityMetadata } from "../metadata/entity-metadata.js";
@@ -36,8 +37,8 @@ const SETTINGS_KEYS = [
 
 /**
  * An `EntityConfig`/`OperationConfig` mixes settings keys with structural
- * keys (`dto`, `allowlists`, `handler`, …); only the settings subset
- * participates in the merge algebra.
+ * keys (`dto`, `allowlists`, `computed`, `handler`, …); only the settings
+ * subset participates in the merge algebra.
  */
 function pickSettings(config: Readonly<Record<string, unknown>> | undefined): DeepPartial<KavoSettings> | undefined {
   if (config === undefined) return undefined;
@@ -60,7 +61,8 @@ export function resolveEntityConfig<Entity extends object>(
   globalDefaults: DeepPartial<KavoSettings> | undefined,
 ): ResolvedEntityConfig<Entity> {
   const entityName = metadata.name;
-  const allowlists = resolveAllowlists(metadata, entityConfig);
+  const computed = resolveComputedFields(metadata, entityConfig);
+  const allowlists = resolveAllowlists(metadata, entityConfig, computed);
   const entitySettings = mergeSettings(
     BUILT_IN_DEFAULTS,
     globalDefaults,
@@ -102,8 +104,61 @@ export function resolveEntityConfig<Entity extends object>(
     allowlists,
     softDelete: resolveSoftDelete(metadata, entitySettings),
     dto: new DefaultDtoResolver<Entity>(entityConfig?.dto),
+    computed,
     relations: new DefaultRelationRegistry<Entity>(metadata.relations, entitySettings.relations.edges, entityName),
   };
+  return Object.freeze(resolved);
+}
+
+/** Assignable to `ComputedFieldMap<Entity>` for every `Entity`. */
+const NO_COMPUTED_FIELDS: Readonly<Record<string, never>> = Object.freeze({});
+
+/**
+ * Computed-field resolution (ADR-0019). `computed` carries functions, so
+ * like `dto` it sits outside `SETTINGS_KEYS` and never merges through the
+ * precedence chain — an entity's declaration is the whole story, resolved
+ * once here.
+ *
+ * Both ways a declaration can be structurally wrong fail at bootstrap
+ * rather than as a surprising response later: a name that shadows a real
+ * column or relation (the shadowed value would silently disappear from
+ * every response), and a descriptor with no `resolve` function.
+ */
+function resolveComputedFields<Entity extends object>(
+  metadata: EntityMetadata<Entity>,
+  entityConfig: EntityConfig<Entity> | undefined,
+): ComputedFieldMap<Entity> {
+  const entityName = metadata.name;
+  // `EntityConfig<Entity>` fixes the `Computed` parameter to `never`, so
+  // the declared record erases to `{}` at this internal call site; the
+  // key/value types are recovered here, once.
+  const declared = (entityConfig as { readonly computed?: ComputedFieldMap<Entity> } | undefined)?.computed;
+  if (declared === undefined) return NO_COMPUTED_FIELDS;
+
+  const columns = new Set(metadata.fields.map((field) => field.name));
+  const relations = new Set(metadata.relations.map((relation) => relation.name));
+  const resolved: Record<string, ComputedFieldDescriptor<Entity>> = {};
+  for (const name of Object.keys(declared)) {
+    const descriptor = declared[name];
+    if (typeof descriptor?.resolve !== "function") {
+      throw new ConfigurationException(
+        entityName,
+        `computed.${name}`,
+        `computed field '${name}' has no 'resolve' function — a computed field is defined by ` +
+          `how it is derived, e.g. { resolve: (entity) => … }`,
+      );
+    }
+    if (columns.has(name) || relations.has(name)) {
+      const kind = columns.has(name) ? "column" : "relation";
+      throw new ConfigurationException(
+        entityName,
+        `computed.${name}`,
+        `computed field '${name}' collides with an existing ${kind} on '${entityName}' — ` +
+          `a computed field must have a name of its own, or the ${kind} would never reach a response`,
+      );
+    }
+    resolved[name] = descriptor;
+  }
   return Object.freeze(resolved);
 }
 
@@ -113,18 +168,42 @@ export function resolveEntityConfig<Entity extends object>(
  * columns** — relation paths are never filterable/sortable/selectable
  * unless opted in explicitly. Anything outside the list is a 400 at query
  * time, never a silent drop.
+ *
+ * Computed fields join the `selectable` base set (so `fields=fullName`
+ * works with no further configuration) unless the descriptor opts out with
+ * `selectable: false`, and are barred from `filterable`/`sortable`
+ * outright — there is no column to translate to `WHERE`/`ORDER BY`
+ * (ADR-0019).
  */
 function resolveAllowlists<Entity extends object>(
   metadata: EntityMetadata<Entity>,
   entityConfig: EntityConfig<Entity> | undefined,
+  computed: ComputedFieldMap<Entity>,
 ): ResolvedQueryAllowlists<Entity> {
   const ownColumns = metadata.fields.map((field) => field.name) as unknown as readonly FieldPath<Entity>[];
+  const selectableBase = [
+    ...(ownColumns as readonly string[]),
+    ...Object.keys(computed).filter((name) => computed[name]?.selectable !== false),
+  ] as unknown as readonly FieldPath<Entity>[];
   const configured = entityConfig?.allowlists;
-  return deepFreeze({
+  const allowlists = {
     filterable: resolveFieldSelector(ownColumns, configured?.filterable),
     sortable: resolveFieldSelector(ownColumns, configured?.sortable),
-    selectable: resolveFieldSelector(ownColumns, configured?.selectable),
-  });
+    selectable: resolveFieldSelector(selectableBase, configured?.selectable),
+  };
+  for (const key of ["filterable", "sortable"] as const) {
+    for (const field of allowlists[key] as readonly string[]) {
+      if (!Object.prototype.hasOwnProperty.call(computed, field)) continue;
+      throw new ConfigurationException(
+        metadata.name,
+        `allowlists.${key}`,
+        `'${field}' is a computed field on '${metadata.name}', which can never be ${
+          key === "filterable" ? "filtered on" : "sorted on"
+        } — it has no column to translate to ${key === "filterable" ? "WHERE" : "ORDER BY"}`,
+      );
+    }
+  }
+  return deepFreeze(allowlists);
 }
 
 /**
@@ -179,6 +258,7 @@ export function describeResolvedConfig<Entity>(
     entityName: config.entityName,
     settings: config.settings,
     allowlists: config.allowlists,
+    computed: Object.keys(config.computed),
     softDelete: config.softDelete,
     relations: config.relations.all().map((relation) => ({
       name: relation.name,

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -1,4 +1,5 @@
 import type { KavoSettings } from "./settings.js";
+import type { ComputedFieldMap } from "./computed-field.js";
 import type { FieldPath } from "../types/field-path.js";
 import type { DtoResolver } from "../dto/dto.js";
 import type { OperationId } from "../operations/operation.js";
@@ -36,6 +37,13 @@ export interface ResolvedEntityConfig<Entity = unknown> {
   readonly softDelete: ResolvedSoftDelete;
   /** Bootstrap-cached DTO resolution. */
   readonly dto: DtoResolver<Entity>;
+  /**
+   * Declared computed fields, validated at bootstrap — an empty record when
+   * the entity declares none. Read by the serializer (to evaluate them) and
+   * by the deserializer (to keep them out of writes), for this entity and,
+   * through the catalog, for any relation target (ADR-0019).
+   */
+  readonly computed: ComputedFieldMap<Entity>;
   /** Relation edges of this entity. */
   readonly relations: RelationRegistry<Entity>;
 }

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -173,6 +173,9 @@ export class KavoEngine<Entity extends object> {
       // against the settings actually in force for this call.
       softDelete: resolveSoftDelete(this.deps.metadata, settings, `${config.entityName} (${request.operation})`),
       dto: config.dto,
+      // Structural entity config, outside the settings precedence chain
+      // entirely (ADR-0019) — a per-call settings override cannot reach it.
+      computed: config.computed,
       relations: config.relations,
     };
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export type {
 } from "./config/settings.js";
 export type { GlobalConfig } from "./config/global-config.js";
 export type { EntityConfig, OperationConfig, QueryAllowlists, QueryFieldSelector } from "./config/entity-config.js";
+export type { ComputedFieldDescriptor, ComputedFieldMap } from "./config/computed-field.js";
 export type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./config/resolved-entity-config.js";
 
 // ── Operations ────────────────────────────────────────────────────────

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -55,9 +55,10 @@ export interface KavoInstance {
     QueryDto = QueryContext<Entity>,
     ItemDto = Entity,
     ListDto = ItemDto,
+    Computed extends string = never,
   >(
     entity: ClassRef<Entity>,
-    config?: EntityConfig<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>,
+    config?: EntityConfig<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto, Computed>,
     runtime?: KavoRuntime<Entity>,
   ): DefaultKavoService<Entity, EntityId, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>;
 
@@ -128,8 +129,8 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
         metadata: metadata as EntityMetadata<Entity>,
         config: resolved,
         registry,
-        serializer: new DefaultSerializer(metadata as EntityMetadata<Entity>, catalog),
-        deserializer: new DefaultDeserializer(metadata as EntityMetadata<Entity>, catalog),
+        serializer: new DefaultSerializer(metadata as EntityMetadata<Entity>, catalog, resolved.computed),
+        deserializer: new DefaultDeserializer(metadata as EntityMetadata<Entity>, catalog, resolved.computed),
         normalizer: new QueryNormalizer(
           metadata as EntityMetadata<Entity>,
           options.paginationStrategies ?? [],
@@ -187,9 +188,10 @@ export function createCrud<
   QueryDto = QueryContext<Entity>,
   ItemDto = Entity,
   ListDto = ItemDto,
+  Computed extends string = never,
 >(
   entity: ClassRef<Entity>,
-  config?: EntityConfig<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>,
+  config?: EntityConfig<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto, Computed>,
   runtime?: KavoRuntime<Entity>,
 ): DefaultKavoService<Entity, EntityId, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto> {
   return createKavo().createCrud(entity, config, runtime);

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -110,7 +110,12 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
       // row itself, and an inherited `constructor`/`toString` must not be
       // mistaken for a declared computed field.
       if (Object.prototype.hasOwnProperty.call(projection.computed, key)) {
-        result[key] = projection.computed[key]?.resolve(entity as never, context as never);
+        const value = projection.computed[key]?.resolve(entity as never, context as never);
+        // `undefined` is absence, `null` is data — the same distinction the
+        // column branch draws below, so a resolver that opts out of
+        // emitting a value reads the same programmatically as it does once
+        // `JSON.stringify` has dropped the key.
+        if (value !== undefined) result[key] = value;
         continue;
       }
       if (key in source) result[key] = source[key];

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -1,4 +1,5 @@
 import type { KavoContext } from "../context/kavo-context.js";
+import type { ComputedFieldMap } from "../config/computed-field.js";
 import type { DtoClass } from "../dto/dto.js";
 import type { Deserializer, Serializer } from "./serializer.js";
 import type { EntityCatalog } from "../metadata/entity-catalog.js";
@@ -6,12 +7,26 @@ import type { EntityMetadata } from "../metadata/entity-metadata.js";
 import type { IncludeNode, IncludeTree } from "../relations/include-tree.js";
 import { dtoShapeKeys } from "../dto/dto-shape.js";
 
+/**
+ * Computed fields as the projector consumes them: entity type erased,
+ * because one serializer projects rows of several entity types — the
+ * root's, and every included relation target's, which it reads off the
+ * catalog. The entity-typed contract is `ComputedFieldDescriptor<Entity>`,
+ * which is what the *caller* declares and what every `ComputedFieldMap`
+ * flowing in here satisfies.
+ */
+type ErasedComputedFields = Readonly<Record<string, { resolve(entity: never, context: never): unknown }>>;
+
+const NO_COMPUTED_FIELDS: ErasedComputedFields = Object.freeze({});
+
 /** The projection rules for one entity type, resolved from the catalog. */
 interface Projection {
   /** Allowed keys, or `null` when the shape is unknown (own keys apply). */
   readonly keys: readonly string[] | null;
   /** Relation property names — never emitted unless the node is included. */
   readonly relations: readonly string[];
+  /** Computed fields, evaluated instead of read off the row (ADR-0019). */
+  readonly computed: ErasedComputedFields;
 }
 
 /**
@@ -22,7 +37,12 @@ interface Projection {
  * Projection sources, in order:
  * 1. An explicit DTO class with initialized fields → its key set.
  * 2. Otherwise the entity-derived default: every scalar column from
- *    adapter metadata.
+ *    adapter metadata, plus every declared computed field (ADR-0019).
+ *
+ * A key that names a computed field is produced by calling the
+ * descriptor's `resolve`, never by reading it off the row — which is what
+ * makes computed fields behave identically over a TypeORM class instance
+ * and a Prisma/Mongoose plain object.
  *
  * Relation properties are emitted **only** for nodes on the request's
  * include tree, each projected through its own target entity's
@@ -36,10 +56,12 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
   constructor(
     metadata: EntityMetadata<Entity>,
     private readonly catalog?: EntityCatalog,
+    computed: ComputedFieldMap<Entity> = {},
   ) {
     this.rootProjection = {
-      keys: metadata.fields.map((field) => field.name),
+      keys: [...metadata.fields.map((field) => field.name), ...Object.keys(computed)],
       relations: metadata.relations.map((relation) => relation.name),
+      computed,
     };
   }
 
@@ -50,8 +72,7 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
   ): ItemDto {
     return this.project(
       entity,
-      dtoShapeKeys(dto) ?? this.rootProjection.keys,
-      this.rootProjection.relations,
+      narrowToDto(this.rootProjection, dto),
       context.query?.fields.root as readonly string[] | null | undefined,
       context.query?.include ?? {},
       context,
@@ -74,18 +95,24 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
    */
   private project(
     entity: unknown,
-    keys: readonly string[] | null,
-    relations: readonly string[],
+    projection: Projection,
     selection: readonly string[] | null | undefined,
     include: IncludeTree,
     context: KavoContext<Entity>,
   ): Record<string, unknown> {
     const source = entity as Record<string, unknown>;
-    const projection = keys ?? Object.keys(source);
+    const keys = projection.keys ?? Object.keys(source);
     const result: Record<string, unknown> = {};
-    for (const key of projection) {
-      if (relations.includes(key)) continue;
+    for (const key of keys) {
+      if (projection.relations.includes(key)) continue;
       if (selection != null && !selection.includes(key)) continue;
+      // Own properties only: `keys` can come from a DTO class or from the
+      // row itself, and an inherited `constructor`/`toString` must not be
+      // mistaken for a declared computed field.
+      if (Object.prototype.hasOwnProperty.call(projection.computed, key)) {
+        result[key] = projection.computed[key]?.resolve(entity as never, context as never);
+        continue;
+      }
       if (key in source) result[key] = source[key];
     }
     for (const [name, node] of Object.entries(include)) {
@@ -103,24 +130,40 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
     }
     const target = this.projectionFor(node);
     const one = (row: unknown): Record<string, unknown> =>
-      this.project(row, target.keys, target.relations, node.fields, node.children, context);
+      this.project(row, target, node.fields, node.children, context);
     return Array.isArray(value) ? value.map(one) : one(value);
   }
 
   /**
    * The target entity's own projection: its registered `item` DTO (or
    * `list` for a to-many, which itself falls back to `item`), else the
-   * target's columns.
+   * target's columns plus its own computed fields — which is how a
+   * computed field on an included relation resolves without this class
+   * ever knowing more than one entity (ADR-0019).
    */
   private projectionFor(node: IncludeNode): Projection {
     const info = this.catalog?.get(node.relation.target());
-    if (info === undefined) return { keys: null, relations: [] };
+    if (info === undefined) return { keys: null, relations: [], computed: NO_COMPUTED_FIELDS };
     const dto = info.config.dto.resolve(node.relation.cardinality === "many" ? "list" : "item", "findMany");
+    const computed: ErasedComputedFields = info.config.computed;
     return {
-      keys: dtoShapeKeys(dto) ?? info.metadata.fields.map((field) => field.name),
+      keys: dtoShapeKeys(dto) ?? [...info.metadata.fields.map((field) => field.name), ...Object.keys(computed)],
       relations: info.metadata.relations.map((relation) => relation.name),
+      computed,
     };
   }
+}
+
+/**
+ * DTO mapping, step one of the normative order: a registered class with a
+ * runtime shape replaces the projection's key set and nothing else — the
+ * relation and computed tables still describe the same entity, so a DTO
+ * that names a computed field still gets it evaluated, and one that omits
+ * it narrows it away like any other field.
+ */
+function narrowToDto(projection: Projection, dto: DtoClass | null): Projection {
+  const keys = dtoShapeKeys(dto);
+  return keys === null ? projection : { ...projection, keys };
 }
 
 /**
@@ -134,12 +177,21 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
  * a scalar id, an `{ id }` reference, or an array of either.
  * A nested object carrying more than the id is narrowed to the id, because
  * a deep nested write is not something this layer should do by accident.
+ *
+ * Computed fields are **never** writable (ADR-0019). Keeping them out of
+ * the derived projection is not enough on its own: a registered
+ * `create`/`update` DTO *replaces* that projection, so a DTO class naming
+ * a computed field would otherwise pass the key straight through to the
+ * adapter as if it were a column. They are stripped explicitly, whichever
+ * projection is in force.
  */
 export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entity> {
   private readonly writableProjection: readonly string[];
   private readonly relationIdFields: ReadonlyMap<string, () => string | undefined>;
+  private readonly computedNames: ReadonlySet<string>;
 
-  constructor(metadata: EntityMetadata<Entity>, catalog?: EntityCatalog) {
+  constructor(metadata: EntityMetadata<Entity>, catalog?: EntityCatalog, computed: ComputedFieldMap<Entity> = {}) {
+    this.computedNames = new Set(Object.keys(computed));
     const columns = metadata.fields.filter((field) => !field.generated).map((field) => field.name);
     const relations = new Map<string, () => string | undefined>();
     for (const relation of metadata.relations) {
@@ -160,6 +212,9 @@ export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entit
     const source = raw as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const key of allowed) {
+      // A computed field has no column behind it, so a value for it could
+      // only ever reach the adapter as an unknown write (ADR-0019).
+      if (this.computedNames.has(key)) continue;
       // Own properties only. `raw` is a wire body, so an inherited key is
       // never something the client sent — but it *is* something a polluted
       // `Object.prototype` would supply, silently adding a writable field to

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -18,15 +18,29 @@ import { dtoShapeKeys } from "../dto/dto-shape.js";
 type ErasedComputedFields = Readonly<Record<string, { resolve(entity: never, context: never): unknown }>>;
 
 const NO_COMPUTED_FIELDS: ErasedComputedFields = Object.freeze({});
+const NO_RELATIONS: ReadonlySet<string> = new Set<string>();
 
 /** The projection rules for one entity type, resolved from the catalog. */
 interface Projection {
   /** Allowed keys, or `null` when the shape is unknown (own keys apply). */
   readonly keys: readonly string[] | null;
-  /** Relation property names — never emitted unless the node is included. */
-  readonly relations: readonly string[];
+  /**
+   * Relation property names — never emitted unless the node is included.
+   * A `Set` rather than an array: `project` tests every key against it, so
+   * an array would make the per-row cost quadratic in the entity's width.
+   */
+  readonly relations: ReadonlySet<string>;
   /** Computed fields, evaluated instead of read off the row (ADR-0019). */
   readonly computed: ErasedComputedFields;
+}
+
+/**
+ * A sparse fieldset as `project` consumes it. Built once per response (or
+ * once per relation node), never once per row — the same reason
+ * `Projection.relations` is a `Set`.
+ */
+function selectionSet(selection: readonly string[] | null | undefined): ReadonlySet<string> | null {
+  return selection == null ? null : new Set(selection);
 }
 
 /**
@@ -60,7 +74,7 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
   ) {
     this.rootProjection = {
       keys: [...metadata.fields.map((field) => field.name), ...Object.keys(computed)],
-      relations: metadata.relations.map((relation) => relation.name),
+      relations: new Set(metadata.relations.map((relation) => relation.name)),
       computed,
     };
   }
@@ -73,18 +87,27 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
     return this.project(
       entity,
       narrowToDto(this.rootProjection, dto),
-      context.query?.fields.root as readonly string[] | null | undefined,
+      selectionSet(context.query?.fields.root as readonly string[] | null | undefined),
       context.query?.include ?? {},
       context,
     ) as ItemDto;
   }
 
+  /**
+   * The DTO narrowing and the fieldset `Set` are the same for every row of
+   * one response, so they are resolved once here rather than once per item
+   * — this is `serializeItem`'s body with the per-row constants hoisted,
+   * not a second projection path.
+   */
   serializeList<ListDto>(
     entities: readonly Entity[],
     dto: DtoClass<ListDto & object> | null,
     context: KavoContext<Entity>,
   ): readonly ListDto[] {
-    return entities.map((entity) => this.serializeItem(entity, dto as DtoClass<ListDto & object> | null, context));
+    const projection = narrowToDto(this.rootProjection, dto as DtoClass | null);
+    const selection = selectionSet(context.query?.fields.root as readonly string[] | null | undefined);
+    const include = context.query?.include ?? {};
+    return entities.map((entity) => this.project(entity, projection, selection, include, context) as ListDto);
   }
 
   /**
@@ -96,7 +119,7 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
   private project(
     entity: unknown,
     projection: Projection,
-    selection: readonly string[] | null | undefined,
+    selection: ReadonlySet<string> | null,
     include: IncludeTree,
     context: KavoContext<Entity>,
   ): Record<string, unknown> {
@@ -104,8 +127,10 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
     const keys = projection.keys ?? Object.keys(source);
     const result: Record<string, unknown> = {};
     for (const key of keys) {
-      if (projection.relations.includes(key)) continue;
-      if (selection != null && !selection.includes(key)) continue;
+      if (projection.relations.has(key)) continue;
+      // Before the computed branch: a deselected computed field's `resolve`
+      // must never run, or `fields=` would pay for work it discards.
+      if (selection !== null && !selection.has(key)) continue;
       // Own properties only: `keys` can come from a DTO class or from the
       // row itself, and an inherited `constructor`/`toString` must not be
       // mistaken for a declared computed field.
@@ -118,6 +143,11 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
         if (value !== undefined) result[key] = value;
         continue;
       }
+      // Reached only when the key names no computed field: the branch order
+      // above is normative, because a row *can* carry a computed key —
+      // a TypeORM entity with a `get fullName()`, or an adapter row with a
+      // column the metadata seam does not describe. Resolving wins; reading
+      // the row here would resurrect the exact accident ADR-0019 replaced.
       if (key in source) result[key] = source[key];
     }
     for (const [name, node] of Object.entries(include)) {
@@ -134,8 +164,9 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
       return node.relation.cardinality === "many" ? [] : null;
     }
     const target = this.projectionFor(node);
-    const one = (row: unknown): Record<string, unknown> =>
-      this.project(row, target, node.fields, node.children, context);
+    // Resolved once per node, not once per element of a to-many.
+    const selection = selectionSet(node.fields);
+    const one = (row: unknown): Record<string, unknown> => this.project(row, target, selection, node.children, context);
     return Array.isArray(value) ? value.map(one) : one(value);
   }
 
@@ -148,12 +179,12 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
    */
   private projectionFor(node: IncludeNode): Projection {
     const info = this.catalog?.get(node.relation.target());
-    if (info === undefined) return { keys: null, relations: [], computed: NO_COMPUTED_FIELDS };
+    if (info === undefined) return { keys: null, relations: NO_RELATIONS, computed: NO_COMPUTED_FIELDS };
     const dto = info.config.dto.resolve(node.relation.cardinality === "many" ? "list" : "item", "findMany");
     const computed: ErasedComputedFields = info.config.computed;
     return {
       keys: dtoShapeKeys(dto) ?? [...info.metadata.fields.map((field) => field.name), ...Object.keys(computed)],
-      relations: info.metadata.relations.map((relation) => relation.name),
+      relations: new Set(info.metadata.relations.map((relation) => relation.name)),
       computed,
     };
   }
@@ -183,12 +214,15 @@ function narrowToDto(projection: Projection, dto: DtoClass | null): Projection {
  * A nested object carrying more than the id is narrowed to the id, because
  * a deep nested write is not something this layer should do by accident.
  *
- * Computed fields are **never** writable (ADR-0019). Keeping them out of
- * the derived projection is not enough on its own: a registered
- * `create`/`update` DTO *replaces* that projection, so a DTO class naming
- * a computed field would otherwise pass the key straight through to the
- * adapter as if it were a column. They are stripped explicitly, whichever
- * projection is in force.
+ * Computed fields are **never** writable (ADR-0019), and this class is the
+ * inner of the two layers that make that true. A registered
+ * `create`/`update`/`patch` DTO naming a computed field is rejected at
+ * bootstrap (`resolveComputedFields`' neighbour in `resolve-entity-config`),
+ * so through `createCrud` the derived writable projection is the only one
+ * that reaches here and it never carries a computed name. The explicit
+ * strip below is what keeps that true for a `DefaultDeserializer`
+ * constructed directly — it is exported, and its contract is "computed
+ * names never reach the adapter", not "the config resolver checked first".
  */
 export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entity> {
   private readonly writableProjection: readonly string[];

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -25,6 +25,8 @@ const PUBLIC_SURFACE: readonly string[] = [
   "BUILT_IN_DEFAULTS",
   "CatalogedErrorCode",
   "ClassRef",
+  "ComputedFieldDescriptor",
+  "ComputedFieldMap",
   "ConfigurationException",
   "ConflictException",
   "KavoCallOptions",

--- a/packages/core/tests/computed-fields.spec.ts
+++ b/packages/core/tests/computed-fields.spec.ts
@@ -43,6 +43,25 @@ async function seeded(config: EntityConfig<User> = {}) {
   return fixture;
 }
 
+/**
+ * Every config error names the entity, the key path and the offending
+ * value (the bar `config-validation.spec.ts` sets) — `messageParams` is
+ * where the first two live, so asserting the rendered message alone
+ * would leave the key path free to drift.
+ */
+function expectConfigError(build: () => unknown, path: string, fragment: string, entity = "User"): void {
+  try {
+    build();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+    expect((error as ConfigurationException).messageParams).toMatchObject({ entity, path });
+    expect((error as ConfigurationException).message).toContain(fragment);
+    return;
+  }
+  throw new Error("expected a ConfigurationException");
+}
+
 describe("computed fields — default projection (ADR-0019)", () => {
   it("appears in a findOne response with no DTO registered", async () => {
     const { crud } = await seeded({ computed: { shout } } as never);
@@ -66,6 +85,46 @@ describe("computed fields — default projection (ADR-0019)", () => {
       metadata: userMetadata,
     }) as DefaultKavoService<User>;
     expect(await crud.findOne(1)).toEqual({ id: 1, name: "Ada", email: "a@x.io", age: 36, shout: "ADA" });
+  });
+
+  it("beats a row that already carries the key — resolving wins over reading", async () => {
+    // The branch order in `DefaultSerializer.project` is normative, and a
+    // row really can carry a computed key: a Prisma/Mongoose row with a
+    // column the metadata seam does not describe, or an ORM that hydrates
+    // extra properties. Reading the row instead would put the response back
+    // where ADR-0019's Context section found it.
+    const { crud, adapter } = makeCrud({ computed: { shout } } as never);
+    adapter.rows.push(Object.assign(new User(), { id: 1, name: "Ada", shout: "FROM ROW" }));
+    expect(await crud.findOne(1)).toMatchObject({ id: 1, name: "Ada", shout: "ADA" });
+  });
+
+  it("beats a class getter of the same name — ADR-0019's motivating case", async () => {
+    // The superseded workaround was exactly this: a DTO naming a property
+    // the entity class exposes as a getter, which the serializer copied
+    // because `key in source` was true. A declared computed field is the
+    // replacement, so it has to win over the thing it replaces.
+    class Legacy extends User {
+      get shout(): string {
+        return "FROM GETTER";
+      }
+    }
+    const { crud, adapter } = makeCrud({ computed: { shout } } as never);
+    adapter.rows.push(Object.assign(new Legacy(), { id: 1, name: "Ada" }));
+    expect(await crud.findOne(1)).toMatchObject({ id: 1, name: "Ada", shout: "ADA" });
+  });
+
+  it("does not mistake an inherited name for a declared computed field", async () => {
+    // `project` consults the computed table with `hasOwnProperty`, not
+    // `in`: with `in`, `toString` would hit `Object.prototype`, `.resolve`
+    // would be `undefined`, and the row's own value would silently vanish
+    // from the response instead of being emitted.
+    class UserItemDto {
+      id = 0;
+      toString = "";
+    }
+    const { crud, adapter } = makeCrud({ dto: { item: UserItemDto } } as never);
+    adapter.rows.push(Object.assign(new User(), { id: 1, toString: "shadowed" }) as User);
+    expect(await crud.findOne(1)).toEqual({ id: 1, toString: "shadowed" });
   });
 
   it("receives the same KavoContext a custom handler gets, so it can vary by caller", async () => {
@@ -124,6 +183,19 @@ describe("computed fields — selection", () => {
   it("is dropped by a fieldset that does not name it — selection narrows uniformly", async () => {
     const { crud } = await seeded({ computed: { shout } } as never);
     expect(await crud.findOne(1, { fields: ["name"] } as never)).toEqual({ name: "Ada" });
+  });
+
+  it("never runs a deselected field's resolver", async () => {
+    // Load-bearing ordering, not an implementation detail: `resolve` is
+    // caller code with an unbounded cost, so the selection check has to
+    // come *before* the computed branch. Seeded through the adapter,
+    // because `createOne` serializes its own result with no fieldset and
+    // would call the resolver before the read under test.
+    const resolve = vi.fn((user: User) => user.name.toUpperCase());
+    const { crud, adapter } = makeCrud({ computed: { shout: { resolve } } } as never);
+    adapter.rows.push(Object.assign(new User(), { id: 1, name: "Ada" }));
+    expect(await crud.findOne(1, { fields: ["name"] } as never)).toEqual({ name: "Ada" });
+    expect(resolve).not.toHaveBeenCalled();
   });
 
   it("opts out of the selectable allowlist with `selectable: false` and is then a 400", async () => {
@@ -190,25 +262,6 @@ describe("computed fields — selection", () => {
 });
 
 describe("computed fields — bootstrap validation", () => {
-  /**
-   * Every config error names the entity, the key path and the offending
-   * value (the bar `config-validation.spec.ts` sets) — `messageParams` is
-   * where the first two live, so asserting the rendered message alone
-   * would leave the key path free to drift.
-   */
-  const expectConfigError = (build: () => unknown, path: string, fragment: string, entity = "User") => {
-    try {
-      build();
-    } catch (error) {
-      expect(error).toBeInstanceOf(ConfigurationException);
-      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
-      expect((error as ConfigurationException).messageParams).toMatchObject({ entity, path });
-      expect((error as ConfigurationException).message).toContain(fragment);
-      return;
-    }
-    throw new Error("expected a ConfigurationException");
-  };
-
   it("rejects a computed field listed as filterable", () => {
     expectConfigError(
       () => makeCrud({ computed: { shout }, allowlists: { filterable: ["shout"] } } as never),
@@ -263,12 +316,25 @@ describe("computed fields — bootstrap validation", () => {
     );
   });
 
-  it("rejects `__proto__` as a name rather than losing the declaration", () => {
+  it("rejects the computed-key `__proto__` spelling rather than losing the declaration", () => {
     // Assigning it into the accumulator would set that object's prototype
     // instead of adding a key, so the field would vanish with no error —
     // the same class of hazard as the filter parser's bracket segments.
     expectConfigError(
       () => makeCrud({ computed: { ["__proto__"]: shout } } as never),
+      "computed.__proto__",
+      "'__proto__' cannot name a computed field",
+    );
+  });
+
+  it("rejects the object-literal `__proto__` spelling too — the one people actually write", () => {
+    // `{ __proto__: … }` invokes the prototype *setter* rather than
+    // creating an own key, so the name never reaches `Object.keys` and the
+    // per-key loop above cannot see it. Without the prototype check the
+    // declaration registers nothing and throws nothing — precisely the
+    // outcome the message promises to prevent.
+    expectConfigError(
+      () => makeCrud({ computed: { __proto__: shout } } as never),
       "computed.__proto__",
       "'__proto__' cannot name a computed field",
     );
@@ -347,21 +413,47 @@ describe("computed fields — never writable (ADR-0019)", () => {
     expect(patch.mock.calls[0]?.[1]).toEqual({});
   });
 
-  it("stays stripped when a registered create DTO names it", async () => {
-    // The derived writable projection alone is not enough: a registered DTO
-    // *replaces* it (`dtoShapeKeys(dto) ?? this.writableProjection`), so
-    // without the explicit strip this key would reach the adapter as if it
-    // were a column.
+  /**
+   * The outer of the two layers. A write DTO naming a computed field is
+   * the one computed misuse that used to be handled silently — a per-
+   * request drop — while every other one is a bootstrap error naming the
+   * key path. It is judgeable once, at `createCrud`, and it has a wire
+   * consequence the strip cannot reach: `@kavo/nest` builds `@ApiBody`
+   * from the DTO's runtime shape, so OpenAPI advertised a property the
+   * engine unconditionally discarded.
+   */
+  for (const slot of ["create", "update", "patch"] as const) {
+    it(`rejects a registered ${slot} DTO that declares it, at bootstrap`, () => {
+      class WriteUserDto {
+        name = "";
+        shout = "";
+      }
+      expectConfigError(
+        () => makeCrud({ computed: { shout }, dto: { [slot]: WriteUserDto } } as never),
+        `dto.${slot}`,
+        `the '${slot}' DTO declares 'shout', which is a computed field on 'User'`,
+      );
+    });
+  }
+
+  it("accepts a write DTO that omits it, so the check is not just 'any DTO'", async () => {
     class CreateUserDto {
       name = "";
-      shout = "";
+      email = "";
     }
     const { crud, adapter } = makeCrud({ computed: { shout }, dto: { create: CreateUserDto } } as never);
     const create = vi.spyOn(adapter, "create");
-    await crud.createOne({ name: "Ada", shout: "NOPE" } as never);
-    expect(create.mock.calls[0]?.[0]).toEqual({ name: "Ada" });
+    await crud.createOne({ name: "Ada", email: "a@x.io", shout: "NOPE" } as never);
+    expect(create.mock.calls[0]?.[0]).toEqual({ name: "Ada", email: "a@x.io" });
   });
 
+  /**
+   * The inner layer, and the only place it is reachable now that the outer
+   * one rejects the config that produced it. `DefaultDeserializer` is
+   * exported, so its contract is "a computed name never reaches the
+   * adapter" on its own terms — not "the config resolver checked first".
+   * Deleting the strip in `deserialize` fails exactly this test.
+   */
   it("is stripped by DefaultDeserializer directly, whichever projection is in force", () => {
     class UpdateUserDto {
       name = "";

--- a/packages/core/tests/computed-fields.spec.ts
+++ b/packages/core/tests/computed-fields.spec.ts
@@ -65,7 +65,7 @@ describe("computed fields — default projection (ADR-0019)", () => {
       adapter: adapter as never,
       metadata: userMetadata,
     }) as DefaultKavoService<User>;
-    expect(await crud.findOne(1)).toMatchObject({ shout: "ADA" });
+    expect(await crud.findOne(1)).toEqual({ id: 1, name: "Ada", email: "a@x.io", age: 36, shout: "ADA" });
   });
 
   it("receives the same KavoContext a custom handler gets, so it can vary by caller", async () => {
@@ -137,6 +137,45 @@ describe("computed fields — selection", () => {
       code: "KAVO_QUERY_INVALID",
       issues: [{ field: "shout", code: "KAVO_QUERY_INVALID_FIELD" }],
     });
+    // And the limit of what the flag buys: `selectable: false` narrows the
+    // allowlist, not the projection, so any fieldset that omits the field
+    // still drops it — with no way for the client to ask for it back.
+    expect(await crud.findOne(1, { fields: ["name"] } as never)).toEqual({ name: "Ada" });
+  });
+
+  it("survives an `{ exclude }` selectable list, which resolves against columns *and* computed", async () => {
+    // The exclude form resolves against the same base set the plain default
+    // uses; a regression to own-columns-only here is invisible to the
+    // default-selector cases above, because that is a different branch.
+    const { crud } = await seeded({
+      computed: { shout },
+      allowlists: { selectable: { exclude: ["email"] } },
+    } as never);
+    expect(await crud.findOne(1, { fields: ["shout"] } as never)).toEqual({ shout: "ADA" });
+    await expect(crud.findOne(1, { fields: ["email"] } as never)).rejects.toBeInstanceOf(QueryValidationException);
+  });
+
+  it("can be excluded by name, without leaving the default projection", async () => {
+    const { crud } = await seeded({
+      computed: { shout },
+      allowlists: { selectable: { exclude: ["shout"] } },
+    } as never);
+    expect(await crud.findOne(1)).toMatchObject({ shout: "ADA" });
+    await expect(crud.findOne(1, { fields: ["shout"] } as never)).rejects.toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      issues: [{ field: "shout", code: "KAVO_QUERY_INVALID_FIELD" }],
+    });
+  });
+
+  it("lets an explicit selectable list override the descriptor's `selectable: false`", async () => {
+    // The descriptor's flag governs the *derived* default; naming the field
+    // in an explicit list is the same deliberate opt-in that an explicit
+    // list always is, so it wins — the flag is a default, not a veto.
+    const { crud } = await seeded({
+      computed: { shout: { ...shout, selectable: false } },
+      allowlists: { selectable: ["id", "shout"] },
+    } as never);
+    expect(await crud.findOne(1, { fields: ["shout"] } as never)).toEqual({ shout: "ADA" });
   });
 
   it("never joins the filterable or sortable defaults", async () => {
@@ -151,12 +190,19 @@ describe("computed fields — selection", () => {
 });
 
 describe("computed fields — bootstrap validation", () => {
-  const expectConfigError = (build: () => unknown, fragment: string) => {
+  /**
+   * Every config error names the entity, the key path and the offending
+   * value (the bar `config-validation.spec.ts` sets) — `messageParams` is
+   * where the first two live, so asserting the rendered message alone
+   * would leave the key path free to drift.
+   */
+  const expectConfigError = (build: () => unknown, path: string, fragment: string, entity = "User") => {
     try {
       build();
     } catch (error) {
       expect(error).toBeInstanceOf(ConfigurationException);
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).messageParams).toMatchObject({ entity, path });
       expect((error as ConfigurationException).message).toContain(fragment);
       return;
     }
@@ -166,6 +212,7 @@ describe("computed fields — bootstrap validation", () => {
   it("rejects a computed field listed as filterable", () => {
     expectConfigError(
       () => makeCrud({ computed: { shout }, allowlists: { filterable: ["shout"] } } as never),
+      "allowlists.filterable",
       "'shout' is a computed field on 'User', which can never be filtered on",
     );
   });
@@ -173,6 +220,7 @@ describe("computed fields — bootstrap validation", () => {
   it("rejects a computed field listed as sortable", () => {
     expectConfigError(
       () => makeCrud({ computed: { shout }, allowlists: { sortable: ["shout"] } } as never),
+      "allowlists.sortable",
       "'shout' is a computed field on 'User', which can never be sorted on",
     );
   });
@@ -180,6 +228,7 @@ describe("computed fields — bootstrap validation", () => {
   it("rejects a name that collides with a real column", () => {
     expectConfigError(
       () => makeCrud({ computed: { email: shout } } as never),
+      "computed.email",
       "computed field 'email' collides with an existing column on 'User'",
     );
   });
@@ -192,14 +241,36 @@ describe("computed fields — bootstrap validation", () => {
           adapter: new SeededAdapter<Post>() as never,
           metadata: postMetadata as EntityMetadata<Post>,
         }),
+      "computed.author",
       "computed field 'author' collides with an existing relation on 'Post'",
+      "Post",
     );
   });
 
   it("rejects a descriptor with no resolve function", () => {
     expectConfigError(
       () => makeCrud({ computed: { shout: {} } } as never),
+      "computed.shout",
       "computed field 'shout' has no 'resolve' function",
+    );
+  });
+
+  it("rejects an async resolve rather than emitting an unawaited promise", () => {
+    expectConfigError(
+      () => makeCrud({ computed: { shout: { resolve: async () => "ADA" } } } as never),
+      "computed.shout",
+      "computed field 'shout' has an async 'resolve'",
+    );
+  });
+
+  it("rejects `__proto__` as a name rather than losing the declaration", () => {
+    // Assigning it into the accumulator would set that object's prototype
+    // instead of adding a key, so the field would vanish with no error —
+    // the same class of hazard as the filter parser's bracket segments.
+    expectConfigError(
+      () => makeCrud({ computed: { ["__proto__"]: shout } } as never),
+      "computed.__proto__",
+      "'__proto__' cannot name a computed field",
     );
   });
 
@@ -215,6 +286,46 @@ describe("computed fields — bootstrap validation", () => {
   it("lists the declared names in the debug dump", () => {
     const { kavo } = makeCrud({ computed: { shout } } as never);
     expect(kavo.describe("User")).toMatchObject({ computed: ["shout"] });
+  });
+});
+
+describe("computed fields — a throwing or empty resolver", () => {
+  it("surfaces a throwing resolver as a persistence failure, with the cause kept", async () => {
+    // `resolve` is caller code running inside response mapping, after the
+    // handler has already succeeded. Nothing in core catches it, so it
+    // takes the engine's ordinary untranslated-error path.
+    const boom = new Error("resolver exploded");
+    const { crud, adapter } = makeCrud({
+      computed: {
+        shout: {
+          resolve: () => {
+            throw boom;
+          },
+        },
+      },
+    } as never);
+    // Seeded through the adapter, not `createOne` — writes serialize their
+    // result too, so a throwing resolver takes down the write as well.
+    adapter.rows.push(Object.assign(new User(), { id: 1, name: "Ada" }));
+    await expect(crud.findOne(1)).rejects.toMatchObject({
+      code: "KAVO_PERSISTENCE_FAILED",
+      status: 500,
+      cause: boom,
+    });
+  });
+
+  it("omits the key when a resolver returns undefined, and keeps an explicit null", async () => {
+    // Same distinction the column branch draws: `undefined` is absence,
+    // `null` is data — so the programmatic shape and the JSON body agree.
+    const { crud } = await seeded({
+      computed: {
+        absent: { resolve: () => undefined },
+        empty: { resolve: () => null },
+      },
+    } as never);
+    const item = (await crud.findOne(1)) as unknown as Record<string, unknown>;
+    expect(item).not.toHaveProperty("absent");
+    expect(item).toHaveProperty("empty", null);
   });
 });
 
@@ -266,16 +377,28 @@ describe("computed fields — never writable (ADR-0019)", () => {
 });
 
 describe("computed fields — on an included relation target", () => {
-  /** `Post *—1 Author`, with the computed field declared on the *target*. */
-  function blog() {
+  interface BlogConfigs {
+    readonly author?: object;
+    readonly post?: object;
+    readonly comment?: object;
+  }
+
+  /**
+   * `Author 1—* Post 1—* Comment`, so both include cardinalities are
+   * reachable. Every entity gets a computed field named `label` with a
+   * *different* resolver, which is what makes "each side uses its own
+   * table" an assertion rather than an absence.
+   */
+  function blog(configs: BlogConfigs = {}) {
     const metadata = new Map<unknown, EntityMetadata<object>>([
       [Author, authorMetadata as EntityMetadata<object>],
       [Post, postMetadata as EntityMetadata<object>],
       [Comment, commentMetadata as EntityMetadata<object>],
     ]);
+    const authorAdapter = new SeededAdapter<Author>([]);
     const postAdapter = new SeededAdapter<Post>([]);
     const adapters = new Map<unknown, unknown>([
-      [Author, new SeededAdapter<Author>([])],
+      [Author, authorAdapter],
       [Post, postAdapter],
       [Comment, new SeededAdapter<Comment>([])],
     ]);
@@ -285,21 +408,39 @@ describe("computed fields — on an included relation target", () => {
         adapterFor: (entity) => adapters.get(entity) as never,
       },
     });
-    kavo.createCrud(Author, {
-      computed: { initials: { resolve: (author: Author) => author.name.slice(0, 2) } },
-    } as never);
-    const posts = kavo.createCrud(Post, {
-      relations: { edges: { author: { includable: true } } },
-    } as never) as DefaultKavoService<Post>;
+    const authors = kavo.createCrud(
+      Author,
+      (configs.author ?? {
+        computed: {
+          initials: { resolve: (author: Author) => author.name.slice(0, 2) },
+          label: { resolve: (author: Author) => `author:${author.name}` },
+        },
+        relations: { edges: { posts: { includable: true } } },
+      }) as never,
+    ) as DefaultKavoService<Author>;
+    kavo.createCrud(
+      Comment,
+      (configs.comment ?? {
+        computed: { label: { resolve: (comment: Comment) => `comment:${comment.body}` } },
+      }) as never,
+    );
+    const posts = kavo.createCrud(
+      Post,
+      (configs.post ?? {
+        computed: { label: { resolve: (post: Post) => `post:${post.title}` } },
+        relations: { edges: { author: { includable: true }, comments: { includable: true } } },
+      }) as never,
+    ) as DefaultKavoService<Post>;
     postAdapter.rows.push(
       Object.assign(new Post(), {
         id: 10,
         title: "First",
         authorId: 1,
         author: Object.assign(new Author(), { id: 1, name: "Ada" }),
+        comments: [Object.assign(new Comment(), { id: 100, body: "nice", postId: 10 })],
       }),
     );
-    return { posts };
+    return { posts, authors, authorAdapter, postAdapter };
   }
 
   it("resolves the target's own computed field through the catalog", async () => {
@@ -319,9 +460,82 @@ describe("computed fields — on an included relation target", () => {
     expect(item.author).toEqual({ initials: "Ad" });
   });
 
-  it("never emits a root computed field onto an included relation", async () => {
+  it("gives each side its own table when root and target share a field name", async () => {
+    // `label` is declared on Post *and* on Author with different resolvers.
+    // A serializer that reused the root projection's computed table for a
+    // relation node would emit `author.label === "post:First"` here, which
+    // is precisely the failure an absence assertion cannot see.
     const { posts } = blog();
-    const item = (await posts.findOne(10, { include: ["author"] })) as Post & { author: Record<string, unknown> };
-    expect(item.author).not.toHaveProperty("shout");
+    const item = (await posts.findOne(10, { include: ["author"] })) as Post & {
+      label: string;
+      author: { label: string };
+    };
+    expect(item.label).toBe("post:First");
+    expect(item.author.label).toBe("author:Ada");
+  });
+
+  it("resolves a computed field on every element of a to-many include", async () => {
+    // A to-many node reads the target's `list` DTO slot rather than `item`
+    // — a distinct lookup in `projectionFor` that the to-one cases never
+    // reach.
+    const { posts } = blog();
+    const item = (await posts.findOne(10, { include: ["comments"] })) as Post & {
+      comments: Record<string, unknown>[];
+    };
+    expect(item.comments).toEqual([{ id: 100, body: "nice", postId: 10, label: "comment:nice" }]);
+  });
+
+  it("keeps evaluating a target computed field that the target's item DTO names", async () => {
+    class AuthorItemDto {
+      id = 0;
+      initials = "";
+    }
+    const { posts } = blog({
+      author: {
+        computed: { initials: { resolve: (author: Author) => author.name.slice(0, 2) } },
+        dto: { item: AuthorItemDto },
+      },
+    });
+    const item = (await posts.findOne(10, { include: ["author"] })) as Post & { author: object };
+    expect(item.author).toEqual({ id: 1, initials: "Ad" });
+  });
+
+  it("narrows a target computed field away when the target's item DTO omits it", async () => {
+    class AuthorItemDto {
+      id = 0;
+      name = "";
+    }
+    const { posts } = blog({
+      author: {
+        computed: { initials: { resolve: (author: Author) => author.name.slice(0, 2) } },
+        dto: { item: AuthorItemDto },
+      },
+    });
+    const item = (await posts.findOne(10, { include: ["author"] })) as Post & { author: object };
+    expect(item.author).toEqual({ id: 1, name: "Ada" });
+  });
+
+  it("hands a target's resolver the root request's context, not one of its own", async () => {
+    // One response is one request, so there is only one context to give.
+    // Documented on `ComputedFieldDescriptor.resolve` and in ADR-0019, and
+    // pinned here so it cannot drift into a silent half-truth.
+    let seen: KavoContext<Author> | null = null;
+    const { posts } = blog({
+      author: {
+        computed: {
+          initials: {
+            resolve: (author: Author, context: KavoContext<Author>) => {
+              seen = context;
+              return author.name.slice(0, 2);
+            },
+          },
+        },
+      },
+    });
+    await posts.findOne(10, { include: ["author"] }, { principal: { id: "u-7" } });
+    // Request-scoped members are the caller's, and true from anywhere …
+    expect(seen).toMatchObject({ principal: { id: "u-7" } });
+    // … while the entity-scoped ones describe the *root* operation.
+    expect(seen).toMatchObject({ entityName: "Post", operation: "findOne" });
   });
 });

--- a/packages/core/tests/computed-fields.spec.ts
+++ b/packages/core/tests/computed-fields.spec.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ComputedFieldMap,
+  DefaultKavoService,
+  EntityConfig,
+  EntityMetadata,
+  KavoContext,
+  ListResultDto,
+} from "@kavo/core";
+import {
+  ConfigurationException,
+  DefaultDeserializer,
+  QueryValidationException,
+  WireQuery,
+  createKavo,
+} from "@kavo/core";
+import { InMemoryUserAdapter, User, contextStub, userMetadata } from "./support/user-fixture.js";
+import {
+  Author,
+  Comment,
+  Post,
+  SeededAdapter,
+  authorMetadata,
+  commentMetadata,
+  postMetadata,
+} from "./support/blog-fixture.js";
+
+/** `fullName`-style descriptor: derived from two real columns, nothing else. */
+const shout = {
+  resolve: (user: User): string => user.name.toUpperCase(),
+};
+
+function makeCrud(config: EntityConfig<User> = {}) {
+  const adapter = new InMemoryUserAdapter();
+  const kavo = createKavo();
+  const crud = kavo.createCrud(User, config as never, { adapter, metadata: userMetadata }) as DefaultKavoService<User>;
+  return { crud, adapter, kavo };
+}
+
+async function seeded(config: EntityConfig<User> = {}) {
+  const fixture = makeCrud(config);
+  await fixture.crud.createOne({ name: "Ada", email: "ada@example.com", age: 36 } as never);
+  return fixture;
+}
+
+describe("computed fields — default projection (ADR-0019)", () => {
+  it("appears in a findOne response with no DTO registered", async () => {
+    const { crud } = await seeded({ computed: { shout } } as never);
+    expect(await crud.findOne(1)).toMatchObject({ id: 1, name: "Ada", shout: "ADA" });
+  });
+
+  it("appears on every element of a findMany response", async () => {
+    const { crud } = await seeded({ computed: { shout } } as never);
+    await crud.createOne({ name: "Grace", email: "g@example.com", age: 45 } as never);
+    const list = (await crud.findMany()) as unknown as ListResultDto<User & { shout: string }>;
+    expect(list.items.map((item) => item.shout)).toEqual(["ADA", "GRACE"]);
+  });
+
+  it("is evaluated, not read off the row — a plain object works like a class instance", async () => {
+    // The whole point over the "register a DTO naming a class getter"
+    // workaround: `@kavo/prisma` and `@kavo/mongoose` hand the engine plain
+    // objects that carry no getter at all.
+    const adapter = new SeededAdapter<User>([{ id: 1, name: "Ada", email: "a@x.io", age: 36 } as User]);
+    const crud = createKavo().createCrud(User, { computed: { shout } } as never, {
+      adapter: adapter as never,
+      metadata: userMetadata,
+    }) as DefaultKavoService<User>;
+    expect(await crud.findOne(1)).toMatchObject({ shout: "ADA" });
+  });
+
+  it("receives the same KavoContext a custom handler gets, so it can vary by caller", async () => {
+    let seen: KavoContext<User> | null = null;
+    const { crud } = await seeded({
+      computed: {
+        viewer: {
+          resolve: (_user: User, context: KavoContext<User>) => {
+            seen = context;
+            return (context.principal as { id: string } | null)?.id ?? "anonymous";
+          },
+        },
+      },
+    } as never);
+    const item = (await crud.findOne(1, undefined, { principal: { id: "u-7" } })) as User & { viewer: string };
+    expect(item.viewer).toBe("u-7");
+    expect(seen).toMatchObject({ entityName: "User", operation: "findOne" });
+    expect((seen as unknown as KavoContext<User>).correlationId).toEqual(expect.any(String));
+  });
+});
+
+describe("computed fields — DTO narrowing (doc 04 §5)", () => {
+  it("is narrowed out by an explicit item DTO that omits it", async () => {
+    class UserItemDto {
+      id = 0;
+      name = "";
+    }
+    const { crud } = await seeded({ computed: { shout }, dto: { item: UserItemDto } } as never);
+    expect(await crud.findOne(1)).toEqual({ id: 1, name: "Ada" });
+  });
+
+  it("is still evaluated when an explicit item DTO names it", async () => {
+    class UserItemDto {
+      id = 0;
+      shout = "";
+    }
+    const { crud } = await seeded({ computed: { shout }, dto: { item: UserItemDto } } as never);
+    expect(await crud.findOne(1)).toEqual({ id: 1, shout: "ADA" });
+  });
+});
+
+describe("computed fields — selection", () => {
+  it("is selectable by default, so fields= can name it", async () => {
+    const { crud } = await seeded({ computed: { shout } } as never);
+    expect(await crud.findOne(1, { fields: ["name", "shout"] } as never)).toEqual({ name: "Ada", shout: "ADA" });
+  });
+
+  it("is selectable over the wire grammar too", async () => {
+    const { crud } = await seeded({ computed: { shout } } as never);
+    const list = (await crud.findMany(new WireQuery({ fields: "shout" }) as never)) as unknown as ListResultDto<{
+      shout: string;
+    }>;
+    expect(list.items).toEqual([{ shout: "ADA" }]);
+  });
+
+  it("is dropped by a fieldset that does not name it — selection narrows uniformly", async () => {
+    const { crud } = await seeded({ computed: { shout } } as never);
+    expect(await crud.findOne(1, { fields: ["name"] } as never)).toEqual({ name: "Ada" });
+  });
+
+  it("opts out of the selectable allowlist with `selectable: false` and is then a 400", async () => {
+    const { crud } = await seeded({
+      computed: { shout: { ...shout, selectable: false } },
+    } as never);
+    // Still present in the default projection …
+    expect(await crud.findOne(1)).toMatchObject({ shout: "ADA" });
+    // … but outside the allowlist, so naming it is rejected, never dropped.
+    await expect(crud.findOne(1, { fields: ["shout"] } as never)).rejects.toMatchObject({
+      code: "KAVO_QUERY_INVALID",
+      issues: [{ field: "shout", code: "KAVO_QUERY_INVALID_FIELD" }],
+    });
+  });
+
+  it("never joins the filterable or sortable defaults", async () => {
+    const { crud } = await seeded({ computed: { shout } } as never);
+    await expect(crud.findMany({ sort: [{ field: "shout" as never, direction: "asc" }] })).rejects.toBeInstanceOf(
+      QueryValidationException,
+    );
+    await expect(crud.findMany(new WireQuery({ "filter[shout][eq]": "ADA" }) as never)).rejects.toBeInstanceOf(
+      QueryValidationException,
+    );
+  });
+});
+
+describe("computed fields — bootstrap validation", () => {
+  const expectConfigError = (build: () => unknown, fragment: string) => {
+    try {
+      build();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigurationException);
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).message).toContain(fragment);
+      return;
+    }
+    throw new Error("expected a ConfigurationException");
+  };
+
+  it("rejects a computed field listed as filterable", () => {
+    expectConfigError(
+      () => makeCrud({ computed: { shout }, allowlists: { filterable: ["shout"] } } as never),
+      "'shout' is a computed field on 'User', which can never be filtered on",
+    );
+  });
+
+  it("rejects a computed field listed as sortable", () => {
+    expectConfigError(
+      () => makeCrud({ computed: { shout }, allowlists: { sortable: ["shout"] } } as never),
+      "'shout' is a computed field on 'User', which can never be sorted on",
+    );
+  });
+
+  it("rejects a name that collides with a real column", () => {
+    expectConfigError(
+      () => makeCrud({ computed: { email: shout } } as never),
+      "computed field 'email' collides with an existing column on 'User'",
+    );
+  });
+
+  it("rejects a name that collides with a relation", () => {
+    const kavo = createKavo();
+    expectConfigError(
+      () =>
+        kavo.createCrud(Post, { computed: { author: { resolve: () => 1 } } } as never, {
+          adapter: new SeededAdapter<Post>() as never,
+          metadata: postMetadata as EntityMetadata<Post>,
+        }),
+      "computed field 'author' collides with an existing relation on 'Post'",
+    );
+  });
+
+  it("rejects a descriptor with no resolve function", () => {
+    expectConfigError(
+      () => makeCrud({ computed: { shout: {} } } as never),
+      "computed field 'shout' has no 'resolve' function",
+    );
+  });
+
+  it("still accepts an explicit selectable list naming the computed field", async () => {
+    const { crud } = await seeded({
+      computed: { shout },
+      allowlists: { selectable: ["id", "shout"] },
+    } as never);
+    expect(await crud.findOne(1, { fields: ["shout"] } as never)).toEqual({ shout: "ADA" });
+    await expect(crud.findOne(1, { fields: ["email"] } as never)).rejects.toBeInstanceOf(QueryValidationException);
+  });
+
+  it("lists the declared names in the debug dump", () => {
+    const { kavo } = makeCrud({ computed: { shout } } as never);
+    expect(kavo.describe("User")).toMatchObject({ computed: ["shout"] });
+  });
+});
+
+describe("computed fields — never writable (ADR-0019)", () => {
+  it("is stripped from a create body", async () => {
+    const { crud, adapter } = makeCrud({ computed: { shout } } as never);
+    const create = vi.spyOn(adapter, "create");
+    await crud.createOne({ name: "Ada", email: "a@x.io", shout: "NOPE" } as never);
+    expect(create.mock.calls[0]?.[0]).toEqual({ name: "Ada", email: "a@x.io" });
+  });
+
+  it("is stripped from update and patch bodies", async () => {
+    const { crud, adapter } = await seeded({ computed: { shout } } as never);
+    const update = vi.spyOn(adapter, "update");
+    const patch = vi.spyOn(adapter, "patch");
+    await crud.updateOne(1, { name: "Ada L", shout: "NOPE" } as never);
+    await crud.patchOne(1, { shout: "NOPE" } as never);
+    expect(update.mock.calls[0]?.[1]).toEqual({ name: "Ada L" });
+    expect(patch.mock.calls[0]?.[1]).toEqual({});
+  });
+
+  it("stays stripped when a registered create DTO names it", async () => {
+    // The derived writable projection alone is not enough: a registered DTO
+    // *replaces* it (`dtoShapeKeys(dto) ?? this.writableProjection`), so
+    // without the explicit strip this key would reach the adapter as if it
+    // were a column.
+    class CreateUserDto {
+      name = "";
+      shout = "";
+    }
+    const { crud, adapter } = makeCrud({ computed: { shout }, dto: { create: CreateUserDto } } as never);
+    const create = vi.spyOn(adapter, "create");
+    await crud.createOne({ name: "Ada", shout: "NOPE" } as never);
+    expect(create.mock.calls[0]?.[0]).toEqual({ name: "Ada" });
+  });
+
+  it("is stripped by DefaultDeserializer directly, whichever projection is in force", () => {
+    class UpdateUserDto {
+      name = "";
+      shout = "";
+    }
+    const computed: ComputedFieldMap<User> = { shout };
+    const deserializer = new DefaultDeserializer<User>(userMetadata, undefined, computed);
+    expect(deserializer.deserialize({ name: "Ada", shout: "NOPE" }, null, contextStub())).toEqual({ name: "Ada" });
+    expect(deserializer.deserialize({ name: "Ada", shout: "NOPE" }, UpdateUserDto, contextStub())).toEqual({
+      name: "Ada",
+    });
+  });
+});
+
+describe("computed fields — on an included relation target", () => {
+  /** `Post *—1 Author`, with the computed field declared on the *target*. */
+  function blog() {
+    const metadata = new Map<unknown, EntityMetadata<object>>([
+      [Author, authorMetadata as EntityMetadata<object>],
+      [Post, postMetadata as EntityMetadata<object>],
+      [Comment, commentMetadata as EntityMetadata<object>],
+    ]);
+    const postAdapter = new SeededAdapter<Post>([]);
+    const adapters = new Map<unknown, unknown>([
+      [Author, new SeededAdapter<Author>([])],
+      [Post, postAdapter],
+      [Comment, new SeededAdapter<Comment>([])],
+    ]);
+    const kavo = createKavo({
+      infrastructure: {
+        metadataFor: (entity) => metadata.get(entity) as never,
+        adapterFor: (entity) => adapters.get(entity) as never,
+      },
+    });
+    kavo.createCrud(Author, {
+      computed: { initials: { resolve: (author: Author) => author.name.slice(0, 2) } },
+    } as never);
+    const posts = kavo.createCrud(Post, {
+      relations: { edges: { author: { includable: true } } },
+    } as never) as DefaultKavoService<Post>;
+    postAdapter.rows.push(
+      Object.assign(new Post(), {
+        id: 10,
+        title: "First",
+        authorId: 1,
+        author: Object.assign(new Author(), { id: 1, name: "Ada" }),
+      }),
+    );
+    return { posts };
+  }
+
+  it("resolves the target's own computed field through the catalog", async () => {
+    const { posts } = blog();
+    const item = (await posts.findOne(10, { include: ["author"] })) as Post & {
+      author: Author & { initials: string };
+    };
+    expect(item.author).toMatchObject({ id: 1, name: "Ada", initials: "Ad" });
+  });
+
+  it("honors the target's selectable allowlist for fields[author]", async () => {
+    const { posts } = blog();
+    const item = (await posts.findOne(10, {
+      include: ["author"],
+      fields: { author: ["initials"] },
+    } as never)) as Post & { author: { initials: string } };
+    expect(item.author).toEqual({ initials: "Ad" });
+  });
+
+  it("never emits a root computed field onto an included relation", async () => {
+    const { posts } = blog();
+    const item = (await posts.findOne(10, { include: ["author"] })) as Post & { author: Record<string, unknown> };
+    expect(item.author).not.toHaveProperty("shout");
+  });
+});

--- a/packages/core/tests/types/computed-fields.test-d.ts
+++ b/packages/core/tests/types/computed-fields.test-d.ts
@@ -37,9 +37,31 @@ void kavo.createCrud(Author, {
 // A descriptor can be declared standalone and still infer the key.
 const initials: ComputedFieldDescriptor<Author> = {
   resolve: (author) => author.name.slice(0, 2),
-  selectable: false,
 };
 void kavo.createCrud(Author, { computed: { initials }, allowlists: { selectable: ["id", "initials"] } });
+
+void kavo.createCrud(Author, {
+  computed: {
+    // @ts-expect-error — `resolve` is typed to the entity, so a misspelled
+    // property is caught here rather than as `undefined` in a response.
+    initials: { resolve: (author) => author.nmae },
+  },
+});
+
+void kavo.createCrud(Author, {
+  computed: { initials: { resolve: (author) => author.name } },
+  // @ts-expect-error — the `{ exclude }` form is barred from filterable too:
+  // excluding a name that could never be in the list is a confusion, not a
+  // no-op worth silently accepting.
+  allowlists: { filterable: { exclude: ["initials"] } },
+});
+
+// `{ exclude }` on `selectable` accepts a computed name, because that list
+// really does contain one to remove.
+void kavo.createCrud(Author, {
+  computed: { initials: { resolve: (author) => author.name } },
+  allowlists: { selectable: { exclude: ["initials"] } },
+});
 
 void kavo.createCrud(Author, {
   computed: { initials: { resolve: (author) => author.name } },

--- a/packages/core/tests/types/computed-fields.test-d.ts
+++ b/packages/core/tests/types/computed-fields.test-d.ts
@@ -28,6 +28,16 @@ void kavo.createCrud(Author, {
   },
 });
 
+// ADR-0019's one explicit *negative* claim: declaring a computed field does
+// not change the static response type — the entity-derived `ItemDto` stays
+// `Entity`. Every runtime test casts its way past this, so a drift in either
+// direction (silently growing the key, or losing `Author`) is invisible
+// without a type-level assertion.
+const derived = kavo.createCrud(Author, {
+  computed: { initials: { resolve: (author) => author.name.slice(0, 2) } },
+});
+expectTypeOf(derived.findOne).returns.resolves.toEqualTypeOf<Author>();
+
 // A declared computed name is usable in `selectable` alongside real paths.
 void kavo.createCrud(Author, {
   computed: { initials: { resolve: (author) => author.name.slice(0, 2) } },

--- a/packages/core/tests/types/computed-fields.test-d.ts
+++ b/packages/core/tests/types/computed-fields.test-d.ts
@@ -1,0 +1,66 @@
+import { expectTypeOf } from "vitest";
+import { createKavo } from "@kavo/core";
+import type { ComputedFieldDescriptor, KavoContext } from "@kavo/core";
+import { Author } from "../support/blog-fixture.js";
+
+/**
+ * The type-level half of ADR-0019. `EntityConfig` grows an eighth
+ * parameter, `Computed`, inferred from the keys of `computed` alone
+ * (`allowlists` is a `NoInfer` position, so listing a real column there
+ * cannot widen it). That is what lets an explicit `selectable` list name a
+ * computed field without a cast, while `filterable`/`sortable` — which
+ * stay typed to real entity paths — reject one outright.
+ */
+
+const kavo = createKavo();
+
+// `resolve` is typed to the entity and to the request context, with no
+// manual generic argument at the call site.
+void kavo.createCrud(Author, {
+  computed: {
+    initials: {
+      resolve: (author, context) => {
+        expectTypeOf(author).toEqualTypeOf<Author>();
+        expectTypeOf(context).toEqualTypeOf<KavoContext<Author>>();
+        return author.name.slice(0, 2);
+      },
+    },
+  },
+});
+
+// A declared computed name is usable in `selectable` alongside real paths.
+void kavo.createCrud(Author, {
+  computed: { initials: { resolve: (author) => author.name.slice(0, 2) } },
+  allowlists: { selectable: ["id", "name", "initials"] },
+});
+
+// A descriptor can be declared standalone and still infer the key.
+const initials: ComputedFieldDescriptor<Author> = {
+  resolve: (author) => author.name.slice(0, 2),
+  selectable: false,
+};
+void kavo.createCrud(Author, { computed: { initials }, allowlists: { selectable: ["id", "initials"] } });
+
+void kavo.createCrud(Author, {
+  computed: { initials: { resolve: (author) => author.name } },
+  // @ts-expect-error — a computed field can never be filterable: no column.
+  allowlists: { filterable: ["initials"] },
+});
+
+void kavo.createCrud(Author, {
+  computed: { initials: { resolve: (author) => author.name } },
+  // @ts-expect-error — nor sortable, for the same reason.
+  allowlists: { sortable: ["initials"] },
+});
+
+void kavo.createCrud(Author, {
+  computed: { initials: { resolve: (author) => author.name } },
+  // @ts-expect-error — `selectable` still spell-checks real entity paths.
+  allowlists: { selectable: ["nmae"] },
+});
+
+// @ts-expect-error — and a name no `computed` entry declares stays rejected.
+void kavo.createCrud(Author, { allowlists: { selectable: ["initials"] } });
+
+// @ts-expect-error — a descriptor without `resolve` is not a descriptor.
+void kavo.createCrud(Author, { computed: { initials: { selectable: true } } });

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -156,9 +156,10 @@ export function Kavo<
   QueryDto = QueryContext<Entity>,
   ItemDto = Entity,
   ListDto = ItemDto,
+  Computed extends string = never,
 >(
   entity: ClassRef<Entity>,
-  config?: EntityConfig<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>,
+  config?: EntityConfig<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto, Computed>,
 ): ClassDecorator {
   return (target) => {
     const controller = target as unknown as {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1046,6 +1046,38 @@ describe("@Kavo computed fields over the wire (ADR-0019)", () => {
     await request(server()).post("/todos").send({ title: "Ship It", slug: "hijacked" }).expect(201);
     expect(adapter.rows[1]).not.toHaveProperty("slug");
   });
+
+  it("omits the key over the wire when the resolver returns undefined", async () => {
+    @Kavo(Todo, { computed: { note: { resolve: () => undefined } } })
+    @Controller("todos")
+    class UndefinedComputedController {}
+
+    await app.close();
+    await bootstrap(UndefinedComputedController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    expect((await request(server()).get("/todos/1").expect(200)).body).not.toHaveProperty("note");
+  });
+
+  it("turns a throwing resolver into problem details without leaking the message", async () => {
+    @Kavo(Todo, {
+      computed: {
+        note: {
+          resolve: () => {
+            throw new Error("secret internal detail");
+          },
+        },
+      },
+    })
+    @Controller("todos")
+    class ThrowingComputedController {}
+
+    await app.close();
+    await bootstrap(ThrowingComputedController);
+    // The write serializes its result too, so this is where it surfaces.
+    const response = await request(server()).post("/todos").send({ title: "x" }).expect(500);
+    expect(response.body).toMatchObject({ code: "KAVO_PERSISTENCE_FAILED", status: 500 });
+    expect(JSON.stringify(response.body)).not.toContain("secret internal detail");
+  });
 });
 
 describe("@Kavo Swagger request-body schemas", () => {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1007,8 +1007,11 @@ describe("@Kavo relation includes", () => {
  */
 describe("@Kavo computed fields over the wire (ADR-0019)", () => {
   @Kavo(Todo, {
+    // Defensive by construction: `resolve` must be *total* over anything the
+    // column can hold, because `serializeList` maps it over every row and one
+    // throw takes the whole collection response down (ADR-0019 §1).
     computed: {
-      slug: { resolve: (todo: Todo) => todo.title.toLowerCase().replaceAll(" ", "-") },
+      slug: { resolve: (todo: Todo) => todo.title?.toLowerCase().replaceAll(" ", "-") ?? null },
     },
   })
   @Controller("todos")
@@ -1047,15 +1050,36 @@ describe("@Kavo computed fields over the wire (ADR-0019)", () => {
     expect(adapter.rows[1]).not.toHaveProperty("slug");
   });
 
-  it("omits the key over the wire when the resolver returns undefined", async () => {
-    @Kavo(Todo, { computed: { note: { resolve: () => undefined } } })
-    @Controller("todos")
-    class UndefinedComputedController {}
+  it("fails at bind time when a registered create DTO declares the computed field", async () => {
+    // The wire consequence this closes: `@ApiBody` is built from the DTO's
+    // runtime shape, so a DTO naming a computed field made OpenAPI advertise
+    // a property the engine unconditionally discards. Rejected at
+    // `createCrud` now, which in a Nest app is provider instantiation.
+    class CreateTodoDto {
+      title = "";
+      slug = "";
+    }
 
-    await app.close();
-    await bootstrap(UndefinedComputedController);
-    await request(server()).post("/todos").send({ title: "x" }).expect(201);
-    expect((await request(server()).get("/todos/1").expect(200)).body).not.toHaveProperty("note");
+    @Kavo(Todo, {
+      computed: { slug: { resolve: (todo: Todo) => todo.title?.toLowerCase() ?? null } },
+      dto: { create: CreateTodoDto },
+    })
+    @Controller("todos")
+    class ComputedDtoController {}
+
+    const bind = async (): Promise<unknown> => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          KavoModule.forRoot({ infrastructure: fakeInfrastructure(new InMemoryTodoAdapter()) }),
+          KavoModule.forFeature([ComputedDtoController as never]),
+        ],
+      }).compile();
+      return moduleRef.createNestApplication().init();
+    };
+    await expect(bind()).rejects.toMatchObject({
+      code: "KAVO_CONFIG_INVALID",
+      messageParams: { entity: "Todo", path: "dto.create" },
+    });
   });
 
   it("turns a throwing resolver into problem details without leaking the message", async () => {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -999,6 +999,55 @@ describe("@Kavo relation includes", () => {
   });
 });
 
+/**
+ * ADR-0019 claims `@kavo/nest` needs no changes for computed fields:
+ * generated routes go through the same engine, so the serializer produces
+ * them and the allowlists gate them exactly as they do programmatically.
+ * This is the wire-level evidence for that claim.
+ */
+describe("@Kavo computed fields over the wire (ADR-0019)", () => {
+  @Kavo(Todo, {
+    computed: {
+      slug: { resolve: (todo: Todo) => todo.title.toLowerCase().replaceAll(" ", "-") },
+    },
+  })
+  @Controller("todos")
+  class ComputedController {}
+
+  beforeEach(async () => {
+    await bootstrap(ComputedController);
+    await request(server()).post("/todos").send({ title: "Write Docs", priority: 2 }).expect(201);
+  });
+
+  it("emits the computed field on generated read routes with no DTO registered", async () => {
+    expect((await request(server()).get("/todos/1").expect(200)).body).toMatchObject({
+      title: "Write Docs",
+      slug: "write-docs",
+    });
+    expect((await request(server()).get("/todos").expect(200)).body.items[0]).toMatchObject({ slug: "write-docs" });
+  });
+
+  it("is selectable through the wire fieldset", async () => {
+    const response = await request(server()).get("/todos/1?fields=id,slug").expect(200);
+    expect(response.body).toEqual({ id: 1, slug: "write-docs" });
+  });
+
+  it("is rejected as a filter or sort field with problem details", async () => {
+    for (const query of ["filter[slug][eq]=write-docs", "sort=slug"]) {
+      const response = await request(server()).get(`/todos?${query}`).expect(400);
+      expect(response.body).toMatchObject({
+        code: "KAVO_QUERY_INVALID",
+        errors: [{ field: "slug", code: "KAVO_QUERY_INVALID_FIELD" }],
+      });
+    }
+  });
+
+  it("never reaches the adapter from a request body", async () => {
+    await request(server()).post("/todos").send({ title: "Ship It", slug: "hijacked" }).expect(201);
+    expect(adapter.rows[1]).not.toHaveProperty("slug");
+  });
+});
+
 describe("@Kavo Swagger request-body schemas", () => {
   class CreateTodoDto {
     title = "";

--- a/packages/frameworks/nest/tests/types/kavo-decorator.test-d.ts
+++ b/packages/frameworks/nest/tests/types/kavo-decorator.test-d.ts
@@ -88,3 +88,32 @@ void CompatibleHandlerController;
 @Controller("wrong-entity-todos")
 class WrongEntityController {}
 void WrongEntityController;
+
+// The `Computed` parameter (ADR-0019) is inferred from `computed`'s keys at
+// the decoration site, so an explicit selectable list can name a computed
+// field with no cast.
+@Kavo(Todo, {
+  computed: { slug: { resolve: (todo) => todo.title.toLowerCase() } },
+  allowlists: { selectable: ["id", "title", "slug"] },
+})
+@Controller("computed-todos")
+class ComputedController {}
+void ComputedController;
+
+@Kavo(Todo, {
+  computed: { slug: { resolve: (todo) => todo.title.toLowerCase() } },
+  // @ts-expect-error — and never a filterable one: it has no column.
+  allowlists: { filterable: ["slug"] },
+})
+@Controller("computed-filter-todos")
+class ComputedFilterController {}
+void ComputedFilterController;
+
+@Kavo(Todo, {
+  computed: { slug: { resolve: (todo) => todo.title.toLowerCase() } },
+  // @ts-expect-error — nor a sortable one.
+  allowlists: { sortable: ["slug"] },
+})
+@Controller("computed-sort-todos")
+class ComputedSortController {}
+void ComputedSortController;


### PR DESCRIPTION
## What & why

Kavo's default `item`/`list` projection is built entirely from ORM metadata, so a field derived from other fields — `fullName`, a formatted total, a flag that depends on the caller — had no supported home. The happy-path workaround (register an `item` DTO naming a property the entity class happens to expose as a getter) only worked because `DefaultSerializer` did `if (key in source)`, which is an accident of TypeORM handing the engine class instances: `@kavo/prisma` and `@kavo/mongoose` return plain objects and the same config silently emitted nothing. Nor was the field ever reachable through `fields=`, since `selectable` derives from columns alone.

This adds `EntityConfig.computed` — a record of `ComputedFieldDescriptor<Entity>` keyed by the name each serializes as. `DefaultSerializer` **evaluates** a computed key by calling `resolve(entity, context)` instead of reading it off the row, which makes it uniform across every adapter. Declared fields join the entity-derived projection and the `selectable` allowlist automatically; they are never filterable, sortable, or writable, and those three limits are enforced rather than documented.

No ORM adapter changes were needed, and the reason is stronger than the issue argued: **no adapter consumes `query.fields` at all** (there is zero select pushdown — selection is "kept internally, stripped late"). Rows always arrive fully hydrated, so a computed field's source columns are present even under `fields=fullName`, and no dependency tracking is required.

Closes #121

## Public API impact

**Additive; nothing breaking for callers.**

- **New barrel exports** (ADR-0010's explicit list, plus `tests/barrel.spec.ts`'s manifest): `ComputedFieldDescriptor`, `ComputedFieldMap`.
- **Constructor signatures — the decision (correction #2).** `DefaultSerializer` and `DefaultDeserializer` each take a **new optional third parameter**, `computed: ComputedFieldMap<Entity> = {}`. Both are barrel exports, so this is deliberate: an optional trailing parameter keeps every existing `new DefaultSerializer(metadata, catalog)` call compiling and behaving identically.
  The alternative — reading `context.config.computed` per call — was rejected as *less* explicit, not more: the serializer already takes the root entity's `metadata` in its constructor rather than off the context, and a hand-constructed serializer should behave predictably regardless of what context it is handed. The relation-target path needed **no** signature change at all, since `projectionFor` already pulls the target's `ResolvedEntityConfig` off the `EntityCatalog` and that config now carries `computed`.
- **`ResolvedEntityConfig` gains a required `computed` member.** Kavo produces this type and the serializer/deserializer consume it; the only thing this breaks is code constructing one by hand. Noted in ADR-0019's consequences.
- **`EntityConfig`, `KavoInstance.createCrud`, `createCrud`, and `@Kavo` each gain a trailing type parameter** `Computed extends string = never`. It is inferred, defaults to the pre-existing behavior, and is invisible to every existing call site.

## Testing

`packages/core/tests/computed-fields.spec.ts` (25 cases) covers every criterion the issue lists: present in default `findOne`/`findMany`; evaluated off a plain object (not just a class instance); narrowed out by an item DTO that omits it *and* still evaluated when one names it; selectable through both the typed and wire fieldsets; `selectable: false` opting out into a 400 rather than a silent drop; never joining the filterable/sortable defaults; `KAVO_CONFIG_INVALID` for the filterable, sortable, column-collision, relation-collision and missing-`resolve` cases; stripped from create/update/patch bodies; and resolved on an included relation target through the catalog. `resolve` receiving the real `KavoContext` (principal, correlation id) is pinned too.

`packages/core/tests/types/computed-fields.test-d.ts` pins the inference, with `@ts-expect-error` on `filterable`/`sortable` and on a name no `computed` entry declares.

`packages/frameworks/nest/tests/binding.e2e.spec.ts` gains a wire-level block, which is the actual evidence for the "no `@kavo/nest` changes needed" claim rather than an assertion of it.

Verified locally:

```
pnpm check    →  74 test files passed, 1448 tests passed
                 (generate + build + typecheck + depcruise + lint + test, all green)
pnpm docs:links →  doc links OK — every tracked docs/**.md reference and sidebar link resolves
pnpm docs:build →  build complete
pnpm format:check → All matched files use Prettier code style!
```

## Review notes

**1. The deserializer subtlety (the issue got the rationale wrong).** The issue justified "computed fields are never writable" with "`DefaultDeserializer`'s writable projection is unaffected (already derives from `metadata.fields` only)". That reasoning is false: `deserialize` does `const allowed = dtoShapeKeys(dto) ?? this.writableProjection` — a registered `create`/`update` DTO **replaces** the projection entirely, so a DTO class declaring `fullName` for documentation would have passed the key straight through to the adapter as an unknown write. The requirement stands, but it took new code: the deserializer now holds the computed names and strips them whichever projection is in force. Two tests fail without that strip (verified by disabling it) — `"stays stripped when a registered create DTO names it"` and the direct `DefaultDeserializer` case.

**2. The type-level decision (correction #3).** An explicit `allowlists.selectable` is typed `readonly FieldPath<Entity>[]`, and a computed name is not a path on `Entity` — so without a change, configuring one meant a cast.

I threaded a trailing type parameter, `Computed extends string = never`, through `EntityConfig` → `createCrud` → `@Kavo`. It is inferred from the keys of `computed` (`Readonly<Record<Computed, ComputedFieldDescriptor<Entity>>>`), and `allowlists` sits in a `NoInfer<Computed>` position so listing a real column there cannot widen it and demand a matching `computed` entry.

It widens **only** `selectable`, to `FieldPath<Entity> | Computed`. `filterable`/`sortable` stay typed to real paths, which turns the never-filterable/never-sortable invariant into a compile error *before* it is a bootstrap error — the runtime `ConfigurationException` remains, for erased or cast configs (`@Kavo` erases to `EntityConfig<object>`) and for JS callers.

The tradeoff, stated plainly: a call site that pins all seven earlier generics explicitly gets `Computed = never` and is back to needing a cast for `selectable`. That is rare (the parameters exist to be inferred) and it is the price of not widening `QueryFieldSelector` to `string`, which would have thrown away the misspelling check that `usage-full.test-d.ts` pins today. The issue's "no type-level derivation" stays out of scope in the sense that matters: the *response* type does not grow the key, so a caller wanting it statically typed still registers an `item`/`list` DTO naming it — the same requirement as for any other narrowing.

**3. The ADR (correction #4).** [ADR-0019](docs/internals/adr/0019-computed-fields-are-serializer-evaluated.md) — *Computed fields are serializer-evaluated, and never filterable, sortable, or writable*. It records why the post-fetch placement is the only one available (nothing before response mapping sees both the hydrated entity and the context), and why the filter/sort limit is a permanent rejection rather than a deferral: in-memory predicates silently break pagination (`limit`/`offset` are applied by the database, before the predicate) and `total`. It is wired into the sidebar, into doc 04 §3 (whose "getters/methods never appear" line it supersedes, replaced by a new §7), into doc 05 §4, and into the code comments at each enforcement point.

**4. Left out deliberately.** Automatic type-level derivation of computed keys onto the entity-derived response type (out of scope per the issue, and it would mean synthesizing a response type from a config value, which no other DTO slot does); in-memory post-fetch filtering (explicitly rejected, not deferred); async resolvers (documented as an N+1 hazard, not offered).

**5. Note on a concurrent branch.** `feat/122-list-result-meta` also adds a barrel export. A trivial conflict in `packages/core/src/index.ts` (and `tests/barrel.spec.ts`'s manifest) at merge time is expected.
