### PR TITLE
ci: add Bun-runtime compatibility smoke check

### DIFF
--- a/.github/scripts/bun-compat-check.mjs
+++ b/.github/scripts/bun-compat-check.mjs
@@ -1,0 +1,100 @@
+/**
+ * Bun-runtime compatibility smoke check: every published package's compiled
+ * `dist/` entry point must be importable under Bun with no crash.
+ *
+ * This deliberately imports the *compiled* output, not TypeScript sources.
+ * Bun's own transpiler cannot emit `emitDecoratorMetadata` the way `tsc`
+ * (and the SWC vitest plugin) do, so running the TypeORM/Nest-decorated
+ * sources directly under Bun fails for reasons unrelated to Bun
+ * compatibility. Building first with `tsc` sidesteps that: decorator
+ * metadata is already baked into plain JS by the time Bun ever sees it, so
+ * this checks the thing a Bun consumer actually experiences — "does
+ * `import` work" — not whether Bun can compile TypeScript decorators,
+ * which it never needs to.
+ *
+ * Deliberately a smoke check, not a behavior test: the full suite already
+ * covers behavior under Node/Vitest. This only needs to catch a package
+ * whose compiled output throws on import under a different runtime (e.g. a
+ * Node-only API leaking into a hot path).
+ *
+ * Packages are discovered from `pnpm-workspace.yaml` rather than hardcoded,
+ * so this never drifts from `publish.yml`'s `PACKAGE_DIRS` — both land on
+ * the same set of publishable (non-`private`) workspace packages by
+ * construction, the same reasoning `tests/release-workflow.spec.ts`
+ * "covers exactly the publishable workspace packages" applies.
+ *
+ * Usage: bun run .github/scripts/bun-compat-check.mjs
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REPO_ROOT = process.cwd();
+
+function readWorkspaceRoots() {
+  const source = readFileSync(resolve(REPO_ROOT, "pnpm-workspace.yaml"), "utf8");
+  const lines = source.split("\n");
+  const start = lines.findIndex((line) => line.trimEnd() === "packages:");
+  if (start === -1) {
+    throw new Error("pnpm-workspace.yaml no longer declares a `packages:` list");
+  }
+
+  const patterns = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "") continue;
+    const entry = /^\s+-\s+["']?([^"'\s]+)/.exec(line);
+    if (!entry) break;
+    patterns.push(entry[1]);
+  }
+
+  return [...new Set(patterns.map((pattern) => pattern.split("/")[0]))];
+}
+
+function findWorkspacePackages(dir) {
+  const found = [];
+  for (const entry of readdirSync(resolve(REPO_ROOT, dir), { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === "node_modules" || entry.name === "dist") continue;
+    const child = `${dir}/${entry.name}`;
+    if (existsSync(resolve(REPO_ROOT, child, "package.json"))) found.push(child);
+    else found.push(...findWorkspacePackages(child));
+  }
+  return found;
+}
+
+function readManifest(dir) {
+  return JSON.parse(readFileSync(resolve(REPO_ROOT, dir, "package.json"), "utf8"));
+}
+
+const dirs = readWorkspaceRoots()
+  .flatMap((root) => findWorkspacePackages(root))
+  .filter((dir) => readManifest(dir).private !== true);
+
+const failures = [];
+
+for (const dir of dirs) {
+  const manifest = readManifest(dir);
+  const entry = manifest.exports?.["."]?.default ?? manifest.main ?? "index.js";
+  const entryPath = resolve(REPO_ROOT, dir, entry);
+
+  try {
+    const imported = await import(pathToFileURL(entryPath).href);
+    const exportNames = Object.keys(imported);
+    if (exportNames.length === 0) {
+      throw new Error("module imported but exposed no exports");
+    }
+    console.log(`${manifest.name}: ok (${exportNames.length} exports)`);
+  } catch (error) {
+    failures.push({ name: manifest.name ?? dir, dir, error });
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\nBun compatibility check failed: ${failures.length} of ${dirs.length} packages failed to import.`);
+  for (const { name, dir, error } of failures) {
+    console.error(`  ${name} (${dir}) — ${error.message}`);
+  }
+  process.exit(1);
+}
+
+console.log(`\nBun compatibility check passed: all ${dirs.length} packages imported cleanly.`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,43 @@ jobs:
       - name: Coverage
         run: pnpm run generate && pnpm run test:coverage
 
+  # A smoke check, not a behavior test: the `test` job above already covers
+  # behavior under Node/Vitest. This only confirms every published package's
+  # compiled `dist/` entry point is importable under Bun with no crash — the
+  # thing a Bun consumer actually experiences. It deliberately imports
+  # compiled output rather than running the test suite under `bun test`:
+  # Bun's own transpiler cannot emit `emitDecoratorMetadata` the way `tsc`
+  # (and the SWC vitest plugin) do, so TypeORM/Nest-decorated sources fail
+  # under Bun for reasons unrelated to actual Bun compatibility. Building
+  # first with `tsc` sidesteps that, since decorator metadata is already
+  # baked into plain JS by the time Bun ever sees it.
+  bun-compat:
+    name: bun compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run generate && pnpm run build
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Sanity import under Bun
+        run: bun run .github/scripts/bun-compat-check.mjs
+
   format:
     name: format
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `bun-compat` job to `ci.yml`: builds normally with `tsc`, then has Bun import every published package's compiled `dist/` entry point and confirm it exposes exports with no crash.
- New script `.github/scripts/bun-compat-check.mjs` discovers publishable packages from `pnpm-workspace.yaml` (filtering `private`), the same approach `tests/release-workflow.spec.ts` uses, so the list can't drift from `publish.yml`'s `PACKAGE_DIRS`.

Deliberately imports compiled output rather than running the suite via `bun test`: Bun's own transpiler can't emit `emitDecoratorMetadata` the way `tsc` (and the SWC vitest plugin) do, so TypeORM/Nest-decorated sources fail under Bun for reasons unrelated to actual runtime compatibility. Building first with `tsc` sidesteps that, since decorator metadata is already baked into plain JS by the time Bun sees it.

## Test plan
- [x] `pnpm check` passes (build, typecheck, depcruise, lint, test)
- [x] `pnpm format:check` passes
- [x] `tests/ci-workflow.spec.ts` and `tests/release-workflow.spec.ts` pass unchanged (the new job adds no `pnpm run` step, so it's outside their gate-coverage assertions)
- [x] Ran `.github/scripts/bun-compat-check.mjs` locally under both Node and real Bun (1.3.14) against a fresh `pnpm run build` — all 9 published packages import cleanly under Bun