### PR TITLE
test: close the measured coverage gaps and gate coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,35 @@ jobs:
       - name: Test
         run: pnpm run generate && pnpm run test
 
+  # Deliberately its own job rather than a step in `pnpm check`. It re-runs
+  # the whole suite under v8 instrumentation, so folding it into the gate
+  # would roughly double the command developers run all day for a signal
+  # that only matters per push. A single node version is enough: coverage
+  # measures which lines the suite reaches, which does not vary by runtime.
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "lts/*"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Fails on the thresholds in `vitest.coverage.config.ts`, so coverage
+      # can only ratchet up. `generate` for the same reason the `test` job
+      # needs it.
+      - name: Coverage
+        run: pnpm run generate && pnpm run test:coverage
+
   format:
     name: format
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.coverage/
 .claude/worktrees/
 .vitepress/cache/
 *.tsbuildinfo

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+.coverage/
 *.tsbuildinfo
 pnpm-lock.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ pnpm check        # the full gate: generate (Prisma client + fixture schema) + b
 pnpm build        # tsc -b (project references across the workspace — src only)
 pnpm typecheck    # tsc --noEmit over the root tests/ plus every package's and example's tests/ (tsconfig.tests.json)
 pnpm test         # vitest run (whole monorepo)
+pnpm test:coverage # the same suite under v8 coverage, failing on the thresholds in vitest.coverage.config.ts — its own CI job, deliberately not part of `check`
 pnpm depcruise    # enforce package-boundary rules (.dependency-cruiser.cjs)
 pnpm lint         # oxlint over packages/*, examples/*, tests/ and .github/scripts/
 pnpm prettify     # prettier --write . (printWidth 120)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,8 @@ all day for a signal that only matters per push — so it gets its own CI job
 instead. Run it locally when you want to see what a change left untested;
 `.coverage/index.html` is the browsable report.
 
-The thresholds are a ratchet, not a target, and they are deliberately not 100. Some of what remains uncovered is unreachable by construction —
+The thresholds are a ratchet, not a target, and they are deliberately not set
+at 100. Some of what remains uncovered is unreachable by construction —
 `assertNever` arms over closed unions, `??` fallbacks the calling layer has
 already collapsed, guards behind a precondition that makes them dead — and a
 test that forces its way into one of those asserts the shape of the code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,20 @@ It runs, in order:
 | `lint`      | `oxlint`                       | Lint rules over `packages` and `examples`           |
 | `test`      | `vitest run`                   | The whole suite                                     |
 
+`pnpm test:coverage` is not in that list on purpose. It runs the same suite
+under v8 instrumentation and fails on the thresholds in
+`vitest.coverage.config.ts`, which would roughly double the command you run
+all day for a signal that only matters per push — so it gets its own CI job
+instead. Run it locally when you want to see what a change left untested;
+`.coverage/index.html` is the browsable report.
+
+The thresholds are a ratchet, not a target, and they are deliberately not 100. Some of what remains uncovered is unreachable by construction —
+`assertNever` arms over closed unions, `??` fallbacks the calling layer has
+already collapsed, guards behind a precondition that makes them dead — and a
+test that forces its way into one of those asserts the shape of the code
+rather than any behavior. Raise the numbers when real coverage rises; don't
+chase the gap.
+
 Note that `typecheck` is a hand-maintained list — the root script names each
 project's `tsconfig.tests.json` explicitly, with no glob and no discovery. **If
 you add a package, or add a first `tests/` directory to one, append it to the

--- a/docs/internals/architecture/02-monorepo-and-packages.md
+++ b/docs/internals/architecture/02-monorepo-and-packages.md
@@ -174,12 +174,16 @@ packages or expensive non-tsc pipelines (a future e2e suite is the
 natural checkpoint).
 
 Root scripts: `generate`, `build` (`tsc -b`), `clean`, `typecheck`,
-`depcruise`, `lint`, `test`, `prettify`, `format:check`, `docs:build`,
-`docs:links`, and `check` — the last runs `generate → build → typecheck →
-depcruise → lint → test` and is the verification gate. Three checks sit
-outside it, each as its own CI job: `format:check`, `docs:build` (VitePress,
-which resolves the links inside the pages it renders), and `docs:links`
-(`scripts/check-doc-links.sh`). The last two are complements, not overlaps —
+`depcruise`, `lint`, `test`, `test:coverage`, `prettify`, `format:check`,
+`docs:build`, `docs:links`, and `check` — the last runs `generate → build →
+typecheck → depcruise → lint → test` and is the verification gate. Four
+checks sit outside it, each as its own CI job: `test:coverage` (the same
+suite under v8 instrumentation, failing on the thresholds in
+`vitest.coverage.config.ts` — kept out of the gate because instrumenting a
+second full run doubles the command developers run all day),
+`format:check`, `docs:build` (VitePress, which resolves the links inside the
+pages it renders), and `docs:links` (`scripts/check-doc-links.sh`). The last
+two are complements, not overlaps —
 the docs build never sees a `docs/**.md` reference written from `packages/`
 or `extensions/`, because those are not pages, and it never reads
 `docs/.vitepress/config.mts`, because that is config rather than content. So

--- a/examples/nest-typeorm/tests/pagination-caching.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/pagination-caching.e2e.spec.ts
@@ -1,0 +1,308 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Column, DataSource, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Controller, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { Kavo, KavoModule } from "@kavo/nest";
+import { createInfrastructure } from "@kavo/typeorm";
+import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
+
+/**
+ * Cursor pagination, `since` pagination, and ETag conditional requests,
+ * driven over real HTTP against a real database.
+ *
+ * Each of the three is well covered a layer at a time — core's engine
+ * specs against an in-memory adapter, and (for cursor) each ORM's own
+ * suite against SQLite — but nothing ran the whole path: query string →
+ * `WireQuery` → normalizer → keyset predicate → SQL → envelope →
+ * `meta.nextCursor`/`meta.nextSince` → the client's next request. A token
+ * that survives every unit test and still fails to round-trip through a
+ * URL and a driver is exactly the bug this file exists to catch.
+ *
+ * It builds its own module rather than reusing `AppModule`: the reference
+ * app is adopter-facing documentation and should keep showing the default
+ * offset paging, not carry three extra entities that exist for a test.
+ */
+
+@Entity()
+class Reading {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  label!: string;
+
+  /** Set explicitly by the seeds, so several rows can share a timestamp. */
+  @Column("datetime")
+  recordedAt!: Date;
+}
+
+@Kavo(Reading, {
+  pagination: { strategy: "cursor", defaultLimit: 20, maxLimit: 100 },
+  query: { defaultSort: [{ field: "id", direction: "asc" }] },
+} as never)
+@Controller("cursor-readings")
+class CursorReadingController {}
+
+@Kavo(Reading, {
+  pagination: { strategy: "since", since: { field: "recordedAt" }, defaultLimit: 20, maxLimit: 100 },
+} as never)
+@Controller("since-readings")
+class SinceReadingController {}
+
+@Kavo(Reading, { caching: { etag: true } } as never)
+@Controller("cached-readings")
+class CachedReadingController {}
+
+let dataSource: DataSource;
+let app: INestApplication;
+let httpServer: SupertestTarget | undefined;
+
+beforeAll(async () => {
+  dataSource = new DataSource({
+    type: "better-sqlite3",
+    database: ":memory:",
+    entities: [Reading],
+    synchronize: true,
+  });
+  await dataSource.initialize();
+
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      KavoModule.forRoot({ infrastructure: createInfrastructure(dataSource) }),
+      KavoModule.forFeature([CursorReadingController, SinceReadingController, CachedReadingController]),
+    ],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  httpServer = await listen(app);
+});
+
+afterAll(async () => {
+  httpServer = undefined;
+  if (app !== undefined) await app.close();
+  if (dataSource !== undefined) await dataSource.destroy();
+});
+
+beforeEach(async () => {
+  await dataSource.getRepository(Reading).clear();
+});
+
+function server(): SupertestTarget {
+  return boundServer(httpServer);
+}
+
+const BASE = new Date("2024-01-01T00:00:00.000Z");
+
+/** `count` rows, one minute apart, through the ordinary create route. */
+async function seed(count: number, path = "cursor-readings"): Promise<void> {
+  for (let index = 1; index <= count; index++) {
+    await request(server())
+      .post(`/${path}`)
+      .send({ label: `r-${index}`, recordedAt: new Date(BASE.getTime() + index * 60_000).toISOString() })
+      .expect(201);
+  }
+}
+
+describe("cursor pagination over HTTP", () => {
+  it("walks every row exactly once, in order, following nextCursor", async () => {
+    await seed(7);
+
+    const labels: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    for (;;) {
+      const query = cursor === null ? "?limit=3" : `?limit=3&cursor=${encodeURIComponent(cursor)}`;
+      const response = await request(server()).get(`/cursor-readings${query}`).expect(200);
+      pages++;
+      labels.push(...(response.body.items as { label: string }[]).map((item) => item.label));
+      cursor = (response.body.meta?.nextCursor ?? null) as string | null;
+      if (cursor === null) break;
+      if (pages > 20) throw new Error("cursor paging did not terminate");
+    }
+
+    expect(labels).toEqual(["r-1", "r-2", "r-3", "r-4", "r-5", "r-6", "r-7"]);
+    expect(pages).toBe(3);
+  });
+
+  it("emits a token that survives URL encoding intact", async () => {
+    // The whole point of driving this over HTTP: a base64url token has to
+    // reach the server byte-identical after a round trip through a query
+    // string, or page two silently restarts at page one.
+    await seed(4);
+
+    const first = await request(server()).get("/cursor-readings?limit=2").expect(200);
+    const token = first.body.meta.nextCursor as string;
+
+    const second = await request(server())
+      .get(`/cursor-readings?limit=2&cursor=${encodeURIComponent(token)}`)
+      .expect(200);
+    expect((second.body.items as { label: string }[]).map((item) => item.label)).toEqual(["r-3", "r-4"]);
+  });
+
+  it("reports nextCursor: null on the last page rather than omitting it", async () => {
+    await seed(2);
+
+    const page = await request(server()).get("/cursor-readings?limit=5").expect(200);
+    expect(page.body.items).toHaveLength(2);
+    expect(page.body.meta).toHaveProperty("nextCursor");
+    expect(page.body.meta.nextCursor).toBeNull();
+  });
+
+  it("answers a tampered cursor with problem details, not a 500", async () => {
+    await seed(2);
+
+    const response = await request(server()).get("/cursor-readings?limit=2&cursor=not-a-real-token").expect(400);
+    expect(response.headers["content-type"]).toContain("application/problem+json");
+    expect(response.body).toMatchObject({ status: 400 });
+  });
+
+  it("ignores an offset param — the cursor alone decides the position", async () => {
+    // Asymmetric with the reverse case on purpose, and worth pinning
+    // because it is easy to misread: a `cursor` sent under offset paging
+    // is a 400 (`KAVO_QUERY_UNSUPPORTED_PARAM`), but `offset` sent under
+    // cursor paging is dropped, because `CursorPaginationStrategy` reads
+    // only `limit` and `cursor`. A client mixing the two gets page one.
+    await seed(3);
+
+    const response = await request(server()).get("/cursor-readings?limit=2&offset=1").expect(200);
+    expect((response.body.items as { label: string }[]).map((item) => item.label)).toEqual(["r-1", "r-2"]);
+  });
+});
+
+describe("since pagination over HTTP", () => {
+  it("polls forward through nextSince without repeating or skipping a row", async () => {
+    await seed(6, "since-readings");
+
+    const labels: string[] = [];
+    let since: string | null = null;
+    let polls = 0;
+    for (;;) {
+      const query = since === null ? "?limit=2" : `?limit=2&since=${encodeURIComponent(since)}`;
+      const response = await request(server()).get(`/since-readings${query}`).expect(200);
+      polls++;
+      const page = response.body.items as { label: string }[];
+      labels.push(...page.map((item) => item.label));
+      since = (response.body.meta?.nextSince ?? null) as string | null;
+      if (since === null || page.length === 0) break;
+      if (polls > 20) throw new Error("since paging did not terminate");
+    }
+
+    expect(labels).toEqual(["r-1", "r-2", "r-3", "r-4", "r-5", "r-6"]);
+  });
+
+  it("emits a human-readable value|id token, unlike cursor's opaque blob", async () => {
+    // ADR-0022 makes this token deliberately legible so an operator can
+    // read a poll position out of a log line. Pinning the shape here keeps
+    // that promise from eroding into an opaque encoding.
+    await seed(2, "since-readings");
+
+    const page = await request(server()).get("/since-readings?limit=1").expect(200);
+    expect(page.body.meta.nextSince).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\|\d+$/);
+  });
+
+  it("returns nothing new when polled with the boundary it just issued", async () => {
+    await seed(3, "since-readings");
+
+    const first = await request(server()).get("/since-readings?limit=10").expect(200);
+    expect(first.body.items).toHaveLength(3);
+
+    const caughtUp = await request(server())
+      .get(`/since-readings?limit=10&since=${encodeURIComponent(first.body.meta.nextSince as string)}`)
+      .expect(200);
+    expect(caughtUp.body.items).toEqual([]);
+  });
+
+  it("picks up a row written after the boundary was issued", async () => {
+    await seed(2, "since-readings");
+    const first = await request(server()).get("/since-readings?limit=10").expect(200);
+    const boundary = first.body.meta.nextSince as string;
+
+    await request(server())
+      .post("/since-readings")
+      .send({ label: "r-late", recordedAt: new Date(BASE.getTime() + 99 * 60_000).toISOString() })
+      .expect(201);
+
+    const polled = await request(server())
+      .get(`/since-readings?limit=10&since=${encodeURIComponent(boundary)}`)
+      .expect(200);
+    expect((polled.body.items as { label: string }[]).map((item) => item.label)).toEqual(["r-late"]);
+  });
+
+  it("answers a malformed since token with problem details", async () => {
+    await seed(1, "since-readings");
+
+    const response = await request(server()).get("/since-readings?since=no-pipe-here").expect(400);
+    expect(response.headers["content-type"]).toContain("application/problem+json");
+  });
+});
+
+describe("ETag conditional requests over HTTP", () => {
+  async function createReading(label = "etag"): Promise<{ id: number; etag: string }> {
+    const created = await request(server())
+      .post("/cached-readings")
+      .send({ label, recordedAt: BASE.toISOString() })
+      .expect(201);
+    const id = created.body.id as number;
+    const read = await request(server()).get(`/cached-readings/${id}`).expect(200);
+    return { id, etag: read.headers["etag"] as string };
+  }
+
+  it("serves an ETag on a single-item read", async () => {
+    const { etag } = await createReading();
+    expect(etag).toMatch(/^"[^"]+"$/);
+  });
+
+  it("answers 304 with no body when the client already has that version", async () => {
+    const { id, etag } = await createReading();
+
+    const response = await request(server()).get(`/cached-readings/${id}`).set("If-None-Match", etag).expect(304);
+    expect(response.body).toEqual({});
+  });
+
+  it("serves 200 again once the row changes, with a different tag", async () => {
+    const { id, etag } = await createReading();
+
+    await request(server()).patch(`/cached-readings/${id}`).send({ label: "changed" }).expect(200);
+
+    const response = await request(server()).get(`/cached-readings/${id}`).set("If-None-Match", etag).expect(200);
+    expect(response.headers["etag"]).not.toBe(etag);
+    expect(response.body).toMatchObject({ label: "changed" });
+  });
+
+  it("accepts a write whose If-Match names the current version", async () => {
+    const { id, etag } = await createReading();
+
+    await request(server()).patch(`/cached-readings/${id}`).set("If-Match", etag).send({ label: "ok" }).expect(200);
+  });
+
+  it("refuses a write whose If-Match names a stale version, leaving the row untouched", async () => {
+    // The lost-update case the precondition exists for: two clients read
+    // the same row, both write, and the second must be told rather than
+    // silently overwriting the first.
+    const { id, etag } = await createReading();
+    await request(server()).patch(`/cached-readings/${id}`).send({ label: "first writer" }).expect(200);
+
+    await request(server())
+      .patch(`/cached-readings/${id}`)
+      .set("If-Match", etag)
+      .send({ label: "second writer" })
+      .expect(412);
+
+    const current = await request(server()).get(`/cached-readings/${id}`).expect(200);
+    expect(current.body.label).toBe("first writer");
+  });
+
+  it("reports a 412 as problem details rather than a bare status", async () => {
+    const { id, etag } = await createReading();
+    await request(server()).patch(`/cached-readings/${id}`).send({ label: "moved on" }).expect(200);
+
+    const response = await request(server())
+      .patch(`/cached-readings/${id}`)
+      .set("If-Match", etag)
+      .send({ label: "stale" })
+      .expect(412);
+    expect(response.headers["content-type"]).toContain("application/problem+json");
+    expect(response.body).toMatchObject({ status: 412 });
+  });
+});

--- a/examples/nest-typeorm/tests/pagination-caching.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/pagination-caching.e2e.spec.ts
@@ -41,17 +41,17 @@ class Reading {
 @Kavo(Reading, {
   pagination: { strategy: "cursor", defaultLimit: 20, maxLimit: 100 },
   query: { defaultSort: [{ field: "id", direction: "asc" }] },
-} as never)
+})
 @Controller("cursor-readings")
 class CursorReadingController {}
 
 @Kavo(Reading, {
   pagination: { strategy: "since", since: { field: "recordedAt" }, defaultLimit: 20, maxLimit: 100 },
-} as never)
+})
 @Controller("since-readings")
 class SinceReadingController {}
 
-@Kavo(Reading, { caching: { etag: true } } as never)
+@Kavo(Reading, { caching: { etag: true } })
 @Controller("cached-readings")
 class CachedReadingController {}
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "depcruise": "depcruise packages examples --config .dependency-cruiser.cjs",
     "generate": "pnpm --filter @kavo/prisma run generate",
     "test": "vitest run",
+    "test:coverage": "vitest run --config vitest.coverage.config.ts",
     "typecheck": "tsc -p tsconfig.tests.json && tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/orms/prisma/tsconfig.tests.json && tsc -p packages/orms/mongoose/tsconfig.tests.json && tsc -p packages/orms/mikroorm/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/protocols/mcp/tsconfig.tests.json && tsc -p examples/nest-typeorm/tsconfig.tests.json && tsc -p examples/nest-mongoose/tsconfig.tests.json && tsc -p examples/nest-mikroorm/tsconfig.tests.json",
     "lint": "oxlint packages examples tests .github/scripts",
     "prettify": "prettier --write .",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@swc/core": "^1.15.47",
     "@types/node": "^22.20.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "dependency-cruiser": "^18.1.0",
     "mermaid": "^11.16.1",
     "oxlint": "^1.76.0",

--- a/packages/core/tests/config-validation.spec.ts
+++ b/packages/core/tests/config-validation.spec.ts
@@ -302,3 +302,16 @@ describe("validateSettings — the base of the precedence chain", () => {
     }
   });
 });
+
+describe("validateSettings — pagination.since.field", () => {
+  // The since boundary column is a field *name*, and it is read back off a
+  // row to build `meta.nextSince`. An empty or non-string name would fail
+  // deep inside normalization on the first request instead of at bootstrap.
+  it.each(["", null, 1, false])("rejects %o as a since field name", (value) => {
+    expectRejected({ pagination: { since: { field: value } } }, "pagination.since.field", value);
+  });
+
+  it("accepts a non-empty field name", () => {
+    accept({ pagination: { since: { field: "updatedAt" } } });
+  });
+});

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -16,6 +16,20 @@ describe("mergeSettings — merge algebra", () => {
     expect(merged.query.maxFilterDepth).toBe(3);
   });
 
+  it("skips a key whose override value is explicitly undefined", () => {
+    // This is what makes it safe for a framework layer to spread an
+    // options object with optional keys into a settings override: an
+    // absent option must not erase the scope above it. `false` still
+    // disables (see the next test); only `undefined` means "no opinion".
+    const merged = mergeSettings(BUILT_IN_DEFAULTS, { pagination: { count: undefined } });
+    expect(merged.pagination.count).toBe(BUILT_IN_DEFAULTS.pagination.count);
+  });
+
+  it("distinguishes an undefined override from a false one", () => {
+    expect(mergeSettings(BUILT_IN_DEFAULTS, { pagination: { count: undefined } }).pagination.count).toBe(true);
+    expect(mergeSettings(BUILT_IN_DEFAULTS, { pagination: { count: false } }).pagination.count).toBe(false);
+  });
+
   it("lets `false` disable an inheritable feature", () => {
     const merged = mergeSettings(BUILT_IN_DEFAULTS, { softDelete: false });
     expect(merged.softDelete).toBe(false);

--- a/packages/core/tests/context-state.spec.ts
+++ b/packages/core/tests/context-state.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import type { KavoContext, StateKey } from "@kavo/core";
+import { DefaultKavoContextState, createKavo, createKavoContext } from "@kavo/core";
+import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
+
+/**
+ * The per-request state bag (`context.state`), which is public
+ * barrel-exported API that core itself never reads. Nothing in the engine
+ * touches it: it exists so an overriding or custom handler can thread a
+ * value between pipeline stages of one request, which makes the
+ * request-scoping guarantee below the whole point of the feature rather
+ * than an implementation detail.
+ *
+ * `StateKey<T>` is a branded symbol, so the keys are declared the way the
+ * `KavoContextState` doc comment declares them.
+ */
+const StartedAt = Symbol("startedAt") as StateKey<Date>;
+const Attempts = Symbol("attempts") as StateKey<number>;
+const Absent = Symbol("absent") as StateKey<string>;
+
+function makeCrud(config?: Parameters<ReturnType<typeof createKavo>["createCrud"]>[1]) {
+  const adapter = new InMemoryUserAdapter();
+  const crud = createKavo().createCrud(User, config as never, { adapter, metadata: userMetadata });
+  return { crud, adapter };
+}
+
+const ADA = { name: "Ada", email: "ada@example.com", age: 36, status: "active" as const };
+
+describe("DefaultKavoContextState", () => {
+  it("round-trips a value under its own key", () => {
+    const state = new DefaultKavoContextState();
+    const at = new Date("2024-01-01T00:00:00.000Z");
+
+    state.set(StartedAt, at);
+
+    expect(state.get(StartedAt)).toBe(at);
+  });
+
+  it("keeps two distinct symbol keys from colliding, even with equal descriptions", () => {
+    const state = new DefaultKavoContextState();
+    const left = Symbol("shared") as StateKey<string>;
+    const right = Symbol("shared") as StateKey<string>;
+
+    state.set(left, "left");
+    state.set(right, "right");
+
+    expect(state.get(left)).toBe("left");
+    expect(state.get(right)).toBe("right");
+  });
+
+  it("answers undefined for a key that was never set", () => {
+    const state = new DefaultKavoContextState();
+
+    expect(state.get(Absent)).toBeUndefined();
+    expect(state.has(Absent)).toBe(false);
+  });
+
+  it("distinguishes a key stored as undefined from one never stored", () => {
+    const state = new DefaultKavoContextState();
+    state.set(Absent, undefined as never);
+
+    // `get` cannot tell these apart; `has` is the reason the method exists.
+    expect(state.get(Absent)).toBeUndefined();
+    expect(state.has(Absent)).toBe(true);
+  });
+
+  it("overwrites in place rather than accumulating", () => {
+    const state = new DefaultKavoContextState();
+
+    state.set(Attempts, 1);
+    state.set(Attempts, 2);
+
+    expect(state.get(Attempts)).toBe(2);
+  });
+});
+
+describe("createKavoContext — state is per request", () => {
+  it("hands every context its own bag", () => {
+    const config = { entityName: "User" } as never;
+    const first = createKavoContext({ operation: "findOne", config });
+    const second = createKavoContext({ operation: "findOne", config });
+
+    first.state.set(Attempts, 1);
+
+    expect(first.state.get(Attempts)).toBe(1);
+    expect(second.state.has(Attempts)).toBe(false);
+  });
+
+  it("generates a correlation id when the caller supplies none, and keeps one that is supplied", () => {
+    const config = { entityName: "User" } as never;
+
+    const generated = createKavoContext({ operation: "findOne", config });
+    const forwarded = createKavoContext({ operation: "findOne", config, correlationId: "upstream-42" });
+
+    expect(generated.correlationId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(forwarded.correlationId).toBe("upstream-42");
+  });
+});
+
+describe("KavoContext.state through the engine", () => {
+  it("carries a value a handler wrote for the rest of that request", async () => {
+    let readBack: number | undefined;
+    const { crud } = makeCrud({
+      operations: {
+        findOne: {
+          handler: {
+            async execute(_input: unknown, context: KavoContext<User>) {
+              context.state.set(Attempts, 1);
+              // Same request, later in the same handler: the bag is live,
+              // not a write-only sink.
+              readBack = context.state.get(Attempts);
+              return Object.assign(new User(), { id: 1, name: "Ada" });
+            },
+          },
+        },
+      },
+    } as never);
+
+    await crud.findOne(1);
+
+    expect(readBack).toBe(1);
+  });
+
+  it("gives the next request a fresh bag", async () => {
+    const seen: boolean[] = [];
+    const { crud } = makeCrud({
+      operations: {
+        findOne: {
+          handler: {
+            async execute(_input: unknown, context: KavoContext<User>) {
+              seen.push(context.state.has(Attempts));
+              context.state.set(Attempts, 1);
+              return Object.assign(new User(), { id: 1, name: "Ada" });
+            },
+          },
+        },
+      },
+    } as never);
+
+    await crud.findOne(1);
+    await crud.findOne(1);
+
+    // Never `[false, true]`: leaking state across requests is exactly what
+    // a per-request bag must not do.
+    expect(seen).toEqual([false, false]);
+  });
+
+  it("is reachable from a write operation's handler too, not only reads", async () => {
+    let sawKey = false;
+    const { crud } = makeCrud({
+      operations: {
+        createOne: {
+          handler: {
+            async execute(input: unknown, context: KavoContext<User>) {
+              context.state.set(StartedAt, new Date(0));
+              sawKey = context.state.has(StartedAt);
+              return Object.assign(new User(), input as object, { id: 1 });
+            },
+          },
+        },
+      },
+    } as never);
+
+    await crud.createOne(ADA as never);
+
+    expect(sawKey).toBe(true);
+  });
+});

--- a/packages/core/tests/cursor-pagination.spec.ts
+++ b/packages/core/tests/cursor-pagination.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type {
   DeepPartial,
+  EntityId,
   EntityMetadata,
   KavoSettings,
   ListMetaDto,
   ListResultDto,
+  NormalizedQueryContext,
+  RepositoryAdapter,
   ResolvedEntityConfig,
   Sort,
 } from "@kavo/core";
@@ -950,5 +953,110 @@ describe("cursor pagination end to end", () => {
     } as never);
     const items = (second.list?.items ?? []) as readonly User[];
     expect(items.map((user) => user.name)).toEqual(["user-3", "user-4"]);
+  });
+});
+
+/**
+ * An adapter that honours the `limit + 1` over-fetch but reads
+ * `query.filter` instead of `readFilter(query)`, so the keyset predicate
+ * never reaches the rows. Every page is page 1, `hasMore` never goes
+ * false, and the token the engine derives from the last row is the token
+ * it was handed. This is the exact defect ADR-0021's guard exists to
+ * catch, so the fixture reproduces the defect rather than mocking the
+ * symptom.
+ */
+class KeysetIgnoringAdapter implements RepositoryAdapter<User> {
+  constructor(private readonly inner: InMemoryUserAdapter = new InMemoryUserAdapter()) {}
+
+  get rows(): User[] {
+    return this.inner.rows;
+  }
+
+  async findMany(query: NormalizedQueryContext<User>): Promise<readonly User[]> {
+    const ordered = [...this.inner.rows].sort((left, right) => left.id - right.id);
+    return ordered.slice(0, query.pagination.limit);
+  }
+
+  async findOneById(id: EntityId) {
+    return this.inner.findOneById(id);
+  }
+  async findOne(query: NormalizedQueryContext<User>) {
+    return this.inner.findOne(query);
+  }
+  async count(query: NormalizedQueryContext<User>) {
+    return this.inner.count(query);
+  }
+  async create(data: Partial<User>) {
+    return this.inner.create(data);
+  }
+  async update(id: EntityId, data: Partial<User>) {
+    return this.inner.update(id, data);
+  }
+  async patch(id: EntityId, data: Partial<User>) {
+    return this.inner.patch(id, data);
+  }
+  async delete(id: EntityId) {
+    return this.inner.delete(id);
+  }
+  async restore() {
+    return this.inner.restore();
+  }
+  async purge(id: EntityId) {
+    return this.inner.purge(id);
+  }
+}
+
+describe("cursor pagination fails loudly when a page does not advance (ADR-0021)", () => {
+  function ignoringCrud() {
+    const adapter = new KeysetIgnoringAdapter();
+    const crud = createKavo({
+      defaults: {
+        pagination: { strategy: "cursor" },
+        query: { defaultSort: SORT_BY_ID },
+      },
+    } as never).createCrud(User, undefined, { adapter, metadata: userMetadata });
+    return { crud, adapter };
+  }
+
+  it("throws ConfigurationException instead of handing back the token it was given", async () => {
+    const { crud } = ignoringCrud();
+    await seed(crud as never, 5);
+
+    // Page 1 is well-formed even from a broken adapter: there is no
+    // previous token to compare against, so the guard cannot fire yet.
+    const first = await (crud as never as ReturnType<typeof cursorCrud>["crud"]).findMany({ limit: 2 } as never);
+    const token = nextCursorOf(first);
+    expect(typeof token).toBe("string");
+
+    // Page 2 re-derives the same boundary row, which is where a client
+    // following `nextCursor` would begin looping.
+    await expect(
+      (crud as never as ReturnType<typeof cursorCrud>["crud"]).findMany({ limit: 2, cursor: token } as never),
+    ).rejects.toBeInstanceOf(ConfigurationException);
+  });
+
+  it("names the adapter contract that was broken, so the message is actionable", async () => {
+    const { crud } = ignoringCrud();
+    await seed(crud as never, 5);
+
+    const client = crud as never as ReturnType<typeof cursorCrud>["crud"];
+    const token = nextCursorOf(await client.findMany({ limit: 2 } as never));
+
+    await expect(client.findMany({ limit: 2, cursor: token } as never)).rejects.toThrow(
+      /did not advance.*readFilter\(query\)/s,
+    );
+  });
+
+  it("still reports the entity and the config path the failure belongs to", async () => {
+    const { crud } = ignoringCrud();
+    await seed(crud as never, 5);
+
+    const client = crud as never as ReturnType<typeof cursorCrud>["crud"];
+    const token = nextCursorOf(await client.findMany({ limit: 2 } as never));
+
+    const error = await client.findMany({ limit: 2, cursor: token } as never).catch((thrown: unknown) => thrown);
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect((error as ConfigurationException).message).toContain("User");
+    expect((error as ConfigurationException).message).toContain("pagination.strategy");
   });
 });

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -331,4 +331,84 @@ describe("KavoEngine — per-operation DTO override (issue #131)", () => {
       ConfigurationException,
     );
   });
+
+  it("treats an explicitly undefined dto key as unset, not as an inapplicable override", () => {
+    // The counterpart of the rejection above, and what makes it safe to
+    // build an entity config by spreading optional values: `deleteOne`
+    // permits no `dto` fields at all, yet `{ output: undefined }` states
+    // no opinion rather than stating a wrong one.
+    expect(() => makeCrud({ operations: { deleteOne: { dto: { output: undefined } } } } as never)).not.toThrow();
+  });
+});
+
+describe("KavoEngine — custom operations", () => {
+  /** Registers a custom operation and captures what its handler received. */
+  function withArchive(config?: Parameters<ReturnType<typeof createKavo>["createCrud"]>[1]) {
+    const { crud, adapter } = makeCrud(config);
+    const seen: unknown[] = [];
+    crud.engine.registry.register({
+      id: "archiveOne",
+      kind: "write",
+      cardinality: "single",
+      enabled: true,
+      handler: {
+        async execute(input: unknown) {
+          seen.push(input);
+          return null;
+        },
+      },
+      input: null,
+      output: null,
+      meta: {},
+    } as never);
+    return { crud, adapter, seen };
+  }
+
+  it("hands a custom operation invoked without an id the bare body", async () => {
+    // The body is deserialized through the resolved DTO first, the same as
+    // any standard write, so it arrives projected onto entity columns.
+    const { crud, seen } = withArchive();
+    await crud.engine.execute({ operation: "archiveOne", id: null, body: { name: "Ada" } } as never);
+    expect(seen[0]).toEqual({ name: "Ada" });
+  });
+
+  it("hands a custom operation invoked with an id both halves, with the id coerced", async () => {
+    // A custom route whose path carries `:id` passes the segment through as
+    // a string; the engine coerces it against the id column's kind, so the
+    // handler sees `7`, not `"7"`.
+    const { crud, seen } = withArchive();
+    await crud.engine.execute({ operation: "archiveOne", id: "7", body: { name: "Ada" } } as never);
+    expect(seen[0]).toEqual({ id: 7, body: { name: "Ada" } });
+  });
+});
+
+describe("KavoEngine — the per-call config view", () => {
+  it("answers settingsFor with the per-call settings, whichever operation is named", async () => {
+    // The merge already happened at the requested operation's scope, so the
+    // view's `settingsFor` is a constant function. Pinning that keeps a
+    // caller from believing it re-resolves per operation.
+    let observed: unknown;
+    const { crud } = makeCrud({
+      operations: {
+        findMany: {
+          handler: {
+            async execute(
+              _input: unknown,
+              context: { config: { settingsFor(id: string): { pagination: { count: boolean } } } },
+            ) {
+              observed = {
+                own: context.config.settingsFor("findMany").pagination.count,
+                other: context.config.settingsFor("findOne").pagination.count,
+              };
+              return { entities: [], total: null };
+            },
+          },
+        },
+      },
+    } as never);
+
+    await crud.findMany(undefined, { settings: { pagination: { count: false } } } as never);
+
+    expect(observed).toEqual({ own: false, other: false });
+  });
 });

--- a/packages/core/tests/errors.spec.ts
+++ b/packages/core/tests/errors.spec.ts
@@ -360,3 +360,46 @@ describe("DefaultErrorHandler — engine boundary mapping", () => {
     });
   });
 });
+
+describe("toProblemDetails — codes the catalog does not know", () => {
+  // The extension path: a consumer subclassing the exception hierarchy
+  // with its own code still has to get a well-formed problem document, not
+  // a crash on a missing catalog entry.
+  const custom: KavoExceptionShape = {
+    code: "KAVO_SOMETHING_CUSTOM" as KavoExceptionShape["code"],
+    status: 418,
+    messageKey: "custom.brewing",
+    messageParams: {},
+    detail: "brewing refused",
+    context: {},
+    cause: undefined,
+  };
+
+  it("falls back to a generic title rather than reading undefined", () => {
+    expect(toProblemDetails(custom)).toMatchObject({ title: "Error", status: 418, code: "KAVO_SOMETHING_CUSTOM" });
+  });
+
+  it("still derives the type URI from the code", () => {
+    expect(toProblemDetails(custom).type).toBe("https://kavo.dev/errors/kavo-something-custom");
+  });
+});
+
+describe("toProblemDetails — describing a cause that is not an Error", () => {
+  // `DefaultErrorHandler` keeps a thrown non-`Error` value as the cause
+  // verbatim, so the serializer has to render one. An `Error` cause reads
+  // as `name: message`; anything else goes through `String`.
+  it("renders a string cause through String, under exposeInternals", () => {
+    const handled = new DefaultErrorHandler().handle("boom", {});
+    expect(toProblemDetails(handled, { exposeInternals: true }).detail).toContain("[cause: boom]");
+  });
+
+  it("renders an Error cause as name and message", () => {
+    const handled = new DefaultErrorHandler().handle(new TypeError("bad"), {});
+    expect(toProblemDetails(handled, { exposeInternals: true }).detail).toContain("[cause: TypeError: bad]");
+  });
+
+  it("keeps the cause out of the document by default", () => {
+    const handled = new DefaultErrorHandler().handle("boom", {});
+    expect(toProblemDetails(handled).detail).not.toContain("boom");
+  });
+});

--- a/packages/core/tests/etag.spec.ts
+++ b/packages/core/tests/etag.spec.ts
@@ -117,3 +117,28 @@ describe("entity-tag comparison (RFC 9110 §8.8.3)", () => {
     expect(weakMatch([], '"a"')).toBe(false);
   });
 });
+
+describe("canonicalize — values JSON.stringify cannot encode", () => {
+  // `canonicalize` exists because `JSON.stringify` is not a usable hash
+  // input: it throws on bigint and drops keys non-deterministically. These
+  // are the cases where it has to answer where `JSON.stringify` would not.
+  it("renders a bigint as its quoted decimal string instead of throwing", () => {
+    expect(canonicalize(10n)).toBe('"10"');
+    expect(() => JSON.stringify(10n)).toThrow(TypeError);
+  });
+
+  it("keeps a bigint distinct from the same-valued number, so the tags differ", () => {
+    expect(canonicalize({ n: 10n })).not.toBe(canonicalize({ n: 10 }));
+  });
+
+  it("renders a function or a symbol as null, matching JSON's array behavior", () => {
+    expect(canonicalize([() => undefined])).toBe(canonicalize([null]));
+    expect(canonicalize([Symbol("s")])).toBe(canonicalize([null]));
+  });
+
+  it("still produces a stable tag for a payload carrying one", async () => {
+    const left = await computeEtag({ id: 1, at: 9n });
+    const right = await computeEtag({ at: 9n, id: 1 });
+    expect(left).toBe(right);
+  });
+});

--- a/packages/core/tests/filter-parser.spec.ts
+++ b/packages/core/tests/filter-parser.spec.ts
@@ -518,3 +518,55 @@ describe("DefaultFilterParser — security posture", () => {
     expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" });
   });
 });
+
+describe("DefaultFilterParser — JSON that parses but is not a filter", () => {
+  // The escape hatch already rejects text that is not JSON at all. These
+  // are the inputs that survive `JSON.parse` and would otherwise be walked
+  // as if they were an object.
+  it.each([
+    ["an array", "[1,2]"],
+    ["a bare number", "5"],
+    ["a bare string", '"age"'],
+    ["null", "null"],
+  ])("rejects %s with a query issue rather than a TypeError", (_label, raw) => {
+    const issues = issuesOf(() => parse({ filter: raw }));
+    expect(issues[0]).toMatchObject({ field: "filter", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("reads a scalar multi-value operand as a one-element list", () => {
+    // Only reachable through the JSON hatch, where values keep their JSON
+    // types instead of arriving as comma-joined text.
+    const query = parse({ filter: JSON.stringify({ age: { in: 18 } }) });
+    expect(query.root).toMatchObject({ operator: "IN", value: [18] });
+  });
+});
+
+describe("DefaultFilterParser — an IN list is all-or-nothing", () => {
+  it("emits no condition at all when one member fails coercion", () => {
+    // The alternative would be a silently narrowed list: `age IN (1, 3)`
+    // for a client that asked for three values, which reads as a
+    // successful query returning wrong rows.
+    const issues = issuesOf(() => parse({ "filter[age][in]": "1,abc,3" }));
+    expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("accepts the repeated-key spelling when a framework hands over a bare scalar", () => {
+    // `?filter[status][in][]=active` is an array of one to some parsers and
+    // a plain string to others; both must mean the same thing.
+    const query = parse({ "filter[status][in][]": "active" });
+    expect(query.root).toMatchObject({ operator: "IN", value: ["active"] });
+  });
+
+  it("still accepts the array spelling of the same key", () => {
+    const query = parse({ "filter[status][in][]": ["active", "pending"] });
+    expect(query.root).toMatchObject({ operator: "IN", value: ["active", "pending"] });
+  });
+});
+
+describe("DefaultFilterParser — a bare filter[] key contributes nothing", () => {
+  it("yields an empty filter rather than throwing on the empty path", () => {
+    // An attacker-shaped key on an untrusted-key code path: the contract
+    // worth pinning is that it neither crashes nor smuggles a condition in.
+    expect(parse({ "filter[]": "18" }).root).toBeNull();
+  });
+});

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -322,6 +322,19 @@ describe("include serialization", () => {
     const list = await posts.findMany({ include: ["author", "comments"] });
     expect(list.items[0]).toMatchObject({ author: null, comments: [] });
   });
+
+  it("normalizes a null to-many relation to an empty array, never null", async () => {
+    // Adapters disagree on whether an unhydrated collection comes back as
+    // `[]` or `null`; the envelope must not leak that difference, or a
+    // client would have to null-check a field the schema types as a list.
+    const fixture = blog({
+      post: { relations: { edges: { comments: { includable: true } } } },
+    });
+    const { posts, postRows } = fixture;
+    postRows.push(Object.assign(new Post(), { id: 11, title: "Null comments", comments: null as never }));
+    const list = await posts.findMany({ include: ["comments"] });
+    expect(list.items[0]).toMatchObject({ comments: [] });
+  });
 });
 
 describe("association by id (ADR-0014)", () => {
@@ -445,6 +458,132 @@ describe("include rejection messages", () => {
     expect(detail).toContain("Did you mean 'title'?");
     expect(detail).toContain("Selectable fields on Post: id, title.");
     expect(detail).toContain("allowlists.selectable on the Post config");
+  });
+});
+
+describe("defaultInclude", () => {
+  it("does not duplicate a relation the client also asked for, and keeps the requested subtree", () => {
+    // The dedupe has to lose to the client's own draft, not the other way
+    // round: a `defaultInclude` node carries no children, so clobbering
+    // would silently drop `posts.comments` from the response.
+    const fixture = blog({
+      author: { relations: { edges: { posts: { includable: true, defaultInclude: true } } } },
+      post: { relations: { edges: { comments: { includable: true } } } },
+    } as never);
+
+    return fixture.authors.findMany({ include: ["posts.comments"] } as never).then(() => {
+      const tree = includeTree(fixture.authorAdapter);
+      expect(Object.keys(tree)).toEqual(["posts"]);
+      expect(Object.keys(tree["posts"]!.children)).toEqual(["comments"]);
+    });
+  });
+
+  it("gives a nested defaultInclude relation its full dotted path", async () => {
+    // `path` is what `fields[...]` and every issue message key off, so a
+    // nested default that reported a bare name would be unaddressable.
+    const fixture = blog({
+      author: { relations: { edges: { posts: { includable: true } } } },
+      post: { relations: { edges: { comments: { includable: true, defaultInclude: true } } } },
+    } as never);
+
+    await fixture.authors.findMany({ include: ["posts"] } as never);
+
+    const tree = includeTree(fixture.authorAdapter);
+    expect(tree["posts"]!.children["comments"]!.path).toBe("posts.comments");
+  });
+});
+
+describe("relations.edges — naming an edge is the opt-in", () => {
+  it("treats an edge that omits includable as includable", async () => {
+    // The registry documents this default; every other test in the file
+    // spells `includable: true`, which would leave it free to regress.
+    const fixture = blog({
+      author: { relations: { edges: { posts: { strategy: "join" } } } },
+    } as never);
+
+    await fixture.authors.findMany({ include: ["posts"] } as never);
+
+    expect(Object.keys(includeTree(fixture.authorAdapter))).toEqual(["posts"]);
+  });
+
+  it("still honours an explicit includable: false", async () => {
+    const fixture = blog({
+      author: { relations: { edges: { posts: { includable: false, strategy: "join" } } } },
+    } as never);
+
+    await expect(fixture.authors.findMany({ include: ["posts"] } as never)).rejects.toBeInstanceOf(
+      QueryValidationException,
+    );
+  });
+
+  it("says 'none' rather than trailing a bare colon when the entity has no relations at all", () => {
+    // `Comment` declares no relations, so the message has an empty list to
+    // render — the one case where the join would produce nothing.
+    expect(() => blog({ comment: { relations: { edges: { ghosts: { includable: true } } } } } as never)).toThrow(
+      /relations: none/,
+    );
+  });
+});
+
+describe("malformed include paths", () => {
+  it.each([
+    ["a trailing dot", "posts."],
+    ["a leading dot", ".posts"],
+    ["a doubled dot", "posts..comments"],
+    ["an empty string", ""],
+  ])("rejects %s as a query issue rather than building an empty-named node", async (_label, path) => {
+    const fixture = blog({
+      author: { relations: { edges: { posts: { includable: true } } } },
+      post: { relations: { edges: { comments: { includable: true } } } },
+    } as never);
+
+    const issues = await fixture.authors
+      .findMany({ include: [path] } as unknown as { include: readonly IncludePath<Author>[] })
+      .then(
+        () => {
+          throw new Error("expected a QueryValidationException");
+        },
+        (error: unknown) => (error as QueryValidationException).issues,
+      );
+
+    expect(issues[0]).toMatchObject({ field: "include", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+});
+
+describe("an includable relation whose target is unknown to this instance", () => {
+  it("reports an unsupported-param issue on that path instead of throwing a TypeError", async () => {
+    // `Comment` is never registered here, so the catalog cannot resolve
+    // `posts.comments`'s target. A missing `createCrud` call is an ordinary
+    // adopter mistake and must not surface as a crash.
+    const metadata = new Map<unknown, EntityMetadata<object>>([
+      [Author, authorMetadata as EntityMetadata<object>],
+      [Post, postMetadata as EntityMetadata<object>],
+    ]);
+    const authorAdapter = new SeededAdapter<Author>([]);
+    const postAdapter = new SeededAdapter<Post>([]);
+    const adapters = new Map<unknown, unknown>([
+      [Author, authorAdapter],
+      [Post, postAdapter],
+    ]);
+    const kavo = createKavo({
+      infrastructure: {
+        metadataFor: (entity) => metadata.get(entity) as never,
+        adapterFor: (entity) => adapters.get(entity) as never,
+      },
+    });
+    const authors = kavo.createCrud(Author, {
+      relations: { edges: { posts: { includable: true } } },
+    } as never) as DefaultKavoService<Author>;
+    kavo.createCrud(Post, { relations: { edges: { comments: { includable: true } } } } as never);
+
+    const issues = await authors.findMany({ include: ["posts.comments"] } as never).then(
+      () => {
+        throw new Error("expected a QueryValidationException");
+      },
+      (error: unknown) => (error as QueryValidationException).issues,
+    );
+
+    expect(issues[0]).toMatchObject({ field: "posts.comments", code: "KAVO_QUERY_UNSUPPORTED_PARAM" });
   });
 });
 

--- a/packages/core/tests/kavo-service.spec.ts
+++ b/packages/core/tests/kavo-service.spec.ts
@@ -15,6 +15,7 @@ import {
   DefaultKavoService,
   OperationDisabledException,
   WireQuery,
+  createCrud,
   createKavo,
 } from "@kavo/core";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
@@ -430,5 +431,47 @@ describe("DefaultKavoService — query paths", () => {
     const { crud, adapter } = makeCrud();
     await crud.createOne(ADA as never);
     expect(adapter.last.query).toBeNull();
+  });
+});
+
+describe("createCrud — the standalone zero-config front door", () => {
+  // The bare `createCrud(Entity, config?, runtime)` free function, which
+  // creates an implicit root instance. Every other suite goes through
+  // `createKavo().createCrud(...)`, so nothing exercised the barrel export
+  // adopters reach for first.
+  it("round-trips a create and a read with no root instance in sight", async () => {
+    const crud = createCrud(User, undefined, { adapter: new InMemoryUserAdapter(), metadata: userMetadata });
+
+    const created = await crud.createOne(ADA as never);
+    expect(created).toMatchObject({ id: 1, name: "Ada" });
+    expect(await crud.findOne(1)).toMatchObject({ email: "ada@example.com" });
+  });
+
+  it("still applies an entity config passed to it", async () => {
+    class UserItemDto {
+      id = 0;
+      name = "";
+    }
+    const crud = createCrud(User, { dto: { item: UserItemDto } } as never, {
+      adapter: new InMemoryUserAdapter(),
+      metadata: userMetadata,
+    });
+
+    const created = await crud.createOne(ADA as never);
+    expect(Object.keys(created as object)).toEqual(["id", "name"]);
+  });
+
+  it("gives each call its own catalog, which is why createKavo exists", async () => {
+    // Two entities registered through the free function cannot see each
+    // other, so a nested include across them is unresolvable. That is the
+    // cost of the implicit root, and it is the reason a multi-entity app
+    // wires one `createKavo` instead.
+    const first = createCrud(User, undefined, { adapter: new InMemoryUserAdapter(), metadata: userMetadata });
+    const second = createCrud(User, undefined, { adapter: new InMemoryUserAdapter(), metadata: userMetadata });
+
+    await first.createOne(ADA as never);
+
+    // Separate roots mean separate adapters: the row is not shared.
+    await expect(second.findOne(1)).rejects.toThrow();
   });
 });

--- a/packages/core/tests/kavo-service.spec.ts
+++ b/packages/core/tests/kavo-service.spec.ts
@@ -13,6 +13,7 @@ import type {
 import {
   ConfigurationException,
   DefaultKavoService,
+  NotFoundException,
   OperationDisabledException,
   WireQuery,
   createCrud,
@@ -461,17 +462,18 @@ describe("createCrud — the standalone zero-config front door", () => {
     expect(Object.keys(created as object)).toEqual(["id", "name"]);
   });
 
-  it("gives each call its own catalog, which is why createKavo exists", async () => {
-    // Two entities registered through the free function cannot see each
-    // other, so a nested include across them is unresolvable. That is the
-    // cost of the implicit root, and it is the reason a multi-entity app
-    // wires one `createKavo` instead.
+  it("gives each call its own implicit root, which is why createKavo exists", async () => {
+    // Every call builds a fresh root, so two services share nothing — not
+    // the runtime they were handed and not the catalog that root owns.
+    // Entities registered through separate calls cannot see each other,
+    // which is why a multi-entity app wires one `createKavo` instead.
     const first = createCrud(User, undefined, { adapter: new InMemoryUserAdapter(), metadata: userMetadata });
     const second = createCrud(User, undefined, { adapter: new InMemoryUserAdapter(), metadata: userMetadata });
 
     await first.createOne(ADA as never);
 
-    // Separate roots mean separate adapters: the row is not shared.
-    await expect(second.findOne(1)).rejects.toThrow();
+    // A plain 404, not an incidental crash: the second service is fully
+    // functional, it simply never saw the row the first one wrote.
+    await expect(second.findOne(1)).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { ClassRef, EntityMetadata } from "@kavo/core";
-import { DefaultEntityCatalog, DefaultIncludeResolver, QueryNormalizer, resolveEntityConfig } from "@kavo/core";
+import {
+  ConfigurationException,
+  DefaultEntityCatalog,
+  DefaultIncludeResolver,
+  QueryNormalizer,
+  QueryValidationException,
+  resolveEntityConfig,
+} from "@kavo/core";
 import { userMetadata } from "./support/user-fixture.js";
 import { accountMetadata } from "./support/account-fixture.js";
 import type { Post } from "./support/blog-fixture.js";
@@ -510,5 +517,209 @@ describe("allowlist rejection messages", () => {
     const issues = issuesOf(() => normalizer.normalizeWire({ sort: "emial", fields: "nmae" }, config));
     expect(issues).toHaveLength(2);
     expect(issues.every((issue) => issue.detail.includes("Did you mean"))).toBe(true);
+  });
+});
+
+/**
+ * The programmatic path does not run `DefaultFilterParser` or any
+ * pagination strategy: its input is already typed, so there is nothing to
+ * parse. That makes `normalizeInput` the *sole* gate for a hand-built
+ * request, and every limit the wire path enforces has to be enforced here
+ * independently. The wire equivalents of these live in
+ * `filter-parser.spec.ts` and `pagination-strategies.spec.ts`, neither of
+ * which this code path shares.
+ */
+describe("QueryNormalizer — programmatic input is bounded, not trusted", () => {
+  it.each([
+    ["a limit below one", { limit: 0 }, "limit"],
+    ["a fractional limit", { limit: 1.5 }, "limit"],
+    ["a negative offset", { offset: -1 }, "offset"],
+    ["a fractional offset", { offset: 2.5 }, "offset"],
+  ])("rejects %s, naming the parameter at fault", (_label, input, field) => {
+    const issues = issuesOf(() => normalizer.normalizeInput(input as never, config));
+    expect(issues[0]).toMatchObject({ field, code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("accepts the boundary values either side of those rejections", () => {
+    expect(normalizer.normalizeInput({ limit: 1, offset: 0 }, config).pagination).toEqual({ limit: 1, offset: 0 });
+  });
+
+  it("enforces maxFilterDepth on a hand-built AST", () => {
+    // Four levels of nesting against the default budget of three. Without
+    // this gate a programmatic caller could hand the adapter an
+    // arbitrarily deep tree that the wire path would have refused.
+    const nest = (child: unknown) => ({ kind: "group", operator: "AND", children: [child] });
+    const deep = nest(nest(nest({ kind: "condition", field: "age", operator: "EQ", value: 1 })));
+
+    const issues = issuesOf(() => normalizer.normalizeInput({ filter: deep } as never, config));
+    expect(issues[0]).toMatchObject({ field: "filter", code: "KAVO_QUERY_LIMIT_EXCEEDED" });
+  });
+
+  it("enforces maxInValues on a hand-built IN condition, naming the field and operator", () => {
+    const issues = issuesOf(() =>
+      normalizer.normalizeInput(
+        {
+          filter: {
+            kind: "condition",
+            field: "age",
+            operator: "IN",
+            value: Array.from({ length: 101 }, (_unused, index) => index),
+          },
+        } as never,
+        config,
+      ),
+    );
+    expect(issues[0]).toMatchObject({ field: "age", code: "KAVO_QUERY_LIMIT_EXCEEDED" });
+    expect(issues[0]?.detail).toContain("IN");
+  });
+
+  it("accepts an IN list exactly at the budget", () => {
+    const query = normalizer.normalizeInput(
+      {
+        filter: {
+          kind: "condition",
+          field: "age",
+          operator: "IN",
+          value: Array.from({ length: 100 }, (_unused, index) => index),
+        },
+      } as never,
+      config,
+    );
+    expect(query.filter.root).toMatchObject({ operator: "IN" });
+  });
+});
+
+/**
+ * `pagination.strategy` is validated as a *string* at bootstrap, never
+ * probed against the registry, so a typo survives `createCrud` and
+ * surfaces on the first request instead. That is a deliberate trade (the
+ * registry is per-normalizer, the config is not), which makes the failure
+ * mode worth pinning: a `ConfigurationException` naming both the typo and
+ * the registered alternatives, not a `TypeError` on `undefined`.
+ */
+describe("QueryNormalizer — an unregistered pagination strategy", () => {
+  const typoed = resolveEntityConfig(userMetadata, { pagination: { strategy: "ofset" } } as never, undefined);
+
+  it("throws ConfigurationException rather than collecting a query issue", () => {
+    expect(() => normalizer.normalizeWire({}, typoed)).toThrow(ConfigurationException);
+  });
+
+  it("names the unknown strategy and lists the registered ones", () => {
+    let message = "";
+    try {
+      normalizer.normalizeWire({}, typoed);
+    } catch (thrown) {
+      message = (thrown as Error).message;
+    }
+    expect(message).toContain("'ofset'");
+    expect(message).toMatch(/offset/);
+    expect(message).toMatch(/cursor/);
+    expect(message).toMatch(/since/);
+  });
+
+  it("propagates out of the programmatic path too", () => {
+    // `collectIssues` re-throws anything that is not a
+    // `QueryValidationException`, so a misconfiguration surfaces as a 500
+    // rather than being flattened into a 400 the client cannot act on.
+    expect(() => normalizer.normalizeInput({}, typoed)).toThrow(ConfigurationException);
+  });
+});
+
+/**
+ * A third-party strategy decides the *shape* the programmatic path
+ * normalizes to, which `paginationShape` discovers by probing it with an
+ * empty request. Both arms of that probe's catch matter: a strategy that
+ * rejects an empty request pages as offset (its real issues surface on the
+ * wire, where its params exist), while anything else is a bug and must not
+ * be swallowed.
+ */
+describe("QueryNormalizer — probing a custom pagination strategy", () => {
+  class RejectsEmpty {
+    readonly name = "demanding";
+    normalize() {
+      throw new QueryValidationException([
+        { field: "token", code: "KAVO_QUERY_INVALID_VALUE", detail: "token is required" },
+      ]);
+    }
+  }
+
+  class ThrowsOutright {
+    readonly name = "broken";
+    normalize(): never {
+      throw new Error("boom");
+    }
+  }
+
+  it("treats a strategy that refuses an empty request as offset-shaped", () => {
+    const normalizerWith = new QueryNormalizer(userMetadata, [new RejectsEmpty() as never]);
+    const demanding = resolveEntityConfig(userMetadata, { pagination: { strategy: "demanding" } } as never, undefined);
+
+    expect(normalizerWith.normalizeInput({}, demanding).pagination).toEqual({ limit: 20, offset: 0 });
+  });
+
+  it("rejects a programmatic cursor against that offset shape rather than paging silently", () => {
+    const normalizerWith = new QueryNormalizer(userMetadata, [new RejectsEmpty() as never]);
+    const demanding = resolveEntityConfig(userMetadata, { pagination: { strategy: "demanding" } } as never, undefined);
+
+    const issues = issuesOf(() => normalizerWith.normalizeInput({ cursor: "abc" } as never, demanding));
+    expect(issues[0]).toMatchObject({ field: "cursor", code: "KAVO_QUERY_UNSUPPORTED_PARAM" });
+  });
+
+  it("lets a non-validation throw escape, so a broken strategy is not mistaken for offset paging", () => {
+    const normalizerWith = new QueryNormalizer(userMetadata, [new ThrowsOutright() as never]);
+    const broken = resolveEntityConfig(userMetadata, { pagination: { strategy: "broken" } } as never, undefined);
+
+    expect(() => normalizerWith.normalizeInput({}, broken)).toThrow(/boom/);
+  });
+});
+
+/**
+ * A query string can spell the same parameter twice (`?sort=a&sort=b`),
+ * which every mainstream parser hands over as an array rather than a
+ * string. None of these are reachable from the programmatic path, which
+ * reads its input already typed, so the wire path owns the whole burden of
+ * not trusting the shape it is given.
+ */
+describe("QueryNormalizer — repeated-key and malformed wire spellings", () => {
+  it("accepts the repeated-key array form of include", () => {
+    const query = postNormalizer.normalizeWire({ include: ["comments"] } as never, postConfig);
+    expect(Object.keys(query.include)).toEqual(["comments"]);
+  });
+
+  it("reports a non-string include token instead of throwing", () => {
+    const issues = issuesOf(() => normalizer.normalizeWire({ include: 42 } as never, config));
+    expect(issues[0]).toMatchObject({ field: "include", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("reports a repeated-key sort instead of throwing", () => {
+    const issues = issuesOf(() => normalizer.normalizeWire({ sort: ["name", "email"] } as never, config));
+    expect(issues[0]).toMatchObject({ field: "sort", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("skips an empty token inside sort rather than rejecting it as an empty field name", () => {
+    const query = normalizer.normalizeWire({ sort: "name,,email" }, config);
+    expect(query.sort).toEqual([
+      { field: "name", direction: "asc" },
+      { field: "email", direction: "asc" },
+    ]);
+  });
+
+  it("reports a repeated-key root fields instead of throwing, and selects nothing", () => {
+    const issues = issuesOf(() => normalizer.normalizeWire({ fields: ["id", "name"] } as never, config));
+    expect(issues[0]).toMatchObject({ field: "fields", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("skips an empty token inside fields", () => {
+    const query = normalizer.normalizeWire({ fields: "id,,name" }, config);
+    expect(query.fields.root).toEqual(["id", "name"]);
+  });
+
+  it("reports a non-string relation fieldset under its raw wire key", () => {
+    // The key is echoed verbatim (`fields[comments]`, not `comments`) so
+    // the client can find the parameter it actually sent.
+    const issues = issuesOf(() =>
+      postNormalizer.normalizeWire({ include: "comments", "fields[comments]": ["id"] } as never, postConfig),
+    );
+    expect(issues[0]).toMatchObject({ field: "fields[comments]", code: "KAVO_QUERY_INVALID_VALUE" });
   });
 });

--- a/packages/core/tests/serializer.spec.ts
+++ b/packages/core/tests/serializer.spec.ts
@@ -73,6 +73,19 @@ describe("DefaultSerializer — response projection", () => {
     expect(Object.keys(serializer.serializeItem(ada(), OpaqueDto, contextStub()))).toEqual(COLUMNS);
   });
 
+  it("falls back the same way when the DTO's constructor throws", () => {
+    // A DTO with required constructor arguments, or a field initializer
+    // that throws, is an ordinary mistake. Probing its shape must not turn
+    // that into a 500 on every response: the projection degrades, the
+    // request still answers.
+    class NeedsArgumentsDto {
+      constructor() {
+        throw new Error("needs arguments");
+      }
+    }
+    expect(Object.keys(serializer.serializeItem(ada(), NeedsArgumentsDto, contextStub()))).toEqual(COLUMNS);
+  });
+
   it("narrows with the request's fieldset but never widens the DTO", () => {
     // Serialization order is normative: DTO mapping first, then field
     // selection — so `email`, which the DTO hides, cannot be selected back.

--- a/packages/core/tests/since-pagination.spec.ts
+++ b/packages/core/tests/since-pagination.spec.ts
@@ -20,6 +20,7 @@ import {
   createKavo,
   hasKeyset,
   readFilter,
+  sinceValueOf,
 } from "@kavo/core";
 import { issuesOf } from "./support/query-issues.js";
 
@@ -580,5 +581,146 @@ describe("since pagination end to end", () => {
     const issues = await issuesOfAsync(() => client.findMany({ limit: 10, since: boundary } as never));
     expect(issues[0]).toMatchObject({ field: "since", code: "KAVO_QUERY_INVALID_VALUE" });
     expect(issues[0]?.detail).toContain("'deletedAt'");
+  });
+});
+
+// ── sinceValueOf: encoding the boundary off a row ────────────────────────
+
+describe("sinceValueOf — a boundary column's runtime type must be encodable", () => {
+  // The since mirror of `cursorValuesOf`'s guard (ADR-0021's documented
+  // bigint/decimal limitation, which ADR-0022 inherits). `meta.nextSince`
+  // is read off the entity before serialization, so a column whose runtime
+  // value is neither string, number, nor Date has no wire form. It must
+  // fail loudly rather than stringify into a token that will not replay.
+  const occurredAt = eventMetadata.fields.find((field) => field.name === "occurredAt")!;
+  const idField = eventMetadata.fields.find((field) => field.name === "id")!;
+  const externalId = eventMetadata.fields.find((field) => field.name === "externalId")!;
+
+  it("joins the boundary value and the id tiebreaker with a pipe", () => {
+    const row = { occurredAt: new Date("2024-01-01T00:00:00.000Z"), id: 7 };
+    expect(sinceValueOf(row, occurredAt, idField, "Event")).toBe("2024-01-01T00:00:00.000Z|7");
+  });
+
+  it("encodes a string boundary column as-is", () => {
+    expect(sinceValueOf({ externalId: "018f2c8e", id: 7 }, externalId, idField, "Event")).toBe("018f2c8e|7");
+  });
+
+  it("writes the literal 'null' for an absent boundary, leaving the replay to reject it", () => {
+    // Deliberately not a throw: an absent boundary column is the
+    // normalizer's problem on replay, where it can name the column in a
+    // 400, not the encoder's to refuse mid-response (ADR-0022).
+    expect(sinceValueOf({ occurredAt: null, id: 7 }, occurredAt, idField, "Event")).toBe("null|7");
+    expect(sinceValueOf({ occurredAt: undefined, id: 7 }, occurredAt, idField, "Event")).toBe("null|7");
+  });
+
+  it("refuses a bigint id rather than emitting a token that cannot round-trip", () => {
+    const encode = () => sinceValueOf({ occurredAt: new Date(0), id: 1n }, occurredAt, idField, "Event");
+    expect(encode).toThrow(ConfigurationException);
+    expect(encode).toThrow(/bigint/);
+  });
+
+  it("names the offending column, its declared kind, and the entity", () => {
+    let message = "";
+    try {
+      sinceValueOf({ occurredAt: new Date(0), id: 1n }, occurredAt, idField, "Event");
+    } catch (thrown) {
+      message = (thrown as Error).message;
+    }
+    expect(message).toContain("'id'");
+    expect(message).toContain("number");
+    expect(message).toContain("Event");
+  });
+
+  it("describes a class instance by its constructor name, so a Decimal column is diagnosable", () => {
+    class Decimal {}
+    expect(() => sinceValueOf({ occurredAt: new Decimal(), id: 1 }, occurredAt, idField, "Event")).toThrow(
+      /Decimal object/,
+    );
+  });
+
+  it("degrades to plain 'object' for a value carrying no constructor", () => {
+    expect(() => sinceValueOf({ occurredAt: Object.create(null), id: 1 }, occurredAt, idField, "Event")).toThrow(
+      /runtime value is a object/,
+    );
+  });
+});
+
+// ── Replaying a token: both halves are validated ─────────────────────────
+
+describe("since token replay validates each half independently", () => {
+  it("rejects a token whose value half does not coerce to the boundary column", async () => {
+    const { crud } = sinceCrud({ pagination: { since: { field: "occurredAt" } } } as never);
+    const issues = await issuesOfAsync(() => crud.findMany({ since: "not-a-date|1" } as never));
+    expect(issues[0]).toMatchObject({ field: "since", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+
+  it("rejects a token whose id half does not coerce to the id column", async () => {
+    const { crud } = sinceCrud({ pagination: { since: { field: "occurredAt" } } } as never);
+    const issues = await issuesOfAsync(() => crud.findMany({ since: "2024-01-01T01:00:00.000Z|nope" } as never));
+    expect(issues[0]).toMatchObject({ field: "since", code: "KAVO_QUERY_INVALID_VALUE" });
+  });
+});
+
+// ── `since` under the wrong strategy, over the wire ──────────────────────
+
+describe("a since param under a non-since strategy is refused, not ignored", () => {
+  // The programmatic half of this is already pinned; the wire half is the
+  // one a real client hits. Silently dropping the param would serve page 1
+  // forever while the client believed it was polling forward.
+  function offsetCrud() {
+    return createKavo({}).createCrud(Event, undefined, {
+      adapter: new InMemoryEventAdapter(),
+      metadata: eventMetadata,
+    });
+  }
+
+  it("reports KAVO_QUERY_UNSUPPORTED_PARAM for ?since= under offset pagination", async () => {
+    const crud = offsetCrud();
+    const issues = await issuesOfAsync(() =>
+      crud.engine.execute({
+        operation: "findMany",
+        query: new WireQuery({ since: "2024-01-01T00:00:00.000Z|1" }),
+      } as never),
+    );
+    expect(issues[0]).toMatchObject({ field: "since", code: "KAVO_QUERY_UNSUPPORTED_PARAM" });
+  });
+
+  it("treats an empty ?since= as absent rather than unsupported", async () => {
+    const crud = offsetCrud();
+    const response = await crud.engine.execute({
+      operation: "findMany",
+      query: new WireQuery({ since: "" }),
+    } as never);
+    expect(response.list?.items).toEqual([]);
+  });
+});
+
+// ── Bootstrap: the selectable allowlist half ─────────────────────────────
+
+describe("bootstrap validation of pagination.since.field — the selectable allowlist", () => {
+  // The filterable half is what composes the keyset predicate; the
+  // selectable half is what lets the engine read the next boundary back
+  // off a returned row. Both are required, and each fails with its own
+  // wording so the adopter knows which allowlist to fix.
+  function bootstrap(allowlists: unknown) {
+    return () =>
+      createKavo({
+        defaults: { pagination: { strategy: "since", since: { field: "occurredAt" } } },
+      } as never).createCrud(Event, { allowlists } as never, {
+        adapter: new InMemoryEventAdapter(),
+        metadata: eventMetadata,
+      });
+  }
+
+  it("fails fast when the since field is excluded from selectable", () => {
+    expect(bootstrap({ selectable: { exclude: ["occurredAt"] } })).toThrow(/selectable allowlist/);
+  });
+
+  it("fails fast when the forced idField tiebreaker is excluded from selectable", () => {
+    expect(bootstrap({ selectable: { exclude: ["id"] } })).toThrow(/forced tiebreaker 'idField'/);
+  });
+
+  it("fails fast when the forced idField tiebreaker is excluded from filterable", () => {
+    expect(bootstrap({ filterable: { exclude: ["id"] } })).toThrow(/forced tiebreaker 'idField'/);
   });
 });

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -7,7 +7,16 @@ import { Test } from "@nestjs/testing";
 import type { DefaultKavoService, NormalizedQueryContext, OperationHandler } from "@kavo/core";
 import { ConfigurationException, WireQuery } from "@kavo/core";
 import type { KavoModuleOptions } from "@kavo/nest";
-import { Kavo, KavoModule, Override, enumProp, flattenQuery, getKavoServiceToken, oneOfArray } from "@kavo/nest";
+import {
+  Kavo,
+  KavoModule,
+  Override,
+  boundKavoService,
+  enumProp,
+  flattenQuery,
+  getKavoServiceToken,
+  oneOfArray,
+} from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
 
@@ -390,6 +399,28 @@ describe("@Kavo operation control surface", () => {
     expect(response.body).toEqual({ manual: true });
     // Other routes still generate.
     await request(server()).post("/todos").send({ title: "x" }).expect(201);
+  });
+
+  it("boundKavoService(this) reaches the service the discovery binder assigned", async () => {
+    // The access pattern CLAUDE.md tells consumers to prefer over both
+    // `forFeature` and constructor injection, and until now the only one
+    // with no test at all. A hand-written route is the case it exists for.
+    @Kavo(Todo)
+    @Controller("todos")
+    class SelfServingController {
+      @Get("mine")
+      async mine(): Promise<{ titles: string[] }> {
+        const service = boundKavoService<Todo>(this);
+        const list = await service.findMany();
+        return { titles: list.items.map((item) => (item as Todo).title) };
+      }
+    }
+
+    await bootstrap(SelfServingController);
+    await request(server()).post("/todos").send({ title: "own route" }).expect(201);
+
+    const response = await request(server()).get("/todos/mine").expect(200);
+    expect(response.body).toEqual({ titles: ["own route"] });
   });
 
   it("overrides all five singular standard operations, alongside manual-method-wins and a disabled operation (issue #21)", async () => {
@@ -1191,6 +1222,85 @@ describe("@Kavo computed fields over the wire (ADR-0019)", () => {
   });
 });
 
+describe("@Kavo Swagger — per-operation DTO overrides are what gets documented", () => {
+  /**
+   * The engine deserializes through `descriptor.input` and serializes
+   * through `descriptor.output` ahead of the entity's root slots, so
+   * documenting the slot alone would publish a shape no request or
+   * response actually has. `packages/core` covers the registry side of
+   * this; nothing covered the OpenAPI side, which meant an override could
+   * ship documented as the wrong shape with no test to catch it.
+   */
+  class RootCreateDto {
+    title = "";
+    priority = 0;
+  }
+  class OverrideCreateDto {
+    title = "";
+    urgency = 0;
+  }
+  class RootUpdateDto {
+    title = "";
+    done = false;
+  }
+  class RootItemDto {
+    id = 0;
+    title = "";
+  }
+  class OverrideCreatedDto {
+    id = 0;
+    done = false;
+  }
+
+  @Kavo(Todo, {
+    dto: { create: RootCreateDto, update: RootUpdateDto, item: RootItemDto },
+    operations: { createOne: { dto: { input: OverrideCreateDto, output: OverrideCreatedDto } } },
+  })
+  @Controller("todos")
+  class OverriddenDtoController {}
+
+  type Schema = { properties?: Record<string, unknown> };
+
+  let document: ReturnType<typeof SwaggerModule.createDocument>;
+
+  beforeEach(async () => {
+    await bootstrap(OverriddenDtoController);
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+  });
+
+  const requestSchema = (path: string, verb: string): Schema | undefined =>
+    (document.paths[path] as Record<string, { requestBody?: { content?: Record<string, { schema?: Schema }> } }>)?.[
+      verb
+    ]?.requestBody?.content?.["application/json"]?.schema;
+
+  const responseSchema = (path: string, verb: string, status: string): Schema | undefined =>
+    (
+      document.paths[path] as Record<
+        string,
+        { responses?: Record<string, { content?: Record<string, { schema?: Schema }> }> }
+      >
+    )?.[verb]?.responses?.[status]?.content?.["application/json"]?.schema;
+
+  it("documents the operation's input override ahead of the entity's create slot", () => {
+    expect(Object.keys(requestSchema("/todos", "post")?.properties ?? {})).toEqual(["title", "urgency"]);
+  });
+
+  it("documents the operation's output override ahead of the entity's item slot", () => {
+    expect(Object.keys(responseSchema("/todos", "post", "201")?.properties ?? {})).toEqual(["id", "done"]);
+  });
+
+  it("leaves operations that declared no override on the root slots", () => {
+    // The override is scoped, not global: `findOne` still documents `item`.
+    expect(Object.keys(responseSchema("/todos/{id}", "get", "200")?.properties ?? {})).toEqual(["id", "title"]);
+  });
+
+  it("does not leak an operation's input override onto a sibling operation's body", () => {
+    // `updateOne` declared no override, so it documents the root `update`
+    // slot — not `createOne`'s override and not `createOne`'s slot either.
+    expect(Object.keys(requestSchema("/todos/{id}", "put")?.properties ?? {})).toEqual(["title", "done"]);
+  });
+});
+
 describe("@Kavo Swagger request-body schemas", () => {
   class CreateTodoDto {
     title = "";
@@ -1259,6 +1369,94 @@ describe("@Kavo Swagger request-body schemas", () => {
     expect(schema?.properties?.title).toEqual({ type: "string" });
     expect(schema?.properties?.priority).toEqual({ type: "integer" });
     expect(schema?.properties?.done).toEqual({ type: "boolean" });
+  });
+
+  it("distinguishes the JSON number types a field initializer can imply", async () => {
+    // `jsonSchemaForValue` reads the runtime initializer, so an integer and
+    // a fractional default are different documented types, and a `bigint`
+    // documents as an integer rather than falling through to `{}`.
+    class NumericDto {
+      count = 0;
+      ratio = 1.5;
+      ticket = 0n;
+    }
+    @Kavo(Todo, { dto: { create: NumericDto } })
+    @Controller("todos")
+    class NumericController {}
+
+    await app.close();
+    await bootstrap(NumericController);
+    const numericDocument = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle("t").setVersion("0").build(),
+    );
+    const schema = (
+      numericDocument.paths["/todos"] as Record<
+        string,
+        { requestBody?: { content?: Record<string, { schema?: Schema }> } }
+      >
+    )?.["post"]?.requestBody?.content?.["application/json"]?.schema;
+
+    expect(schema?.properties?.count).toEqual({ type: "integer" });
+    expect(schema?.properties?.ratio).toEqual({ type: "number" });
+    expect(schema?.properties?.ticket).toEqual({ type: "integer" });
+  });
+
+  it("keeps a field whose initializer says nothing about its type, as an open schema", async () => {
+    // The key still has to appear: dropping it would publish a body schema
+    // that omits a field the DTO genuinely accepts.
+    class LooseDto {
+      title = "";
+      note = undefined;
+    }
+    @Kavo(Todo, { dto: { create: LooseDto } })
+    @Controller("todos")
+    class LooseController {}
+
+    await app.close();
+    await bootstrap(LooseController);
+    const looseDocument = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle("t").setVersion("0").build(),
+    );
+    const schema = (
+      looseDocument.paths["/todos"] as Record<
+        string,
+        { requestBody?: { content?: Record<string, { schema?: Schema }> } }
+      >
+    )?.["post"]?.requestBody?.content?.["application/json"]?.schema;
+
+    expect(Object.keys(schema?.properties ?? {})).toContain("note");
+    expect(schema?.properties?.note).toEqual({});
+  });
+
+  it("defers to Swagger's own introspection for a DTO with no runtime own properties", async () => {
+    // A declared-only DTO (`title!: string`) erases at runtime, so there
+    // are no initializers to read. Emitting an empty inline schema would
+    // publish "this endpoint takes nothing"; handing Swagger the class
+    // lets its own decorators answer instead.
+    class DeclaredOnlyDto {
+      title!: string;
+    }
+    @Kavo(Todo, { dto: { create: DeclaredOnlyDto } })
+    @Controller("todos")
+    class DeclaredOnlyController {}
+
+    await app.close();
+    await bootstrap(DeclaredOnlyController);
+    const declaredDocument = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle("t").setVersion("0").build(),
+    );
+    const body = (
+      declaredDocument.paths["/todos"] as Record<
+        string,
+        { requestBody?: { content?: Record<string, { schema?: Schema & { $ref?: string } }> } }
+      >
+    )?.["post"]?.requestBody?.content?.["application/json"]?.schema;
+
+    expect(body?.properties).toBeUndefined();
+    expect(body?.$ref).toContain("DeclaredOnlyDto");
   });
 
   it("documents create/put/patch/get-item responses with the item DTO", () => {

--- a/packages/frameworks/nest/tests/default-graphql-controller.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/default-graphql-controller.e2e.spec.ts
@@ -108,4 +108,46 @@ describe("KavoModule.forRoot({ graphql: true })", () => {
 
     await request(server).post("/graphql").expect(404);
   });
+
+  it("falls back to the default path when given an options object that omits one", async () => {
+    // `graphql: {}` is what an app writes when it builds the option object
+    // programmatically with no path to contribute; it must mean the same
+    // thing as `graphql: true`, not "mount at undefined".
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), graphql: {} })],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    const server = await listen(app);
+
+    const created = await request(server)
+      .post("/graphql")
+      .send({ query: `mutation { createTodo(input: { title: "empty options", done: false }) { id title } }` })
+      .expect(200);
+    expect(created.body.errors).toBeUndefined();
+    expect(created.body.data.createTodo).toEqual({ id: 1, title: "empty options" });
+  });
+
+  it("mounts the same way under forRootAsync", async () => {
+    // The async form resolves its options through a factory and implies
+    // `provideServices`, so the merged schema's container lookups run
+    // through a different branch than `forRoot`'s.
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        KavoModule.forRootAsync({ useFactory: () => ({ infrastructure: fakeInfrastructure(adapter) }), graphql: true }),
+      ],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    const server = await listen(app);
+
+    const created = await request(server)
+      .post("/graphql")
+      .send({ query: `mutation { createTodo(input: { title: "async", done: false }) { id title } }` })
+      .expect(200);
+    expect(created.body.errors).toBeUndefined();
+    expect(created.body.data.createTodo).toEqual({ id: 1, title: "async" });
+  });
 });

--- a/packages/frameworks/nest/tests/default-mcp-controller.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/default-mcp-controller.e2e.spec.ts
@@ -116,6 +116,63 @@ describe("KavoModule.forRoot({ mcp: true })", () => {
     await mcpRequest(server).send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }).expect(404);
   });
 
+  it("falls back to the default path when given an options object that omits one", async () => {
+    // `mcp: {}` is what an app writes when it builds the option object
+    // programmatically and has no path to contribute. It has to mean the
+    // same thing as `mcp: true`, not "mount at undefined".
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), mcp: {} })],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    const server = await listen(app);
+
+    const listed = await mcpRequest(server).send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    expect(listed.status).toBe(200);
+  });
+
+  it("mounts the same way under forRootAsync", async () => {
+    // The async form resolves its options through a factory, so the
+    // controller is built from a different branch than `forRoot`'s.
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        KavoModule.forRootAsync({ useFactory: () => ({ infrastructure: fakeInfrastructure(adapter) }), mcp: true }),
+      ],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    const server = await listen(app);
+
+    const listed = await mcpRequest(server).send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    expect(listed.status).toBe(200);
+    expect((listed.body.result.tools as { name: string }[]).length).toBeGreaterThan(0);
+  });
+
+  it("treats a tools/call with no arguments key as an empty argument object", async () => {
+    // An MCP client legitimately omits `arguments` for a tool that needs
+    // none, so reading it unguarded would turn a valid call into a crash.
+    const adapter = new InMemoryTodoAdapter();
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), mcp: true })],
+      controllers: [TodoController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    const server = await listen(app);
+
+    const called = await mcpRequest(server).send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "todo.findMany" },
+    });
+
+    expect(called.status).toBe(200);
+    expect(called.body.result.isError).toBeUndefined();
+    expect(JSON.parse(called.body.result.content[0].text)).toMatchObject({ items: [] });
+  });
+
   it("maps a not-found id to an isError tool result over HTTP", async () => {
     const adapter = new InMemoryTodoAdapter();
     const moduleRef = await Test.createTestingModule({

--- a/packages/frameworks/nest/tests/for-feature-rejections.spec.ts
+++ b/packages/frameworks/nest/tests/for-feature-rejections.spec.ts
@@ -1,0 +1,61 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { Controller } from "@nestjs/common";
+import { ConfigurationException } from "@kavo/core";
+import { Kavo, KavoModule } from "@kavo/nest";
+import { Todo } from "./support/fake-infrastructure.js";
+
+/**
+ * The two ways `KavoModule.forFeature` refuses to guess, both of which
+ * throw synchronously at module-definition time rather than producing a
+ * container that fails later.
+ *
+ * This needs its own file because the no-arg form reads the process-wide
+ * registry in `kavo.decorator.ts`, and vitest isolates modules per test
+ * file. `for-feature-registry.e2e.spec.ts` is the file whose premise is a
+ * *single* registrant; this one's premise is two, so they cannot share.
+ */
+
+@Kavo(Todo)
+@Controller("todos")
+class FirstTodoController {}
+
+@Kavo(Todo)
+@Controller("archived-todos")
+class SecondTodoController {}
+
+describe("KavoModule.forFeature([...]) — an undecorated class", () => {
+  it("refuses a class carrying no @Kavo metadata, naming it", () => {
+    // Silently skipping it would leave the app booting with a route table
+    // missing an entity the developer believes they registered.
+    class PlainController {}
+
+    expect(() => KavoModule.forFeature([PlainController])).toThrow(ConfigurationException);
+    expect(() => KavoModule.forFeature([PlainController])).toThrow(/PlainController/);
+    expect(() => KavoModule.forFeature([PlainController])).toThrow(/@Kavo/);
+  });
+
+  it("still accepts a decorated one alongside", () => {
+    expect(() => KavoModule.forFeature([FirstTodoController])).not.toThrow();
+  });
+});
+
+describe("KavoModule.forFeature() — two controllers claiming one entity", () => {
+  it("refuses to pick, naming both controllers and the entity", () => {
+    // Each `@Kavo` class carries its own config, so the provider for
+    // `getKavoServiceToken(Todo)` would be whichever registered last —
+    // a silent coin flip between two different service configurations.
+    expect(() => KavoModule.forFeature()).toThrow(ConfigurationException);
+    expect(() => KavoModule.forFeature()).toThrow(/FirstTodoController/);
+    expect(() => KavoModule.forFeature()).toThrow(/SecondTodoController/);
+    expect(() => KavoModule.forFeature()).toThrow(/Todo/);
+  });
+
+  it("points at the explicit-array form as the way out", () => {
+    expect(() => KavoModule.forFeature()).toThrow(/explicit array/);
+  });
+
+  it("accepts the same two controllers when the array disambiguates them", () => {
+    expect(() => KavoModule.forFeature([FirstTodoController, SecondTodoController])).not.toThrow();
+  });
+});

--- a/packages/frameworks/nest/tests/load-mcp-sdk.spec.ts
+++ b/packages/frameworks/nest/tests/load-mcp-sdk.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConfigurationException } from "@kavo/core";
+
+/**
+ * The MCP twin of `load-graphql.spec.ts`, and the same bug class.
+ * `@modelcontextprotocol/sdk` is an *optional* peer, so nothing in
+ * `@kavo/nest`'s always-loaded module graph (`index.ts`,
+ * `kavo.module.ts`) may import it eagerly — otherwise `import { Kavo }
+ * from "@kavo/nest"` crashes with a raw `ERR_MODULE_NOT_FOUND` for every
+ * app that never touches MCP.
+ *
+ * `@kavo/mcp` itself is imported directly rather than lazily, which is
+ * safe because it consumes the SDK for *types only* (doc 16, §5). The
+ * default MCP controller is the one place `@kavo/nest` instantiates SDK
+ * classes, and it reaches them through `loadMcpSdk`. Mocking the three
+ * SDK entry points to throw stands in for "the package is not installed".
+ */
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => {
+  throw new Error("Cannot find package '@modelcontextprotocol/sdk'");
+});
+vi.mock("@modelcontextprotocol/sdk/server/streamableHttp.js", () => {
+  throw new Error("Cannot find package '@modelcontextprotocol/sdk'");
+});
+vi.mock("@modelcontextprotocol/sdk/types.js", () => {
+  throw new Error("Cannot find package '@modelcontextprotocol/sdk'");
+});
+
+describe("loadMcpSdk", () => {
+  it("importing @kavo/nest's barrel never touches the SDK at runtime, even when it would throw", async () => {
+    // The regression worth guarding: this import must resolve despite the
+    // mocks above making every SDK entry point explode, which is only true
+    // while nothing reachable from the barrel loads the SDK eagerly.
+    await expect(import("@kavo/nest")).resolves.toBeDefined();
+  });
+
+  it("wraps a failed dynamic import in a ConfigurationException", async () => {
+    const { loadMcpSdk } = await import("../src/mcp/load-mcp-sdk.js");
+    await expect(loadMcpSdk()).rejects.toThrow(ConfigurationException);
+  });
+
+  it("names the package to install and the option to drop", async () => {
+    // A raw module-resolution error tells an adopter nothing about which
+    // of their choices caused it; this message names both ways out.
+    const { loadMcpSdk } = await import("../src/mcp/load-mcp-sdk.js");
+    await expect(loadMcpSdk()).rejects.toThrow(/@modelcontextprotocol\/sdk/);
+    await expect(loadMcpSdk()).rejects.toThrow(/install/i);
+  });
+
+  it("stays failed on a second call rather than retrying the import", async () => {
+    // The result is cached either way; a missing package does not become
+    // present mid-process, so re-attempting the import per request would
+    // only add latency to an error path.
+    const { loadMcpSdk } = await import("../src/mcp/load-mcp-sdk.js");
+    await expect(loadMcpSdk()).rejects.toThrow(ConfigurationException);
+    await expect(loadMcpSdk()).rejects.toThrow(ConfigurationException);
+  });
+});

--- a/packages/frameworks/nest/tests/settings.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/settings.e2e.spec.ts
@@ -4,8 +4,9 @@ import request from "supertest";
 import { Controller, type INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import { withListMeta } from "@kavo/core";
+import type { DefaultKavoService } from "@kavo/core";
 import type { KavoModuleOptions } from "@kavo/nest";
-import { Kavo, KavoModule } from "@kavo/nest";
+import { Kavo, KavoModule, getKavoServiceToken } from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
 
@@ -27,6 +28,7 @@ let httpServer: SupertestTarget | undefined;
 interface BootstrapOptions {
   readonly defaults?: KavoModuleOptions["defaults"];
   readonly async?: boolean;
+  readonly paginationStrategies?: KavoModuleOptions["paginationStrategies"];
 }
 
 async function bootstrap(controller: unknown, options: BootstrapOptions = {}): Promise<void> {
@@ -35,7 +37,11 @@ async function bootstrap(controller: unknown, options: BootstrapOptions = {}): P
   const rootModule =
     options.async === true
       ? KavoModule.forRootAsync({ useFactory: () => ({ infrastructure, defaults: options.defaults }) })
-      : KavoModule.forRoot({ infrastructure, defaults: options.defaults });
+      : KavoModule.forRoot({
+          infrastructure,
+          defaults: options.defaults,
+          ...(options.paginationStrategies !== undefined && { paginationStrategies: options.paginationStrategies }),
+        });
   const moduleRef = await Test.createTestingModule({
     imports: [rootModule, KavoModule.forFeature([controller as never])],
   }).compile();
@@ -236,6 +242,81 @@ describe("@Kavo custom meta.routes on a standard, non-@Override'd operation", ()
     await request(server()).post("/todos").send({ title: "x" }).expect(201);
 
     await request(server()).delete("/todos/1").expect(404);
+  });
+});
+
+describe("@Kavo meta.routes.enabled: false — service-only operations", () => {
+  // "Service-only" has to mean both halves: no route, and the operation
+  // still callable in code. Testing only the 404 would pass just as well
+  // if the operation had been disabled outright, which is a different
+  // feature with a different meaning.
+  @Kavo(Todo, { operations: { deleteOne: { meta: { routes: { enabled: false } } } } })
+  @Controller("todos")
+  class ServiceOnlyDeleteController {}
+
+  it("generates no route for the operation", async () => {
+    await bootstrap(ServiceOnlyDeleteController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    await request(server()).delete("/todos/1").expect(404);
+  });
+
+  it("leaves every other operation's route intact", async () => {
+    await bootstrap(ServiceOnlyDeleteController);
+    const created = await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    await request(server())
+      .get(`/todos/${created.body.id as number}`)
+      .expect(200);
+  });
+
+  it("still runs the operation through the injected service", async () => {
+    await bootstrap(ServiceOnlyDeleteController);
+    const created = await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    const id = created.body.id as number;
+
+    const service = app.get<DefaultKavoService<Todo>>(getKavoServiceToken(Todo));
+    await service.deleteOne(id);
+
+    await request(server()).get(`/todos/${id}`).expect(404);
+  });
+});
+
+describe("KavoModule.forRoot({ paginationStrategies }) — a custom strategy reaches the engine", () => {
+  // A declared public option with no coverage of its wiring: a typo in the
+  // thread-through would leave the strategy silently unregistered and the
+  // entity paging by offset, which looks like working software.
+  class EveryOtherRowStrategy {
+    readonly name = "alternating";
+    normalize(rawParams: Readonly<Record<string, unknown>>, limits: { defaultLimit: number }) {
+      const raw = rawParams["page"];
+      const page = typeof raw === "string" ? Number(raw) : 0;
+      return { limit: limits.defaultLimit, offset: page * 2 };
+    }
+  }
+
+  @Kavo(Todo)
+  @Controller("todos")
+  class AlternatingController {}
+
+  it("pages through the registered custom strategy rather than falling back to offset", async () => {
+    await bootstrap(AlternatingController, {
+      defaults: { pagination: { strategy: "alternating", defaultLimit: 1 } },
+      paginationStrategies: [new EveryOtherRowStrategy() as never],
+    });
+    for (const title of ["a", "b", "c"]) {
+      await request(server()).post("/todos").send({ title }).expect(201);
+    }
+
+    const second = await request(server()).get("/todos?page=1").expect(200);
+    expect(second.body.items).toHaveLength(1);
+    expect(second.body.items[0]).toMatchObject({ title: "c" });
+  });
+
+  it("fails loudly when the configured strategy is not registered at all", async () => {
+    await bootstrap(AlternatingController, { defaults: { pagination: { strategy: "missing" } } });
+
+    await request(server()).get("/todos").expect(500);
   });
 });
 

--- a/packages/frameworks/nest/tests/unhandled-exception.spec.ts
+++ b/packages/frameworks/nest/tests/unhandled-exception.spec.ts
@@ -3,11 +3,23 @@ import { BadRequestException, HttpException, NotFoundException } from "@nestjs/c
 import { toKavoExceptionShape } from "../src/unhandled-exception.js";
 
 describe("toKavoExceptionShape", () => {
-  it("maps a string-body HttpException to KAVO_HTTP_ERROR at its own status", () => {
+  it("maps a built-in HttpException to KAVO_HTTP_ERROR at its own status", () => {
+    // Nest's own subclasses build an *object* body (`{ statusCode, message,
+    // error }`) even when constructed from a string, so this exercises the
+    // object arm. The genuine string-body case is the next test.
     const shape = toKavoExceptionShape(new NotFoundException("no boom here"));
     expect(shape.code).toBe("KAVO_HTTP_ERROR");
     expect(shape.status).toBe(404);
     expect(shape.detail).toContain("no boom here");
+  });
+
+  it("surfaces a bare string response body as the detail", () => {
+    // `new HttpException("...", status)` keeps the response as a raw
+    // string, which an app writing its own exceptions does routinely.
+    const shape = toKavoExceptionShape(new HttpException("plain text body", 418));
+    expect(shape.code).toBe("KAVO_HTTP_ERROR");
+    expect(shape.status).toBe(418);
+    expect(shape.detail).toContain("plain text body");
   });
 
   it("joins an array `message` (ValidationPipe shape) into one detail string", () => {

--- a/packages/orms/mikroorm/tests/adapter.spec.ts
+++ b/packages/orms/mikroorm/tests/adapter.spec.ts
@@ -8,6 +8,7 @@ import {
   NotFoundException,
   PersistenceException,
   QueryValidationException,
+  createCrud,
   type DefaultKavoService,
   type KavoInstance,
 } from "@kavo/core";
@@ -317,6 +318,43 @@ describe("MikroOrmRepositoryAdapter — relation writes", () => {
   });
 });
 
+describe("MikroOrmRepositoryAdapter — relation values core never narrowed", () => {
+  /**
+   * A service built on core's explicit-runtime path — `createCrud(Entity,
+   * config, runtime)`, no root instance and therefore no entity catalog.
+   * That is the state the adapter's own unwrapping exists for: core's
+   * deserializer narrows a relation to `{ id }` only when the *target* is in
+   * the catalog, so with an empty one the client's raw value reaches the
+   * adapter exactly as it was sent. (Through `createMikroOrmKavo` the catalog
+   * derives every target from MikroORM's own metadata, so core narrows first
+   * and these shapes never get that far.)
+   */
+  function bareBooks(): DefaultKavoService<Book> {
+    return createCrud(Book, undefined, {
+      metadata: buildEntityMetadata(orm, Book),
+      adapter: createInfrastructure(orm).adapterFor(Book),
+    }) as DefaultKavoService<Book>;
+  }
+
+  it("associates a bare scalar id, which MikroORM takes as the foreign key", async () => {
+    const ada = (await authors.createOne({ email: "ada@x.io", name: "Ada", age: 36 } as never)) as Author;
+    const created = (await bareBooks().createOne({ title: "Notes", author: ada.id } as never)) as Book;
+    expect(await readAuthorId(created.id)).toBe(ada.id);
+  });
+
+  it("drops an id-less relation object rather than deep-writing it", async () => {
+    // ADR-0014: relations are associated by id, never deep-written. Handing
+    // `{ name: "nope" }` to `em.create` would leave a nested write one cascade
+    // setting away from working, so an object carrying no id becomes `null` —
+    // the book is written, the smuggled author is not.
+    const before = await orm.em.fork().count(Author, {});
+    const created = (await bareBooks().createOne({ title: "smuggled", author: { name: "nope" } } as never)) as Book;
+
+    expect(await orm.em.fork().count(Author, {})).toBe(before);
+    expect(await readAuthorId(created.id)).toBeUndefined();
+  });
+});
+
 describe("MikroOrmRepositoryAdapter — findOne by query", () => {
   it("returns the first row when the query carries no filter at all", async () => {
     // Regression: MikroORM's validator rejects `em.findOne` with an empty
@@ -330,6 +368,16 @@ describe("MikroOrmRepositoryAdapter — findOne by query", () => {
     const reader = createInfrastructure(orm).adapterFor(Author);
     const row = await reader.findOne(unfilteredQuery() as never, hardDeleteContext() as never);
     expect(row).not.toBeNull();
+  });
+
+  it("returns null when the query matches nothing", async () => {
+    // The limit-1 `em.find` behind this answers with an empty array, so the
+    // adapter has to produce the `null` itself — `findOne`'s contract is "a
+    // row or null", and core reads that null as the 404 signal. An
+    // `undefined` leaking through instead would be serialized as a body.
+    const reader = createInfrastructure(orm).adapterFor(Author);
+    const row = await reader.findOne(unfilteredQuery() as never, hardDeleteContext() as never);
+    expect(row).toBeNull();
   });
 
   it("still applies sort and soft-delete scope on the unfiltered path", async () => {

--- a/packages/orms/mikroorm/tests/metadata.spec.ts
+++ b/packages/orms/mikroorm/tests/metadata.spec.ts
@@ -73,12 +73,43 @@ class Widget {
   bulky: string | null = null;
 }
 
+/**
+ * Column types MikroORM cannot give a JavaScript equivalent for: every
+ * property here comes back with a `runtimeType` that narrows nothing
+ * (`"unknown"`, `"any"`, `"Buffer"`), so the *declared* type is the only
+ * thing left to read a field kind off. Custom types and driver-native column
+ * types are the real-world case — Kavo's coercion depends on getting them
+ * right, and there is no reflection to fall back on.
+ */
+@Entity()
+class Reading {
+  @PrimaryKey({ type: "number" })
+  id!: number;
+
+  @Property({ type: "int8", nullable: true })
+  samples: unknown = null;
+
+  @Property({ type: "timestamptz", nullable: true })
+  observedAt: unknown = null;
+
+  @Property({ type: "bool", nullable: true })
+  verified: unknown = null;
+
+  @Property({ type: "jsonb", nullable: true })
+  extra: unknown = null;
+
+  @Property({ type: "blob", nullable: true })
+  raw: unknown = null;
+}
+
 let orm: MikroORM;
 let byName: Record<string, FieldMetadata>;
+let declaredOnly: Record<string, FieldMetadata>;
 
 beforeAll(async () => {
-  orm = await newTestOrm([Widget]);
+  orm = await newTestOrm([Widget, Reading]);
   byName = Object.fromEntries(buildEntityMetadata(orm, Widget).fields.map((field) => [field.name, field]));
+  declaredOnly = Object.fromEntries(buildEntityMetadata(orm, Reading).fields.map((field) => [field.name, field]));
 });
 
 afterAll(async () => {
@@ -108,6 +139,22 @@ describe("buildEntityMetadata — field kinds", () => {
     // `JsonType`'s `runtimeType` is `"any"`, which narrows nothing; the
     // declared type is the only thing left that says "json".
     expect(byName["payload"]).toMatchObject({ kind: "json" });
+  });
+
+  it.each([
+    ["samples", "int8", "number"],
+    ["observedAt", "timestamptz", "date"],
+    ["verified", "bool", "boolean"],
+    ["extra", "jsonb", "json"],
+    ["raw", "blob", "string"],
+  ])("reads %s, declared '%s', as the %s field kind", (field, _declared, kind) => {
+    // The declared-type ladder, one row per rung. It is not a guard: these
+    // are ordinary columns whose `runtimeType` narrows nothing, and getting
+    // one wrong is silent — `filter[observedAt][gt]=2024-01-01` would be
+    // compared as a string, and `int8` values would never coerce to numbers.
+    // The last rung is the honest one: an unrecognized type degrades to
+    // `string`, so comparison still works even though coercion cannot narrow.
+    expect(declaredOnly[field]).toMatchObject({ kind });
   });
 
   it("carries the enum's allowed values as the coercion allowlist", () => {
@@ -223,6 +270,16 @@ describe("buildEntityMetadata — relation targets", () => {
       await named.close();
     }
   });
+
+  // `targetOf`'s final `ConfigurationException` — the guard that stops a
+  // bare string reaching core, where relation targets are matched by class
+  // identity — is deliberately left uncovered. MikroORM's discovery
+  // validator refuses to initialize an ORM whose relation names an
+  // undiscovered entity, so the only way in is to forge the discovered
+  // property afterwards, and a test that rewrites ORM internals asserts
+  // the shape of those internals rather than any behavior of ours.
+  // `@kavo/mongoose` covers the same guard through a supported path,
+  // because an unregistered `ref` there is an ordinary runtime state.
 });
 
 describe("buildEntityMetadata — single-table inheritance", () => {

--- a/packages/orms/mikroorm/tests/soft-delete.spec.ts
+++ b/packages/orms/mikroorm/tests/soft-delete.spec.ts
@@ -219,6 +219,23 @@ describe("MikroOrmRepositoryAdapter — soft delete", () => {
   });
 });
 
+describe("MikroOrmRepositoryAdapter — an id that is not there", () => {
+  // A missing row and an already-deleted one are different answers: 404
+  // versus 409. Conflating them would tell a client to retry something that
+  // can never succeed, because there is no row to act on in the first place.
+  it("404s on soft delete of an absent id, rather than reporting a conflict", async () => {
+    await expect(tickets.deleteOne(9999)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("404s on purge of an absent id under the soft strategy", async () => {
+    // The hard-strategy sibling gets its 404 from `nativeDelete` reporting
+    // zero affected rows; under soft the answer has to come earlier, from the
+    // lookup the already-deleted check does — otherwise a missing id would
+    // surface as "not deleted" (409) instead.
+    await expect(tickets.purgeOne(9999)).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
 describe("MikroOrmRepositoryAdapter — a differently named marker column", () => {
   it("soft-deletes, excludes, and restores over an ordinary column", async () => {
     const created = await invoices.createOne({ number: "INV-1" } as never);

--- a/packages/orms/mongoose/tests/adapter.spec.ts
+++ b/packages/orms/mongoose/tests/adapter.spec.ts
@@ -7,8 +7,9 @@ import {
   QueryValidationException,
   type DefaultKavoService,
   type KavoInstance,
+  type RepositoryAdapter,
 } from "@kavo/core";
-import { createMongooseKavo } from "@kavo/mongoose";
+import { createInfrastructure, createMongooseKavo } from "@kavo/mongoose";
 import {
   clearCollections,
   ensureIndexes,
@@ -108,6 +109,29 @@ async function seed(): Promise<void> {
   for (const row of rows) await authors.createOne(row as never);
 }
 
+/** A normalized query with no filter — what a custom handler hands the reader. */
+function unfilteredQuery() {
+  return {
+    filter: { root: null },
+    sort: [],
+    include: {},
+    fields: { root: null, relations: {} },
+    pagination: { limit: 10, offset: 0 },
+    count: false,
+    withDeleted: false,
+    onlyDeleted: false,
+  };
+}
+
+/** The context core resolves for `Author`, which configures no soft delete. */
+function hardDeleteContext() {
+  return { entityName: "Author", operation: "findOne", config: { softDelete: { strategy: "hard" } } };
+}
+
+function authorAdapter(): RepositoryAdapter<Author> {
+  return createInfrastructure(database.connection).adapterFor(models.Author as never) as RepositoryAdapter<Author>;
+}
+
 describe("MongooseRepositoryAdapter — CRUD", () => {
   it("creates, reads, updates, patches, deletes against a real MongoDB", async () => {
     const created = (await authors.createOne({ email: "ada@x.io", name: "Ada", age: 36 } as never)) as Author;
@@ -169,6 +193,73 @@ describe("MongooseRepositoryAdapter — CRUD", () => {
     const created = (await authors.createOne({ email: "noop@x.io", name: "Noop", age: 5 } as never)) as Author;
     const patched = (await authors.patchOne(created._id, {} as never)) as Author;
     expect(patched).toMatchObject({ _id: created._id, name: "Noop", age: 5 });
+  });
+
+  it("still answers 404 when a patch carrying no fields addresses an absent document", async () => {
+    // The empty-body path above skips the write entirely, so it also skips
+    // the "matched nothing" signal every other write is 404'd by — it reads
+    // instead, and that read coming back empty is the only thing left to
+    // tell a missing document from an unchanged one.
+    const error = await rejectionOf(authors.patchOne(ABSENT_ID, {} as never));
+    expect(error).toBeInstanceOf(NotFoundException);
+    expect(error.code).toBe("KAVO_NOT_FOUND");
+  });
+});
+
+describe("MongooseRepositoryAdapter — reads that only a custom handler reaches", () => {
+  // Every engine read addresses a document by id and goes through
+  // `findOneById` with a query object, so neither `findOne(query, …)` nor a
+  // null query has a generated route standing behind it. Both are still part
+  // of the adapter's contract — a custom handler or a programmatic caller is
+  // the way in — which is why they are exercised against the adapter
+  // directly here rather than through a service.
+
+  it("returns the single row a by-query read matches", async () => {
+    await seed();
+    const row = await authorAdapter().findOne(
+      {
+        ...unfilteredQuery(),
+        filter: { root: { kind: "condition", field: "name", operator: "EQ", value: "Grace" } },
+      } as never,
+      hardDeleteContext() as never,
+    );
+    expect(row).toMatchObject({ name: "Grace", age: 45 });
+  });
+
+  it("answers null for a by-query read that matches nothing, rather than throwing", async () => {
+    await seed();
+    const row = await authorAdapter().findOne(
+      {
+        ...unfilteredQuery(),
+        filter: { root: { kind: "condition", field: "name", operator: "EQ", value: "Nobody" } },
+      } as never,
+      hardDeleteContext() as never,
+    );
+    expect(row).toBeNull();
+  });
+
+  it("applies the by-query read's sort, so the row it returns is a chosen one", async () => {
+    // `findOne` builds its own sort — the unsorted call would answer in
+    // MongoDB's natural order, so "the youngest author" would be right only
+    // by accident, and a dropped sort would never fail a hit/miss test.
+    await seed();
+    const row = await authorAdapter().findOne(
+      { ...unfilteredQuery(), sort: [{ field: "age", direction: "asc" }] } as never,
+      hardDeleteContext() as never,
+    );
+    expect(row).toMatchObject({ name: "Joan" });
+  });
+
+  it("reads by id with no query at all, and answers null for an absent one", async () => {
+    // `findOneById`'s signature admits a null query — a caller with nothing
+    // to ask beyond the id passes one — so every optional-chained read of
+    // `include`/`withDeleted`/`onlyDeleted` has to hold with no query object
+    // present rather than throwing on a property of null.
+    const created = (await authors.createOne({ email: "byid@x.io", name: "ById", age: 3 } as never)) as Author;
+    const adapter = authorAdapter();
+
+    expect(await adapter.findOneById(created._id, null, hardDeleteContext() as never)).toMatchObject({ name: "ById" });
+    expect(await adapter.findOneById(ABSENT_ID, null, hardDeleteContext() as never)).toBeNull();
   });
 });
 

--- a/packages/orms/mongoose/tests/document-mapping.spec.ts
+++ b/packages/orms/mongoose/tests/document-mapping.spec.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Schema } from "mongoose";
 import type { DefaultKavoService } from "@kavo/core";
-import { createMongooseKavo } from "@kavo/mongoose";
+import { createMongooseKavo, toPlainDocument } from "@kavo/mongoose";
 import { clearCollections, startTestDatabase, type TestDatabase } from "./support/database.js";
 
 /**
@@ -121,6 +121,34 @@ describe("arbitrary-precision numerics cross the wire as numbers", () => {
     expect(typeof fetched.big).toBe("number");
     expect(typeof fetched.dec).toBe("number");
     expect(() => JSON.stringify(fetched)).not.toThrow();
+  });
+});
+
+describe("toPlainDocument decides what it recurses into", () => {
+  // The two BSON shapes below never reach the engine through the models in
+  // this file, so they are pinned against the exported helper directly.
+
+  it("passes a Buffer through untouched instead of shredding it into an index map", () => {
+    // `Object.entries(Buffer.from("x"))` is `[["0", 120]]`, so a recursion
+    // that treated every object as plain would turn stored binary into
+    // `{"0":120}` on every read. This adapter's contract is the id and
+    // numeric conversion, not a BSON-wide codec.
+    const blob = Buffer.from("x");
+    const plain = toPlainDocument({ blob }) as { blob: unknown };
+    expect(plain.blob).toBe(blob);
+    expect(Buffer.isBuffer(plain.blob)).toBe(true);
+  });
+
+  it("recurses into a null-prototype object, which is what a lean document can be", () => {
+    // This is the whole reason the plain-object test reads the prototype
+    // rather than checking `constructor === Object`: under the stricter test
+    // a lean document would pass straight through and its `_id` would leave
+    // the adapter as a raw ObjectId.
+    const source = Object.assign(Object.create(null) as Record<string, unknown>, {
+      _id: { toHexString: () => "507f1f77bcf86cd799439011" },
+      a: 1,
+    });
+    expect(toPlainDocument(source)).toEqual({ _id: "507f1f77bcf86cd799439011", a: 1 });
   });
 });
 

--- a/packages/orms/mongoose/tests/error-mapping.spec.ts
+++ b/packages/orms/mongoose/tests/error-mapping.spec.ts
@@ -47,6 +47,41 @@ describe("mapDriverError — cast failures", () => {
     expect(mapped.message.replace("not-an-objectid", "X")).toBe(absent.message.replace(ABSENT_ID, "X"));
   });
 
+  it("renders a rejected id that is not a string, rather than blanking it", () => {
+    // Same security property as the test above, for the ids core cannot
+    // coerce to a string on the way in: a custom operation passing an id off
+    // a JSON body reaches the adapter with a number or an object. Both still
+    // have to render as *something*, because `with id ''` is exactly the
+    // key-format oracle answering 404 here exists to avoid.
+    const numeric = mapDriverError(new mongoose.Error.CastError("ObjectId", 12345 as never, "_id"), CONTEXT, "_id");
+    expect(numeric).toBeInstanceOf(NotFoundException);
+    expect(numeric.messageParams).toMatchObject({ id: "12345" });
+
+    // An object renders the same way. What matters is that it renders at
+    // all, and off the raw value rather than off Mongoose's own message
+    // text — which quotes and pretty-prints it, so `'{ '$gt': '' }'` would
+    // reach the wire carrying the empty pair this branch is meant to avoid.
+    const structured = mapDriverError(
+      new mongoose.Error.CastError("ObjectId", { $gt: "" } as never, "_id"),
+      CONTEXT,
+      "_id",
+    );
+    expect(structured).toBeInstanceOf(NotFoundException);
+    expect(structured.messageParams).toMatchObject({ id: "[object Object]" });
+    expect(structured.message).not.toContain("''");
+  });
+
+  it("falls back to stringValue with its quotes stripped, so the id is not double-quoted", () => {
+    // Mongoose quotes `stringValue` for its own message text while core
+    // interpolates the id into `'{id}'`; left as supplied the 404 would read
+    // `with id '"abc"'` — a shape difference a caller could read as a signal.
+    const error = Object.assign(new Error("cast failed"), { name: "CastError", path: "_id", stringValue: '"abc"' });
+    const mapped = mapDriverError(error, CONTEXT, "_id");
+    expect(mapped).toBeInstanceOf(NotFoundException);
+    expect(mapped.messageParams).toMatchObject({ id: "abc" });
+    expect(mapped.message).toContain("'abc'");
+  });
+
   it("answers 400 for a cast failure on any other path", () => {
     const error = new mongoose.Error.CastError("ObjectId", "nope", "author");
     const mapped = mapDriverError(error, CONTEXT, "_id");
@@ -118,5 +153,17 @@ describe("mapDriverError — pass-through and fallback", () => {
     const mapped = mapDriverError("boom", CONTEXT, "_id");
     expect(mapped).toBeInstanceOf(PersistenceException);
     expect(mapped.cause).toBe("boom");
+  });
+
+  it("falls back to a generic entity name when the context names none", () => {
+    // Every field of `ErrorContext` is optional, so a mapped exception must
+    // still render a complete message — a missing name would otherwise reach
+    // the wire as the literal `{entity}` the catalog template spells.
+    const mapped = mapDriverError(new mongoose.Error.CastError("ObjectId", "not-an-objectid", "_id"), {}, "_id");
+    expect(mapped.messageParams).toEqual({ entity: "entity", id: "not-an-objectid" });
+  });
+
+  it("reports the operation as 'unknown' when the context does not name one", () => {
+    expect(mapDriverError(serverError(9999), {}).messageParams).toEqual({ operation: "unknown" });
   });
 });

--- a/packages/orms/mongoose/tests/metadata.spec.ts
+++ b/packages/orms/mongoose/tests/metadata.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import mongoose, { Schema } from "mongoose";
 import type { ClassRef, FieldMetadata } from "@kavo/core";
 import { ConfigurationException } from "@kavo/core";
-import { buildEntityMetadata } from "@kavo/mongoose";
+import { asModel, buildEntityMetadata } from "@kavo/mongoose";
 
 /**
  * Metadata derivation reads `schema.paths` only — it never talks to a
@@ -169,6 +169,32 @@ describe("buildEntityMetadata — renamed and disabled schema options", () => {
     expect(byName["updated_at"]).toMatchObject({ generated: true });
   });
 
+  it("honours a timestamps pair where only one side is renamed", () => {
+    // `{ updatedAt: "modified_at" }` renames one side and leaves the other at
+    // its default name. Missing the default-named side would make
+    // `createdAt` an ordinary writable field, so it would land in every
+    // derived write DTO and a caller could set the document's creation time.
+    const registry = newRegistry();
+    const Doc = registry.model(
+      "PartiallyRenamed",
+      new Schema({ title: String }, { timestamps: { updatedAt: "modified_at" } }),
+    );
+    const byName = fieldsByName(buildEntityMetadata(Doc as unknown as ClassRef, registry).fields);
+    expect(byName["createdAt"]).toMatchObject({ kind: "date", generated: true });
+    expect(byName["modified_at"]).toMatchObject({ kind: "date", generated: true });
+  });
+
+  it("stamps only the enabled side when one timestamp is switched off", () => {
+    const registry = newRegistry();
+    const Doc = registry.model(
+      "OneSidedTimestamps",
+      new Schema({ title: String }, { timestamps: { createdAt: false } }),
+    );
+    const byName = fieldsByName(buildEntityMetadata(Doc as unknown as ClassRef, registry).fields);
+    expect(byName["createdAt"]).toBeUndefined(); // Mongoose never adds the path
+    expect(byName["updatedAt"]).toMatchObject({ kind: "date", generated: true });
+  });
+
   it("excludes a renamed version key, and includes nothing extra when it is disabled", () => {
     const registry = newRegistry();
     const Renamed = registry.model("Renamed", new Schema({ title: String }, { versionKey: "_version" }));
@@ -267,5 +293,44 @@ describe("buildEntityMetadata — rejected inputs", () => {
     expect(thrown).toBeInstanceOf(ConfigurationException);
     expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
     expect((thrown as Error).message).toContain("Mongoose model");
+  });
+
+  it("rejects a primitive and null without reading a property off either", () => {
+    // A class — the case above — is `typeof "function"` and sails past both
+    // of `asModel`'s narrowing guards on its way to the missing `modelName`.
+    // `null` and a bare string reach different arms, and reading
+    // `null.modelName` would be a TypeError from deep inside bootstrap
+    // instead of the exception that names what was actually passed.
+    for (const notAModel of [null, "Author"]) {
+      let thrown: unknown;
+      try {
+        asModel(notAModel as never);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ConfigurationException);
+      expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((thrown as Error).message).toContain("Mongoose model");
+    }
+  });
+
+  it("refuses a schema that disables the _id path", () => {
+    // `{ _id: false }` is legal Mongoose — it is how a subdocument opts out
+    // of its own key — but a collection without `_id` has nothing for Kavo
+    // to address a document by, so it is refused at bootstrap rather than
+    // 404ing every single-document route at runtime.
+    const registry = newRegistry();
+    const NoId = registry.model("NoId", new Schema({ title: String }, { _id: false }));
+    expect(Object.keys(NoId.schema.paths)).not.toContain("_id"); // Mongoose really does this
+
+    let thrown: unknown;
+    try {
+      buildEntityMetadata(NoId as unknown as ClassRef, registry);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationException);
+    expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+    expect((thrown as Error).message).toContain("_id");
   });
 });

--- a/packages/orms/mongoose/tests/soft-delete.spec.ts
+++ b/packages/orms/mongoose/tests/soft-delete.spec.ts
@@ -2,12 +2,14 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Schema } from "mongoose";
 import {
   AlreadyDeletedException,
+  ConfigurationException,
   ConflictException,
   NotDeletedException,
   NotFoundException,
   type DefaultKavoService,
+  type RepositoryAdapter,
 } from "@kavo/core";
-import { buildEntityMetadata, createMongooseKavo } from "@kavo/mongoose";
+import { buildEntityMetadata, createInfrastructure, createMongooseKavo } from "@kavo/mongoose";
 import {
   clearCollections,
   ensureIndexes,
@@ -234,5 +236,44 @@ describe("MongooseRepositoryAdapter — configured marker field", () => {
 
     const list = await invoices.findMany({ onlyDeleted: true });
     expect(list.items).toMatchObject([{ _id: deleted._id }]);
+  });
+});
+
+describe("MongooseRepositoryAdapter — hard-delete contexts assembled by hand", () => {
+  // Core refuses to *enable* `restoreOne` or `purgeOne` on a hard-delete
+  // entity at bootstrap, so neither guard below is reachable through
+  // `createCrud`. They are the adapter's second line, for a programmatic
+  // caller that assembles its own context and calls the adapter directly.
+
+  function invoiceAdapter(): RepositoryAdapter<Invoice> {
+    return createInfrastructure(database.connection).adapterFor(models.Invoice as never) as RepositoryAdapter<Invoice>;
+  }
+
+  function hardContext(operation: string) {
+    return { entityName: "Invoice", operation, config: { softDelete: { strategy: "hard" } } };
+  }
+
+  it("refuses restore outright on a hard-delete entity instead of silently no-opping", async () => {
+    const created = (await invoices.createOne({ number: "INV-guard" } as never)) as Invoice;
+
+    const error = await rejectionOf(invoiceAdapter().restore(created._id, hardContext("restoreOne") as never));
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error.code).toBe("KAVO_CONFIG_INVALID");
+    expect(error.message).toMatch(/hard delete strategy/);
+  });
+
+  it("purges a hard-delete document outright, then reports it as 404 once it is gone", async () => {
+    // Under a hard strategy `purge` has no delete marker to check, so its
+    // existence pre-check is the only thing between a second call and a
+    // `deleteOne` that quietly matches nothing and reports success.
+    const created = (await invoices.createOne({ number: "INV-purge" } as never)) as Invoice;
+    const adapter = invoiceAdapter();
+
+    await adapter.purge(created._id, hardContext("purgeOne") as never);
+    expect(await models.Invoice.countDocuments({})).toBe(0);
+
+    const error = await rejectionOf(adapter.purge(created._id, hardContext("purgeOne") as never));
+    expect(error).toBeInstanceOf(NotFoundException);
+    expect(error.code).toBe("KAVO_NOT_FOUND");
   });
 });

--- a/packages/orms/prisma/tests/adapter.spec.ts
+++ b/packages/orms/prisma/tests/adapter.spec.ts
@@ -8,7 +8,7 @@ import {
   type KavoInstance,
   type DefaultKavoService,
 } from "@kavo/core";
-import { buildEntityMetadata, createPrismaKavo } from "@kavo/prisma";
+import { buildEntityMetadata, createInfrastructure, createPrismaKavo } from "@kavo/prisma";
 import { newTestPrismaClient } from "./support/client.js";
 
 // Marker classes: Prisma models have no runtime class of their own, so
@@ -66,6 +66,33 @@ async function seed(): Promise<void> {
   for (const row of rows) await authors.createOne(row as never);
 }
 
+/** The adapter on its own, with no engine in front of it. */
+function authorAdapter() {
+  return createInfrastructure(client as never, {
+    datamodel: Prisma.dmmf.datamodel,
+    entities: [Author, Book],
+    caseInsensitiveFilters: false,
+  }).adapterFor(Author);
+}
+
+/** A normalized query with no filter — what a custom handler hands the reader. */
+function unfilteredQuery() {
+  return {
+    filter: { root: null },
+    sort: [],
+    include: {},
+    fields: { root: null, relations: {} },
+    pagination: { limit: 10, offset: 0 },
+    count: false,
+    withDeleted: false,
+    onlyDeleted: false,
+  };
+}
+
+function hardDeleteContext() {
+  return { entityName: "Author", operation: "findOne", config: { softDelete: { strategy: "hard" } } };
+}
+
 describe("metadata derivation seam", () => {
   it("derives fields, id, generated flags, and relations", () => {
     const metadata = buildEntityMetadata(Prisma.dmmf.datamodel, Author, new Map([["Book", Book] as const]));
@@ -111,6 +138,71 @@ describe("PrismaRepositoryAdapter — CRUD", () => {
     await expect(authors.createOne({ email: "dup@x.io", name: "B", age: 2 } as never)).rejects.toBeInstanceOf(
       ConflictException,
     );
+  });
+});
+
+/**
+ * No engine read reaches `findOne` by query — the standard `findOne` is by
+ * id, so `findOneById` is the only single-row read core ever issues. This
+ * overload exists for custom handlers and programmatic callers, which means
+ * nothing but a direct adapter call keeps it honest.
+ */
+describe("PrismaRepositoryAdapter — findOne by query", () => {
+  it("returns the first row when the query carries no filter at all", async () => {
+    await seed();
+    const row = await authorAdapter().findOne(unfilteredQuery() as never, hardDeleteContext() as never);
+    expect(row).not.toBeNull();
+  });
+
+  it("answers null for a query that matches nothing, rather than throwing", async () => {
+    // A miss is the caller's to interpret — `findOneById` reports it the same
+    // way, and it is the handler above that decides whether it is a 404.
+    await seed();
+    const row = await authorAdapter().findOne(
+      {
+        ...unfilteredQuery(),
+        filter: { root: { kind: "condition", field: "name", operator: "EQ", value: "Nobody" } },
+      } as never,
+      hardDeleteContext() as never,
+    );
+    expect(row).toBeNull();
+  });
+
+  it("applies the query's sort, so the row is the first match and not just any", async () => {
+    await seed();
+    const row = await authorAdapter().findOne(
+      { ...unfilteredQuery(), sort: [{ field: "age", direction: "asc" }] } as never,
+      hardDeleteContext() as never,
+    );
+    expect(row).toMatchObject({ name: "Joan" }); // the youngest, not whichever row came back first
+  });
+
+  it("applies the query's filter", async () => {
+    await seed();
+    const row = await authorAdapter().findOne(
+      {
+        ...unfilteredQuery(),
+        filter: { root: { kind: "condition", field: "status", operator: "EQ", value: "banned" } },
+      } as never,
+      hardDeleteContext() as never,
+    );
+    expect(row).toMatchObject({ name: "Alan" });
+  });
+});
+
+describe("PrismaRepositoryAdapter — findOneById without a query", () => {
+  // The signature admits `null` for a caller that has nothing to narrow by,
+  // so every `query?.` fallback inside `findOneById` has to stand on its own
+  // rather than lean on the engine always supplying a normalized query.
+  it("reads the row by id when the caller passes no query", async () => {
+    const created = (await authors.createOne({ email: "byid@x.io", name: "ById", age: 3 } as never)) as Author;
+    expect(await authorAdapter().findOneById(created.id, null, hardDeleteContext() as never)).toMatchObject({
+      name: "ById",
+    });
+  });
+
+  it("answers null for an id that does not exist", async () => {
+    expect(await authorAdapter().findOneById(4242, null, hardDeleteContext() as never)).toBeNull();
   });
 });
 
@@ -251,6 +343,25 @@ describe("PrismaRepositoryAdapter — query translation", () => {
       filter: { kind: "condition", field: "author.name" as never, operator: "EQ", value: "Ada" },
     });
     expect(list.items.map((b) => (b as Book).title)).toEqual(["Notes"]);
+  });
+
+  it("sorts on an allowlisted relation path", async () => {
+    // Prisma's `orderBy` nests a relation path (`{ author: { name: "asc" } }`)
+    // the same way its `where` does; handed the flat `"author.name"` it
+    // rejects the argument outright, so a sort the allowlist admits would
+    // reach the client as a 500 instead of an ordering.
+    const scoped = kavo.createCrud(Book, {
+      allowlists: { sortable: ["title", "author.name" as never] },
+    }) as DefaultKavoService<Book>;
+    await seed();
+    const all = (await authors.findMany()).items.map((a) => a as Author);
+    const ada = all.find((a) => a.name === "Ada")!;
+    const alan = all.find((a) => a.name === "Alan")!;
+    await client.book.create({ data: { title: "By Alan", authorId: alan.id } });
+    await client.book.create({ data: { title: "By Ada", authorId: ada.id } });
+
+    const list = await scoped.findMany({ sort: [{ field: "author.name" as never, direction: "asc" }] });
+    expect(list.items.map((b) => (b as Book).title)).toEqual(["By Ada", "By Alan"]);
   });
 
   it("filters on a to-many relation path, restricting root rows rather than 500ing", async () => {

--- a/packages/orms/prisma/tests/metadata.spec.ts
+++ b/packages/orms/prisma/tests/metadata.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Prisma } from "@prisma/client";
 import { ConfigurationException } from "@kavo/core";
-import { buildEntityMetadata, createInfrastructure, type PrismaDatamodel } from "@kavo/prisma";
+import { buildEntityMetadata, createInfrastructure, type PrismaDatamodel, type PrismaField } from "@kavo/prisma";
 import { newTestPrismaClient } from "./support/client.js";
 
 class Author {
@@ -48,7 +48,84 @@ const ghostDatamodel: PrismaDatamodel = {
   enums: [],
 };
 
+/**
+ * A synthetic DMMF scalar field. `Prisma.dmmf.datamodel` can only describe
+ * what `prisma/schema.prisma` declares, and the fixture schema is on SQLite
+ * — which has no scalar lists at all — so the shapes below are written by
+ * hand rather than generated.
+ */
+function scalar(name: string, type: string, overrides: Partial<PrismaField> = {}): PrismaField {
+  return {
+    name,
+    kind: "scalar",
+    type,
+    isId: false,
+    isList: false,
+    isRequired: true,
+    hasDefaultValue: false,
+    ...overrides,
+  };
+}
+
+/** Matches `model Shapes` in {@link shapesDatamodel} by name, as every marker class must. */
+class Shapes {
+  id!: number;
+}
+const shapesDatamodel: PrismaDatamodel = {
+  models: [
+    {
+      name: "Shapes",
+      fields: [
+        scalar("id", "Int", { isId: true }),
+        scalar("published", "Boolean"),
+        scalar("payload", "Json"),
+        scalar("updatedAt", "DateTime", { isUpdatedAt: true }),
+        scalar("tags", "String", { isList: true, isRequired: false }),
+      ],
+    },
+  ],
+  enums: [],
+};
+
+describe("buildEntityMetadata — scalar field shapes", () => {
+  const fieldsByName = () =>
+    Object.fromEntries(
+      buildEntityMetadata(shapesDatamodel, Shapes, new Map()).fields.map((field) => [field.name, field]),
+    );
+
+  it("maps a Boolean column to kind 'boolean'", () => {
+    expect(fieldsByName()["published"]).toMatchObject({ kind: "boolean" });
+  });
+
+  it("maps a Json column to kind 'json'", () => {
+    expect(fieldsByName()["payload"]).toMatchObject({ kind: "json" });
+  });
+
+  it("marks an @updatedAt column generated, keeping it out of the create/update DTOs", () => {
+    // `@updatedAt` carries no `@default`, so the function-default branch never
+    // sees it — without its own check the DTO would ask a caller for a
+    // timestamp Prisma overwrites on every write anyway.
+    expect(fieldsByName()["updatedAt"]).toMatchObject({ kind: "date", generated: true });
+  });
+
+  it("reports a scalar list as non-nullable even when the column is optional", () => {
+    // A list column holds a possibly-empty array, never null, so `isRequired:
+    // false` on it says nothing about nullability — honoring it would put a
+    // `| null` into the DTO for a value that can never arrive as null.
+    expect(fieldsByName()["tags"]).toMatchObject({ nullable: false });
+  });
+});
+
 describe("buildEntityMetadata — bootstrap error paths", () => {
+  /** Matches the one-model datamodel each primary-key test builds for it. */
+  class Keyed {
+    left!: number;
+  }
+  const keyedDatamodel = (fields: readonly PrismaField[]): PrismaDatamodel => ({
+    models: [{ name: "Keyed", fields }],
+    enums: [],
+  });
+
   it("throws ConfigurationException when the marker class name matches no Prisma model", () => {
     expect(() => buildEntityMetadata(Prisma.dmmf.datamodel, NotAModel, new Map())).toThrow(ConfigurationException);
     try {
@@ -58,6 +135,39 @@ describe("buildEntityMetadata — bootstrap error paths", () => {
       expect(error).toBeInstanceOf(ConfigurationException);
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
     }
+  });
+
+  it("refuses a model with no @id field", () => {
+    // Every operation past `findMany` addresses a row by its id, so a model
+    // without one cannot be served at all — bootstrap is where that has to
+    // be said, not the first request that tries to read one.
+    let thrown: unknown;
+    try {
+      buildEntityMetadata(keyedDatamodel([scalar("left", "Int")]), Keyed, new Map());
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationException);
+    expect((thrown as ConfigurationException).messageParams).toMatchObject({ entity: "Keyed", path: "id" });
+    expect((thrown as Error).message).toMatch(/composite primary keys/);
+  });
+
+  it("refuses a model whose primary key spans two @id fields", () => {
+    // A composite key has no single value to put in a route path or a
+    // cursor; picking one of the two silently would address the wrong rows.
+    let thrown: unknown;
+    try {
+      buildEntityMetadata(
+        keyedDatamodel([scalar("left", "Int", { isId: true }), scalar("right", "Int", { isId: true })]),
+        Keyed,
+        new Map(),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationException);
+    expect((thrown as ConfigurationException).messageParams).toMatchObject({ entity: "Keyed", path: "id" });
+    expect((thrown as Error).message).toMatch(/composite primary keys/);
   });
 
   it("throws ConfigurationException when a relation's target model wasn't registered in 'entities'", () => {

--- a/packages/orms/prisma/tests/soft-delete.spec.ts
+++ b/packages/orms/prisma/tests/soft-delete.spec.ts
@@ -2,12 +2,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Prisma, type PrismaClient } from "@prisma/client";
 import {
   AlreadyDeletedException,
+  ConfigurationException,
   ConflictException,
   NotDeletedException,
   NotFoundException,
   type DefaultKavoService,
 } from "@kavo/core";
-import { buildEntityMetadata, createPrismaKavo } from "@kavo/prisma";
+import { buildEntityMetadata, createInfrastructure, createPrismaKavo } from "@kavo/prisma";
 import { newTestPrismaClient } from "./support/client.js";
 
 /** Soft delete over a marker column named through config. */
@@ -57,6 +58,19 @@ beforeEach(async () => {
 async function newTicket(reference = "T-1"): Promise<number> {
   const created = await tickets.createOne({ reference, title: "broken login" } as never);
   return (created as Ticket).id;
+}
+
+/** The adapter on its own, so a caller can hand it a context `createCrud` refuses to build. */
+function invoiceAdapter() {
+  return createInfrastructure(client as never, {
+    datamodel: Prisma.dmmf.datamodel,
+    entities: [Ticket, Invoice],
+    caseInsensitiveFilters: false,
+  }).adapterFor(Invoice);
+}
+
+function hardDeleteContext(operation: string) {
+  return { entityName: "Invoice", operation, config: { softDelete: { strategy: "hard" } } };
 }
 
 describe("metadata seam — no auto-detected soft-delete column", () => {
@@ -117,6 +131,25 @@ describe("PrismaRepositoryAdapter — soft delete", () => {
     await expect(tickets.deleteOne(id)).rejects.toBeInstanceOf(AlreadyDeletedException);
   });
 
+  it("404s a delete of an id that never existed, rather than 409ing it as already deleted", async () => {
+    // The two say opposite things to a client: 409 already-deleted describes
+    // a row that is still there and invites a `restore`, while a row that
+    // never existed can never be reached by any follow-up call.
+    await expect(tickets.deleteOne(4242)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("404s a restore of an id that never existed", async () => {
+    // Absent and present-but-live are separate answers: 404 says no such row,
+    // and the 409 not-deleted above says the row is there but was never
+    // deleted. The existence check is what keeps the two apart.
+    await expect(tickets.restoreOne(4242)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("404s a purge of an id that never existed", async () => {
+    // Same split as restore, over the same marker column read.
+    await expect(tickets.purgeOne(4242)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
   it("restores a deleted row and refuses to restore a live one", async () => {
     const id = await newTicket();
     await tickets.deleteOne(id);
@@ -168,5 +201,55 @@ describe("PrismaRepositoryAdapter — configured marker column", () => {
 
     const list = await invoices.findMany({ onlyDeleted: true });
     expect(list.items).toMatchObject([{ id: deletedId }]);
+  });
+});
+
+/**
+ * Core refuses to *enable* `restoreOne` or `purgeOne` on a hard-delete entity
+ * at bootstrap, so neither branch below is reachable through `createCrud`.
+ * They are the adapter's second line of defence, for a programmatic caller
+ * that assembles its own context.
+ */
+describe("PrismaRepositoryAdapter — hard-delete strategy guards", () => {
+  it("refuses restore under a hand-built hard-delete context", async () => {
+    // A hard-delete entity names no marker column, so "restore" has nothing
+    // to clear — refusing loudly beats writing null into a column chosen at
+    // random or silently reporting success.
+    const created = (await invoices.createOne({ number: "INV-guard" } as never)) as Invoice;
+
+    let thrown: unknown;
+    try {
+      await invoiceAdapter().restore(created.id, hardDeleteContext("restoreOne") as never);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ConfigurationException);
+    expect((thrown as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+    expect((thrown as Error).message).toMatch(/hard delete strategy/);
+  });
+
+  it("purges a hard-delete row outright, and 404s by id when it is already gone", async () => {
+    // Under a hard strategy `purge` skips the already-deleted check and is
+    // just a delete — but it still pre-checks existence, and that is what
+    // names the missing row. Letting Prisma's own P2025 answer instead still
+    // maps to a 404, just one whose `id` is blank (see `mapDriverError`), so
+    // the id in `messageParams` is what pins the pre-check.
+    const created = (await invoices.createOne({ number: "INV-purge" } as never)) as Invoice;
+    const adapter = invoiceAdapter();
+
+    await adapter.purge(created.id, hardDeleteContext("purgeOne") as never);
+    expect(await client.invoice.count()).toBe(0);
+
+    let thrown: unknown;
+    try {
+      await adapter.purge(created.id, hardDeleteContext("purgeOne") as never);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(NotFoundException);
+    expect((thrown as NotFoundException).messageParams).toMatchObject({
+      entity: "Invoice",
+      id: String(created.id),
+    });
   });
 });

--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -1,8 +1,9 @@
 import "reflect-metadata";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { DataSource } from "typeorm";
-import { Column, CreateDateColumn, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, ManyToOne, OneToMany, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
 import {
+  ConfigurationException,
   ConflictException,
   NotFoundException,
   PersistenceException,
@@ -10,7 +11,7 @@ import {
   type KavoInstance,
   type DefaultKavoService,
 } from "@kavo/core";
-import { buildEntityMetadata, createTypeOrmKavo } from "@kavo/typeorm";
+import { buildEntityMetadata, createInfrastructure, createTypeOrmKavo } from "@kavo/typeorm";
 
 // Explicit column types throughout: the swc test transform emits decorator
 // metadata, but explicit types keep entities transform-agnostic.
@@ -53,6 +54,37 @@ class Book {
   author!: Author;
 }
 
+/**
+ * The column spellings the rest of the fixtures deliberately avoid.
+ * Everything above uses an explicit driver-type string to stay
+ * transform-agnostic, which leaves the constructor-typed and JSON arms of
+ * `fieldKindOf` unexercised.
+ */
+@Entity()
+class Widget {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: String })
+  label!: string;
+
+  @Column({ type: Boolean, default: false })
+  active!: boolean;
+
+  @Column("simple-json", { nullable: true })
+  payload!: unknown;
+}
+
+/** Two primary columns: the shape Kavo refuses rather than half-supports. */
+@Entity()
+class CompositeKey {
+  @PrimaryColumn("int")
+  left!: number;
+
+  @PrimaryColumn("int")
+  right!: number;
+}
+
 let dataSource: DataSource;
 let kavo: KavoInstance;
 let authors: DefaultKavoService<Author>;
@@ -61,7 +93,7 @@ beforeAll(async () => {
   dataSource = new DataSource({
     type: "better-sqlite3",
     database: ":memory:",
-    entities: [Author, Book],
+    entities: [Author, Book, Widget, CompositeKey],
     synchronize: true,
   });
   await dataSource.initialize();
@@ -104,6 +136,28 @@ describe("metadata derivation seam", () => {
       cardinality: "many",
       includable: false,
     });
+  });
+
+  it("maps constructor-typed columns, which never reach the driver-string ladder", () => {
+    // `@Column({ type: String })` leaves `column.type` as the constructor
+    // itself, so it is answered before the regex fallbacks below it. Every
+    // other fixture here spells a driver string, which is why this arm was
+    // unexercised.
+    const byName = Object.fromEntries(buildEntityMetadata(dataSource, Widget).fields.map((f) => [f.name, f]));
+    expect(byName["label"]).toMatchObject({ kind: "string" });
+    expect(byName["active"]).toMatchObject({ kind: "boolean" });
+  });
+
+  it("maps a JSON column to the json kind, so core does not coerce it as text", () => {
+    const byName = Object.fromEntries(buildEntityMetadata(dataSource, Widget).fields.map((f) => [f.name, f]));
+    expect(byName["payload"]).toMatchObject({ kind: "json", nullable: true });
+  });
+
+  it("refuses a composite primary key at metadata time, naming the count it found", () => {
+    // Failing here rather than later is the point: a two-column key would
+    // otherwise surface as a wrong-row read on the first `findOne`.
+    expect(() => buildEntityMetadata(dataSource, CompositeKey)).toThrow(ConfigurationException);
+    expect(() => buildEntityMetadata(dataSource, CompositeKey)).toThrow(/exactly one primary column; found 2/);
   });
 });
 
@@ -348,5 +402,82 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
       },
     });
     expect(list.items.map((b) => (b as Book).title)).toEqual(["Notes"]);
+  });
+});
+
+/** A normalized query with no filter — what a custom handler hands the reader. */
+function unfilteredQuery() {
+  return {
+    filter: { root: null },
+    sort: [],
+    include: {},
+    fields: { root: null, relations: {} },
+    pagination: { limit: 10, offset: 0 },
+    count: false,
+    withDeleted: false,
+    onlyDeleted: false,
+  };
+}
+
+function hardDeleteContext() {
+  return { entityName: "Author", operation: "findOne", config: { softDelete: { strategy: "hard" } } };
+}
+
+describe("TypeOrmRepositoryAdapter — findOne by query", () => {
+  // `findOne` is on the `EntityReader` contract but core never calls it:
+  // every engine read goes through `findOneById`. It exists for custom
+  // handlers and programmatic callers, which is exactly why nothing was
+  // exercising it.
+  it("returns the first row for a query carrying no filter at all", async () => {
+    await seed();
+    const reader = createInfrastructure(dataSource).adapterFor(Author);
+    const row = await reader.findOne(unfilteredQuery() as never, hardDeleteContext() as never);
+    expect(row).not.toBeNull();
+  });
+
+  it("applies the query's sort rather than returning an arbitrary row", async () => {
+    await seed();
+    const reader = createInfrastructure(dataSource).adapterFor(Author);
+    const row = (await reader.findOne(
+      { ...unfilteredQuery(), sort: [{ field: "age", direction: "asc" }] } as never,
+      hardDeleteContext() as never,
+    )) as Author | null;
+    expect(row).toMatchObject({ name: "Joan" });
+  });
+
+  it("applies the query's filter", async () => {
+    await seed();
+    const reader = createInfrastructure(dataSource).adapterFor(Author);
+    const row = (await reader.findOne(
+      {
+        ...unfilteredQuery(),
+        filter: { root: { kind: "condition", field: "status", operator: "EQ", value: "banned" } },
+      } as never,
+      hardDeleteContext() as never,
+    )) as Author | null;
+    expect(row).toMatchObject({ name: "Alan" });
+  });
+
+  it("answers null rather than throwing when nothing matches", async () => {
+    const reader = createInfrastructure(dataSource).adapterFor(Author);
+    expect(await reader.findOne(unfilteredQuery() as never, hardDeleteContext() as never)).toBeNull();
+  });
+});
+
+describe("TypeOrmRepositoryAdapter — findOneById with no query", () => {
+  it("reads a row when the caller passes null for the query", async () => {
+    // The signature admits `null`, so a programmatic caller with no query
+    // to hand must still get its row rather than a crash on `query.include`.
+    await seed();
+    const reader = createInfrastructure(dataSource).adapterFor(Author);
+    const first = (await reader.findOne(unfilteredQuery() as never, hardDeleteContext() as never)) as Author;
+
+    const row = (await reader.findOneById(first.id, null, hardDeleteContext() as never)) as Author | null;
+    expect(row).toMatchObject({ id: first.id });
+  });
+
+  it("answers null for an id that is not there", async () => {
+    const reader = createInfrastructure(dataSource).adapterFor(Author);
+    expect(await reader.findOneById(9999, null, hardDeleteContext() as never)).toBeNull();
   });
 });

--- a/packages/orms/typeorm/tests/error-mapping.spec.ts
+++ b/packages/orms/typeorm/tests/error-mapping.spec.ts
@@ -150,6 +150,17 @@ describe("mapDriverError — the fallback row", () => {
     const lookAlike = Object.assign(new Error("unique violation"), { driverError: { code: "23505" } });
     expect(mapDriverError(lookAlike, context)).toBeInstanceOf(PersistenceException);
   });
+
+  it("still classifies by errno when the driver reports no code", () => {
+    // The SQLite sniffing further down calls `code.startsWith(...)`, which
+    // a missing code would break — so the `?? ""` guard is what lets an
+    // errno-only driver error reach its own row instead of crashing.
+    expect(mapDriverError(queryFailed({ errno: 1062 }), context)).toBeInstanceOf(ConflictException);
+  });
+
+  it("falls back to a persistence failure when there is neither a code nor a known errno", () => {
+    expect(mapDriverError(queryFailed({}), context)).toBeInstanceOf(PersistenceException);
+  });
 });
 
 describe("mapDriverError — cause and context propagation", () => {

--- a/packages/orms/typeorm/tests/includes.spec.ts
+++ b/packages/orms/typeorm/tests/includes.spec.ts
@@ -65,6 +65,7 @@ let kavo: KavoInstance;
 let blogs: DefaultKavoService<Blog>;
 let joinedBlogs: DefaultKavoService<Blog>;
 let articles: DefaultKavoService<Article>;
+let batchedArticles: DefaultKavoService<Article>;
 const queryLogger = new QueryCountingLogger();
 
 beforeAll(async () => {
@@ -94,6 +95,12 @@ beforeAll(async () => {
   joinedBlogs = createTypeOrmKavo(dataSource).createCrud(Blog, {
     relations: { edges: { articles: { includable: true, strategy: "join" } } },
   }) as DefaultKavoService<Blog>;
+  // A *to-one* forced to `batch`. Left on `auto` a to-one joins, so the
+  // batched to-one path only exists when a config asks for it.
+  batchedArticles = createTypeOrmKavo(dataSource).createCrud(Article, {
+    softDelete: { strategy: "soft" },
+    relations: { edges: { blog: { includable: true, strategy: "batch" } } },
+  } as never) as DefaultKavoService<Article>;
 });
 
 afterAll(async () => {
@@ -225,6 +232,29 @@ describe("Includes and soft delete", () => {
     expect(list.items).toHaveLength(2);
     const deleted = (list.items as readonly { id: number; notes: unknown[] }[]).find((row) => row.id === articleId);
     expect(deleted?.notes).toHaveLength(1);
+  });
+});
+
+describe("TypeOrmRepositoryAdapter — a batched to-one relation", () => {
+  it("embeds the related row when there is one", async () => {
+    const { blogId } = await seed();
+    const list = await batchedArticles.findMany({
+      include: ["blog"],
+      sort: [{ field: "id", direction: "asc" }],
+    });
+    expect(list.items[0]).toMatchObject({ blog: { id: blogId } });
+  });
+
+  it("reports null, never undefined, when the foreign key is empty", async () => {
+    // Core's serializer treats an absent key as "never hydrated" and omits
+    // it; only an explicit `null` says "included, and there is nothing
+    // there". A batched to-one with no match must produce the latter.
+    await dataSource.getRepository(Article).save({ title: "Orphan", blog: null });
+
+    const list = await batchedArticles.findMany({ include: ["blog"] });
+
+    expect(list.items[0]).toHaveProperty("blog");
+    expect((list.items[0] as { blog: unknown }).blog).toBeNull();
   });
 });
 

--- a/packages/orms/typeorm/tests/soft-delete.spec.ts
+++ b/packages/orms/typeorm/tests/soft-delete.spec.ts
@@ -3,12 +3,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Column, DataSource, DeleteDateColumn, Entity, PrimaryGeneratedColumn } from "typeorm";
 import {
   AlreadyDeletedException,
+  ConfigurationException,
   ConflictException,
   NotDeletedException,
   NotFoundException,
   type DefaultKavoService,
 } from "@kavo/core";
-import { buildEntityMetadata, createTypeOrmKavo } from "@kavo/typeorm";
+import { buildEntityMetadata, createInfrastructure, createTypeOrmKavo } from "@kavo/typeorm";
 
 /** Soft delete the ORM-declared way: one `@DeleteDateColumn`. */
 @Entity()
@@ -39,15 +40,26 @@ class Invoice {
   archivedAt!: Date | null;
 }
 
+/** No delete column at all: rows go away when deleted. */
+@Entity()
+class Receipt {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  number!: string;
+}
+
 let dataSource: DataSource;
 let tickets: DefaultKavoService<Ticket>;
 let invoices: DefaultKavoService<Invoice>;
+let receipts: DefaultKavoService<Receipt>;
 
 beforeAll(async () => {
   dataSource = new DataSource({
     type: "better-sqlite3",
     database: ":memory:",
-    entities: [Ticket, Invoice],
+    entities: [Ticket, Invoice, Receipt],
     synchronize: true,
   });
   await dataSource.initialize();
@@ -59,6 +71,7 @@ beforeAll(async () => {
   invoices = kavo.createCrud(Invoice, {
     softDelete: { field: "archivedAt" },
   }) as DefaultKavoService<Invoice>;
+  receipts = kavo.createCrud(Receipt) as DefaultKavoService<Receipt>;
 });
 
 afterAll(async () => {
@@ -68,7 +81,17 @@ afterAll(async () => {
 beforeEach(async () => {
   await dataSource.getRepository(Ticket).clear();
   await dataSource.getRepository(Invoice).clear();
+  await dataSource.getRepository(Receipt).clear();
 });
+
+/**
+ * The context a programmatic caller assembles by hand. Core refuses to
+ * *enable* `restoreOne`/`purgeOne` on a hard-delete entity at bootstrap, so
+ * the adapter's own guards are only reachable this way.
+ */
+function hardContext(operation: string) {
+  return { entityName: "Receipt", operation, config: { softDelete: { strategy: "hard" } } };
+}
 
 async function newTicket(reference = "T-1"): Promise<number> {
   const created = await tickets.createOne({ reference, title: "broken login" } as never);
@@ -187,5 +210,48 @@ describe("TypeOrmRepositoryAdapter — configured marker column", () => {
 
     const list = await invoices.findMany({ onlyDeleted: true });
     expect(list.items).toMatchObject([{ id: deletedId }]);
+  });
+});
+
+describe("TypeOrmRepositoryAdapter — an id that is not there", () => {
+  // A missing row and an already-deleted row are different answers: 404
+  // versus 409. Conflating them would tell a client to retry a restore that
+  // can never succeed.
+  it("404s on soft delete of an absent id, rather than reporting a conflict", async () => {
+    await expect(tickets.deleteOne(9999)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("404s on restore of an absent id", async () => {
+    await expect(tickets.restoreOne(9999)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("404s on purge of an absent id under the soft strategy", async () => {
+    await expect(tickets.purgeOne(9999)).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+describe("TypeOrmRepositoryAdapter — the adapter's own hard-delete guards", () => {
+  it("refuses restore on a hard-delete entity instead of silently no-opping", async () => {
+    const created = (await receipts.createOne({ number: "R-1" } as never)) as Receipt;
+    const adapter = createInfrastructure(dataSource).adapterFor(Receipt);
+
+    await expect(adapter.restore(created.id, hardContext("restoreOne") as never)).rejects.toBeInstanceOf(
+      ConfigurationException,
+    );
+    await expect(adapter.restore(created.id, hardContext("restoreOne") as never)).rejects.toThrow(
+      /hard delete strategy/,
+    );
+  });
+
+  it("purges a hard-delete row outright, then 404s once it is gone", async () => {
+    // Under a hard strategy `purge` skips the already-deleted check and is
+    // just a delete, so the missing-row answer comes from the row count.
+    const created = (await receipts.createOne({ number: "R-2" } as never)) as Receipt;
+    const adapter = createInfrastructure(dataSource).adapterFor(Receipt);
+
+    await adapter.purge(created.id, hardContext("purgeOne") as never);
+    expect(await dataSource.getRepository(Receipt).countBy({ id: created.id })).toBe(0);
+
+    await expect(adapter.purge(created.id, hardContext("purgeOne") as never)).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/packages/protocols/graphql/tests/graphql-schema.spec.ts
+++ b/packages/protocols/graphql/tests/graphql-schema.spec.ts
@@ -216,6 +216,25 @@ describe("createKavoGraphQLSchema", () => {
     expect(adapter.lastQuery?.filter.root).toEqual({ kind: "condition", field: "done", operator: "EQ", value: true });
   });
 
+  it("reads an unprefixed sort token as ascending, alongside a '-' descending one", async () => {
+    // The `-` prefix is the only descending spelling, so its absence is
+    // what carries "ascending". The MCP binding duplicates this parser
+    // deliberately (the two may not import each other), so both need it.
+    const { adapter, schema } = setup();
+    adapter.rows.push({ id: 1, title: "a", done: false });
+
+    const result = await graphql({
+      schema,
+      source: `query { todos(sort: ["-title", "done"]) { items { id } } }`,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(adapter.lastQuery?.sort).toEqual([
+      { field: "title", direction: "desc" },
+      { field: "done", direction: "asc" },
+    ]);
+  });
+
   it("resolves restore/purge mutations against a soft-deletable entity", async () => {
     const adapter = new InMemoryNoteAdapter();
     const service = createKavo().createCrud(

--- a/packages/protocols/mcp/tests/mcp-tools.spec.ts
+++ b/packages/protocols/mcp/tests/mcp-tools.spec.ts
@@ -80,6 +80,39 @@ describe("crudTools", () => {
     expect(adapter.lastQuery?.filter.root).toEqual({ kind: "condition", field: "done", operator: "EQ", value: true });
   });
 
+  it("reads an unprefixed sort token as ascending, alongside a '-' descending one", async () => {
+    // The `-` prefix is the only descending spelling, so the absence of one
+    // is what carries "ascending". Testing only `-title` leaves the default
+    // direction free to flip unnoticed.
+    const { adapter, bindings } = setup();
+    adapter.rows.push({ id: 1, title: "a", done: false });
+
+    await find(bindings, "todo.findMany").handler({ sort: ["-title", "done"] });
+
+    expect(adapter.lastQuery?.sort).toEqual([
+      { field: "title", direction: "desc" },
+      { field: "done", direction: "asc" },
+    ]);
+  });
+
+  it("lets a non-Kavo throw escape as a protocol error rather than a routine tool result", async () => {
+    // A `KavoException` is a domain answer and becomes `isError` content a
+    // model can reason about. A bug is not an answer: reframing it the same
+    // way would hide a 500 behind a tidy tool response. The engine wraps
+    // adapter throws into `PersistenceFailedException`, so reaching this
+    // path takes a stub service rather than a real one.
+    const bindings = crudTools({
+      name: "Todo",
+      service: {
+        async findOne() {
+          throw new Error("bug");
+        },
+      } as never,
+    });
+
+    await expect(find(bindings, "todo.findOne").handler({ id: 1 })).rejects.toThrow("bug");
+  });
+
   it("carries the list envelope's contributed meta into the tool result unchanged", async () => {
     // Doc 16 §"A successful call returns" claims the whole envelope is
     // stringified, so whatever a `findMany` handler contributes to `meta`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       dependency-cruiser:
         specifier: ^18.1.0
         version: 18.1.0
@@ -48,7 +51,7 @@ importers:
         version: 2.0.17(mermaid@11.16.1)(vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@22.20.1)(jiti@2.7.0)(postcss@8.5.25)(search-insights@2.17.3)(typescript@5.9.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
 
   examples/nest-mikroorm:
     dependencies:
@@ -450,6 +453,10 @@ packages:
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -1683,6 +1690,15 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -1894,6 +1910,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
@@ -2745,6 +2764,9 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -2839,6 +2861,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterare@1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
@@ -2852,6 +2886,9 @@ packages:
 
   jose@6.2.7:
     resolution: {integrity: sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-yaml@5.2.3:
     resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
@@ -2931,9 +2968,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
@@ -4321,6 +4365,8 @@ snapshots:
 
   '@balena/dockerignore@1.0.2': {}
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@6.0.4':
@@ -5339,6 +5385,20 @@ snapshots:
       vite: 6.4.3(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.40(typescript@5.9.3)
 
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5583,6 +5643,12 @@ snapshots:
       safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-lock@1.4.1: {}
 
@@ -6514,6 +6580,8 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-escaper@2.0.2: {}
+
   html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
@@ -6586,6 +6654,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterare@1.2.1: {}
 
   jackspeak@3.4.3:
@@ -6597,6 +6678,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.7: {}
+
+  js-tokens@10.0.0: {}
 
   js-yaml@5.2.3:
     dependencies:
@@ -6652,9 +6735,19 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   mark.js@8.11.1: {}
 
@@ -7862,7 +7955,7 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.10(@types/node@22.20.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -7886,6 +7979,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/tests/ci-workflow.spec.ts
+++ b/tests/ci-workflow.spec.ts
@@ -115,6 +115,39 @@ describe("the CI split covers the whole gate", () => {
   });
 });
 
+/**
+ * Coverage sits outside the `build`/`test` split on purpose: it re-runs the
+ * whole suite instrumented, so it is not part of `pnpm check` and the two
+ * assertions above deliberately do not see it. That exemption is exactly
+ * what would let the job be deleted without anything going red, so its
+ * existence is asserted here instead.
+ */
+describe("the coverage job", () => {
+  const coverage = jobSteps("coverage");
+
+  it("runs `pnpm run test:coverage`", () => {
+    expect(coverage).toContain("test:coverage");
+  });
+
+  it("generates the Prisma client first, like the test job", () => {
+    expect(coverage).toContain("generate");
+  });
+
+  it("stays out of `pnpm check`, so the local gate is not doubled", () => {
+    expect(gateSteps()).not.toContain("test:coverage");
+  });
+
+  it("is backed by a real script and a config that sets thresholds", () => {
+    // A job running a script that no longer exists fails loudly; a script
+    // running a config with no thresholds passes while measuring nothing.
+    const script = manifest.scripts?.["test:coverage"] ?? "";
+    expect(script).toContain("vitest.coverage.config.ts");
+
+    const config = readFileSync(resolve(REPO_ROOT, "vitest.coverage.config.ts"), "utf8");
+    expect(config).toContain("thresholds");
+  });
+});
+
 describe("the README status badges point at real check runs", () => {
   it("filters on a check-run name ci.yml actually produces", () => {
     const badged = badgedCheckRunNames();

--- a/vitest.coverage.config.ts
+++ b/vitest.coverage.config.ts
@@ -1,0 +1,46 @@
+import { mergeConfig } from "vitest/config";
+import base from "./vitest.config.js";
+
+/**
+ * `pnpm test:coverage` — the same suite `pnpm test` runs, measured.
+ *
+ * It is a separate config rather than a flag on the main one because
+ * coverage instrumentation is pure overhead for the run developers do
+ * hundreds of times a day, and because the thresholds below only make
+ * sense against the *whole* suite. Measuring a single file would report
+ * every other file as uncovered and fail.
+ *
+ * The thresholds are a ratchet, not a target. They sit just under what the
+ * suite achieves today, so an ordinary change has room to move while a
+ * real regression fails the run. They are deliberately **not** 100:
+ * roughly a third of the remaining uncovered lines are guards that no
+ * input can reach — `assertNever` arms over closed unions, `??` fallbacks
+ * the calling layer has already collapsed, and type-narrowing checks like
+ * `bracket-notation.ts`'s unclosed-bracket return, which the
+ * `endsWith("]")` precondition above it makes unreachable. Tests written
+ * to close those would assert nothing and still have to be maintained.
+ * Raise these numbers when real coverage rises; do not chase the gap.
+ */
+export default mergeConfig(base, {
+  test: {
+    coverage: {
+      enabled: true,
+      provider: "v8",
+      // Published sources only. The `examples/*` apps are exercised
+      // end-to-end by their own suites, but they are reference wiring
+      // rather than shipped code, and holding them to a package
+      // threshold would measure the wrong thing.
+      include: ["packages/**/src/**/*.ts"],
+      exclude: ["**/dist/**", "**/node_modules/**", "**/*.d.ts"],
+      reporter: ["text-summary", "json-summary", "html"],
+      reportsDirectory: "./.coverage",
+      // Achieved at the time of writing: 98.92 / 97.67 / 99.68 / 99.07.
+      thresholds: {
+        statements: 98,
+        branches: 97,
+        functions: 99,
+        lines: 98,
+      },
+    },
+  },
+});

--- a/vitest.coverage.config.ts
+++ b/vitest.coverage.config.ts
@@ -35,10 +35,19 @@ export default mergeConfig(base, {
       reporter: ["text-summary", "json-summary", "html"],
       reportsDirectory: "./.coverage",
       // Achieved at the time of writing: 98.92 / 97.67 / 99.68 / 99.07.
+      //
+      // The gaps below those numbers are budgets, not rounding. Each one
+      // is worth roughly 40 branches or 10 functions, which is wide enough
+      // that the job does not go red for reasons unrelated to coverage —
+      // v8 derives its counts from V8 itself, so they can shift a little
+      // when the `lts/*` the job runs on rolls to a new major — and still
+      // narrow enough that losing a real behavior's tests fails the run.
+      // Tighten them when coverage rises; a threshold pinned flush against
+      // the current number is a flaky gate, not a strict one.
       thresholds: {
         statements: 98,
-        branches: 97,
-        functions: 99,
+        branches: 96,
+        functions: 98,
         lines: 98,
       },
     },


### PR DESCRIPTION
Closes #136.

Coverage went from 95.14% statements / 91.61% branches to 98.92% / 97.67%, and the suite from 1812 tests to 2018. The numbers matter less than how they were found: every gap here came from reading the uncovered lines and asking what behavior they represent, so what landed is tests for things that were genuinely unproven rather than padding.

## What was actually unproven

Cursor pagination's non-advancement guard had never run. `kavo-engine.ts:581` raises `ConfigurationException` when a page hands back the token it was given, which is what stops a client looping forever (ADR-0021). The new fixture reproduces the real defect it guards against, an adapter that honours the `limit + 1` over-fetch but reads `query.filter` instead of `readFilter(query)`, rather than mocking the symptom.

`RepositoryAdapter.findOne` (the by-query one) was dead to the test suite in three of four adapters. Core only ever calls `findOneById`, so `findOne` exists for custom handlers and programmatic callers. `@kavo/mikroorm` tested it, after a real bug; TypeORM, Prisma and Mongoose did not.

`since` pagination was the least-covered module in the repo at 62% statements, and the only pagination strategy with no adapter-level coverage at all. Its refusal of a bigint or Decimal boundary column mirrors a cursor guard that was already tested.

Two public entry points had never been called by anything. `KavoContextState`, the per-request state bag, is barrel-exported and documented. `boundKavoService` is the pattern `CLAUDE.md` tells adopters to prefer over both `forFeature` and constructor injection.

Per-operation DTO overrides shipped documented but untested. Core covered the registry side of ff8ea46, but nothing proved the OpenAPI side, so an override could publish the wrong shape with nothing to catch it. Both `dto.input` and `dto.output` are pinned now. The `output` half was invisible in the coverage report too, because v8 counts `??` operand evaluations rather than outcomes.

Nothing exercised cursor, `since`, or ETag over HTTP against a real database. Each was covered a layer at a time, never end to end, so a token that survives every unit test and still fails to round-trip through a URL and a driver had nothing to catch it.

## Coverage is now measured and gated

`pnpm test:coverage` runs the suite under v8 and fails on thresholds set just under what it achieves. It gets its own CI job rather than joining `pnpm check`, which would roughly double the command you run all day for a signal that only matters per push. That exemption is also what would let the job be deleted unnoticed, so `tests/ci-workflow.spec.ts` asserts the job exists, runs the script, and that the script's config really sets thresholds.

The thresholds are deliberately not 100. Roughly a third of the remaining uncovered lines are unreachable by construction: `assertNever` arms over closed unions, `??` fallbacks the calling layer has already collapsed, and guards sitting behind a precondition that makes them dead, like `bracket-notation.ts:18` under the `endsWith("]")` check above it.

## Three things found on the way

A test title was lying. The "string-body HttpException" case in `unhandled-exception.spec.ts` used `new NotFoundException("...")`, which builds an object body, so the string arm never ran. It is renamed, with a test for the genuine case beside it.

A MikroORM test proves a core guard rather than the adapter's. "refuses to deep-write a relation whose target Kavo never registered" never reaches `unwrapAssociation`: core's `associate` drops the id-less object first, because `DefaultEntityCatalog` derives metadata for unregistered classes and MikroORM knows every entity. The test is not wrong, it just covers a different layer than its name suggests. The adapter's own arms are reached through the explicit-runtime path instead, where the catalog really is empty.

`offset` under cursor pagination is silently dropped. A `cursor` sent under offset paging is a 400, but the reverse is ignored, since `CursorPaginationStrategy` reads only `limit` and `cursor`. A client mixing the two gets page one. The e2e suite pins the current behavior and says so; changing it would be a behavior change and belongs in its own issue.

## What I chose not to test

Defensive branches, on the grounds that a test which forces its way into one asserts the shape of the code rather than any behavior. One test was written and then removed on exactly that basis: reaching MikroORM's `targetOf` guard requires forging a discovered property, because the ORM's own validator refuses to initialize in that state. A comment in `metadata.spec.ts` records why it stays uncovered, and notes that `@kavo/mongoose` covers the equivalent guard through a supported path.

Also out of scope, as called out in #136: mutation testing, and bringing the Mongoose example's e2e suite up to parity with TypeORM's.

## Verification

`pnpm check` green, at 2018 tests across 90 files. `pnpm format:check`, `pnpm docs:links` and `pnpm test:coverage` green as well. No production code changed: every commit here touches `tests/` directories, the coverage config, CI wiring, and docs.
