### PR TITLE
feat(realtime): add @kavo/sse — the first RealtimeTransport implementation

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -48,7 +48,7 @@ workflow.
 3. **Apply the version, in lockstep** (ADR-0004 — [`docs/internals/adr/0004-lockstep-versioning.md`](../../docs/internals/adr/0004-lockstep-versioning.md)):
    set the new version in the `package.json` of **every** published package.
    `PACKAGE_DIRS` in `.github/workflows/publish.yml` is the single source of
-   truth for that set — read it and bump exactly those. Today it is all eight:
+   truth for that set — read it and bump exactly those. Today it is all nine:
 
    | Directory                    | Package          |
    | ---------------------------- | ---------------- |
@@ -57,6 +57,7 @@ workflow.
    | `packages/orms/prisma`       | `@kavo/prisma`   |
    | `packages/orms/mongoose`     | `@kavo/mongoose` |
    | `packages/orms/mikroorm`     | `@kavo/mikroorm` |
+   | `packages/realtime/sse`      | `@kavo/sse`      |
    | `packages/protocols/graphql` | `@kavo/graphql`  |
    | `packages/protocols/mcp`     | `@kavo/mcp`      |
    | `packages/frameworks/nest`   | `@kavo/nest`     |

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -9,10 +9,17 @@
  *      │                ├── @kavo/prisma
  *      │                ├── @kavo/mongoose
  *      │                ├── @kavo/mikroorm
+ *      │                ├── @kavo/sse
  *      │                ├── @kavo/graphql ◀─┐
  *      │                └── @kavo/mcp     ◀─┤
  *      └── the one sanctioned sideways edge ┘
  *          (frameworks/* → protocols/*, ADR-0016; never the reverse)
+ *
+ * `@kavo/sse` (`packages/realtime/sse`) is a sibling of the ORM adapters,
+ * not a `protocols/*` binding — it implements one seam (`RealtimeTransport`)
+ * the same way an ORM adapter implements `RepositoryAdapter`, so it gets no
+ * ADR-0016 exception and @kavo/nest may only reach it through a lazy
+ * `import()`, never a static edge (issue #155).
  *
  * `@kavo/core` imports nothing. Every other package imports the `@kavo/core`
  * barrel and its own peer dependency, and nothing else from the workspace —
@@ -69,6 +76,26 @@ module.exports = {
       },
     },
     {
+      name: "realtime-transports-only-import-core",
+      severity: "error",
+      comment:
+        "A realtime transport's `src` may import the `@kavo/core` barrel and " +
+        "its own peer, if any (`@kavo/sse` has none) — nothing else in the " +
+        "workspace, the same rule `orm-adapters-only-import-core` gives an " +
+        "ORM adapter (issue #155: `packages/realtime/*` is a sibling of " +
+        "`packages/orms/*`, an interchangeable implementation of one seam, " +
+        "not a different API surface like `protocols/*`). Not a framework " +
+        "binding, not a protocol binding, and not another realtime " +
+        "transport. `$1` is the transport's own directory captured from " +
+        "`from`, so its internal relative imports stay legal while every " +
+        "sibling package is forbidden in both spellings.",
+      from: { path: "^packages/realtime/([^/]+)/src" },
+      to: {
+        path: "^(@kavo/|packages/)",
+        pathNot: "^(@kavo/core$|packages/realtime/$1/)",
+      },
+    },
+    {
       name: "protocol-bindings-only-import-core",
       severity: "error",
       comment:
@@ -121,15 +148,15 @@ module.exports = {
         "above: this one also covers each package's `tests/` and the " +
         "`examples/*` apps, which are the reference apps, so an illegal " +
         "import there teaches one.",
-      from: { path: "^(packages/(orms|frameworks|protocols)|examples)" },
+      from: { path: "^(packages/(orms|realtime|frameworks|protocols)|examples)" },
       to: { path: "^(packages/core/src/.+|@kavo/core/.+)" },
     },
     {
       name: "no-cross-package-deep-imports-adapters",
       severity: "error",
-      comment: "Same rule for adapter/framework/protocol package internals.",
+      comment: "Same rule for adapter/realtime-transport/framework/protocol package internals.",
       from: { path: "^packages/core" },
-      to: { path: "^packages/(orms|frameworks|protocols)/[^/]+/src/.+" },
+      to: { path: "^packages/(orms|realtime|frameworks|protocols)/[^/]+/src/.+" },
     },
     {
       name: "no-deep-imports-through-a-barrel",
@@ -151,10 +178,10 @@ module.exports = {
         "`packages/**/src`-scoped and never look at `examples/`. `$1` is the " +
         "importing package root, so same-package relative imports stay legal.",
       from: {
-        path: "^(packages/(?:core|orms/[^/]+|frameworks/[^/]+|protocols/[^/]+)|examples/[^/]+)/",
+        path: "^(packages/(?:core|orms/[^/]+|realtime/[^/]+|frameworks/[^/]+|protocols/[^/]+)|examples/[^/]+)/",
       },
       to: {
-        path: "^(@kavo/[^/]+/.+|packages/(?:core|orms/[^/]+|frameworks/[^/]+|protocols/[^/]+)/src/.+)",
+        path: "^(@kavo/[^/]+/.+|packages/(?:core|orms/[^/]+|realtime/[^/]+|frameworks/[^/]+|protocols/[^/]+)/src/.+)",
         pathNot: "^$1/",
       },
     },
@@ -162,11 +189,12 @@ module.exports = {
       name: "only-framework-bindings-import-a-host-framework",
       severity: "error",
       comment:
-        "An ORM adapter and a protocol binding are both leaves that adapt " +
-        "exactly one external technology, and a host framework is never it. " +
-        "ADR-0002 puts it as 'an adapter must be usable from any future " +
-        "framework binding'; doc 16 says @kavo/mcp 'has no idea Nest, " +
-        "Express, or any other host exists'. The rules above cannot say this " +
+        "An ORM adapter, a realtime transport, and a protocol binding are " +
+        "all leaves that adapt exactly one external technology, and a host " +
+        "framework is never it. ADR-0002 puts it as 'an adapter must be " +
+        "usable from any future framework binding'; doc 16 says @kavo/mcp " +
+        "'has no idea Nest, Express, or any other host exists' — the same " +
+        "is true of @kavo/sse (issue #155). The rules above cannot say this " +
         "— they gate on `to.path: ^(@kavo/|packages/)`, so a bare " +
         "`@nestjs/common` is outside what they look at, and a hard import of " +
         "it would break every consumer wiring the package into a non-Nest " +
@@ -180,7 +208,7 @@ module.exports = {
         "index.js`. Anchoring on `^` alone matches only the undeclared case, " +
         "which `tsc -b` already rejects as TS2307, so the rule would fire " +
         "exclusively where it is redundant and never where it is needed.",
-      from: { path: "^packages/(orms|protocols)/[^/]+/src" },
+      from: { path: "^packages/(orms|realtime|protocols)/[^/]+/src" },
       to: { path: "(^|/)@nestjs/" },
     },
     {
@@ -196,10 +224,10 @@ module.exports = {
         "back-reference is the package root captured from `from`, so " +
         "same-package imports stay legal.",
       from: {
-        path: "^(packages/core|packages/orms/[^/]+|packages/frameworks/[^/]+|packages/protocols/[^/]+|examples/[^/]+)/tests/",
+        path: "^(packages/core|packages/orms/[^/]+|packages/realtime/[^/]+|packages/frameworks/[^/]+|packages/protocols/[^/]+|examples/[^/]+)/tests/",
       },
       to: {
-        path: "^(packages/core|packages/orms/[^/]+|packages/frameworks/[^/]+|packages/protocols/[^/]+|examples/[^/]+)/(src|tests)/",
+        path: "^(packages/core|packages/orms/[^/]+|packages/realtime/[^/]+|packages/frameworks/[^/]+|packages/protocols/[^/]+|examples/[^/]+)/(src|tests)/",
         pathNot: "^$1/",
       },
     },
@@ -208,15 +236,16 @@ module.exports = {
       severity: "error",
       comment:
         "Core's tests are held to core's own ignorance: the engine must be " +
-        "testable with an in-memory fake and no ORM or framework anywhere " +
-        "(ADR-0005, ADR-0001). `core-imports-nothing` is scoped to `src` so " +
-        "core's tests may use the barrel and vitest; this keeps the part that " +
-        "still matters — no adapter, no framework — enforced for them too. " +
-        "Spelled as `not @kavo/core` rather than as a package list, so a new " +
-        "adapter or protocol package is covered the day it is created.",
+        "testable with an in-memory fake and no ORM, transport, or framework " +
+        "anywhere (ADR-0005, ADR-0001). `core-imports-nothing` is scoped to " +
+        "`src` so core's tests may use the barrel and vitest; this keeps the " +
+        "part that still matters — no adapter, no transport, no framework — " +
+        "enforced for them too. Spelled as `not @kavo/core` rather than as a " +
+        "package list, so a new adapter, realtime transport, or protocol " +
+        "package is covered the day it is created.",
       from: { path: "^packages/core/tests" },
       to: {
-        path: "^(@kavo/|packages/(orms|frameworks|protocols))",
+        path: "^(@kavo/|packages/(orms|realtime|frameworks|protocols))",
         pathNot: "^@kavo/core$",
       },
     },

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
         packages/orms/prisma
         packages/orms/mongoose
         packages/orms/mikroorm
+        packages/realtime/sse
         packages/protocols/graphql
         packages/protocols/mcp
         packages/frameworks/nest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,17 +38,18 @@ Because the build compiles `src` only, each package also has a `tsconfig.tests.j
 
 ## Architecture
 
-Eight published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, which globs in the three `examples/*` apps as well), plus one sanctioned sideways edge:
+Nine published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, which globs in the three `examples/*` apps as well), plus one sanctioned sideways edge:
 
 ```
 @kavo/nest ──▶ @kavo/core ◀── @kavo/typeorm
-   │            ▲ ▲ ▲ ▲ ▲
-   │            │ │ │ │ └─── @kavo/prisma
-   │            │ │ │ └───── @kavo/mongoose
-   │            │ │ └─────── @kavo/mikroorm
-   │            │ └───────── @kavo/mcp     ◀─┐
-   │            └─────────── @kavo/graphql ◀─┤
-   └───── the one sanctioned sideways edge ──┘
+   │            ▲ ▲ ▲ ▲ ▲ ▲
+   │            │ │ │ │ │ └─── @kavo/prisma
+   │            │ │ │ │ └───── @kavo/mongoose
+   │            │ │ │ └─────── @kavo/mikroorm
+   │            │ │ └───────── @kavo/sse
+   │            │ └─────────── @kavo/mcp     ◀─┐
+   │            └───────────── @kavo/graphql ◀─┤
+   └────── the one sanctioned sideways edge ───┘
           (frameworks/* → protocols/*, ADR-0016; never the reverse)
 ```
 
@@ -57,6 +58,7 @@ Eight published packages in a hub-and-spoke topology (`pnpm-workspace.yaml`, whi
 - **`@kavo/prisma`** (`packages/orms/prisma`) — the same seams over a Prisma Client delegate, fed from Prisma's DMMF. Needs caller-declared marker classes as entity identities (ADR-0017). `@prisma/client` is a peer dependency.
 - **`@kavo/mongoose`** (`packages/orms/mongoose`) — the same seams over a Mongoose model, fed from `schema.paths`. A Mongoose model _is_ the entity identity, so nothing is declared twice, and `ObjectId` converts to a hex string at the adapter boundary (ADR-0018). `mongoose` is a peer dependency.
 - **`@kavo/mikroorm`** (`packages/orms/mikroorm`) — the same seams over a MikroORM `EntityManager`, fed from MikroORM's `MetadataStorage`. A decorated entity class _is_ the identity, as with TypeORM, so it needs no marker classes; the query surface is declarative like Prisma's, so the filter translator nests relation paths rather than building joins. Every operation forks its own `EntityManager`, and soft delete must name its column explicitly (MikroORM declares none). `@mikro-orm/core` is a peer dependency.
+- **`@kavo/sse`** (`packages/realtime/sse`) — the first `RealtimeTransport` implementation (ADR-0023, issue #155): plain HTTP `text/event-stream`, no peer dependency at all. A sibling of `packages/orms/*` — an interchangeable implementation of one seam, not a `protocols/*` API surface — so it gets no ADR-0016 exception; `@kavo/nest` may only reach it through a lazy `import()`.
 - **`@kavo/nest`** (`packages/frameworks/nest`) — the `@Kavo` decorator and NestJS route generation.
 - **`@kavo/graphql`** (`packages/protocols/graphql`) — host-framework-agnostic GraphQL schema binding: builds a schema over a `createCrud` service, delegating every resolver to the same engine REST uses. Depends only on `@kavo/core` and the `graphql` peer, never on `@kavo/nest` — the `frameworks/* → protocols/*` edge is one-directional (ADR-0016). `@kavo/nest` is the side that imports it, to provide `BaseKavoGraphQLController`; it does so through a lazy `import("@kavo/graphql")` so the peer stays genuinely optional.
 - **`@kavo/mcp`** (`packages/protocols/mcp`) — host-framework-agnostic MCP binding: exposes a `createCrud` service's standard operations as MCP tools, every tool handler a direct call into the same engine REST uses. Same `protocols/*` constraint as `@kavo/graphql` — `@kavo/core` plus the `@modelcontextprotocol/sdk` peer, which it consumes for **types only**, never at runtime. That is why `@kavo/nest` imports it directly rather than lazily, to provide `BaseKavoMcpController`; the one place `@kavo/nest` actually runs the SDK is its zero-config default MCP controller, which lazy-loads it (`load-mcp-sdk.ts`).

--- a/docs/internals/architecture/02-monorepo-and-packages.md
+++ b/docs/internals/architecture/02-monorepo-and-packages.md
@@ -23,6 +23,9 @@ kavo/
 │  │  │  └─ src/index.ts
 │  │  └─ mikroorm/            # @kavo/mikroorm
 │  │     └─ src/index.ts
+│  ├─ realtime/
+│  │  └─ sse/                 # @kavo/sse
+│  │     └─ src/index.ts
 │  ├─ frameworks/
 │  │  └─ nest/                # @kavo/nest
 │  │     └─ src/index.ts
@@ -41,19 +44,30 @@ kavo/
 └─ docs/                      # this documentation
 ```
 
-The `orms/`, `frameworks/`, and `protocols/` parent folders keep the door
-open for future adapters, host framework bindings (Express, Fastify,
-Next.js, …), and wire protocols (gRPC, …) without implying any get built
-ahead of real work landing (ADR-0002, ADR-0016). `@kavo/prisma` and
-`@kavo/mongoose` are the second and third `orms/*` adapters, alongside
-`@kavo/typeorm` — see ADR-0017 for the one place Prisma's design departs
-from the TypeORM adapter's shape (marker classes standing in for Prisma's
-lack of runtime entity classes), and ADR-0018 for Mongoose's two (a model
-is already the entity identity, and `ObjectId` converts at the adapter
-boundary rather than widening core's `EntityId`). `@kavo/mikroorm` is the
-fourth, and needed no ADR of its own: a decorated MikroORM entity class is
-already the identity, exactly as under TypeORM, so the only decisions it
-makes are adapter-local and live in doc 17.
+The `orms/`, `realtime/`, `frameworks/`, and `protocols/` parent folders
+keep the door open for future adapters, transports, host framework
+bindings (Express, Fastify, Next.js, …), and wire protocols (gRPC, …)
+without implying any get built ahead of real work landing (ADR-0002,
+ADR-0016). `@kavo/prisma` and `@kavo/mongoose` are the second and third
+`orms/*` adapters, alongside `@kavo/typeorm` — see ADR-0017 for the one
+place Prisma's design departs from the TypeORM adapter's shape (marker
+classes standing in for Prisma's lack of runtime entity classes), and
+ADR-0018 for Mongoose's two (a model is already the entity identity, and
+`ObjectId` converts at the adapter boundary rather than widening core's
+`EntityId`). `@kavo/mikroorm` is the fourth, and needed no ADR of its own:
+a decorated MikroORM entity class is already the identity, exactly as
+under TypeORM, so the only decisions it makes are adapter-local and live
+in doc 17.
+
+`realtime/` is a new parent folder alongside `orms/` (issue #155,
+building on the `RealtimeTransport` seam ADR-0023 added): `@kavo/sse` is
+its first package, and — like an ORM adapter — an interchangeable
+implementation of one seam rather than a different API surface the way
+`protocols/*` is. It follows the exact `orms/*` boundary shape (own
+directory, `@kavo/core` plus its own peer only) rather than the
+`protocols/*`/ADR-0016 one: `@kavo/nest` may only reach it through a lazy
+`import()`, the same way it lazy-loads the MCP SDK, never a static import
+edge.
 
 ## 2. Responsibility statements
 
@@ -79,6 +93,12 @@ makes are adapter-local and live in doc 17.
   under the same no-framework rule. See doc 17 for the two places it splits
   the difference between its siblings — TypeORM's decorated-class metadata
   seam, Prisma's declarative query surface.
+- **`@kavo/sse`** (`packages/realtime/sse`, issue #155) exists to
+  implement core's `RealtimeTransport` seam over Server-Sent Events —
+  plain HTTP `text/event-stream`, no peer dependency at all, since SSE
+  needs no client/server library the way WebSocket needs `ws`. Same
+  no-framework rule as an ORM adapter: `@kavo/core` only, never
+  `@kavo/nest`. See `packages/realtime/sse/README.md`.
 - **`@kavo/nest`** exists to bind Kavo to NestJS (module, decorator,
   route generation, exception filter, Swagger). It can't depend on TypeORM
   or `@kavo/typeorm` — it sees persistence only as an injected
@@ -164,7 +184,7 @@ Two independent enforcement layers:
 ## 4. Workspace tooling: pnpm + plain scripts (ADR-0003)
 
 pnpm workspaces with **plain root scripts**, no
-task runner. The entire build graph is eight packages and three example apps,
+task runner. The entire build graph is nine packages and three example apps,
 whose ordering is already fully expressed by TS project references — `tsc -b`
 performs incremental, dependency-ordered, cached builds natively. A task runner
 (turborepo/nx) would add a second place where the graph is declared, a
@@ -210,7 +230,7 @@ dual ESM+CJS output is a future deliverable.
 ## 6. Build strategy
 
 `tsc -b` against the solution file: incremental (`.tsbuildinfo`),
-project-reference-ordered (core → typeorm/prisma/mongoose/mikroorm/graphql/mcp → nest),
+project-reference-ordered (core → typeorm/prisma/mongoose/mikroorm/sse/graphql/mcp → nest),
 each package emitting
 `dist/` with declarations + declaration maps. Consumers inside the
 workspace resolve `@kavo/*` via pnpm workspace links to the built
@@ -249,6 +269,7 @@ uninstallable — and npm does not allow republishing a version to correct it.
 | `@kavo/prisma`   | `@kavo/core`                               | `@prisma/client`                                                                                                                   |
 | `@kavo/mongoose` | `@kavo/core`                               | `mongoose`                                                                                                                         |
 | `@kavo/mikroorm` | `@kavo/core`                               | `@mikro-orm/core`                                                                                                                  |
+| `@kavo/sse`      | `@kavo/core`                               | — (none)                                                                                                                           |
 | `@kavo/graphql`  | `@kavo/core`                               | `graphql`                                                                                                                          |
 | `@kavo/mcp`      | `@kavo/core`                               | `@modelcontextprotocol/sdk`                                                                                                        |
 | `@kavo/nest`     | `@kavo/core`, `@kavo/graphql`, `@kavo/mcp` | `@nestjs/common`, `@nestjs/core`, `graphql`, `@modelcontextprotocol/sdk` (+ `@nestjs/swagger`, all three protocol peers, optional) |

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate": "pnpm --filter @kavo/prisma run generate",
     "test": "vitest run",
     "test:coverage": "vitest run --config vitest.coverage.config.ts",
-    "typecheck": "tsc -p tsconfig.tests.json && tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/orms/prisma/tsconfig.tests.json && tsc -p packages/orms/mongoose/tsconfig.tests.json && tsc -p packages/orms/mikroorm/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/protocols/mcp/tsconfig.tests.json && tsc -p examples/nest-typeorm/tsconfig.tests.json && tsc -p examples/nest-mongoose/tsconfig.tests.json && tsc -p examples/nest-mikroorm/tsconfig.tests.json",
+    "typecheck": "tsc -p tsconfig.tests.json && tsc -p packages/core/tsconfig.tests.json && tsc -p packages/orms/typeorm/tsconfig.tests.json && tsc -p packages/orms/prisma/tsconfig.tests.json && tsc -p packages/orms/mongoose/tsconfig.tests.json && tsc -p packages/orms/mikroorm/tsconfig.tests.json && tsc -p packages/realtime/sse/tsconfig.tests.json && tsc -p packages/frameworks/nest/tsconfig.tests.json && tsc -p packages/protocols/graphql/tsconfig.tests.json && tsc -p packages/protocols/mcp/tsconfig.tests.json && tsc -p examples/nest-typeorm/tsconfig.tests.json && tsc -p examples/nest-mongoose/tsconfig.tests.json && tsc -p examples/nest-mikroorm/tsconfig.tests.json",
     "lint": "oxlint packages examples tests .github/scripts",
     "prettify": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/realtime/sse/README.md
+++ b/packages/realtime/sse/README.md
@@ -1,0 +1,88 @@
+# @kavo/sse
+
+The first `RealtimeTransport` implementation (`@kavo/core`, ADR-0023):
+plain HTTP `text/event-stream`, no client or server library required —
+SSE is one-directional, so there is no socket to open and nothing to
+depend on beyond Node's own `http` types.
+
+**May depend on:** `@kavo/core` only, no peer. **Never on:** `@kavo/nest`
+or any other framework — same rule `packages/orms/*` follows.
+
+## Usage
+
+```ts
+import { createSseTransport } from "@kavo/sse";
+import { createKavo } from "@kavo/core";
+
+const sse = createSseTransport({
+  verifyToken: (token) => verifyJwt(token), // returns a principal, or null
+  subscribableFields: (entityName) => (entityName === "Book" ? ["title", "status", "price"] : undefined),
+});
+
+const kavo = createKavo({
+  infrastructure,
+  realtimeTransports: [sse],
+  defaults: {
+    realtime: { enabled: true, events: { created: true, updated: true, patched: true, deleted: true } },
+  },
+});
+```
+
+Mount `sse.handleRequest` on a plain Node HTTP route (or any host
+framework's request/response — Express, Nest, Fastify's raw
+req/res, … — since `IncomingMessage`/`ServerResponse` is what all of
+them extend or wrap):
+
+```ts
+http.createServer((req, res) => {
+  if (req.url?.startsWith("/realtime")) {
+    void sse.handleRequest(req, res);
+    return;
+  }
+  // ... the rest of the app's routing
+});
+```
+
+A client subscribes to one entity/id with `EventSource`, or any HTTP
+client that reads a chunked `text/event-stream` body:
+
+```js
+const source = new EventSource("/realtime?channel=Book.42&token=...");
+source.addEventListener("updated", (message) => {
+  const event = JSON.parse(message.data); // RealtimeEventDto
+});
+```
+
+`channel` is required and always `<entity>.<id>` — entity-level
+subscriptions only; collection/view subscriptions are a future issue.
+`token` may be passed as a query param (what `EventSource` needs, since it
+cannot set custom headers) or as a normal `Authorization: Bearer <token>`
+header for any other client. An invalid or missing token gets a `401`
+_before_ any SSE frame is written. An optional `fields` query param
+(comma-separated) is checked against that entity's configured
+`realtime.subscribableFields`, if any — a field outside the allowlist gets
+a `400`, the same way `allowlists.selectable` rejects an unlisted field
+over REST; the field list does not filter what a subscription receives yet
+(entity-level events are always the whole item), it only bounds what a
+future field-scoped subscription could reach.
+
+A connection that cannot keep up with its publish rate (the writable
+buffer on its response exceeds `bufferLimitBytes`, default 64 KiB) is
+closed rather than left to block delivery to every other subscriber.
+
+## Known limitations
+
+- **No resume-on-reconnect.** Every SSE frame carries an `id:`, but
+  nothing reads `Last-Event-ID` yet — a dropped connection means missed
+  events, not replayed ones. This matters more for SSE than it will for
+  `@kavo/websocket`: browsers' native `EventSource` **auto-reconnects by
+  default** on a dropped connection, with no application code asking for
+  it, so a client silently starts receiving only new events after a gap it
+  never signaled. Building resume via the `since` cursor is a future issue.
+- **No multi-node fan-out.** The channel registry is one process's
+  in-memory `Map` — a subscriber connected to one instance of a
+  horizontally-scaled app never sees a write handled by another instance.
+- **No subscriber-level authorization.** Every subscription within
+  `subscribableFields` is trusted once the connection is authenticated;
+  row-level/tenant scoping of subscribers is a future issue (`authorize`,
+  out of scope here — see `RealtimeTransport`'s own doc).

--- a/packages/realtime/sse/package.json
+++ b/packages/realtime/sse/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@kavo/sse",
+  "version": "0.7.2",
+  "description": "Kavo SSE realtime transport — implements @kavo/core's RealtimeTransport over Server-Sent Events, plain HTTP with no required peer library.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kavo-labs/kavo.git",
+    "directory": "packages/realtime/sse"
+  },
+  "homepage": "https://github.com/kavo-labs/kavo/tree/main/packages/realtime/sse#readme",
+  "type": "module",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@kavo/core": "workspace:^"
+  }
+}

--- a/packages/realtime/sse/src/index.ts
+++ b/packages/realtime/sse/src/index.ts
@@ -1,0 +1,1 @@
+export { createSseTransport, type SseTransport, type SseTransportOptions } from "./sse-transport.js";

--- a/packages/realtime/sse/src/sse-transport.ts
+++ b/packages/realtime/sse/src/sse-transport.ts
@@ -1,0 +1,243 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RealtimeEventDto, RealtimeFieldSelector, RealtimeTransport } from "@kavo/core";
+
+/**
+ * Bytes buffered in a connection's underlying socket before it is dropped
+ * rather than blocking `publish` for every other subscriber. `res.
+ * writableLength` (Node's `http.ServerResponse` is a `stream.Writable`) is
+ * the amount queued but not yet flushed to the OS — a slow reader grows
+ * this, a healthy one keeps it near zero. 64 KiB is generous for
+ * `RealtimeEventDto`-sized JSON frames while still catching a genuinely
+ * stuck client quickly.
+ */
+const DEFAULT_BUFFER_LIMIT_BYTES = 64 * 1024;
+
+/** What `handleRequest` needs to authenticate and scope one subscription. */
+export interface SseTransportOptions {
+  /**
+   * Authenticates a subscribe request the same way REST does: a bearer
+   * token, read from the `Authorization` header or a `token` query param
+   * (`EventSource` cannot set custom headers, so the query param is the
+   * only option a browser client actually has). Returning `null` (or
+   * `undefined`) fails the request with `401` *before* any SSE frame is
+   * written — `handleRequest` never opens the stream on an invalid or
+   * missing token. The resolved value is only used to gate the connection;
+   * `@kavo/sse` carries no `authorize` seam (out of scope for this issue,
+   * see `RealtimeTransport`'s own doc on subscriber-level access control).
+   */
+  verifyToken(token: string): unknown | Promise<unknown>;
+  /**
+   * Per-entity `RealtimeSettings.subscribableFields`, the same allowlist an
+   * app already configured via `createCrud` — this package has no config
+   * resolution of its own, so the caller supplies the lookup. A request
+   * naming a `fields` query param outside the allowlist is rejected with
+   * `400` before the stream opens, the same way `allowlists.selectable`
+   * rejects an unlisted field over REST. Returning `undefined` (including
+   * when the callback itself is omitted) means no allowlist is configured
+   * for that entity, so any requested field is accepted.
+   */
+  subscribableFields?(entityName: string): RealtimeFieldSelector | undefined;
+  /** See `DEFAULT_BUFFER_LIMIT_BYTES`. */
+  bufferLimitBytes?: number;
+}
+
+/** A `RealtimeTransport` plus the HTTP entry point a host wires a route to. */
+export interface SseTransport extends RealtimeTransport {
+  /**
+   * Handles one incoming SSE subscribe request: `GET ?channel=<entity>.<id>`
+   * with `Accept: text/event-stream`. Host-framework-agnostic — takes
+   * Node's own `IncomingMessage`/`ServerResponse`, which every Node HTTP
+   * framework's request/response either extends or wraps directly.
+   * Resolves once the response is settled (an error status was written, or
+   * the stream was opened) — the connection itself then lives for as long
+   * as the client keeps it open, torn down by the request's own `close`.
+   */
+  handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void>;
+  /** Number of currently open subscriptions, across every channel. */
+  readonly connectionCount: number;
+  /** Ends every open connection and forgets them. For graceful shutdown and tests. */
+  close(): void;
+}
+
+interface Connection {
+  readonly res: ServerResponse;
+  readonly channel: string;
+}
+
+/**
+ * Same array-or-`exclude` semantics `resolveFieldSelector` (core,
+ * internal) applies for REST's `selectable`/`filterable`/`sortable` — but
+ * with no "base" field list to fall back on, because `RealtimeFieldSelector`
+ * carries none (`settings.ts`'s own doc on why: this schema has no `Entity`
+ * type parameter to check a field name against). An explicit array is a
+ * positive allowlist; `{ exclude }` is checked negatively instead — "not
+ * excluded" rather than "in some base set minus excluded" — since there is
+ * no base set here to subtract from.
+ */
+function isFieldAllowed(selector: RealtimeFieldSelector | undefined, field: string): boolean {
+  if (selector === undefined) return true;
+  // `"exclude" in selector`, not `Array.isArray` — `Array.isArray`'s guard is
+  // `arg is any[]`, and a `readonly string[]` is not assignable to `any[]`,
+  // so it fails to narrow the union in the negative branch. Same reason
+  // core's own `resolveFieldSelector` (resolve-entity-config.ts) checks it
+  // this way.
+  if ("exclude" in selector) return !selector.exclude.includes(field);
+  return selector.includes(field);
+}
+
+function bearerToken(req: IncomingMessage): string | undefined {
+  const header = req.headers.authorization;
+  if (typeof header !== "string") return undefined;
+  const match = /^Bearer (.+)$/.exec(header);
+  return match?.[1];
+}
+
+function sendJson(res: ServerResponse, status: number, body: Record<string, unknown>): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) });
+  res.end(payload);
+}
+
+/**
+ * `id:` set even though nothing consumes it yet (resume-on-reconnect is a
+ * future issue) — a monotonically increasing counter, shared across every
+ * channel on this transport instance, so it stays meaningful the day resume
+ * is built instead of forcing a wire-format change then.
+ */
+function frame(id: number, event: RealtimeEventDto): string {
+  return `id: ${id}\nevent: ${event.event}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+/**
+ * The first real `RealtimeTransport` implementation (issue #155, over the
+ * seam #154 added): plain HTTP `text/event-stream`, no client or server
+ * library required. Entity-level subscriptions only — the channel a
+ * connection opens is exactly the `<entity>.<id>` string `RealtimeEventDto.
+ * channel` carries, and `publish` fans an event out to every connection
+ * registered under that same string.
+ *
+ * One process, one in-memory channel registry: a subscriber connected to
+ * this instance never sees a write handled by another instance of a
+ * horizontally-scaled app (see the package README's "Known limitations").
+ */
+export function createSseTransport(options: SseTransportOptions): SseTransport {
+  const bufferLimitBytes = options.bufferLimitBytes ?? DEFAULT_BUFFER_LIMIT_BYTES;
+  const channels = new Map<string, Set<Connection>>();
+  let nextEventId = 1;
+
+  function subscribe(connection: Connection): void {
+    let subscribers = channels.get(connection.channel);
+    if (!subscribers) {
+      subscribers = new Set();
+      channels.set(connection.channel, subscribers);
+    }
+    subscribers.add(connection);
+  }
+
+  function unsubscribe(connection: Connection): void {
+    const subscribers = channels.get(connection.channel);
+    if (!subscribers) return;
+    subscribers.delete(connection);
+    if (subscribers.size === 0) channels.delete(connection.channel);
+  }
+
+  return {
+    name: "sse",
+
+    get connectionCount(): number {
+      let total = 0;
+      for (const subscribers of channels.values()) total += subscribers.size;
+      return total;
+    },
+
+    async publish(event: RealtimeEventDto): Promise<void> {
+      const subscribers = channels.get(event.channel);
+      if (!subscribers || subscribers.size === 0) return;
+
+      const payload = frame(nextEventId++, event);
+      // Direct `for...of` over the live `Set`, not a snapshot copy: deleting
+      // the current entry mid-iteration (the `unsubscribe` below, for a
+      // connection that can't keep up) is well-defined under the Set
+      // iteration protocol — already-visited and about-to-be-visited
+      // entries are unaffected.
+      for (const connection of subscribers) {
+        if (connection.res.writableLength > bufferLimitBytes) {
+          // Can't keep up: dropped rather than left to block publish to
+          // every other subscriber of this channel.
+          unsubscribe(connection);
+          connection.res.end();
+          continue;
+        }
+        connection.res.write(payload);
+      }
+    },
+
+    async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+      if (req.method !== "GET") {
+        sendJson(res, 400, { error: "SSE subscription requires GET" });
+        return;
+      }
+      const accept = req.headers.accept;
+      if (typeof accept !== "string" || !accept.includes("text/event-stream")) {
+        sendJson(res, 400, { error: "requires 'Accept: text/event-stream'" });
+        return;
+      }
+
+      const url = new URL(req.url ?? "", "http://kavo.invalid");
+      const channel = url.searchParams.get("channel");
+      const dot = channel?.indexOf(".") ?? -1;
+      if (!channel || dot <= 0 || dot === channel.length - 1) {
+        sendJson(res, 400, { error: "a 'channel' query parameter of the form '<entity>.<id>' is required" });
+        return;
+      }
+
+      const token = bearerToken(req) ?? url.searchParams.get("token") ?? undefined;
+      let principal: unknown = null;
+      if (token !== undefined) {
+        try {
+          principal = (await options.verifyToken(token)) ?? null;
+        } catch {
+          principal = null;
+        }
+      }
+      if (principal === null) {
+        sendJson(res, 401, { error: "unauthorized" });
+        return;
+      }
+
+      const entityName = channel.slice(0, dot);
+      const fieldsParam = url.searchParams.get("fields");
+      if (fieldsParam !== null) {
+        const selector = options.subscribableFields?.(entityName);
+        const requested = fieldsParam
+          .split(",")
+          .map((field) => field.trim())
+          .filter((field) => field.length > 0);
+        const disallowed = requested.filter((field) => !isFieldAllowed(selector, field));
+        if (disallowed.length > 0) {
+          sendJson(res, 400, { error: `field(s) not subscribable: ${disallowed.join(", ")}` });
+          return;
+        }
+      }
+
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.flushHeaders();
+
+      const connection: Connection = { res, channel };
+      subscribe(connection);
+      req.on("close", () => unsubscribe(connection));
+      res.on("error", () => unsubscribe(connection));
+    },
+
+    close(): void {
+      for (const subscribers of channels.values()) {
+        for (const connection of subscribers) connection.res.end();
+      }
+      channels.clear();
+    },
+  };
+}

--- a/packages/realtime/sse/tests/integration.spec.ts
+++ b/packages/realtime/sse/tests/integration.spec.ts
@@ -34,6 +34,24 @@ function readSseFrames(body: ReadableStream<Uint8Array>): { next(): Promise<stri
   return { next, cancel: () => reader.cancel() };
 }
 
+/**
+ * A real client disconnect frees the connection asynchronously — the
+ * server only learns about it once the socket teardown propagates to the
+ * request's own `close` event, which `handleRequest` listens for. Polling
+ * is what proves that actually happens over a genuine socket, as opposed
+ * to `sse-transport.spec.ts`'s fake, which only proves the transport reacts
+ * correctly *given* a `close` event, not that Node produces one.
+ */
+async function waitForConnectionCount(transport: SseTransport, expected: number): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (transport.connectionCount !== expected) {
+    if (Date.now() > deadline) {
+      throw new Error(`connectionCount never reached ${expected}, stuck at ${transport.connectionCount}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 describe("@kavo/sse — end-to-end over a real HTTP server", () => {
   let server: Server;
   let baseUrl: string;
@@ -76,6 +94,7 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
     });
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toContain("application/json");
     const body = (await response.json()) as { error: string };
     expect(body.error).toContain("price");
     expect(transport.connectionCount).toBe(0);
@@ -101,7 +120,6 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
     await crud.createOne({ title: "Dune", status: "draft", price: 999 } as never);
 
     const frame = await frames.next();
-    frames.cancel();
 
     expect(frame).toMatch(/^id: \d+\n/);
     expect(frame).toContain("event: created\n");
@@ -117,5 +135,11 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
     expect(event.entity).toBe("Book");
     expect(event.channel).toBe("Book.1");
     expect(event.item).toMatchObject({ title: "Dune" });
+
+    expect(transport.connectionCount).toBe(1);
+    await frames.cancel();
+    // Proves the real disconnect path over a genuine socket, not just the
+    // fake-driven mechanism sse-transport.spec.ts exercises.
+    await waitForConnectionCount(transport, 0);
   });
 });

--- a/packages/realtime/sse/tests/integration.spec.ts
+++ b/packages/realtime/sse/tests/integration.spec.ts
@@ -1,0 +1,121 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createKavo } from "@kavo/core";
+import { createSseTransport, type SseTransport } from "@kavo/sse";
+import { Book, bookMetadata, InMemoryBookAdapter } from "./support/book-fixture.js";
+
+/**
+ * The acceptance criterion's own words: "a real HTTP client consuming the
+ * text/event-stream response against a running transport wired to an
+ * in-memory Kavo instance". A real `http.Server` plus the platform's own
+ * `fetch`, not a mocked request/response — `sse-transport.spec.ts` covers
+ * the same logic in isolation with fakes; this suite is what proves the
+ * wiring actually works over a socket.
+ */
+
+function readSseFrames(body: ReadableStream<Uint8Array>): { next(): Promise<string>; cancel(): Promise<void> } {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  async function next(): Promise<string> {
+    while (!buffer.includes("\n\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("stream ended before a full SSE frame arrived");
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const end = buffer.indexOf("\n\n") + 2;
+    const frame = buffer.slice(0, end);
+    buffer = buffer.slice(end);
+    return frame;
+  }
+
+  return { next, cancel: () => reader.cancel() };
+}
+
+describe("@kavo/sse — end-to-end over a real HTTP server", () => {
+  let server: Server;
+  let baseUrl: string;
+  let transport: SseTransport;
+  let adapter: InMemoryBookAdapter;
+
+  beforeEach(async () => {
+    adapter = new InMemoryBookAdapter();
+    transport = createSseTransport({
+      verifyToken: (token) => (token === "good-token" ? { sub: "u1" } : null),
+      subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
+    });
+
+    server = createServer((req, res) => {
+      void transport.handleRequest(req, res);
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    transport.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("rejects with 401 and never opens the stream when the token is missing or invalid", async () => {
+    const response = await fetch(`${baseUrl}/realtime?channel=Book.1`, {
+      headers: { Accept: "text/event-stream" },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(transport.connectionCount).toBe(0);
+  });
+
+  it("rejects a 'fields' request naming a field outside subscribableFields with 400", async () => {
+    const response = await fetch(`${baseUrl}/realtime?channel=Book.1&token=good-token&fields=title,price`, {
+      headers: { Accept: "text/event-stream" },
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("price");
+    expect(transport.connectionCount).toBe(0);
+  });
+
+  it("delivers a created event as a spec-correct SSE frame to a connected subscriber", async () => {
+    const kavo = createKavo({ realtimeTransports: [transport] });
+    const crud = kavo.createCrud(Book, { realtime: { enabled: true, events: {} } } as never, {
+      adapter,
+      metadata: bookMetadata,
+    });
+
+    const response = await fetch(`${baseUrl}/realtime?channel=Book.1&token=good-token`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const frames = readSseFrames(response.body!);
+    // Book.1: this adapter's ids start at 1, and this is the first write —
+    // an entity-level SSE channel is exactly `<entity>.<id>`, known ahead of
+    // the write only because nothing else has created a Book yet.
+    await crud.createOne({ title: "Dune", status: "draft", price: 999 } as never);
+
+    const frame = await frames.next();
+    frames.cancel();
+
+    expect(frame).toMatch(/^id: \d+\n/);
+    expect(frame).toContain("event: created\n");
+
+    const dataLine = frame.split("\n").find((line) => line.startsWith("data: "))!;
+    const event = JSON.parse(dataLine.slice("data: ".length)) as {
+      event: string;
+      entity: string;
+      channel: string;
+      item: { title: string };
+    };
+    expect(event.event).toBe("created");
+    expect(event.entity).toBe("Book");
+    expect(event.channel).toBe("Book.1");
+    expect(event.item).toMatchObject({ title: "Dune" });
+  });
+});

--- a/packages/realtime/sse/tests/sse-transport.spec.ts
+++ b/packages/realtime/sse/tests/sse-transport.spec.ts
@@ -252,6 +252,11 @@ describe("createSseTransport — opening a stream", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.ended).toBe(false);
+    expect(res.headers).toMatchObject({
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
     expect(transport.connectionCount).toBe(1);
   });
 
@@ -264,6 +269,22 @@ describe("createSseTransport — opening a stream", () => {
     expect(transport.connectionCount).toBe(1);
 
     close();
+    expect(transport.connectionCount).toBe(0);
+  });
+
+  it("unsubscribes the connection once the underlying response errors", async () => {
+    // The other half of cleanup, alongside the request's own 'close' above —
+    // a broken pipe surfaces as an 'error' on the response, not a 'close' on
+    // the request, and both must free the connection or a channel accumulates
+    // dead subscribers forever.
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+    expect(transport.connectionCount).toBe(1);
+
+    res.emit("error", new Error("ECONNRESET"));
     expect(transport.connectionCount).toBe(0);
   });
 });
@@ -319,19 +340,33 @@ describe("createSseTransport — publish", () => {
 
     expect(first.frames).toHaveLength(1);
     expect(second.frames).toHaveLength(1);
+    // Same payload delivered to both, not just the same count — a fan-out
+    // bug that mutated per-connection state or reused a stale event object
+    // would still pass a length-only assertion.
+    expect(second.frames[0]).toBe(first.frames[0]);
   });
 
   it("assigns increasing 'id:' values across successive publishes, shared across channels", async () => {
     const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
-    const res = fakeResponse();
-    await transport.handleRequest(req, res);
+    const bookRes = fakeResponse();
+    const authorRes = fakeResponse();
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      bookRes,
+    );
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Author.5&token=t", { accept: "text/event-stream" }).req,
+      authorRes,
+    );
 
-    await transport.publish(createdEvent());
-    await transport.publish(createdEvent({ event: "patched" }));
+    await transport.publish(createdEvent({ channel: "Book.1" }));
+    await transport.publish(createdEvent({ entity: "Author", id: 5, channel: "Author.5" }));
 
     const idOf = (frame: string) => Number(/^id: (\d+)/.exec(frame)![1]);
-    expect(idOf(res.frames[1]!)).toBeGreaterThan(idOf(res.frames[0]!));
+    // One counter shared across every channel on the transport, not a
+    // per-channel one — the second publish landed on a different channel's
+    // connection entirely, and its id must still be greater.
+    expect(idOf(authorRes.frames[0]!)).toBeGreaterThan(idOf(bookRes.frames[0]!));
   });
 
   it("drops a connection whose write buffer exceeds bufferLimitBytes instead of blocking other subscribers", async () => {

--- a/packages/realtime/sse/tests/sse-transport.spec.ts
+++ b/packages/realtime/sse/tests/sse-transport.spec.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RealtimeEventDto } from "@kavo/core";
+import { createSseTransport } from "@kavo/sse";
+import { fakeRequest, fakeResponse, setWritableLength } from "./support/fake-http.js";
+
+function createdEvent(overrides: Partial<RealtimeEventDto> = {}): RealtimeEventDto {
+  return {
+    event: "created",
+    entity: "Book",
+    id: 1,
+    channel: "Book.1",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    item: { id: 1, title: "Dune" },
+    ...overrides,
+  };
+}
+
+describe("createSseTransport — name", () => {
+  it("identifies itself as 'sse'", () => {
+    expect(createSseTransport({ verifyToken: () => ({}) }).name).toBe("sse");
+  });
+});
+
+describe("createSseTransport — handleRequest auth", () => {
+  it("rejects with 401 before opening the stream when no token is supplied", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({ sub: "u1" }) });
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.frames).toHaveLength(0);
+    expect(transport.connectionCount).toBe(0);
+  });
+
+  it("rejects with 401 when verifyToken returns null", async () => {
+    const transport = createSseTransport({ verifyToken: () => null });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=bad", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.jsonBody).toMatchObject({ error: expect.any(String) });
+  });
+
+  it("rejects with 401 when verifyToken rejects", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => Promise.reject(new Error("token service down")),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=whatever", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects with 401 when verifyToken throws synchronously", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => {
+        throw new Error("malformed token");
+      },
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=whatever", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("reads the token from a query param — what EventSource can actually set", async () => {
+    const verifyToken = vi.fn().mockReturnValue({ sub: "u1" });
+    const transport = createSseTransport({ verifyToken });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=abc123", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(verifyToken).toHaveBeenCalledWith("abc123");
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("prefers the Authorization header over a token query param when both are present", async () => {
+    const verifyToken = vi.fn().mockReturnValue({ sub: "u1" });
+    const transport = createSseTransport({ verifyToken });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=from-query", {
+      accept: "text/event-stream",
+      authorization: "Bearer from-header",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(verifyToken).toHaveBeenCalledWith("from-header");
+  });
+});
+
+describe("createSseTransport — handleRequest request shape", () => {
+  it("rejects a non-GET method with 400 before opening the stream", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    (req as { method: string }).method = "POST";
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a request with no 'Accept: text/event-stream' header with 400", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "application/json" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a request with no 'channel' query parameter with 400", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it.each(["", ".42", "Book.", "Book"])("rejects a malformed channel %j with 400", async (channel) => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest(`/realtime?channel=${encodeURIComponent(channel)}&token=t`, {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("createSseTransport — subscribableFields enforcement", () => {
+  it("accepts a 'fields' request naming only allowlisted fields (array form)", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title,status", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("rejects a 'fields' request naming a field outside the allowlist (array form) with 400", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title,price", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonBody).toMatchObject({ error: expect.stringContaining("price") });
+    expect(transport.connectionCount).toBe(0);
+  });
+
+  it("rejects a field named in an 'exclude' selector with 400", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: () => ({ exclude: ["price"] }),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=price", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("accepts a field not named by an 'exclude' selector", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: () => ({ exclude: ["price"] }),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("accepts any field when no subscribableFields callback is configured", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=anything", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("accepts any field when the callback returns undefined for that entity", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: () => undefined,
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=anything", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("skips field validation entirely when no 'fields' param is given", async () => {
+    const subscribableFields = vi.fn().mockReturnValue([]);
+    const transport = createSseTransport({ verifyToken: () => ({}), subscribableFields });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(subscribableFields).not.toHaveBeenCalled();
+  });
+});
+
+describe("createSseTransport — opening a stream", () => {
+  it("writes text/event-stream response headers and registers the connection", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.ended).toBe(false);
+    expect(transport.connectionCount).toBe(1);
+  });
+
+  it("unsubscribes the connection once the underlying request closes", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req, close } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+    expect(transport.connectionCount).toBe(1);
+
+    close();
+    expect(transport.connectionCount).toBe(0);
+  });
+});
+
+describe("createSseTransport — publish", () => {
+  it("writes a spec-correct SSE frame (id/event/data) to a subscriber of the matching channel", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    const event = createdEvent();
+    await transport.publish(event);
+
+    expect(res.frames).toHaveLength(1);
+    const frame = res.frames[0]!;
+    expect(frame).toMatch(/^id: \d+\n/);
+    expect(frame).toContain(`event: ${event.event}\n`);
+    expect(frame).toContain(`data: ${JSON.stringify(event)}\n`);
+    expect(frame.endsWith("\n\n")).toBe(true);
+  });
+
+  it("does not deliver to a connection subscribed to a different channel", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.2&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ channel: "Book.1" }));
+
+    expect(res.frames).toHaveLength(0);
+  });
+
+  it("is a no-op when no connection is subscribed to the event's channel", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    await expect(transport.publish(createdEvent())).resolves.toBeUndefined();
+  });
+
+  it("fans one event out to every connection subscribed to the same channel", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const first = fakeResponse();
+    const second = fakeResponse();
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      first,
+    );
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      second,
+    );
+
+    await transport.publish(createdEvent());
+
+    expect(first.frames).toHaveLength(1);
+    expect(second.frames).toHaveLength(1);
+  });
+
+  it("assigns increasing 'id:' values across successive publishes, shared across channels", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent());
+    await transport.publish(createdEvent({ event: "patched" }));
+
+    const idOf = (frame: string) => Number(/^id: (\d+)/.exec(frame)![1]);
+    expect(idOf(res.frames[1]!)).toBeGreaterThan(idOf(res.frames[0]!));
+  });
+
+  it("drops a connection whose write buffer exceeds bufferLimitBytes instead of blocking other subscribers", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}), bufferLimitBytes: 10 });
+    const slow = fakeResponse();
+    const healthy = fakeResponse();
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      slow,
+    );
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      healthy,
+    );
+    setWritableLength(slow, 1_000_000);
+
+    expect(transport.connectionCount).toBe(2);
+    await transport.publish(createdEvent());
+
+    expect(slow.frames).toHaveLength(0);
+    expect(slow.ended).toBe(true);
+    expect(healthy.frames).toHaveLength(1);
+    expect(transport.connectionCount).toBe(1);
+  });
+});
+
+describe("createSseTransport — close", () => {
+  it("ends every open connection and clears the registry", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const res = fakeResponse();
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      res,
+    );
+    expect(transport.connectionCount).toBe(1);
+
+    transport.close();
+
+    expect(res.ended).toBe(true);
+    expect(transport.connectionCount).toBe(0);
+  });
+});

--- a/packages/realtime/sse/tests/support/book-fixture.ts
+++ b/packages/realtime/sse/tests/support/book-fixture.ts
@@ -1,0 +1,88 @@
+import type { EntityId, EntityMetadata, RepositoryAdapter } from "@kavo/core";
+import { NotFoundException } from "@kavo/core";
+
+/**
+ * The smallest entity this package's integration test needs: enough for
+ * `createOne`/`patchOne` to round-trip through a real `KavoEngine` and
+ * trigger the realtime emit hook, wired to a real `createSseTransport`
+ * over a real HTTP server. Not a general-purpose fixture — every method
+ * the engine doesn't exercise in these tests throws instead of pretending
+ * to work.
+ */
+export class Book {
+  id = 0;
+  title = "";
+  status: "draft" | "published" = "draft";
+  price = 0;
+}
+
+export const bookMetadata: EntityMetadata<Book> = {
+  entity: Book,
+  name: "Book",
+  idField: "id",
+  fields: [
+    { name: "id", kind: "number", nullable: false, generated: true },
+    { name: "title", kind: "string", nullable: false, generated: false },
+    { name: "status", kind: "enum", nullable: false, generated: false, enumValues: ["draft", "published"] },
+    { name: "price", kind: "number", nullable: false, generated: false },
+  ],
+  relations: [],
+};
+
+export class InMemoryBookAdapter implements RepositoryAdapter<Book> {
+  rows: Book[] = [];
+  private nextId = 1;
+
+  async findOneById(id: EntityId): Promise<Book | null> {
+    return this.rows.find((row) => row.id === Number(id)) ?? null;
+  }
+
+  async findOne(): Promise<Book | null> {
+    return this.rows[0] ?? null;
+  }
+
+  async findMany(): Promise<readonly Book[]> {
+    return this.rows;
+  }
+
+  async count(): Promise<number> {
+    return this.rows.length;
+  }
+
+  async create(data: Partial<Book>): Promise<Book> {
+    const row = { ...new Book(), ...data, id: this.nextId++ };
+    this.rows.push(row);
+    return row;
+  }
+
+  async update(id: EntityId, data: Partial<Book>): Promise<Book> {
+    const row = await this.require(id);
+    Object.assign(row, data);
+    return row;
+  }
+
+  async patch(id: EntityId, data: Partial<Book>): Promise<Book> {
+    return this.update(id, data);
+  }
+
+  async delete(id: EntityId): Promise<void> {
+    await this.require(id);
+    this.rows = this.rows.filter((row) => row.id !== Number(id));
+  }
+
+  async restore(): Promise<Book> {
+    throw new Error("Book is not soft-deletable");
+  }
+
+  async purge(id: EntityId): Promise<void> {
+    await this.delete(id);
+  }
+
+  private async require(id: EntityId): Promise<Book> {
+    const row = await this.findOneById(id);
+    if (row === null) {
+      throw new NotFoundException({ messageParams: { entity: "Book", id: String(id) } });
+    }
+    return row;
+  }
+}

--- a/packages/realtime/sse/tests/support/fake-http.ts
+++ b/packages/realtime/sse/tests/support/fake-http.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from "node:events";
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http";
+
+/**
+ * Just enough of `IncomingMessage`/`ServerResponse` for `handleRequest` unit
+ * tests to drive `createSseTransport` without a real socket — the
+ * integration suite (`integration.spec.ts`) is what exercises a genuine
+ * `http.Server` end to end. `writableLength` is settable directly so the
+ * bounded-buffer test can simulate a slow reader without actually stalling
+ * one.
+ */
+export function fakeRequest(url: string, headers: IncomingHttpHeaders = {}): { req: IncomingMessage; close(): void } {
+  const emitter = new EventEmitter();
+  const req = Object.assign(emitter, { method: "GET", url, headers }) as unknown as IncomingMessage;
+  return {
+    req,
+    close: () => emitter.emit("close"),
+  };
+}
+
+/**
+ * A class (not an object literal merged onto an `EventEmitter`) because
+ * `statusCode`/`ended`/`jsonBody` must stay *live* accessors — `Object.
+ * assign` would have read a getter once at construction time and copied
+ * its snapshot value instead, which is exactly wrong for state a test
+ * mutates by calling `writeHead`/`end` and then asserts on afterward.
+ */
+class FakeServerResponse extends EventEmitter {
+  writableLength = 0;
+  readonly frames: string[] = [];
+  private _statusCode = 0;
+  private _jsonBody: unknown;
+  private _ended = false;
+
+  get statusCode(): number {
+    return this._statusCode;
+  }
+
+  get jsonBody(): unknown {
+    return this._jsonBody;
+  }
+
+  get ended(): boolean {
+    return this._ended;
+  }
+
+  writeHead(code: number): this {
+    this._statusCode = code;
+    return this;
+  }
+
+  write(chunk: string): boolean {
+    this.frames.push(chunk);
+    return true;
+  }
+
+  end(chunk?: string): this {
+    if (chunk !== undefined) {
+      try {
+        this._jsonBody = JSON.parse(chunk) as unknown;
+      } catch {
+        this.frames.push(chunk);
+      }
+    }
+    this._ended = true;
+    return this;
+  }
+
+  flushHeaders(): void {
+    // no-op: nothing to flush over a fake socket.
+  }
+}
+
+export interface FakeResponse extends ServerResponse {
+  readonly frames: string[];
+  readonly jsonBody: unknown;
+  readonly ended: boolean;
+}
+
+export function fakeResponse(): FakeResponse {
+  return new FakeServerResponse() as unknown as FakeResponse;
+}
+
+/**
+ * `ServerResponse.writableLength` is declared read-only in `@types/node`
+ * (it is, on a real socket) — this is the one place a test needs to fake a
+ * slow reader by setting it directly, so the cast lives here once instead
+ * of in every test that simulates backpressure.
+ */
+export function setWritableLength(res: FakeResponse, bytes: number): void {
+  (res as unknown as { writableLength: number }).writableLength = bytes;
+}

--- a/packages/realtime/sse/tests/support/fake-http.ts
+++ b/packages/realtime/sse/tests/support/fake-http.ts
@@ -29,11 +29,16 @@ class FakeServerResponse extends EventEmitter {
   writableLength = 0;
   readonly frames: string[] = [];
   private _statusCode = 0;
+  private _headers: Record<string, string | number> = {};
   private _jsonBody: unknown;
   private _ended = false;
 
   get statusCode(): number {
     return this._statusCode;
+  }
+
+  get headers(): Record<string, string | number> {
+    return this._headers;
   }
 
   get jsonBody(): unknown {
@@ -44,8 +49,9 @@ class FakeServerResponse extends EventEmitter {
     return this._ended;
   }
 
-  writeHead(code: number): this {
+  writeHead(code: number, headers?: Record<string, string | number>): this {
     this._statusCode = code;
+    if (headers !== undefined) this._headers = headers;
     return this;
   }
 
@@ -73,6 +79,7 @@ class FakeServerResponse extends EventEmitter {
 
 export interface FakeResponse extends ServerResponse {
   readonly frames: string[];
+  readonly headers: Record<string, string | number>;
   readonly jsonBody: unknown;
   readonly ended: boolean;
 }

--- a/packages/realtime/sse/tsconfig.json
+++ b/packages/realtime/sse/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/realtime/sse/tsconfig.tests.json
+++ b/packages/realtime/sse/tsconfig.tests.json
@@ -1,0 +1,15 @@
+{
+  // Typecheck-only project for `tests/` — see packages/core/tsconfig.tests.json.
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["node"],
+    "paths": {
+      "@kavo/core": ["../../core/src/index.ts"],
+      "@kavo/sse": ["./src/index.ts"]
+    }
+  },
+  "include": ["tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,12 @@ importers:
         specifier: ^1.0.0
         version: 1.30.0(zod@4.4.3)
 
+  packages/realtime/sse:
+    dependencies:
+      '@kavo/core':
+        specifier: workspace:^
+        version: link:../../core
+
 packages:
 
   '@algolia/abtesting@1.22.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/core
   - packages/orms/*
+  - packages/realtime/*
   - packages/frameworks/*
   - packages/protocols/*
   - examples/*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "packages/orms/prisma" },
     { "path": "packages/orms/mongoose" },
     { "path": "packages/orms/mikroorm" },
+    { "path": "packages/realtime/sse" },
     { "path": "packages/frameworks/nest" },
     { "path": "packages/protocols/graphql" },
     { "path": "packages/protocols/mcp" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       "@kavo/prisma": new URL("./packages/orms/prisma/src/index.ts", import.meta.url).pathname,
       "@kavo/mongoose": new URL("./packages/orms/mongoose/src/index.ts", import.meta.url).pathname,
       "@kavo/mikroorm": new URL("./packages/orms/mikroorm/src/index.ts", import.meta.url).pathname,
+      "@kavo/sse": new URL("./packages/realtime/sse/src/index.ts", import.meta.url).pathname,
       "@kavo/nest": new URL("./packages/frameworks/nest/src/index.ts", import.meta.url).pathname,
       "@kavo/graphql": new URL("./packages/protocols/graphql/src/index.ts", import.meta.url).pathname,
       "@kavo/mcp": new URL("./packages/protocols/mcp/src/index.ts", import.meta.url).pathname,


### PR DESCRIPTION
<!-- Keep this short. It gets read once, before a merge decision. -->

## What & why

Adds `@kavo/sse` (`packages/realtime/sse`), the first `RealtimeTransport`
implementation over the transport-agnostic seam #154/#157 added: plain HTTP
`text/event-stream`, no peer dependency required since SSE needs no
client/server library. `createSseTransport(options)` implements
`RealtimeTransport` and exposes `handleRequest(req, res)` for a host to mount
on any Node HTTP route. It authenticates via a caller-supplied `verifyToken`
(query param or `Authorization: Bearer`, since `EventSource` can set
neither custom headers nor a body) and returns `401` before writing any SSE
byte on a missing/invalid/throwing token; a `channel=<entity>.<id>` query
param selects the entity-level subscription, and an optional `fields` param
is checked against a caller-supplied `subscribableFields` lookup, mirroring
`allowlists.selectable` for REST. Each event is written as a spec-correct
`id:`/`event:`/`data:` frame, and a connection whose write buffer exceeds
`bufferLimitBytes` (default 64 KiB) is dropped instead of blocking publish
to every other subscriber.

`packages/realtime/*` is wired into the workspace the same way
`packages/orms/*` is: a new `.dependency-cruiser.cjs` per-tier rule
(`realtime-transports-only-import-core`) plus `realtime` added everywhere
else that previously hardcoded `(orms|frameworks|protocols)`, the
`pnpm-workspace.yaml` glob, root `tsconfig.json`/`typecheck`/vitest alias,
and `publish.yml`'s `PACKAGE_DIRS` (kept in sync with `publish.md`'s table,
which `tests/release-workflow.spec.ts` asserts). `@kavo/nest` gets no
static import edge to `@kavo/sse` — that's deliberate, per the issue: it is
not a `protocols/*` package and gets no ADR-0016 exception, so a future
zero-config wiring would need a lazy `import()`, matching
`load-mcp-sdk.ts`. This PR does not add that wiring.

Closes #155

## Public API impact

New package, new export surface (`@kavo/sse`'s barrel: `createSseTransport`,
`SseTransport`, `SseTransportOptions`). No change to `packages/core/src/index.ts`
or any existing package's barrel — not breaking for existing consumers.

## Testing

- `packages/realtime/sse/tests/sse-transport.spec.ts` — unit tests against
  fake `IncomingMessage`/`ServerResponse`: auth (missing/invalid/throwing
  token, header-vs-query precedence), malformed requests (bad method, missing
  `Accept`, missing/malformed `channel`), both `subscribableFields` forms
  (array allowlist and `{ exclude }`), SSE frame shape, multi-subscriber
  fan-out, the bounded-buffer drop, and `close()`.
- `packages/realtime/sse/tests/integration.spec.ts` — end-to-end over a real
  `http.Server` + the platform `fetch`, wired to a real `createKavo` instance
  with an in-memory adapter: connects, triggers a write via `crud.createOne`,
  and asserts the frame arrives correctly shaped; also covers rejected auth
  and a `fields` request outside `subscribableFields`, both over the real
  socket — per the issue's acceptance criteria.

Verified `pnpm check`: `generate`/`build`/`typecheck`/`depcruise`/`lint` all
pass. `pnpm test` passes everywhere except 11 pre-existing failures in
`packages/orms/mongoose` and the Postgres/MariaDB/CockroachDB/Mongo
`examples/*` e2e suites — all `testcontainers`/MongoDB-binary-download
failures from this sandbox having no Docker and no network egress to
MongoDB's CDN, unrelated to this change (excluding those files, `1446/1446`
pass). `pnpm docs:links` and `pnpm format:check` are both clean.

## Review notes

Two judgment calls worth a close look:

- **`RealtimeFieldSelector`'s `{ exclude }` form has no "base" field set to
  subtract from** (unlike REST's `allowlists.selectable`, which has real
  entity columns to check against) — `isFieldAllowed` treats it as "allowed
  unless named in `exclude`" rather than "allowed if in some base set minus
  `exclude`", since there's no base set here. Flagged in the code comment.
- **The bounded write buffer** is checked via `res.writableLength` against
  `bufferLimitBytes` before each write, closing the connection instead of
  queuing further; the unit test simulates it with a fake response rather
  than a genuinely stalled socket, for determinism.

Left out, per the issue's explicit scope: collection/view subscriptions,
resume-on-reconnect (`since`-cursor replay), and subscriber-level
`authorize`/row-level scoping — all called out as known limitations in
`packages/realtime/sse/README.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JSoZDs2N1QCyVABiMmD4QE)_