### PR TITLE
Apply application/problem+json to every error, not just KavoException

### DIFF
--- a/docs/internals/adr/0009-problem-details-error-shape.md
+++ b/docs/internals/adr/0009-problem-details-error-shape.md
@@ -25,3 +25,9 @@ boundary that maps them.
   hierarchy never changes.
 - `exposeInternals` (off by default) governs whether driver detail leaks
   into `detail`/`cause` output.
+- The `@kavo/nest` filter is registered globally and also normalizes errors
+  that never reach `KavoEngine.execute` (an unmatched route, a global
+  `ValidationPipe`, an unexpected error in application code) into the same
+  problem-details shape, so it stays the _one_ wire error shape for the
+  whole app rather than only for `@Kavo`-generated routes (architecture
+  doc 06 §6).

--- a/docs/internals/architecture/06-error-handling.md
+++ b/docs/internals/architecture/06-error-handling.md
@@ -53,6 +53,8 @@ policy). Source of truth: `ERROR_CATALOG` in
 | `KAVO_PERSISTENCE_FAILED`       | 500  | Unrecognized adapter/driver error                                                                                  | `cause` kept internally           |
 | `KAVO_TRANSACTION_FAILED`       | 500  | Deadlock/serialization failure                                                                                     | `retryable` flag                  |
 | `KAVO_CONFIG_INVALID`           | 500  | Bootstrap config error (fails startup, not a response)                                                             | —                                 |
+| `KAVO_HTTP_ERROR`               | *    | Framework-level `HttpException` reaching the filter without ever going through `KavoEngine.execute` (§6)           | —                                 |
+| `KAVO_UNEXPECTED_ERROR`         | 500  | Any other error reaching the filter without ever going through `KavoEngine.execute` (§6)                           | `cause` kept internally           |
 
 ## 3. Error context & message strategy
 
@@ -84,3 +86,35 @@ document: `type` (`https://kavo.dev/errors/<kebab-code>`), `title` and
 maps it 1:1 with `Content-Type: application/problem+json`; a different
 wire shape means swapping this serializer, never the hierarchy. Core
 never depends on NestJS exceptions — the filter is the boundary.
+
+## 6. Errors that never reach `KavoEngine.execute`
+
+`KavoExceptionFilter` is registered globally (`APP_FILTER`), so it is the
+one error boundary for the whole Nest app, not only `@Kavo`-generated
+routes — a global `ValidationPipe`, an unmatched route, or a bug in
+application code outside a Kavo handler must still answer with
+problem-details (ADR-0009), never Nest's default `{ statusCode, message,
+error }` shape. `@Catch()` (no token) is what makes that possible; the
+filter narrows to HTTP contexts itself (`host.getType() !== "http"`
+rethrows) since a global filter also runs for ws/rpc contexts a
+REST-only framework binding has nothing to map.
+
+`toKavoExceptionShape` (`@kavo/nest/src/unhandled-exception.ts`) adapts
+whatever isn't a `KavoException` into the same `KavoExceptionShape`
+contract `toProblemDetails` already serializes:
+
+- A Nest `HttpException` → `KAVO_HTTP_ERROR`, with the **response's**
+  `status` taken from the exception's own `getStatus()`, not the catalog's
+  (nominal 500) entry — the one place a shape's status legitimately
+  disagrees with its code's catalog row, because Nest already picked the
+  correct one. Its `detail` is the exception's own message (Nest's
+  built-ins, and a `ValidationPipe`'s `message: string[]`, are already
+  meant for a client to see, so this happens regardless of
+  `exposeInternals`).
+- Anything else → `KAVO_UNEXPECTED_ERROR`, fixed at 500, with the original
+  value as `cause` — leaked into `detail` only when `exposeInternals` is
+  on, same as `PersistenceException`.
+
+This mapping lives in `@kavo/nest`, not in the exception hierarchy: these
+are framework-level errors Kavo did not raise and does not own the shape
+of, so no new `KavoException` leaf exists for them.

--- a/packages/core/src/errors/error-catalog.ts
+++ b/packages/core/src/errors/error-catalog.ts
@@ -160,6 +160,22 @@ export const ERROR_CATALOG = {
     title: "Invalid configuration",
     message: "Invalid configuration for entity '{entity}' at '{path}': {problem}",
   },
+  KAVO_HTTP_ERROR: {
+    // Nominal only: this code is never thrown by a `KavoException` leaf, so
+    // nothing in the hierarchy binds a fixed status to it. The `@kavo/nest`
+    // filter uses it to wrap a framework-level `HttpException` (a global
+    // `ValidationPipe`, an unmatched route) that reaches the boundary
+    // un-normalized; the response carries that exception's *own* status,
+    // not this one — see doc 06 §6.
+    status: 500,
+    title: "HTTP error",
+    message: "The request failed before reaching the Kavo engine: {detail}",
+  },
+  KAVO_UNEXPECTED_ERROR: {
+    status: 500,
+    title: "Unexpected error",
+    message: "An unexpected error occurred while processing the request.",
+  },
 } as const satisfies Record<KavoErrorCode, ErrorCatalogEntry>;
 
 /** A code present in the shipped catalog. */

--- a/packages/core/tests/errors.spec.ts
+++ b/packages/core/tests/errors.spec.ts
@@ -46,6 +46,8 @@ const CATALOG: Readonly<Record<CatalogedErrorCode, { status: number; title: stri
   KAVO_PERSISTENCE_FAILED: { status: 500, title: "Persistence failure" },
   KAVO_TRANSACTION_FAILED: { status: 500, title: "Transaction failure" },
   KAVO_CONFIG_INVALID: { status: 500, title: "Invalid configuration" },
+  KAVO_HTTP_ERROR: { status: 500, title: "HTTP error" },
+  KAVO_UNEXPECTED_ERROR: { status: 500, title: "Unexpected error" },
 };
 
 /** Every `KAVO_*` code literal appearing anywhere in core's source. */

--- a/packages/frameworks/nest/src/kavo-exception.filter.ts
+++ b/packages/frameworks/nest/src/kavo-exception.filter.ts
@@ -3,6 +3,7 @@ import { Catch, Inject, Optional } from "@nestjs/common";
 import { KavoException, toProblemDetails } from "@kavo/core";
 import { KAVO_MODULE_OPTIONS } from "./tokens.js";
 import type { KavoModuleOptions } from "./kavo-options.js";
+import { toKavoExceptionShape } from "./unhandled-exception.js";
 
 interface ProblemResponse {
   status(code: number): ProblemResponse;
@@ -11,15 +12,21 @@ interface ProblemResponse {
 }
 
 /**
- * The one boundary between Kavo's exception hierarchy and HTTP:
- * every `KavoException` becomes its RFC 9457 problem-details
- * document with the status from the error catalog. Kavo exceptions never
- * extend Nest's — this filter is the mapping, not inheritance.
+ * The one boundary between HTTP and every error the app can raise: every
+ * `KavoException` becomes its RFC 9457 problem-details document with the
+ * status from the error catalog (ADR-0009), and everything else — a
+ * framework-level `HttpException`, or a genuinely unexpected error that
+ * never passed through `KavoEngine.execute` — is normalized to the same
+ * shape via {@link toKavoExceptionShape} rather than falling through to
+ * Nest's own `{ statusCode, message, error }` default. Kavo exceptions
+ * never extend Nest's — this filter is the mapping, not inheritance.
  *
- * Registered globally by `KavoModule.forRoot`; consumers can also apply
- * it per controller with `@UseFilters`.
+ * Registered globally by `KavoModule.forRoot`, so it governs every route in
+ * the app, not only `@Kavo`-generated ones — that is what "the one wire
+ * error shape" (ADR-0009) means in practice. Consumers can also apply it
+ * per controller with `@UseFilters`.
  */
-@Catch(KavoException)
+@Catch()
 export class KavoExceptionFilter implements ExceptionFilter {
   constructor(
     @Optional()
@@ -27,11 +34,19 @@ export class KavoExceptionFilter implements ExceptionFilter {
     private readonly options?: KavoModuleOptions,
   ) {}
 
-  catch(exception: KavoException, host: ArgumentsHost): void {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    // `@Catch()` with no token runs for every context type Nest supports
+    // (ws, rpc), not only http — `@kavo/nest` only ever generates HTTP
+    // routes, so outside an HTTP context this filter has nothing to map and
+    // must not swallow the exception Nest's own per-transport handling
+    // would otherwise see.
+    if (host.getType() !== "http") throw exception;
+
+    const shape = exception instanceof KavoException ? exception : toKavoExceptionShape(exception);
     const response = host.switchToHttp().getResponse<ProblemResponse>();
-    const body = toProblemDetails(exception, {
+    const body = toProblemDetails(shape, {
       exposeInternals: this.options?.defaults?.errors?.exposeInternals ?? false,
     });
-    response.status(exception.status).type("application/problem+json").json(body);
+    response.status(shape.status).type("application/problem+json").json(body);
   }
 }

--- a/packages/frameworks/nest/src/unhandled-exception.ts
+++ b/packages/frameworks/nest/src/unhandled-exception.ts
@@ -1,0 +1,71 @@
+import { HttpException } from "@nestjs/common";
+import type { KavoExceptionShape } from "@kavo/core";
+import { renderMessage } from "@kavo/core";
+
+/** `HttpException.getResponse()`'s shape when Nest built it from a string/object body. */
+interface HttpExceptionBody {
+  readonly message?: unknown;
+}
+
+function isHttpExceptionBody(value: unknown): value is HttpExceptionBody {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * `HttpException.getResponse()` is a string for `new HttpException("msg", status)`,
+ * or `{ statusCode, message, error }` for Nest's built-ins (`NotFoundException`,
+ * a `ValidationPipe`'s `BadRequestException` with `message: string[]`). Either way
+ * it is text the throw site meant a client to see — Nest's own default handler
+ * would have shown it verbatim — so it is safe to surface regardless of
+ * `exposeInternals`.
+ */
+function messageFrom(exception: HttpException): string {
+  const response = exception.getResponse();
+  if (typeof response === "string") return response;
+  if (isHttpExceptionBody(response)) {
+    const { message } = response;
+    if (typeof message === "string") return message;
+    if (Array.isArray(message)) return message.join(" ");
+  }
+  return exception.message;
+}
+
+/**
+ * Wraps whatever reaches `KavoExceptionFilter` that is not a `KavoException`
+ * into the same `KavoExceptionShape` contract `toProblemDetails` serializes,
+ * so problem-details stays the one wire error shape (ADR-0009) even for
+ * errors that never passed through `KavoEngine.execute` — a global
+ * `ValidationPipe`, an unmatched route, a guard, or a bug in application
+ * code outside a Kavo handler.
+ *
+ * Never adds a `KavoException` subclass for this: these are framework-level
+ * errors Kavo did not raise and does not own the shape of, so the mapping
+ * lives at the HTTP boundary, not in the hierarchy (see doc 06 §6).
+ */
+export function toKavoExceptionShape(exception: unknown): KavoExceptionShape {
+  if (exception instanceof HttpException) {
+    const detail = messageFrom(exception);
+    return {
+      code: "KAVO_HTTP_ERROR",
+      // The catalog's status for this code is nominal (see its comment) —
+      // this is the one place a shape's status legitimately disagrees with
+      // its code's catalog entry, because the original `HttpException`
+      // already picked the correct one.
+      status: exception.getStatus(),
+      messageKey: "KAVO_HTTP_ERROR",
+      messageParams: { detail },
+      detail: renderMessage("KAVO_HTTP_ERROR", { detail }),
+      context: {},
+    };
+  }
+
+  return {
+    code: "KAVO_UNEXPECTED_ERROR",
+    status: 500,
+    messageKey: "KAVO_UNEXPECTED_ERROR",
+    messageParams: {},
+    detail: renderMessage("KAVO_UNEXPECTED_ERROR", {}),
+    context: {},
+    cause: exception,
+  };
+}

--- a/packages/frameworks/nest/src/unhandled-exception.ts
+++ b/packages/frameworks/nest/src/unhandled-exception.ts
@@ -16,8 +16,12 @@ function isHttpExceptionBody(value: unknown): value is HttpExceptionBody {
  * or `{ statusCode, message, error }` for Nest's built-ins (`NotFoundException`,
  * a `ValidationPipe`'s `BadRequestException` with `message: string[]`). Either way
  * it is text the throw site meant a client to see — Nest's own default handler
- * would have shown it verbatim — so it is safe to surface regardless of
- * `exposeInternals`.
+ * would have shown it verbatim, with no `exposeInternals`-equivalent gate of
+ * its own — so surfacing it here regardless of `exposeInternals` mirrors
+ * Nest's existing behavior rather than exposing anything new. It is *not*
+ * governed by `errors.exposeInternals` the way `KAVO_UNEXPECTED_ERROR`'s
+ * `cause` is below — an app throwing `HttpException`s with internal detail
+ * in the message was already showing that detail before this filter existed.
  */
 function messageFrom(exception: HttpException): string {
   const response = exception.getResponse();

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -867,6 +867,14 @@ describe("KavoExceptionFilter — errors that never reach KavoEngine.execute", (
       .expect("Content-Type", /application\/problem\+json/);
     expect(response.body).toMatchObject({ code: "KAVO_HTTP_ERROR", status: 404 });
   });
+
+  it("never reports a correlation instance for either synthetic code, unlike a KavoException", async () => {
+    await bootstrapDiagnostics();
+    const httpError = await request(server()).get("/diagnostics/boom-http").expect(404);
+    const unexpectedError = await request(server()).get("/diagnostics/boom-unexpected").expect(500);
+    expect(httpError.body).not.toHaveProperty("instance");
+    expect(unexpectedError.body).not.toHaveProperty("instance");
+  });
 });
 
 describe("@Kavo soft-delete routes", () => {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import request from "supertest";
-import { Controller, Get, Inject, Param, type INestApplication } from "@nestjs/common";
+import { Controller, Get, Inject, NotFoundException, Param, type INestApplication } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { Test } from "@nestjs/testing";
 import type { DefaultKavoService, NormalizedQueryContext, OperationHandler } from "@kavo/core";
@@ -788,6 +788,84 @@ describe("KavoExceptionFilter — non-Kavo handler failures", () => {
     await bootstrap(ExplodingController);
     const response = await request(server()).post("/todos").send({ title: "x" }).expect(500);
     expect(response.body.instance).toMatch(/^urn:kavo:request:/);
+  });
+});
+
+describe("KavoExceptionFilter — errors that never reach KavoEngine.execute", () => {
+  // No `@Kavo` here on purpose, and registered as an ordinary Nest
+  // controller rather than through `KavoModule.forFeature` (which only
+  // accepts `@Kavo` classes): the filter is registered globally
+  // (`APP_FILTER`), so it must also normalize errors from a controller that
+  // has nothing to do with Kavo.
+  @Controller("diagnostics")
+  class DiagnosticsController {
+    @Get("boom-http")
+    boomHttp(): never {
+      throw new NotFoundException("no boom here");
+    }
+
+    @Get("boom-unexpected")
+    boomUnexpected(): never {
+      throw new Error("totally unexpected crash");
+    }
+  }
+
+  async function bootstrapDiagnostics(options: BootstrapOptions = {}): Promise<void> {
+    adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), defaults: options.defaults })],
+      controllers: [DiagnosticsController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    httpServer = await listen(app);
+  }
+
+  it("wraps a Nest HttpException thrown outside the engine as problem-details, keeping its own status", async () => {
+    await bootstrapDiagnostics();
+    const response = await request(server())
+      .get("/diagnostics/boom-http")
+      .expect(404)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body).toMatchObject({
+      type: "https://kavo.dev/errors/kavo-http-error",
+      status: 404,
+      code: "KAVO_HTTP_ERROR",
+    });
+    expect(response.body.detail).toContain("no boom here");
+  });
+
+  it("wraps an unrecognized thrown error as problem-details at 500", async () => {
+    await bootstrapDiagnostics();
+    const response = await request(server())
+      .get("/diagnostics/boom-unexpected")
+      .expect(500)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body).toMatchObject({
+      type: "https://kavo.dev/errors/kavo-unexpected-error",
+      status: 500,
+      code: "KAVO_UNEXPECTED_ERROR",
+    });
+  });
+
+  it("keeps the unrecognized error's message out of the body while exposeInternals is off", async () => {
+    await bootstrapDiagnostics();
+    const response = await request(server()).get("/diagnostics/boom-unexpected").expect(500);
+    expect(JSON.stringify(response.body)).not.toContain("totally unexpected crash");
+  });
+
+  it("leaks the unrecognized error's message only when exposeInternals is turned on", async () => {
+    await bootstrapDiagnostics({ defaults: { errors: { exposeInternals: true } } });
+    const response = await request(server()).get("/diagnostics/boom-unexpected").expect(500);
+    expect(response.body.detail).toContain("totally unexpected crash");
+  });
+
+  it("answers an unmatched route with problem-details too, since the filter is global", async () => {
+    await bootstrapDiagnostics();
+    const response = await request(server())
+      .get("/does-not-exist")
+      .expect(404)
+      .expect("Content-Type", /application\/problem\+json/);
+    expect(response.body).toMatchObject({ code: "KAVO_HTTP_ERROR", status: 404 });
   });
 });
 

--- a/packages/frameworks/nest/tests/kavo-exception.filter.spec.ts
+++ b/packages/frameworks/nest/tests/kavo-exception.filter.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import type { ArgumentsHost } from "@nestjs/common";
+import { KavoExceptionFilter } from "../src/kavo-exception.filter.js";
+
+/** A minimal stand-in for a non-HTTP `ArgumentsHost` (ws/rpc) — no real transport needed. */
+function fakeNonHttpHost(type: "ws" | "rpc"): ArgumentsHost {
+  return {
+    getType: () => type,
+    switchToHttp: () => {
+      throw new Error("switchToHttp must never be called for a non-http context");
+    },
+  } as unknown as ArgumentsHost;
+}
+
+describe("KavoExceptionFilter — non-HTTP contexts", () => {
+  it.each(["ws", "rpc"] as const)(
+    "rethrows the original exception untouched for a %s context, without touching the response",
+    (type) => {
+      const filter = new KavoExceptionFilter();
+      const original = new Error("microservice failure");
+      expect(() => filter.catch(original, fakeNonHttpHost(type))).toThrow(original);
+    },
+  );
+});

--- a/packages/frameworks/nest/tests/unhandled-exception.spec.ts
+++ b/packages/frameworks/nest/tests/unhandled-exception.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { toKavoExceptionShape } from "../src/unhandled-exception.js";
+
+describe("toKavoExceptionShape", () => {
+  it("maps a string-body HttpException to KAVO_HTTP_ERROR at its own status", () => {
+    const shape = toKavoExceptionShape(new NotFoundException("no boom here"));
+    expect(shape.code).toBe("KAVO_HTTP_ERROR");
+    expect(shape.status).toBe(404);
+    expect(shape.detail).toContain("no boom here");
+  });
+
+  it("joins an array `message` (ValidationPipe shape) into one detail string", () => {
+    const shape = toKavoExceptionShape(new BadRequestException(["title must be a string", "title is required"]));
+    expect(shape.status).toBe(400);
+    expect(shape.detail).toContain("title must be a string");
+    expect(shape.detail).toContain("title is required");
+  });
+
+  it("maps a plain thrown Error to KAVO_UNEXPECTED_ERROR at 500, keeping it as the cause", () => {
+    const original = new Error("db pool exhausted");
+    const shape = toKavoExceptionShape(original);
+    expect(shape.code).toBe("KAVO_UNEXPECTED_ERROR");
+    expect(shape.status).toBe(500);
+    expect(shape.cause).toBe(original);
+    expect(shape.detail).not.toContain("db pool exhausted");
+  });
+
+  it("maps a non-Error thrown value to KAVO_UNEXPECTED_ERROR without throwing itself", () => {
+    const shape = toKavoExceptionShape("just a string throw");
+    expect(shape.code).toBe("KAVO_UNEXPECTED_ERROR");
+    expect(shape.status).toBe(500);
+    expect(shape.cause).toBe("just a string throw");
+  });
+});

--- a/packages/frameworks/nest/tests/unhandled-exception.spec.ts
+++ b/packages/frameworks/nest/tests/unhandled-exception.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { BadRequestException, HttpException, NotFoundException } from "@nestjs/common";
 import { toKavoExceptionShape } from "../src/unhandled-exception.js";
 
 describe("toKavoExceptionShape", () => {
@@ -26,10 +26,26 @@ describe("toKavoExceptionShape", () => {
     expect(shape.detail).not.toContain("db pool exhausted");
   });
 
-  it("maps a non-Error thrown value to KAVO_UNEXPECTED_ERROR without throwing itself", () => {
-    const shape = toKavoExceptionShape("just a string throw");
+  it.each([
+    ["a string", "just a string throw"],
+    ["null", null],
+    ["undefined", undefined],
+    ["a plain object", { reason: "not an Error at all" }],
+  ])("maps %s thrown value to KAVO_UNEXPECTED_ERROR without throwing itself", (_label, thrown) => {
+    const shape = toKavoExceptionShape(thrown);
     expect(shape.code).toBe("KAVO_UNEXPECTED_ERROR");
     expect(shape.status).toBe(500);
-    expect(shape.cause).toBe("just a string throw");
+    expect(shape.cause).toBe(thrown);
+  });
+
+  it("falls back to the HttpException's own .message when getResponse() has no message field", () => {
+    const shape = toKavoExceptionShape(new HttpException({ statusCode: 400 }, 400));
+    expect(shape.status).toBe(400);
+    expect(shape.detail.length).toBeGreaterThan(0);
+  });
+
+  it("never sets a correlation instance for either synthetic shape", () => {
+    expect(toKavoExceptionShape(new NotFoundException("x")).context.correlationId).toBeUndefined();
+    expect(toKavoExceptionShape(new Error("x")).context.correlationId).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What & why

`KavoExceptionFilter` was `@Catch(KavoException)` only, so anything that reached it without first passing through `KavoEngine.execute` — a global `ValidationPipe`'s `HttpException`, an unmatched route's 404, or a genuinely unexpected error thrown outside a Kavo handler — fell through to Nest's default `{ statusCode, message, error }` shape instead of RFC 9457 problem-details, contradicting ADR-0009's "one wire error shape" decision.

The filter now catches everything (`@Catch()`), and a new `toKavoExceptionShape()` in `@kavo/nest` maps whatever isn't a `KavoException` into the same `KavoExceptionShape` contract `toProblemDetails` already serializes: a Nest `HttpException` becomes `KAVO_HTTP_ERROR` (keeping its own real status), anything else becomes `KAVO_UNEXPECTED_ERROR` (fixed 500, cause gated by `exposeInternals` same as `PersistenceException`). Since the filter is a global `APP_FILTER`, it also now guards non-HTTP `ArgumentsHost` contexts (ws/rpc) by rethrowing rather than trying to map them.

Closes #132

## Public API impact

None — no barrel export changes. Two additive entries in the (already-public) error-code catalog: `KAVO_HTTP_ERROR`, `KAVO_UNEXPECTED_ERROR`.

## Testing

- New `packages/frameworks/nest/tests/unhandled-exception.spec.ts`: unit tests for the mapping function (string/object/array-message `HttpException` bodies, plain `Error`, non-`Error` thrown values).
- New e2e cases in `packages/frameworks/nest/tests/binding.e2e.spec.ts`: a plain (non-`@Kavo`) controller registered alongside `KavoModule` proves the filter's reach is app-wide — covers a Nest `HttpException` keeping its real status, an unrecognized thrown error at 500, `exposeInternals` on/off, and an unmatched route.
- Extended the pinned catalog test in `packages/core/tests/errors.spec.ts` with the two new codes.
- `pnpm check`: build/typecheck/depcruise/lint all green; 1391 tests passing. The only failures are 5 pre-existing `examples/nest-*` e2e suites that need a Docker container runtime unavailable in this sandbox (Postgres/MariaDB/CockroachDB/Mongo) — unrelated to this change, none of those files are touched here.
- `pnpm docs:links`: green.

## Review notes

Worth a close look: `KAVO_HTTP_ERROR`'s catalog entry carries a nominal status (500) since `ERROR_CATALOG` entries are normally fixed-per-code, but the actual response status comes from the wrapped `HttpException.getStatus()` — this is the one place a shape's `status` legitimately disagrees with its code's catalog row. Documented in `docs/internals/architecture/06-error-handling.md` §6 and `ADR-0009`.