### PR TITLE
fix(nest): resolve KavoContext.principal from the request on generated routes

### DIFF
--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -31,11 +31,62 @@ KavoModule.forRootAsync({
 | `infrastructure`       | `KavoInfrastructure`                    | Where entity metadata and the repository adapter come from — `createInfrastructure(dataSource)` or `createInfrastructure(client, opts)`. Required for any `@Kavo` route to actually run.                                                                                                                                                                                                                                                                                                     |
 | `defaults`             | `DeepPartial<KavoSettings>`             | App-wide settings, one level below the built-in defaults and above every entity's own config. See **Settings fields** below for what's in `KavoSettings`.                                                                                                                                                                                                                                                                                                                                    |
 | `paginationStrategies` | `readonly PaginationStrategy[]`         | Registers custom pagination strategies beyond the built-in `"offset"`, so `pagination.strategy` can name one of these instead.                                                                                                                                                                                                                                                                                                                                                               |
+| `principal`            | `boolean \| ((request) => unknown)`     | Where a generated route finds the authenticated caller to put on `KavoContext.principal`. `true` reads `request.user`; a function reads whatever it likes. Unset (or `false`) leaves `principal` `null`. See [The principal](#the-principal) below.                                                                                                                                                                                                                                          |
 | `useFactory`           | `(...args) => KavoModuleOptions`        | (`forRootAsync` only) Builds the options object, e.g. after awaiting `dataSource.initialize()`.                                                                                                                                                                                                                                                                                                                                                                                              |
 | `inject`               | `readonly (string \| symbol \| Type)[]` | (`forRootAsync` only) DI tokens injected as `useFactory`'s arguments.                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `provideServices`      | `boolean`                               | Also provides `getKavoServiceToken(Entity)` as a real DI provider for every `@Kavo`-decorated class the process has seen — needed only if some other class constructor-injects a `@Kavo` entity's service directly.                                                                                                                                                                                                                                                                          |
 | `graphql`              | `boolean \| { path?: string }`          | Mounts a default GraphQL controller merging every entity that called `registerKavoGraphQLTypes` onto one schema. `true` mounts at `POST /graphql`; `{ path }` mounts elsewhere. Implies `provideServices`.                                                                                                                                                                                                                                                                                   |
 | `mcp`                  | `boolean \| { path?: string }`          | Mounts a default MCP controller (Streamable HTTP, stateless) exposing every `@Kavo` entity's full standard toolset — no per-entity opt-in. `true` mounts at `POST /mcp`; `{ path }` mounts elsewhere. Implies `provideServices`. Requires `@modelcontextprotocol/sdk` installed. Carries no auth guard of its own — a guard on an entity's REST controller does not extend to this route; write your own controller extending `BaseKavoMcpController` instead if the MCP surface needs auth. |
+
+### The principal
+
+`KavoContext.principal` is the authenticated caller. Kavo carries it and nothing more: core never reads or judges the value. Your own code does — a [computed field](#computed) that varies by viewer, or a replacement `OperationHandler`.
+
+Two separate jobs get it there, and only the second is Kavo's. Authenticating the caller is yours: a guard, a middleware, `@nestjs/passport`, whatever already runs ahead of the route handler and leaves the caller on the request. Kavo adds no auth dependency and mounts no guard of its own. What `principal` configures is the other half, moving that caller from the request onto the context:
+
+```ts
+KavoModule.forRootAsync({
+  useFactory: () => ({
+    infrastructure: createInfrastructure(dataSource),
+    // `request.user` — where Passport and most hand-rolled guards leave it.
+    principal: true,
+  }),
+});
+
+// Or name the property yourself:
+KavoModule.forRoot({
+  infrastructure: createInfrastructure(dataSource),
+  principal: (request) => (request["session"] as Session | undefined)?.account ?? null,
+});
+```
+
+The extractor runs once per request, inside the generated route handler, and what it returns is that request's `principal`. Nothing is memoized between requests, so one caller's identity can never be served to the next. Keep it synchronous and cheap: read a property some guard already set, rather than verifying a token or querying a table. Throwing from it fails the request with a 500 problem-details document instead of quietly producing `null`.
+
+- Leave `principal` unset and it stays `null`. Nothing is populated by assumption: an ownership predicate that quietly starts answering differently is worse than one you can see is unwired.
+- It reaches standard and custom operations alike — one generated handler builds the request for every route, so a replacement handler on `POST /books/:id/claim` sees the same `context.principal` a plain `GET /books/1` does.
+- It reaches the generated **REST** routes and nothing else. The GraphQL and MCP surfaces (`graphql`/`mcp` above, and controllers extending `BaseKavoGraphQLController`/`BaseKavoMcpController`) call the service directly, so `context.principal` is `null` there whatever this option says — a computed field that varies by viewer answers for an anonymous caller over `POST /graphql`.
+- Programmatic callers pass their own: `crud.findOne(id, query, { principal })`. The module option is HTTP wiring, not a global; a background job has no request to extract from.
+- A method Kavo does not generate passes its own too. An `@Override`'d method or a fully custom route reaches the engine itself, so nothing fills `options` for it. `boundKavoPrincipal(this, request)` runs the extractor the module configured, so the method does not restate where the caller lives:
+
+  ```ts
+  @Override()
+  async findOne(
+    id: EntityId,
+    query: WireQuery,
+    preconditions: RequestPreconditions | null,
+    request: KavoPrincipalRequest,
+  ) {
+    const principal = boundKavoPrincipal(this, request);
+    return boundKavoService<Book>(this).findOne(id, query, {
+      principal,
+      preconditions: preconditions ?? undefined,
+    });
+  }
+  ```
+
+  The request is the trailing parameter of the [fixed layout](/internals/architecture/10-nestjs-integration) Kavo wires for you; declare it only if you want it.
+
+Authorization stays out of scope in both directions: Kavo will not scope rows to the principal, and will not refuse an operation on its behalf. A guard decides who may call the route; a replacement handler decides what they get back.
 
 ## Settings fields (`KavoSettings`)
 
@@ -204,13 +255,15 @@ A declared computed field is in the default `item`/`list` projection with no DTO
 
 **`resolve` must be total, not merely pure.** It runs once per served item and nothing catches it, so **one** row whose resolver throws turns the whole collection endpoint into a 500 — not for that row, for every caller, until the row is fixed. Write it against everything the column can actually hold, including `null`: `resolve: (todo) => todo.title?.toLowerCase() ?? null`, never `todo.title.toLowerCase()` on a nullable column. A `POST` that sets `title: null` succeeds (computed fields are stripped from the payload; `title` is an ordinary column), and `GET /todos` is dead from then on. A throwing resolver surfaces as a 500 `KAVO_PERSISTENCE_FAILED` with the cause attached and the message not leaked.
 
+A resolver reading `context.principal`, like `canEdit` above, needs the module's [`principal`](#the-principal) option set — over HTTP that option is the only thing that fills the field, and without it the caller is `null` on every request, so `canEdit` is uniformly `false` and its inverse uniformly `true`.
+
 Keep it a pure function of the entity as well (plus `context.principal` where a field has to vary by caller). It runs per row, so a resolver that queries the database or calls out over the network reintroduces exactly the N+1 that batched includes exist to avoid. Declaring it `async` is a bootstrap error rather than a slow success: the serializer never awaits, so the promise would be emitted as-is and serialize to `{}`.
 
 **`resolve` receives the full fetched row**, not the projected object — selection is "kept internally, stripped late", so every column is present regardless of `fields=` or the registered `item` DTO. A computed field can therefore surface a value a narrowed DTO or `selectable` list deliberately hides. That is deliberate (`resolve` is server-authored code, the same trust level as `exposeInternals`), but it makes the resolver part of the exposure decision: narrowing the DTO does not narrow what the resolver can see.
 
 **What `selectable: false` does and does not mean.** It removes the name from the allowlist, so `?fields=auditNote` is a 400. It does **not** pin the field into every response: selection narrows the projection uniformly, so any request that sends `fields=` at all still drops it, and the client has no way to ask for it back. Read it as "not individually selectable", not "always present". An explicit `allowlists.selectable` list naming the field overrides the flag — an explicit list is always the deliberate answer.
 
-On an **included relation target**, `resolve` receives the _root_ request's `KavoContext` — serving `GET /posts/1?include=author` hands an `Author` computed field a context whose `entityName`, `operation`, `config` and `query` describe Post. Only `principal`, `correlationId`, `transaction` and `state` mean what they say from a relation target.
+On an **included relation target**, `resolve` receives the _root_ request's `KavoContext` — serving `GET /posts/1?include=author` hands an `Author` computed field a context whose `entityName`, `operation`, `config` and `query` describe Post. Only `principal`, `correlationId`, `transaction` and `state` mean what they say from a relation target — `principal` being whatever the module's [`principal`](#the-principal) option extracted for the root request, or `null` when no option is set.
 
 **The generated OpenAPI response schema does not mention a computed field** when no `item`/`list` DTO is registered: the schema falls back to the entity class, whose columns are all the reflection can see, while the runtime response carries the computed key. Registering an `item`/`list` DTO naming the field fixes the document and the static response type in one move — the same escape hatch, for both consequences.
 

--- a/docs/internals/architecture/07-crud-engine.md
+++ b/docs/internals/architecture/07-crud-engine.md
@@ -37,8 +37,10 @@ same as `updateOne`/`patchOne` — needs the id to identify its target, and
 ## 2. `KavoContext` contents
 
 Entity + operation identity, the resolved config view (with per-call
-settings already merged), `principal` (opaque to core, set by the
-framework layer), `transaction` (an opaque handle a programmatic caller may
+settings already merged), `principal` (opaque to core, copied from
+`KavoCallOptions.principal` and `null` when the caller sent none — the
+framework layer fills it per request from the module's `principal`
+extractor, doc 10 §1a), `transaction` (an opaque handle a programmatic caller may
 pass through `KavoCallOptions`; `null` otherwise, and nothing in v6 creates
 one — the adapter-level hook is reserved), the normalized
 query for reads (`null` for writes), a `correlationId` (generated if the

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -29,6 +29,9 @@ boundary) — infrastructure arrives through DI.
   (in `AppModule` or anywhere else) sufficient on its own; no explicit
   per-entity registration is needed for the generated route methods, which
   only read that property at request time, well after `onModuleInit`.
+  The resolved `principal` extractor rides the same pass onto
+  `this[KAVO_PRINCIPAL_PROPERTY]`, for the same reason and with the same
+  timing (§1a).
 - **`KavoModule.forFeature(controllers)`**: registers the controllers
   (redundant if they're already in some module's `controllers:` array) and
   additionally provides the entity's service under
@@ -62,6 +65,42 @@ boundary) — infrastructure arrives through DI.
 per-request concern (principal, transaction, query, correlation id,
 state) through `KavoContext`, so request-scoped providers would buy
 nothing and cost per-request instantiation of the whole graph.
+
+### 1a. The principal (a per-request value under a decoration-time route)
+
+`KavoContext.principal` reaches core one way only —
+`KavoRequest.options.principal`, which the engine copies onto the context
+(`KavoCallOptions` is per-call scope, so this is a parameter, never a
+config write). A programmatic caller fills it directly. A generated route
+has to fill it from the incoming request, and that is the awkward part:
+routes are generated at decoration time (ADR-0012), while both the value
+and the rule for finding it are things decoration time cannot see.
+
+The two halves split along that seam:
+
+- **The rule** is a `KavoModule` option, `principal`: `true` for
+  `request.user`, or a `(request) => unknown` extractor. It is resolved
+  once, in `KavoBinder`, and bound onto the controller **instance** beside
+  the service. Instance-scoped rather than on the prototype for the reason
+  the service already is — the class is process-wide, so a second app in
+  the same process would otherwise inherit the first one's options, which
+  is every `@kavo/nest` test file.
+- **The value** is resolved per request, inside `makeHandler`'s generated
+  function, from the raw request that `applyParamDecorators` now wires as
+  the layout's trailing `@Req()` parameter. Nothing is memoized between
+  requests; nothing is read at decoration time.
+
+Absent the option, the extractor is `undefined` and the handler sends
+`options: null`, byte for byte the request an unconfigured route has
+always sent, so `principal` stays `null` for an app that never opts in.
+Kavo does not authenticate and does not judge: whatever the extractor
+returns is carried opaquely (doc 01 §8), and a throwing extractor fails
+the request rather than degrading to `null`.
+
+Methods Kavo does not generate reach the engine themselves, so nothing
+fills `options` for them; `boundKavoPrincipal(controller, request)` runs
+the same configured extractor for an `@Override`'d method or a fully
+custom route, which is why they get the request in the layout too.
 
 ## 2. Route generation (registry-driven, decoration-time)
 
@@ -135,7 +174,8 @@ overrides get through `context` inside a plain `OperationHandler`.
 
 Because Kavo owns the param wiring, the decorated method must accept
 parameters in the same fixed position a generated route would — reads:
-`(id?, query, preconditions)`; writes: `(id?, body?, preconditions)`;
+`(id?, query, preconditions, request)`; writes:
+`(id?, body?, preconditions, request)`;
 declare only as many as the method actually uses — and must not declare its own
 `@Param`/`@Query`/`@Body`: `@Kavo` checks for existing Nest route-argument
 metadata on the method and fails at decoration time (ADR-0012's only

--- a/packages/core/src/context/kavo-context.ts
+++ b/packages/core/src/context/kavo-context.ts
@@ -31,9 +31,18 @@ export interface KavoContext<Entity = unknown> {
   readonly operation: OperationId;
   readonly config: ResolvedEntityConfig<Entity>;
   /**
-   * The authenticated caller — opaque to core. Set by the framework layer
-   * (`@kavo/nest` from the request), available to custom operation
-   * handlers; core never inspects it (v6 ships no policy layer).
+   * The authenticated caller — opaque to core, and available to custom
+   * operation handlers and computed-field resolvers. Core never inspects
+   * it and never populates it: it is whatever the caller put in
+   * `KavoCallOptions.principal`, and `null` when nothing did.
+   *
+   * A programmatic caller passes it per call
+   * (`crud.findOne(id, query, { principal })`). Over HTTP it is the
+   * framework layer's job, and `@kavo/nest` does it only when the app has
+   * said where the caller lives — `KavoModule.forRoot({ principal: true })`
+   * for `request.user`, or an extractor function for anything else.
+   * Without that option a generated route sends no options at all and this
+   * stays `null`.
    */
   readonly principal: unknown;
   /** Active transaction, if any; `null` outside transactions. */

--- a/packages/frameworks/nest/src/index.ts
+++ b/packages/frameworks/nest/src/index.ts
@@ -21,7 +21,14 @@ export { KavoResponseInterceptor } from "./kavo-response.interceptor.js";
 export { ConditionalRequest, parseEntityTags } from "./conditional-request.decorator.js";
 export { flattenQuery } from "./flatten-query.js";
 export { enumProp, oneOfArray, type SchemaHint } from "./schema-hints.js";
-export { KAVO_INSTANCE, KAVO_MODULE_OPTIONS, getKavoServiceToken, boundKavoService } from "./tokens.js";
+export type { KavoPrincipalExtractor, KavoPrincipalOption, KavoPrincipalRequest } from "./principal.js";
+export {
+  KAVO_INSTANCE,
+  KAVO_MODULE_OPTIONS,
+  getKavoServiceToken,
+  boundKavoService,
+  boundKavoPrincipal,
+} from "./tokens.js";
 export { BaseKavoGraphQLController } from "./graphql/base-kavo-graphql.controller.js";
 export { BaseKavoMcpController } from "./mcp/base-kavo-mcp.controller.js";
 export type { KavoHttpMethod, KavoRouteOptions } from "./operation-metadata.js";

--- a/packages/frameworks/nest/src/kavo-options.ts
+++ b/packages/frameworks/nest/src/kavo-options.ts
@@ -1,4 +1,5 @@
 import type { KavoInfrastructure, KavoSettings, DeepPartial, PaginationStrategy } from "@kavo/core";
+import type { KavoPrincipalOption } from "./principal.js";
 
 /**
  * `KavoModule.forRoot` options — the NestJS skin over core's
@@ -15,4 +16,18 @@ export interface KavoModuleOptions {
   readonly infrastructure?: KavoInfrastructure;
   readonly defaults?: DeepPartial<KavoSettings>;
   readonly paginationStrategies?: readonly PaginationStrategy[];
+  /**
+   * Where a generated route finds the authenticated caller to put on
+   * `KavoContext.principal` — `true` for `request.user`, or a function for
+   * anything else. Module scope rather than an assumption, because a Nest
+   * app's guard may leave the caller anywhere; and an option rather than a
+   * default, because populating it silently would change what every
+   * existing `principal`-reading computed field or handler returns on
+   * upgrade. Unset means `principal` stays `null`, as it always has.
+   *
+   * It is `@kavo/nest`'s own concern and never reaches `createKavo`: core
+   * takes the principal per call (`KavoCallOptions.principal`) and has no
+   * idea what an HTTP request is (ADR-0005).
+   */
+  readonly principal?: KavoPrincipalOption;
 }

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -1,9 +1,10 @@
-import { Body, Delete, Get, HttpCode, Param, Patch, Post, Put, Query, UseInterceptors } from "@nestjs/common";
+import { Body, Delete, Get, HttpCode, Param, Patch, Post, Put, Query, Req, UseInterceptors } from "@nestjs/common";
 import type {
   ClassRef,
   DefaultKavoService,
   EntityConfig,
   EntityInput,
+  KavoCallOptions,
   OperationDescriptor,
   OperationId,
   QueryContext,
@@ -13,9 +14,15 @@ import type {
 import { ConfigurationException, createOperationRegistry } from "@kavo/core";
 import type { KavoHttpMethod, KavoRouteOptions } from "./operation-metadata.js";
 import type { OverrideMetadata } from "./override.decorator.js";
+import type { KavoPrincipalExtractor, KavoPrincipalRequest } from "./principal.js";
 import { ConditionalRequest } from "./conditional-request.decorator.js";
 import { KavoResponseInterceptor } from "./kavo-response.interceptor.js";
-import { KAVO_CONTROLLER_METADATA, KAVO_OVERRIDE_METADATA, KAVO_SERVICE_PROPERTY } from "./tokens.js";
+import {
+  KAVO_CONTROLLER_METADATA,
+  KAVO_OVERRIDE_METADATA,
+  KAVO_PRINCIPAL_PROPERTY,
+  KAVO_SERVICE_PROPERTY,
+} from "./tokens.js";
 import { WireQueryPipe } from "./wire-query.pipe.js";
 import { applySwaggerMetadata } from "./swagger.js";
 
@@ -144,7 +151,11 @@ interface ResolvedRoute {
  * tokens are handed to the method. Forward them, either as
  * `service.<op>(…, { preconditions })` on the typed surface or by
  * returning `service.engine.execute({ …, preconditions })`, which
- * additionally puts the `ETag` back on the response.
+ * additionally puts the `ETag` back on the response. The same goes for the
+ * principal: a generated route resolves it from the module's `principal`
+ * extractor per request, a replaced method must pass it on itself, and
+ * `boundKavoPrincipal(this, request)` is how it reaches the extractor the
+ * app configured rather than re-deciding where the caller lives.
  *
  * Route generation happens at decoration time (class definition), which is
  * what lets Nest's router see the methods during its normal controller
@@ -341,15 +352,24 @@ function applyRouteDecorators(
 
 /**
  * Parameter layout per generated method (fixed positions):
- * reads → (id?, query, preconditions); writes → (id?, body?, preconditions).
+ * reads → (id?, query, preconditions, request);
+ * writes → (id?, body?, preconditions, request).
  * Nest's param decorators are plain functions; applying them
  * programmatically writes the same route metadata the
  * `@Param`/`@Query`/`@Body` syntax would.
  *
- * The trailing preconditions parameter is unconditional so the two paths
+ * The two trailing parameters are unconditional so the two paths
  * (generated and `@Override`'d) keep identical route metadata: an
- * override that doesn't want `If-Match`/`If-None-Match` simply declares
- * fewer parameters, which is already how it opts out of the others.
+ * override that doesn't want `If-Match`/`If-None-Match` or the raw request
+ * simply declares fewer parameters, which is already how it opts out of
+ * the others. They are last, and in this order, so that adding the request
+ * left every signature written against the older layout intact.
+ *
+ * The request is here for one reason: the principal. Routes are generated
+ * at decoration time (ADR-0012), so the module-scope `principal` extractor
+ * cannot be baked into the generated method — the handler resolves it per
+ * request from the controller instance instead, and needs the request to
+ * run it against.
  */
 function applyParamDecorators(
   prototype: Record<string, unknown>,
@@ -367,6 +387,7 @@ function applyParamDecorators(
     Body()(prototype, methodName, index++);
   }
   ConditionalRequest()(prototype, methodName, index++);
+  Req()(prototype, methodName, index++);
 }
 
 /** Writes that carry a request body — the mirror of `BODYLESS_WRITES`. */
@@ -380,6 +401,8 @@ function usesBody(method: KavoHttpMethod): boolean {
 
 type BoundController = Record<string, unknown> & {
   [KAVO_SERVICE_PROPERTY]: DefaultKavoService<object>;
+  /** `undefined` unless `KavoModule` was configured with a `principal` option. */
+  [KAVO_PRINCIPAL_PROPERTY]?: KavoPrincipalExtractor | undefined;
 };
 
 /**
@@ -394,6 +417,11 @@ type BoundController = Record<string, unknown> & {
  * not-modified flag live on the envelope those methods discard
  * (ADR-0020). One arm instead of nine also means the parameter layout is
  * read from exactly one place, the one that wrote it.
+ *
+ * The `options` it builds are the one thing that is not read off a
+ * parameter: `KavoCallOptions.principal` is core's only channel for the
+ * caller's identity, and it is filled from the module-scope extractor the
+ * binder left on this controller (`callOptionsFor`).
  */
 function makeHandler(
   descriptor: OperationDescriptor<object>,
@@ -410,14 +438,35 @@ function makeHandler(
     const requestId = route.hasIdParam ? (args[index++] as string) : null;
     const query = isRead ? args[index++] : null;
     const body = hasBody ? args[index++] : null;
-    const preconditions = (args[index] ?? null) as RequestPreconditions | null;
+    const preconditions = (args[index++] ?? null) as RequestPreconditions | null;
+    const request = args[index] as KavoPrincipalRequest | undefined;
     return this[KAVO_SERVICE_PROPERTY].engine.execute({
       operation: id,
       id: requestId,
       body: (body ?? null) as never,
       query: (query ?? null) as never,
-      options: null,
+      options: callOptionsFor(this, request),
       preconditions,
     });
   };
+}
+
+/**
+ * The per-call scope a generated route contributes: the caller's
+ * principal, and nothing else — everything else about the request is the
+ * request's own data, not an override of configuration.
+ *
+ * `null` when the app configured no extractor, which is the request an
+ * unconfigured route has always sent, so `KavoContext.principal` stays
+ * `null` for an app that never opts in. Resolved per request, from the
+ * controller instance the binder wrote it onto: nothing here is memoized,
+ * so one caller's identity cannot survive into the next caller's request.
+ */
+function callOptionsFor(
+  controller: BoundController,
+  request: KavoPrincipalRequest | undefined,
+): KavoCallOptions | null {
+  const extractPrincipal = controller[KAVO_PRINCIPAL_PROPERTY];
+  if (extractPrincipal === undefined || request === undefined) return null;
+  return { principal: extractPrincipal(request) };
 }

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -9,10 +9,12 @@ import { getRegisteredKavoControllers } from "./kavo.decorator.js";
 import { KavoExceptionFilter } from "./kavo-exception.filter.js";
 import { createDefaultGraphQLController, DEFAULT_GRAPHQL_PATH } from "./graphql/default-graphql.controller.js";
 import { createDefaultMcpController, DEFAULT_MCP_PATH } from "./mcp/default-mcp.controller.js";
+import { resolvePrincipalExtractor } from "./principal.js";
 import {
   KAVO_INSTANCE,
   KAVO_MODULE_OPTIONS,
   KAVO_CONTROLLER_METADATA,
+  KAVO_PRINCIPAL_PROPERTY,
   KAVO_SERVICE_PROPERTY,
   getKavoServiceToken,
 } from "./tokens.js";
@@ -273,15 +275,24 @@ function serviceProvider(metadata: KavoControllerMetadata): Provider {
  * real module graph, and still well before the first request, which is all
  * the generated route methods need (they read `KAVO_SERVICE_PROPERTY` at
  * request time, never at construction time).
+ *
+ * The `principal` extractor rides along on the same pass, for the same
+ * reason: routes are generated at decoration time (ADR-0012), long before
+ * this module's options exist, so a per-request value that depends on them
+ * cannot be baked into the generated method. Binding the *function* here
+ * and calling it per request in the handler keeps the module option and the
+ * decoration-time route on the two sides of that seam they belong on.
  */
 @Injectable()
 class KavoBinder implements OnModuleInit {
   constructor(
     private readonly discovery: DiscoveryService,
     @Inject(KAVO_INSTANCE) private readonly kavo: KavoInstance,
+    @Inject(KAVO_MODULE_OPTIONS) private readonly options: KavoModuleOptions,
   ) {}
 
   onModuleInit(): void {
+    const extractPrincipal = resolvePrincipalExtractor(this.options.principal);
     for (const wrapper of this.discovery.getControllers()) {
       const metatype = wrapper.metatype;
       const instance = wrapper.instance as Record<string, unknown> | undefined;
@@ -289,6 +300,7 @@ class KavoBinder implements OnModuleInit {
       const metadata = Reflect.getMetadata(KAVO_CONTROLLER_METADATA, metatype) as KavoControllerMetadata | undefined;
       if (metadata === undefined) continue;
       instance[KAVO_SERVICE_PROPERTY] = this.kavo.createCrud(metadata.entity, metadata.config);
+      instance[KAVO_PRINCIPAL_PROPERTY] = extractPrincipal;
     }
   }
 }

--- a/packages/frameworks/nest/src/override.decorator.ts
+++ b/packages/frameworks/nest/src/override.decorator.ts
@@ -15,10 +15,19 @@ export interface OverrideMetadata {
  * already uses; pass it explicitly when the method name differs.
  *
  * The decorated method must accept parameters in the same fixed position
- * `@Kavo` would apply to a generated route — reads: `(id?, query)`; writes:
- * `(id?, body)` — undecorated, since Kavo supplies those decorators itself.
- * Adding your own `@Param`/`@Query`/`@Body` on an overridden method is a
- * decoration-time error (duplicate route-argument metadata).
+ * `@Kavo` would apply to a generated route — reads:
+ * `(id?, query, preconditions, request)`; writes:
+ * `(id?, body?, preconditions, request)` — undecorated, since Kavo supplies
+ * those decorators itself, and declared only as far along as the method
+ * actually reads. Adding your own `@Param`/`@Query`/`@Body` on an
+ * overridden method is a decoration-time error (duplicate route-argument
+ * metadata).
+ *
+ * The two trailing parameters are what an override needs to keep behavior a
+ * generated route would have given it for free: `preconditions` carries the
+ * `If-Match`/`If-None-Match` tokens the engine enforces (ADR-0020), and
+ * `request` is what `boundKavoPrincipal(this, request)` runs the module's
+ * configured `principal` extractor against.
  *
  * For a read operation, `query` arrives already wrapped in `WireQuery` — the
  * same `Query(new WireQueryPipe())` decorator `@Kavo` applies to a generated

--- a/packages/frameworks/nest/src/principal.ts
+++ b/packages/frameworks/nest/src/principal.ts
@@ -1,0 +1,55 @@
+/**
+ * The incoming request as a principal extractor sees it: a property bag.
+ * `@kavo/nest` serves under both Express and Fastify and names neither, so
+ * this is deliberately structural — `user` is spelled out because that is
+ * where Passport, `@nestjs/passport` and most hand-rolled guards leave the
+ * authenticated caller, and the index signature is what lets an extractor
+ * read any other property instead.
+ *
+ * An extractor that wants its framework's own request type casts to it
+ * (`(request) => (request as unknown as Request).user`): a parameter typed
+ * to one framework's class would make the option unassignable from the
+ * other's.
+ */
+export interface KavoPrincipalRequest {
+  readonly user?: unknown;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Pulls the already-authenticated caller off one incoming request. Called
+ * once per request from inside the generated route handler; whatever it
+ * returns becomes `KavoContext.principal` for that request and nothing
+ * else. Kavo never inspects, validates or caches the value — the principal
+ * is carried, never judged (doc 01 §8), and authentication itself stays
+ * the app's (a guard's, a middleware's) job.
+ *
+ * It runs on the request path, so keep it synchronous and cheap: a lookup
+ * off an object a guard already populated, not a token verification or a
+ * database read. Throwing from it fails the request as an unhandled error
+ * (a 500 problem-details document), which is deliberate — an extractor
+ * that cannot answer must not quietly answer `null`.
+ */
+export type KavoPrincipalExtractor = (request: KavoPrincipalRequest) => unknown;
+
+/**
+ * `KavoModule`'s `principal` option: `true` reads `request.user`, a
+ * function reads whatever it likes, and `false` (or leaving the option
+ * unset) leaves `KavoContext.principal` `null` — what every app that never
+ * configured one already gets.
+ */
+export type KavoPrincipalOption = boolean | KavoPrincipalExtractor;
+
+/** What `principal: true` means. */
+const principalFromRequestUser: KavoPrincipalExtractor = (request) => request.user;
+
+/**
+ * @internal The module option as the binder needs it: one function, or
+ * `undefined` for "no extractor configured", which the generated handlers
+ * read as `options: null` — the request an unconfigured route sends, so an
+ * app that never opts in keeps a `null` principal.
+ */
+export function resolvePrincipalExtractor(option: KavoPrincipalOption | undefined): KavoPrincipalExtractor | undefined {
+  if (option === undefined || option === false) return undefined;
+  return option === true ? principalFromRequestUser : option;
+}

--- a/packages/frameworks/nest/src/tokens.ts
+++ b/packages/frameworks/nest/src/tokens.ts
@@ -1,4 +1,6 @@
 import type { ClassRef, DefaultKavoService } from "@kavo/core";
+import { ConfigurationException } from "@kavo/core";
+import type { KavoPrincipalExtractor, KavoPrincipalRequest } from "./principal.js";
 
 /** DI token of the Kavo root instance created by `KavoModule.forRoot`. */
 export const KAVO_INSTANCE = Symbol("KAVO_INSTANCE");
@@ -14,6 +16,20 @@ export const KAVO_OVERRIDE_METADATA = "kavo:override";
 
 /** Property the generated route methods read the injected service from. */
 export const KAVO_SERVICE_PROPERTY = "__kavoService";
+
+/**
+ * Property the generated route methods read the configured principal
+ * extractor from — bound onto the controller instance by the same
+ * `KavoModule` discovery pass that binds the service. Written on every
+ * `@Kavo` controller that pass finds, `undefined` included, so that its
+ * *presence* means "this controller was bound" and its absence means
+ * "this object never was" (`boundKavoPrincipal` reads exactly that
+ * difference). Instance-scoped for the same reason the
+ * service is: the controller *class* is process-wide, so a second app in
+ * the same process (every `@kavo/nest` test file) would otherwise inherit
+ * the first one's module options.
+ */
+export const KAVO_PRINCIPAL_PROPERTY = "__kavoPrincipal";
 
 const serviceTokens = new Map<ClassRef, string>();
 
@@ -39,4 +55,43 @@ export function getKavoServiceToken(entity: ClassRef): string {
  */
 export function boundKavoService<Entity extends object>(controller: object): DefaultKavoService<Entity> {
   return (controller as Record<string, unknown>)[KAVO_SERVICE_PROPERTY] as DefaultKavoService<Entity>;
+}
+
+/**
+ * Runs the `principal` extractor `KavoModule` was configured with against
+ * one incoming request — the counterpart of `boundKavoService` for the
+ * methods Kavo does not generate. A generated route already does this for
+ * itself; an `@Override`'d method or a fully custom native route reaches
+ * the engine on its own and so must pass the principal on itself, either
+ * as `service.<op>(…, { principal })` or through
+ * `service.engine.execute({ …, options: { principal } })`.
+ *
+ * Declare the request as the trailing parameter of an `@Override`'d method
+ * (reads: `(id?, query, preconditions, request)`; writes:
+ * `(id?, body?, preconditions, request)`); a fully custom route declares
+ * its own `@Req()`. `null` when no extractor is configured — the same
+ * answer `KavoContext.principal` gives then.
+ *
+ * Passed an object the binder never visited (anything not `@Kavo`-decorated
+ * — a plain provider, a `BaseKavoGraphQLController` subclass) it throws
+ * rather than answering `null`. The two are indistinguishable to the
+ * caller otherwise, and a silently anonymous principal is exactly the bug
+ * this wiring exists to end (issue #142); the binder writes the property
+ * on every `@Kavo` controller it finds, extractor or not, so its presence
+ * is what separates "not configured" from "wrong object".
+ */
+export function boundKavoPrincipal(controller: object, request: KavoPrincipalRequest): unknown {
+  if (!(KAVO_PRINCIPAL_PROPERTY in controller)) {
+    const name = controller.constructor.name;
+    throw new ConfigurationException(
+      name,
+      "principal",
+      `'${name}' was never bound by KavoModule — boundKavoPrincipal reads the extractor the ` +
+        "discovery pass writes onto a @Kavo-decorated controller instance; a class without @Kavo(Entity) " +
+        "must read the request itself",
+    );
+  }
+  const extractPrincipal = (controller as Record<string, unknown>)[KAVO_PRINCIPAL_PROPERTY] as
+    KavoPrincipalExtractor | undefined;
+  return extractPrincipal === undefined ? null : extractPrincipal(request);
 }

--- a/packages/frameworks/nest/tests/principal.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/principal.e2e.spec.ts
@@ -1,0 +1,253 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Controller, UseGuards, type CanActivate, type ExecutionContext, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import type { KavoContext, OperationHandler, WireQuery } from "@kavo/core";
+import { ConfigurationException } from "@kavo/core";
+import type { KavoPrincipalOption, KavoPrincipalRequest } from "@kavo/nest";
+import { Kavo, KavoModule, Override, boundKavoPrincipal, boundKavoService } from "@kavo/nest";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
+
+/**
+ * The principal over **real HTTP**, which is the whole point of this file:
+ * every existing test of `KavoContext.principal` drives the programmatic
+ * surface (`crud.findOne(id, query, { principal })`), and that path always
+ * worked — the generated routes were the ones sending `options: null`, so
+ * a computed field or a handler reading `context.principal` got `null` from
+ * every caller, silently (issue #142).
+ *
+ * Authentication is deliberately a guard here rather than anything Kavo
+ * owns: `principal` only moves an identity someone else established from
+ * the request onto the context.
+ */
+
+let app: INestApplication;
+let adapter: InMemoryTodoAdapter;
+let httpServer: SupertestTarget | undefined;
+
+/** Stands in for whatever an app's real auth guard does. */
+class HeaderUserGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const incoming = context.switchToHttp().getRequest<{
+      headers: Record<string, string | undefined>;
+      user?: unknown;
+      session?: unknown;
+    }>();
+    const id = incoming.headers["x-user"];
+    if (id === undefined) return true;
+    incoming.user = { id };
+    incoming.session = { account: `session-${id}` };
+    return true;
+  }
+}
+
+async function bootstrap(controller: unknown, principal?: KavoPrincipalOption): Promise<void> {
+  adapter = new InMemoryTodoAdapter();
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      KavoModule.forRoot({ infrastructure: fakeInfrastructure(adapter), principal }),
+      KavoModule.forFeature([controller as never]),
+    ],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  httpServer = await listen(app);
+}
+
+afterEach(async () => {
+  httpServer = undefined;
+  await app.close();
+});
+
+function server(): SupertestTarget {
+  return boundServer(httpServer);
+}
+
+/** `context.principal`'s id, or the marker for "nobody is signed in". */
+const viewerOf = (context: KavoContext<Todo>): string =>
+  (context.principal as { id: string } | null)?.id ?? "anonymous";
+
+describe("KavoContext.principal over HTTP — computed fields (issue #142)", () => {
+  // The exact shape docs/integrations/nest/configuration.md documents: a
+  // computed field whose value varies by caller.
+  @Kavo(Todo, { computed: { viewer: { resolve: (_todo: Todo, context) => viewerOf(context) } } })
+  @Controller("todos")
+  @UseGuards(new HeaderUserGuard())
+  class ViewerController {}
+
+  it("resolves a computed field from the caller the guard authenticated", async () => {
+    await bootstrap(ViewerController, true);
+    await request(server()).post("/todos").send({ title: "x" }).set("x-user", "u-7").expect(201);
+
+    const item = await request(server()).get("/todos/1").set("x-user", "u-7").expect(200);
+    expect(item.body).toMatchObject({ id: 1, title: "x", viewer: "u-7" });
+  });
+
+  it("gives every caller their own value and none of them the last one's", async () => {
+    // The regression this file exists for is silent, so "per request, never
+    // cached" has to be asserted rather than assumed: three requests, three
+    // answers, one of them anonymous, all against one bound controller.
+    await bootstrap(ViewerController, true);
+    await request(server()).post("/todos").send({ title: "x" }).set("x-user", "u-7").expect(201);
+
+    const first = await request(server()).get("/todos/1").set("x-user", "u-7").expect(200);
+    const second = await request(server()).get("/todos/1").set("x-user", "u-9").expect(200);
+    const anonymous = await request(server()).get("/todos/1").expect(200);
+
+    expect([first.body.viewer, second.body.viewer, anonymous.body.viewer]).toEqual(["u-7", "u-9", "anonymous"]);
+  });
+
+  it("carries the principal into a list response too, per served row", async () => {
+    await bootstrap(ViewerController, true);
+    await request(server()).post("/todos").send({ title: "a" }).set("x-user", "u-7").expect(201);
+    await request(server()).post("/todos").send({ title: "b" }).set("x-user", "u-7").expect(201);
+
+    const list = await request(server()).get("/todos").set("x-user", "u-9").expect(200);
+    expect(list.body.items.map((item: { viewer: string }) => item.viewer)).toEqual(["u-9", "u-9"]);
+  });
+
+  it("leaves the principal null when the module configures no extractor", async () => {
+    // The upgrade path: an app that never sets the option keeps exactly the
+    // behavior it had, rather than starting to see `request.user` or a throw.
+    await bootstrap(ViewerController);
+    await request(server()).post("/todos").send({ title: "x" }).set("x-user", "u-7").expect(201);
+
+    const item = await request(server()).get("/todos/1").set("x-user", "u-7").expect(200);
+    expect(item.body.viewer).toBe("anonymous");
+  });
+
+  it("reads a custom property when the extractor names one", async () => {
+    // `request.user` is a convention, not a rule — an app whose guard leaves
+    // the caller elsewhere configures the lookup instead of renaming it.
+    await bootstrap(ViewerController, (incoming: KavoPrincipalRequest) => {
+      const session = incoming["session"] as { account: string } | undefined;
+      return session === undefined ? null : { id: session.account };
+    });
+    await request(server()).post("/todos").send({ title: "x" }).set("x-user", "u-7").expect(201);
+
+    const item = await request(server()).get("/todos/1").set("x-user", "u-7").expect(200);
+    expect(item.body.viewer).toBe("session-u-7");
+  });
+
+  it("leaves the principal null when the extractor is switched off explicitly", async () => {
+    await bootstrap(ViewerController, false);
+    await request(server()).post("/todos").send({ title: "x" }).set("x-user", "u-7").expect(201);
+
+    const item = await request(server()).get("/todos/1").set("x-user", "u-7").expect(200);
+    expect(item.body.viewer).toBe("anonymous");
+  });
+});
+
+describe("KavoContext.principal over HTTP — operation handlers (issue #142)", () => {
+  /**
+   * A hand-written handler on an operation given its own route shape —
+   * `EntityConfig` registers no new operation ids, so this is the
+   * custom-operation surface Kavo actually has, and it exercises the
+   * generator's non-standard-route branch as well as the handler's context.
+   */
+  const claimHandler: OperationHandler<Todo> = {
+    async execute(_input, context) {
+      return {
+        id: 1,
+        title: viewerOf(context as KavoContext<Todo>),
+        done: true,
+        priority: 0,
+        deletedAt: null,
+        list: null,
+      };
+    },
+  };
+
+  @Kavo(Todo, {
+    operations: {
+      updateOne: { handler: claimHandler, meta: { routes: { method: "POST", path: ":id/claim" } } },
+    },
+  })
+  @Controller("todos")
+  @UseGuards(new HeaderUserGuard())
+  class ClaimController {}
+
+  it("hands a custom handler on a custom route the caller's principal", async () => {
+    await bootstrap(ClaimController, true);
+    const claimed = await request(server()).post("/todos/1/claim").send({}).set("x-user", "u-7").expect(200);
+    expect(claimed.body).toMatchObject({ id: 1, title: "u-7" });
+  });
+
+  it("hands the same handler a null principal when nobody is signed in", async () => {
+    await bootstrap(ClaimController, true);
+    const claimed = await request(server()).post("/todos/1/claim").send({}).expect(200);
+    expect(claimed.body).toMatchObject({ title: "anonymous" });
+  });
+
+  it("reaches a standard write handler too, not only reads", async () => {
+    const seen: unknown[] = [];
+    const createHandler: OperationHandler<Todo> = {
+      async execute(_input, context) {
+        seen.push(context.principal);
+        return { id: 1, title: "x", done: false, priority: 0, deletedAt: null, list: null };
+      },
+    };
+
+    @Kavo(Todo, { operations: { createOne: { handler: createHandler } } })
+    @Controller("todos")
+    @UseGuards(new HeaderUserGuard())
+    class CreatingController {}
+
+    await bootstrap(CreatingController, true);
+    await request(server()).post("/todos").send({ title: "x" }).set("x-user", "u-7").expect(201);
+    expect(seen).toEqual([{ id: "u-7" }]);
+  });
+});
+
+describe("boundKavoPrincipal — the methods Kavo does not generate", () => {
+  @Kavo(Todo)
+  @Controller("todos")
+  @UseGuards(new HeaderUserGuard())
+  class OverridingController {
+    // The generated layout's trailing parameter, which is exactly why the
+    // request is in it: an override reaches the engine itself, so it passes
+    // the principal itself — through the app's configured extractor rather
+    // than by re-deciding where the caller lives.
+    @Override()
+    async findOne(id: string, query: WireQuery, _preconditions: unknown, incoming: KavoPrincipalRequest) {
+      const principal = boundKavoPrincipal(this, incoming);
+      const item = await boundKavoService<Todo>(this).findOne(id as never, query as never, { principal });
+      return { ...item, viewer: (principal as { id: string } | null)?.id ?? "anonymous" };
+    }
+  }
+
+  it("runs the configured extractor for an @Override'd method", async () => {
+    await bootstrap(OverridingController, true);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    const item = await request(server()).get("/todos/1").set("x-user", "u-7").expect(200);
+    expect(item.body).toMatchObject({ id: 1, viewer: "u-7" });
+  });
+
+  it("answers null for the same method when no extractor is configured", async () => {
+    await bootstrap(OverridingController);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    const item = await request(server()).get("/todos/1").set("x-user", "u-7").expect(200);
+    expect(item.body.viewer).toBe("anonymous");
+  });
+
+  it("throws on an object the binder never visited, rather than answering null", () => {
+    // "no extractor configured" and "this isn't a @Kavo controller" would
+    // otherwise be the same silent `null` — the failure mode issue #142 is
+    // about, reintroduced one layer up.
+    class PlainService {}
+    let error: unknown;
+    try {
+      boundKavoPrincipal(new PlainService(), {});
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error).toMatchObject({
+      code: "KAVO_CONFIG_INVALID",
+      messageParams: { entity: "PlainService", path: "principal" },
+    });
+  });
+});


### PR DESCRIPTION
`makeHandler` built every `KavoRequest` with `options: null` hardcoded, and `KavoCallOptions.principal` is core's only channel for the caller's identity. So `KavoContext.principal` was `null` on every HTTP request Kavo generates a route for, standard and custom alike, while `docs/integrations/nest/configuration.md` showed adopters an ownership check written against it. The failure was silent rather than loud: `principal` is typed `unknown`, so `book.ownerId === (context.principal as User)?.id` compiled and returned `false` for everybody. Only the programmatic path ever worked, which is why the entire existing suite passed over the bug.

Routes are generated at decoration time (ADR-0012), so a module-scope extractor cannot be baked into the generated method. `KavoModule`'s discovery pass now binds the extractor function onto each controller instance alongside the service, and the handler runs it per request against a trailing `@Req()` parameter. Nothing memoizes, so one caller's identity cannot survive into the next request.

Closes #142

## Public API impact

Additive, non-breaking.

- `@kavo/nest` barrel gains `boundKavoPrincipal`, plus the types `KavoPrincipalExtractor`, `KavoPrincipalOption` and `KavoPrincipalRequest`.
- `KavoModuleOptions` gains an optional `principal`: `true` reads `request.user`, a function reads anything else.
- The generated parameter layout gains a trailing `@Req()`. It is last, and after `preconditions`, so every `@Override`'d signature written against the old layout still compiles — an override opts out by declaring fewer parameters, which is already how it opts out of the others.
- `@kavo/core` is unchanged apart from a doc comment on `KavoContext.principal` that had claimed the framework layer already did this.

**Leaving the option unset leaves `principal` null**, byte for byte today's behavior, so upgrading changes nothing for an app that has not opted in. That is deliberate: populating it silently would change what every existing `principal`-reading computed field or handler returns.

## Testing

A new 253-line e2e suite (`packages/frameworks/nest/tests/principal.e2e.spec.ts`) driving real HTTP, because the existing unit tests all use the programmatic path that already worked, and that is precisely why this survived. It covers a computed field resolving per caller, several callers in one process getting their own values and none inheriting the last one's, the anonymous fallback, a custom extractor, an explicit `false`, custom operation handlers, standard writes, and `boundKavoPrincipal` from an `@Override`'d method.

Verified on this branch, rebased onto `a42f16e`:

- `pnpm check` — 91 files, 2030 tests, 0 depcruise violations
- `pnpm docs:links` — OK
- `pnpm format:check` — OK
- `pnpm test:coverage` — 2030 tests, thresholds met

## Review notes

**`boundKavoPrincipal` is the part to look at hardest.** It is new public API, and it throws a `ConfigurationException` when handed an object `KavoModule`'s binder never visited, rather than answering `null`. That is asymmetric with `boundKavoService`, which returns silently.

The argument for the asymmetry: `boundKavoService` returning `undefined` fails loudly at the next `.engine` access, whereas a principal helper returning `null` fails silently, and a silently anonymous principal is the exact bug this PR exists to end. The invariant it rests on is that the binder assigns the property unconditionally, `undefined` included (`kavo.module.ts`), so `in` genuinely separates "bound but unconfigured" from "never bound". That invariant now spans two files; both comments say so.

It is still two judgment calls past what the issue asked for, and #142's acceptance criteria do not require a helper for hand-written methods. If you would rather it did not ship here, dropping it is a contained revert — the generated-route fix does not depend on it.

**Left for later, deliberately:** `@kavo/graphql` and `@kavo/mcp` have the same hole and are out of scope here, tracked as #144. The shape differs enough to matter: neither builds a `KavoRequest` at all, both call the typed service methods that already accept `KavoCallOptions`, so the channel is reachable and simply never passed. GraphQL additionally discards the value upstream, since every resolver in `schema.ts` declares `(_root, args)` and drops the `context` argument graphql-js passes. The docs added here state that the option reaches generated REST routes and nothing else, rather than leaving the boundary implicit.

**Also noted while implementing:** `EntityConfig` cannot register a genuinely new operation id, so the e2e suite reaches its custom route through a repurposed `updateOne` with `meta.routes`. Same code path, since `makeHandler` is one arm for every registry entry. Filed as #145.
