### PR TITLE
chore: publish an engines field on every @kavo/* package

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ Today Kavo supports NestJS as the framework, over TypeORM, Prisma, Mongoose, or 
 
 ## Requirements
 
-- **Node.js 20 or newer** — the minimum this project declares. Note that the published packages carry no `engines` field, so your package manager will not warn you on an older release.
+- **Node.js 20 or newer** — every `@kavo/*` package declares `engines.node: ">=20"`, so your package manager will warn (or, under `engine-strict`, refuse) an install on an older release.
 - **ESM** — every `@kavo/*` package ships as ESM only, with no CommonJS entry point. Your app must be ESM too (`"type": "module"` in its `package.json`), which the default `nest new` scaffold is not.
 - **Decorator metadata** — `experimentalDecorators` and `emitDecoratorMetadata` must be on. `@Kavo()` reads your entity's decorator metadata, and so do TypeORM's columns and Nest's DI.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo core — framework- and ORM-independent contracts and type system. Zero runtime dependencies.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/packages/frameworks/nest/package.json
+++ b/packages/frameworks/nest/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo NestJS binding — @Kavo decorator, registry-driven route generation, problem-details exception filter, Swagger integration.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/packages/orms/mikroorm/package.json
+++ b/packages/orms/mikroorm/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo MikroORM adapter — implements @kavo/core's RepositoryAdapter over a MikroORM EntityManager.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/packages/orms/mongoose/package.json
+++ b/packages/orms/mongoose/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo Mongoose adapter — implements @kavo/core's RepositoryAdapter over Mongoose models.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/packages/orms/prisma/package.json
+++ b/packages/orms/prisma/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo Prisma adapter — implements @kavo/core's RepositoryAdapter over Prisma Client.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/packages/orms/typeorm/package.json
+++ b/packages/orms/typeorm/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo TypeORM adapter — implements @kavo/core's RepositoryAdapter and TransactionManager over TypeORM.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/packages/protocols/graphql/package.json
+++ b/packages/protocols/graphql/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo GraphQL binding — builds a GraphQL schema over a createCrud service, delegating every resolver to the same engine REST uses.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/packages/protocols/mcp/package.json
+++ b/packages/protocols/mcp/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.1",
   "description": "Kavo MCP binding — exposes a createCrud service's standard operations as MCP tools, delegating every call to the same engine REST uses.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kavo-labs/kavo.git",

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -32,6 +32,7 @@ interface Manifest {
   name?: string;
   version?: string;
   private?: boolean;
+  engines?: Record<string, string>;
   dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
@@ -293,6 +294,32 @@ describe("lockstep versions in this repository", () => {
     const actual = { "packages/core": "0.6.0", "packages/orms/prisma": "0.5.0", "packages/protocols/mcp": "0.5.0" };
 
     expect(findBehind("0.6.0", actual)).toEqual(["packages/protocols/mcp"]);
+  });
+});
+
+/**
+ * The root `package.json` is never published, so its `engines.node` is the
+ * one place the supported Node floor is decided; every published package
+ * must carry a matching literal `engines.node`, or `npm view @kavo/core
+ * engines` (and every sibling) stays empty and an install on an unsupported
+ * Node version succeeds silently. Modelled on the lockstep-version check
+ * above (ADR-0004): the floor is still hand-copied into each manifest, but
+ * drift away from the root's value fails here instead of shipping.
+ */
+describe("engines field lockstep", () => {
+  it("declares a non-empty engines.node on the root manifest", () => {
+    const root = readManifest(".");
+
+    expect(root.engines?.node).toBeTruthy();
+  });
+
+  it("matches every published package's engines.node to the root's", () => {
+    const expectedNode = readManifest(".").engines?.node;
+    const actual = Object.fromEntries(packageDirs.map((dir) => [dir, readManifest(dir).engines?.node]));
+
+    for (const [dir, node] of Object.entries(actual)) {
+      expect(node, `${dir} engines.node`).toBe(expectedNode);
+    }
   });
 });
 


### PR DESCRIPTION
The root `package.json` declares `{ "node": ">=20" }` but is never published, so `npm view @kavo/core engines` came back empty for all eight packages. An install on Node 18 succeeded silently and failed later at runtime. `docs/getting-started.md` had been carrying the consequence as a written caveat — telling adopters their package manager would not warn them — which is documentation standing in for a one-line field.

Closes #141

## Public API impact

No barrel changes. There is a consumer-visible effect, though, and it is the intended one: npm and pnpm will now warn on an install under Node 20, and refuse it under `engine-strict`. That is the behavior the docs already told people to expect, so nothing that worked before stops working.

## Testing

Two assertions added to `tests/release-workflow.spec.ts`, alongside the lockstep-version checks they are modelled on: the root declares a non-empty `engines.node`, and every directory in `publish.yml`'s `PACKAGE_DIRS` matches it exactly. Seeding `packages/core` with `>=18` fails the second one with `expected '>=18' to be '>=20'`, so it catches drift rather than merely asserting presence.

Verified on this branch, rebased onto `a42f16e`:

- `pnpm check` — 90 files, 2020 tests, 0 depcruise violations
- `pnpm docs:links` — OK
- `pnpm format:check` — OK
- `pnpm test:coverage` — 2020 tests, thresholds met

## Review notes

**The first acceptance criterion is not met as written, and I think the criterion was wrong.** I wrote it as "the value stays in one place rather than being hand-copied eight times." `package.json` has no `extends`, so the only ways to satisfy that literally are a codegen or prepack step, and this repo has no precedent for either (ADR-0003 keeps it at plain scripts and `tsc -b`, and every manifest already hand-duplicates `license`, `repository` and the rest with no sync tooling).

What shipped instead is the shape the issue's *second* criterion points at: the root is the single authoritative value, the copies are literal, and drift fails a test. That is exactly how ADR-0004 already treats `version`. Flagging it rather than editing the issue to match, because an acceptance criterion quietly rewritten to fit what was built is worth less than one that is argued with. If you disagree, the alternative is a `prepack` script and I will do it that way.

Nothing else is open.
