### PR TITLE
feat(realtime): add collection-level and filtered subscriptions

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -134,6 +134,7 @@ const config = defineConfig({
               { text: "Mongoose adapter", link: "/internals/architecture/15-mongoose-adapter" },
               { text: "MCP binding", link: "/internals/architecture/16-mcp-binding" },
               { text: "MikroORM adapter", link: "/internals/architecture/17-mikroorm-adapter" },
+              { text: "Realtime", link: "/internals/architecture/18-realtime" },
             ],
           },
           {
@@ -206,6 +207,14 @@ const config = defineConfig({
               {
                 text: "0022 — Since pagination composes a value|id keyset",
                 link: "/internals/adr/0022-since-pagination-composes-a-value-id-keyset",
+              },
+              {
+                text: "0023 — Realtime transports are resolved config, not settings",
+                link: "/internals/adr/0023-realtime-transports-are-not-settings",
+              },
+              {
+                text: "0024 — Collection channels reuse the filter grammar and vocabulary",
+                link: "/internals/adr/0024-collection-channels-reuse-the-filter-grammar-and-vocabulary",
               },
             ],
           },

--- a/docs/internals/adr/0024-collection-channels-reuse-the-filter-grammar-and-vocabulary.md
+++ b/docs/internals/adr/0024-collection-channels-reuse-the-filter-grammar-and-vocabulary.md
@@ -1,0 +1,109 @@
+# ADR-0024 — Collection-level realtime subscriptions reuse the entity name as their channel and the REST filter grammar/vocabulary for scoping
+
+**Status:** accepted
+
+## Context
+
+Issue #160 asked for two things REST already has and realtime (#154/#155)
+didn't: a way to subscribe to every write on an entity, not just one row,
+and a way to scope that subscription to a subset of rows. Four questions had
+to be answered before any code could be written, and each had an obvious
+wrong answer that would have made this a second, parallel query language and
+a wider realtime vocabulary:
+
+1. **Does a collection channel need a new `RealtimeEventDto` field?**
+   `RealtimeEventDto.entity` already carries the entity's name — exactly what
+   a collection channel is named after. Adding a second field (`
+collectionChannel`) would duplicate it and give a transport two sources
+   of truth for the same string.
+2. **Does a subscribe-time filter need its own grammar?** REST already has
+   one (`filter[field][operator]=value`, `docs/internals/architecture/
+05-query-grammar.md` §1), parsed into a `FilterExpression` AST. Building
+   a second one for realtime would mean a client learns two filter
+   languages for the same entities.
+3. **Does a row entering/leaving a filtered subscriber's view need new event
+   ids?** `RealtimeEventId` (`packages/core/src/realtime/realtime-event.ts`)
+   has been a deliberately closed vocabulary since #154 — five ids, no
+   custom-operation id, "closed until a future issue decides." A synthesized
+   `"entered"`/`"left"` pair was the obvious next move and would have grown
+   that vocabulary for the first time.
+4. **What does a filtered subscriber get on `"deleted"`, where `item` is
+   `null`?** There is nothing to evaluate the filter against.
+
+## Decision
+
+**1. The collection channel is the bare entity name; no new DTO field.** A
+transport treats `RealtimeEventDto.channel` (`<entity>.<id>`) as the
+item-level subscription target and `RealtimeEventDto.entity` as the
+collection-level one — the same event, published once by the engine, fans
+out to both kinds of subscriber because a transport reads both fields off
+one payload. `@kavo/sse`'s `handleRequest` accepts either `?channel=<entity>`
+or `?channel=<entity>.<id>`.
+
+**2. Subscribe-time filtering reuses the REST filter grammar and AST
+verbatim, evaluated in memory.** A subscribe request may carry ordinary
+`filter[field][operator]=value` query params; `@kavo/sse` parses them with
+the same `DefaultFilterParser` REST uses (a `FilterableEntity` — an
+entity's `EntityMetadata` + `ResolvedEntityConfig`, supplied by the host app
+the same way `subscribableFields` already is) and validates them against the
+same `filterable` allowlist and `query.maxFilterDepth`/`maxInValues` limits.
+The resulting `FilterExpression` is evaluated per candidate subscriber, per
+publish, by a new core function — `evaluateFilter` (`packages/core/src/
+query/filter-evaluator.ts`) — rather than by building a query and asking an
+adapter. It follows SQL's three-valued-logic convention: a `null`/missing
+item value makes every operator except `IS_NULL`/`IS_NOT_NULL` evaluate to
+`false`, including `NE` and `NOT_IN` (a naive `!(null === x)` would
+otherwise include a null row a real `!= x` predicate excludes). A filter
+field must be one of the entity's own columns — a relation or dotted path
+is rejected with `400` at subscribe time rather than silently matching
+nothing forever, because the evaluator has no join to walk and no
+before-image to reach a relation's current value with.
+
+**3. Filter-boundary crossings are not new events.** A write that makes a
+row start matching a filter ("enter") is delivered as whatever its real
+event id already is (`updated`/`patched`/`restored`) — not a synthesized
+`created`. A write that makes a row stop matching ("leave") is not
+delivered at all: detecting that transition needs the row's pre-write
+match state, and the engine does not read a row before every write today
+(only under an `If-Match` precondition) — adding that read unconditionally,
+paid by every write on a realtime-enabled entity whether or not a filtered
+collection subscriber exists, was rejected as a cost with no matching
+benefit for the common case. This is a documented limitation, not a
+silently-wrong "leave" event: a client that needs to know a row left its
+filtered view cannot rely on this seam for it today.
+
+**4. A `"deleted"` event bypasses the filter unconditionally.** `item` is
+`null` on delete, so there is nothing to evaluate; every filtered
+subscriber of the channel receives it regardless of match. The alternative
+— excluding it — leaves a client with a row in its view that is permanently
+gone and no signal that it should not be. This is a confidentiality
+tradeoff, not just a staleness one: a subscriber on `filter[ownerId][eq]=me`
+now learns the `id` of every row deleted on the entity, including ones it
+never had visibility into. That is acceptable only because subscriber-level
+authorization is already out of scope for `@kavo/sse` (`RealtimeTransport`'s
+own doc, since #154/#155) — a filter narrows _which_ events a subscriber
+receives, it does not establish _whether_ they were authorized to.
+
+`RealtimeEventId`'s vocabulary stays exactly five ids. `"deleted"` is now
+overloaded to mean "stop expecting to see this row," not strictly "this row
+no longer exists" — documented on the type itself.
+
+## Consequences
+
+- A second `RealtimeTransport` (a future `@kavo/websocket`) gets collection
+  channels and filtering for free from `event.channel`/`event.entity` and
+  `evaluateFilter` — it only needs its own per-connection subscription
+  bookkeeping and its own `FilterableEntity` wiring, the same shape
+  `@kavo/sse` uses.
+- `KavoEngine` gained a `metadata` getter (alongside its existing `config`/
+  `registry` ones) so a transport's host app can build a `FilterableEntity`
+  from `service.engine.metadata`/`service.engine.config` without a new core
+  seam.
+- A client cannot yet learn "this row left my filtered view" from an
+  ordinary write — only from a genuine delete. Fixing that is future work
+  gated on deciding whether the extra pre-write read is worth paying for
+  every write on a realtime-enabled entity, not only ones with a filtered
+  collection subscriber.
+- Field-level channels (a topic per field) remain unbuilt; `subscribableFields`
+  narrows the payload of an item- or collection-level channel, but does not
+  create a third channel kind.

--- a/docs/internals/architecture/18-realtime.md
+++ b/docs/internals/architecture/18-realtime.md
@@ -1,0 +1,185 @@
+# 18 — Realtime Events, Channels & Subscription Filtering
+
+A write can publish an event describing itself, to whatever transports an
+app registered. Core owns the event shape and the publish hook; it ships no
+transport of its own (ADR-0005). `@kavo/sse` is the first one.
+
+```ts
+const kavo = createKavo({
+  infrastructure,
+  realtimeTransports: [sse],
+  defaults: { realtime: { enabled: true, events: { created: true, updated: true } } },
+});
+```
+
+That is the whole opt-in for one entity's writes to start publishing.
+
+## 1. The event vocabulary
+
+`RealtimeEventId` (`packages/core/src/realtime/realtime-event.ts`) is a
+closed, five-member vocabulary — `"created" | "updated" | "patched" |
+"deleted" | "restored"` — one per standard write outcome.
+`REALTIME_EVENT_BY_OPERATION` (`kavo-engine.ts`) maps `deleteOne` and
+`purgeOne` both to `"deleted"`: a subscriber only needs to know the row is
+gone, not which delete strategy produced that. A custom operation never
+emits — the vocabulary stays closed until a future issue decides what one
+publishes as.
+
+## 2. The engine's publish hook
+
+`KavoEngine.emitRealtimeEvent` runs once, after every successful write,
+right before `execute` returns (`kavo-engine.ts`). Every check ahead of the
+transport loop is ordered cheapest-first and returns immediately, so an
+entity with realtime off (the default) or a write that maps to no event id
+pays for nothing beyond a couple of property reads — no `RealtimeEventDto`
+is even constructed. `publish` rejecting never fails the mutation that
+already succeeded; a transport's own delivery failure is reported through
+`RealtimeSettings.onPublishError`, if the app supplied one, and swallowed
+otherwise (core has no ambient logger — ADR-0005).
+
+`RealtimeEventDto` (the wire payload):
+
+| Field        | Meaning                                                                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `event`      | The `RealtimeEventId`.                                                                                                    |
+| `entity`     | `EntityMetadata.name` — also the **collection channel** (§3).                                                             |
+| `id`         | The written row's id.                                                                                                     |
+| `channel`    | `<entity>.<id>` — the **item channel** (§3).                                                                              |
+| `occurredAt` | ISO-8601, set once by the engine so every transport agrees on it.                                                         |
+| `item`       | The same output-DTO serialization already computed for the REST response — no second pass. `null` on `"deleted"`.         |
+| `changed`    | `"updated"`/`"patched"` only — the field names present in the write payload, not a diff against the row's previous value. |
+
+## 3. Channels: item-level and collection-level
+
+Issue #160 added collection-level subscriptions without adding a field to
+`RealtimeEventDto` (ADR-0024): the collection channel a subscriber opens is
+exactly the entity name, which `entity` already carries. A transport reads
+`channel` for an item-level subscriber and `entity` for a collection-level
+one off the same payload — the engine still builds and publishes exactly
+one `RealtimeEventDto` per write; the dual routing is the transport's job.
+
+`@kavo/sse`'s `handleRequest` accepts either shape on `?channel=`:
+
+- `<entity>.<id>` — every event for one row.
+- `<entity>` — every event for the entity.
+
+Field-level channels (a topic per field) are not built. `subscribableFields`
+(§5) narrows the payload of either channel above; it does not create a
+third channel kind.
+
+## 4. Subscribe-time filtering
+
+A collection-channel subscribe request may also carry the ordinary REST
+filter grammar (`filter[field][operator]=value`, doc 05 §1) to scope itself
+to a subset of rows — `GET /realtime?channel=Book&filter[status][eq]=published`.
+This reuses REST's grammar and AST verbatim (ADR-0024): no second filter
+language, no new `RealtimeSettings` key. The filter travels on the
+subscribe request's query string, the same transport-level parameter
+`channel`/`fields`/`token` already are.
+
+### 4.1 Parsing and validation
+
+`@kavo/sse` parses a subscribe request's filter with the same
+`DefaultFilterParser` REST uses, against a `FilterableEntity` — an
+entity's `EntityMetadata` + `ResolvedEntityConfig` — that the host app
+supplies via `SseTransportOptions.filterableEntities`, the same pattern
+`subscribableFields` already established:
+
+```ts
+const sse = createSseTransport({
+  verifyToken,
+  subscribableFields: (entity) => (entity === "Book" ? ["title", "status", "price"] : undefined),
+  filterableEntities: (entity) =>
+    entity === "Book" ? { metadata: bookService.engine.metadata, config: bookService.engine.config } : undefined,
+});
+```
+
+An entity with no `filterableEntities` entry rejects any `filter[...]`
+query param with `400` before the stream opens — filtering is opt-in per
+entity, not a fallback that silently does nothing. A malformed filter
+(bad operator, depth over `query.maxFilterDepth`, too many `in` values, …)
+gets the same `400` REST would give it, via the same
+`QueryValidationException`. A filter field that is not one of the entity's
+own columns — a relation path, a computed field — is also rejected with
+`400`: the in-memory evaluator (§4.2) has no join to walk and no
+before-image to reach a relation's current value with, and a subscription
+that silently never matches is worse than one that never opens.
+
+A filter field must also be in `subscribableFields`, when configured — a
+subscriber cannot scope itself by a field it isn't allowed to receive.
+
+### 4.2 Evaluation
+
+Once parsed, the `FilterExpression` is stored on the connection and
+evaluated per candidate subscriber, per publish, by `evaluateFilter`
+(`packages/core/src/query/filter-evaluator.ts`) — no adapter, no query
+builder, no DB round trip. It follows SQL's three-valued-logic convention:
+a `null`/missing item value makes every operator except
+`IS_NULL`/`IS_NOT_NULL` evaluate to `false`, including `NE`/`NOT_IN` (naive
+`!(null === x)` would otherwise include a null row a real `!= x` predicate
+excludes). `LIKE`/`ILIKE` translate to an anchored `RegExp`, escaping every
+regex metacharacter in the literal portion first — this runs once per
+subscriber per publish for the life of a long-lived connection, so an
+unescaped pattern is both wrong and a ReDoS surface, not just wrong.
+
+### 4.3 Filter-boundary crossings (ADR-0024)
+
+A write can move a row across a subscriber's filter boundary:
+
+| Transition                                          | Delivered as                                                                                                                                                           |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Row didn't match, write makes it match ("enter")    | The ordinary event id (`updated`/`patched`/`restored`) — **not** a synthesized `"created"`.                                                                            |
+| Row matched, write makes it stop matching ("leave") | **Nothing.** No before-image is available to detect this without an extra read the engine does not otherwise do — a documented limitation, not a silently-wrong event. |
+| `"deleted"` (item is `null`)                        | **Always**, regardless of filter — there is nothing to evaluate against.                                                                                               |
+| `"restored"`                                        | Evaluated normally against the restored item (it has one).                                                                                                             |
+
+The `"deleted"` bypass is a confidentiality tradeoff, not only a staleness
+one: a subscriber on `filter[ownerId][eq]=me` learns the `id` of every row
+deleted on the entity, including ones it never had visibility into.
+Acceptable only because subscriber-level authorization is already out of
+this seam (§6) — a filter narrows _which_ events a subscriber receives, not
+_whether_ they were authorized to.
+
+## 5. `subscribableFields`: unconditional payload narrowing
+
+`RealtimeSettings.subscribableFields` (or `@kavo/sse`'s equivalent
+callback) bounds an outgoing `item` **unconditionally**, once configured —
+not only when a subscriber names a `fields` query param, the same way
+`allowlists.selectable` bounds a REST response whether or not the caller
+asked for a subset. A `fields` param narrows further _within_ that bound;
+it can never widen past it. A `filter` field must also be in this
+allowlist (§4.1) — a subscriber cannot see, or scope itself by, a field
+outside it.
+
+## 6. Authorization
+
+Out of scope for `@kavo/sse`, deliberately, since #154/#155:
+`RealtimeTransport`'s own doc comment is the authoritative statement — a
+transport that fans `channel`/`entity` into a pub/sub topic without
+checking, per subscriber, whether that principal could have read the row
+over REST leaks it to every subscriber of that channel, filtered or not.
+Row/tenant-level subscriber scoping (`authorize`) is future work.
+
+Authentication itself (`SseTransportOptions.verifyToken`) is optional, not
+mandatory — omitting it disables the `401` check entirely and every
+subscribe request is accepted, regardless of `token`/`Authorization`. That
+is a deliberate opt-out for an internal-only or already
+perimeter-authenticated deployment, not a default worth reaching for on a
+publicly reachable stream: with no `verifyToken`, `subscribableFields`
+narrowing and subscribe-time filtering are the only things bounding what a
+connection can see, and neither is an access-control mechanism (§4.3, §5).
+
+## 7. Known limitations
+
+- **No resume-on-reconnect.** `@kavo/sse` frames carry an `id:`, but
+  nothing reads `Last-Event-ID` yet.
+- **No multi-node fan-out.** `@kavo/sse`'s channel registry is one
+  process's in-memory `Map`.
+- **No "leave" event on an ordinary write** (§4.3) — only a genuine
+  `"deleted"` reliably tells a filtered subscriber a row is gone.
+- **No filtering by which fields changed** (`RealtimeEventDto.changed`) —
+  a subscribe-time filter matches row _data_, not the write's diff.
+
+See also: ADR-0023 (why registered transports live outside `KavoSettings`),
+ADR-0024 (channel/vocabulary/filter decisions above), and doc 05 (the
+filter grammar this seam reuses).

--- a/docs/internals/architecture/18-realtime.md
+++ b/docs/internals/architecture/18-realtime.md
@@ -75,7 +75,7 @@ to a subset of rows — `GET /realtime?channel=Book&filter[status][eq]=published
 This reuses REST's grammar and AST verbatim (ADR-0024): no second filter
 language, no new `RealtimeSettings` key. The filter travels on the
 subscribe request's query string, the same transport-level parameter
-`channel`/`fields`/`token` already are.
+`channel`/`fields` already are.
 
 ### 4.1 Parsing and validation
 
@@ -87,7 +87,6 @@ supplies via `SseTransportOptions.filterableEntities`, the same pattern
 
 ```ts
 const sse = createSseTransport({
-  verifyToken,
   subscribableFields: (entity) => (entity === "Book" ? ["title", "status", "price"] : undefined),
   filterableEntities: (entity) =>
     entity === "Book" ? { metadata: bookService.engine.metadata, config: bookService.engine.config } : undefined,
@@ -160,14 +159,15 @@ checking, per subscriber, whether that principal could have read the row
 over REST leaks it to every subscriber of that channel, filtered or not.
 Row/tenant-level subscriber scoping (`authorize`) is future work.
 
-Authentication itself (`SseTransportOptions.verifyToken`) is optional, not
-mandatory — omitting it disables the `401` check entirely and every
-subscribe request is accepted, regardless of `token`/`Authorization`. That
-is a deliberate opt-out for an internal-only or already
-perimeter-authenticated deployment, not a default worth reaching for on a
-publicly reachable stream: with no `verifyToken`, `subscribableFields`
-narrowing and subscribe-time filtering are the only things bounding what a
-connection can see, and neither is an access-control mechanism (§4.3, §5).
+`@kavo/sse` also has **no authentication of its own** — `handleRequest`
+accepts any subscribe request that otherwise validates. A deployment that
+needs to gate who may open a stream does so in front of `handleRequest` (a
+reverse proxy, or the host framework's own guard/middleware on the mounted
+route); `handleRequest` is an ordinary `(req, res)` handler for that
+purpose, nothing more. `subscribableFields` narrowing and subscribe-time
+filtering are the only things bounding what a connection can _see_, and
+neither is an access-control mechanism — worth restating given how easy
+`filter[ownerId][eq]=me` reads as if it were one (§4.3, §5).
 
 ## 7. Known limitations
 

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -171,6 +171,16 @@ export class KavoEngine<Entity extends object> {
     return this.deps.config;
   }
 
+  /**
+   * The frozen entity metadata this engine was built from — a transport
+   * (e.g. `@kavo/sse`'s filtered subscriptions, issue #160) needs it
+   * alongside `config` to construct a `DefaultFilterParser` for the same
+   * entity, without core exposing anything ORM- or transport-specific.
+   */
+  get metadata(): EntityMetadata<Entity> {
+    return this.deps.metadata;
+  }
+
   async execute(request: KavoRequest<Entity>): Promise<KavoResponse> {
     const { config, errorHandler } = this.deps;
     const correlationId = randomUuid();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export type { FieldSelection, FieldSelectionInput } from "./query/field-selectio
 export type { NormalizedQueryContext, QueryContext } from "./query/query-context.js";
 export type { FilterParser } from "./query/filter-parser.js";
 export type { FilterBuilder } from "./query/filter-builder.js";
+export { evaluateFilter } from "./query/filter-evaluator.js";
 
 // ── DTO system ────────────────────────────────────────────────────────
 export type {

--- a/packages/core/src/query/filter-evaluator.ts
+++ b/packages/core/src/query/filter-evaluator.ts
@@ -1,0 +1,171 @@
+import type { FilterCondition, FilterExpression, FilterScalar } from "./filter.js";
+
+/**
+ * Evaluates a `FilterExpression` (the same AST `DefaultFilterParser` builds
+ * for REST list requests) against one already-serialized item, in memory —
+ * no adapter, no query builder, no DB round trip. Built for issue #160's
+ * filtered realtime subscriptions (ADR-0024, doc 18 §4): a transport calls this once per
+ * candidate subscriber, per publish, against the `RealtimeEventDto.item`
+ * the engine already serialized for that write.
+ *
+ * `root: null` (no filter configured) always matches, mirroring `Filter.
+ * root`'s own "match everything" convention.
+ *
+ * Every operator follows SQL's three-valued-logic convention rather than
+ * naive JavaScript comparison: a `null`/`undefined` item value makes every
+ * operator **except** `IS_NULL`/`IS_NOT_NULL` evaluate to `false` — the
+ * same way `status != 'x'` and `age > 18` both exclude a `NULL` row rather
+ * than naive `!(null === 'x')` (`true`) including it. This is the one place
+ * this function diverges from "identical to how the adapter would have
+ * translated it": there is no SQL engine here to produce UNKNOWN and fold
+ * it into WHERE's false-or-unknown-excludes semantics, so the fold happens
+ * explicitly, up front, for every operator that isn't itself a null check.
+ */
+export function evaluateFilter<Entity = unknown>(
+  root: FilterExpression<Entity> | null,
+  item: Readonly<Record<string, unknown>>,
+): boolean {
+  if (root === null) return true;
+  return evaluateExpression(root, item);
+}
+
+function evaluateExpression<Entity>(
+  expression: FilterExpression<Entity>,
+  item: Readonly<Record<string, unknown>>,
+): boolean {
+  if (expression.kind === "condition") return evaluateCondition(expression, item);
+  switch (expression.operator) {
+    case "AND":
+      return expression.children.every((child) => evaluateExpression(child, item));
+    case "OR":
+      return expression.children.some((child) => evaluateExpression(child, item));
+    // `NOT` is variadic and means `NOT(AND(children))` (doc 05 §1) — the
+    // wire parser only ever builds the unary shape, but a programmatic
+    // caller can hand-build a wider one, so this stays consistent with it
+    // rather than special-casing arity 1.
+    case "NOT":
+      return !expression.children.every((child) => evaluateExpression(child, item));
+  }
+}
+
+function evaluateCondition<Entity>(
+  condition: FilterCondition<Entity>,
+  item: Readonly<Record<string, unknown>>,
+): boolean {
+  const itemValue = item[condition.field as string];
+
+  if (condition.operator === "IS_NULL") return itemValue === null || itemValue === undefined;
+  if (condition.operator === "IS_NOT_NULL") return itemValue !== null && itemValue !== undefined;
+
+  // Every remaining operator: a missing/null item value can never satisfy
+  // it, including `EQ null` — SQL's `NULL = NULL` is itself unknown, not
+  // true, which is exactly why `IS_NULL` exists as its own operator.
+  if (itemValue === null || itemValue === undefined) return false;
+
+  switch (condition.operator) {
+    case "EQ":
+      return valuesEqual(itemValue, condition.value as FilterScalar);
+    case "NE":
+      return !valuesEqual(itemValue, condition.value as FilterScalar);
+    case "GT":
+      return compareOrdered(itemValue, condition.value as FilterScalar, (a, b) => a > b);
+    case "GTE":
+      return compareOrdered(itemValue, condition.value as FilterScalar, (a, b) => a >= b);
+    case "LT":
+      return compareOrdered(itemValue, condition.value as FilterScalar, (a, b) => a < b);
+    case "LTE":
+      return compareOrdered(itemValue, condition.value as FilterScalar, (a, b) => a <= b);
+    case "IN":
+      return (condition.value as readonly FilterScalar[]).some((candidate) => valuesEqual(itemValue, candidate));
+    case "NOT_IN":
+      return !(condition.value as readonly FilterScalar[]).some((candidate) => valuesEqual(itemValue, candidate));
+    case "BETWEEN": {
+      const [low, high] = condition.value as readonly [FilterScalar, FilterScalar];
+      return compareOrdered(itemValue, low, (a, b) => a >= b) && compareOrdered(itemValue, high, (a, b) => a <= b);
+    }
+    case "LIKE":
+      return likePattern(condition.value as string, false).test(String(itemValue));
+    case "ILIKE":
+      return likePattern(condition.value as string, true).test(String(itemValue));
+  }
+}
+
+/** `Date` compares by instant; everything else compares by strict equality after normalizing one side to a `Date` if the other is one. */
+function valuesEqual(itemValue: unknown, filterValue: FilterScalar): boolean {
+  const [a, b] = normalizeForDateCompare(itemValue, filterValue);
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  return a === b;
+}
+
+function compareOrdered(
+  itemValue: unknown,
+  filterValue: FilterScalar,
+  compare: (a: number | string, b: number | string) => boolean,
+): boolean {
+  const [a, b] = normalizeForDateCompare(itemValue, filterValue);
+  const left = orderable(a);
+  const right = orderable(b);
+  if (left === null || right === null) return false;
+  return compare(left, right);
+}
+
+function orderable(value: unknown): number | string | null {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number" || typeof value === "string") return value;
+  return null;
+}
+
+/**
+ * `coerceScalar` turns a date column's wire value into a `Date` (value-
+ * coercion.ts), and `KavoEngine`'s serializer never re-stringifies the row
+ * it just wrote before handing it to `emitRealtimeEvent` — but an ORM
+ * adapter's own item representation isn't guaranteed to agree, and a
+ * hand-built `RealtimeTransport` test fixture even less so. When the
+ * filter's own value is a `Date` and the item's is a parseable string,
+ * parse it once here rather than let every comparator re-derive it.
+ */
+function normalizeForDateCompare(itemValue: unknown, filterValue: FilterScalar): [unknown, FilterScalar] {
+  if (filterValue instanceof Date && typeof itemValue === "string") {
+    const parsed = new Date(itemValue);
+    if (!Number.isNaN(parsed.getTime())) return [parsed, filterValue];
+  }
+  return [itemValue, filterValue];
+}
+
+/**
+ * `LIKE`/`ILIKE` → `RegExp`. The parser passes the pattern through
+ * unmodified (doc 05 §3: callers spell `%`/`_` themselves, and escape a
+ * literal one with a backslash) — every other character is escaped as a
+ * regex literal *before* `%`/`_` are translated, so a pattern containing
+ * `(`, `[`, `+`, `*`, … can't reach `RegExp` unescaped. That matters here
+ * more than it would for a one-off match: this runs once per candidate
+ * subscriber, per publish, for the life of a long-lived connection.
+ */
+function likePattern(pattern: string, caseInsensitive: boolean): RegExp {
+  let out = "";
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i] as string;
+    if (ch === "\\" && i + 1 < pattern.length) {
+      const next = pattern[i + 1] as string;
+      if (next === "%" || next === "_" || next === "\\") {
+        out += escapeRegExp(next);
+        i++;
+        continue;
+      }
+    }
+    if (ch === "%") {
+      out += ".*";
+      continue;
+    }
+    if (ch === "_") {
+      out += ".";
+      continue;
+    }
+    out += escapeRegExp(ch);
+  }
+  return new RegExp(`^${out}$`, caseInsensitive ? "i" : "");
+}
+
+function escapeRegExp(ch: string): string {
+  return ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/core/src/realtime/realtime-event.ts
+++ b/packages/core/src/realtime/realtime-event.ts
@@ -7,6 +7,16 @@ import type { EntityId } from "../types/entity-id.js";
  * delete strategy produced that). There is deliberately no id for a custom
  * operation — the vocabulary stays closed until a future issue decides what
  * a non-standard write publishes as.
+ *
+ * Issue #160 / ADR-0024 (filtered collection subscriptions) considered, and rejected,
+ * adding ids for a row entering/leaving a filtered subscriber's view on an
+ * ordinary `updated`/`patched` write — see `RealtimeTransport`'s doc for the
+ * chosen policy. The vocabulary stayed closed: a filtered subscriber's
+ * "this row left my view" case reuses `"deleted"` rather than earning a new
+ * id, and "entered my view" reuses whichever real event id the write
+ * already produced. The `deleted` overload does mean `"deleted"` no longer
+ * implies the row itself is gone — only that this subscriber should stop
+ * expecting to see it.
  */
 export type RealtimeEventId = "created" | "updated" | "patched" | "deleted" | "restored";
 
@@ -23,9 +33,17 @@ export interface RealtimeEventDto<ItemDto = unknown> {
   readonly entity: string;
   readonly id: EntityId;
   /**
-   * `<entity>.<id>` — the entity-level subscription channel a future
-   * transport routes this event to. Field-level and collection channels
-   * are not built yet (deferred, see the issue that added this seam).
+   * `<entity>.<id>` — the item-level subscription channel a transport
+   * routes this event to. The **collection**-level channel (every event for
+   * the entity, not just one id) is deliberately not a separate field:
+   * it is exactly `entity` above, so a transport that wants to fan one
+   * event out to both an item-channel subscriber and a collection-channel
+   * subscriber reads `channel` for the former and `entity` for the latter
+   * off this same payload (issue #160) — the engine still builds and
+   * publishes exactly one `RealtimeEventDto` per write. Field-level
+   * channels (a topic per field) are still not built; `RealtimeSettings.
+   * subscribableFields` instead bounds which fields a transport may
+   * *include* in the item it delivers on either channel above.
    */
   readonly channel: string;
   /** ISO-8601, set once by the engine so every transport agrees on it. */

--- a/packages/core/src/realtime/realtime-transport.ts
+++ b/packages/core/src/realtime/realtime-transport.ts
@@ -16,16 +16,31 @@ import type { RealtimeEventDto } from "./realtime-event.js";
  * **Authorization is entirely this transport's responsibility.** `publish`
  * receives the same whole-item `RealtimeEventDto` the writing principal's
  * own REST response was serialized from — core attaches no principal,
- * tenant, or per-subscriber scope to it, and `channel` is a bare
- * `<entity>.<id>` string with no access-control meaning of its own
- * (`subscribableFields` bounds which *fields* a subscription may reach,
- * once field-level subscriptions exist, but says nothing about *who*).
- * A transport that fans `channel` straight into a pub/sub topic without
- * checking, for each subscriber, whether that principal could have read
- * this row over REST will leak one principal's full item projection to
- * every subscriber of that entity/id. Row-level/tenant scoping of
- * subscribers (`authorize`) is deliberately out of this seam — see the
- * discussion on issue #154/#155 — until a future issue adds it.
+ * tenant, or per-subscriber scope to it, and `channel`/`entity` are bare
+ * strings with no access-control meaning of their own (`subscribableFields`
+ * bounds which *fields* a subscription may reach, not *who* may reach
+ * them). A transport that fans `channel`/`entity` straight into a pub/sub
+ * topic without checking, for each subscriber, whether that principal
+ * could have read this row over REST will leak one principal's full item
+ * projection to every subscriber of that entity/id, or — once a
+ * collection-channel subscriber can also scope itself with a `filter`
+ * query string (issue #160, ADR-0024) — to every subscriber of a filtered view over
+ * the whole entity. Row-level/tenant scoping of subscribers (`authorize`)
+ * is deliberately out of this seam — see the discussion on issue
+ * #154/#155/#160 — until a future issue adds it.
+ *
+ * **A subscription `filter` is a convenience boundary, not a confidentiality
+ * one.** It narrows *which* events a subscriber receives; it does not
+ * change *whether* they were authorized to receive them. In particular,
+ * `deleted`/`purgeOne`'s `deleted` event carries `item: null`, so a
+ * filter has nothing to evaluate against it — a filtered collection
+ * subscriber therefore receives every `deleted` event on the channel
+ * unconditionally (it might be their row leaving the filtered view; there
+ * is no way to tell without the item that no longer exists to check). That
+ * means a subscriber on `filter[ownerId][eq]=me` still learns the `id` of
+ * every row deleted on that entity, including ones they never had
+ * visibility into — acceptable only because subscriber-level authorization
+ * is already out of scope here, not because the filter hid anything.
  */
 export interface RealtimeTransport {
   /** Identifies the transport in logs — e.g. `"websocket"`, `"sse"`. */

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -110,6 +110,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "IsUnknown",
   "cursorValuesOf",
   "encodeCursor",
+  "evaluateFilter",
   "isCursorPagination",
   "isSincePagination",
   "hasKeyset",

--- a/packages/core/tests/filter-evaluator.spec.ts
+++ b/packages/core/tests/filter-evaluator.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { FilterExpression } from "@kavo/core";
+import { DefaultFilterParser, evaluateFilter, resolveEntityConfig } from "@kavo/core";
+import { userMetadata } from "./support/user-fixture.js";
+
+const config = resolveEntityConfig(userMetadata, undefined, undefined);
+const parser = new DefaultFilterParser(userMetadata);
+
+/** Parses the same wire grammar REST uses, so evaluator tests exercise the real AST, not a hand-built stand-in. */
+function filterOf(params: Record<string, unknown>): FilterExpression<unknown> | null {
+  return parser.parse(params, config).root;
+}
+
+describe("evaluateFilter — root: null", () => {
+  it("matches everything when there is no filter", () => {
+    expect(evaluateFilter(null, { status: "active" })).toBe(true);
+    expect(evaluateFilter(null, {})).toBe(true);
+  });
+});
+
+describe("evaluateFilter — the operator table, against a matching and a non-matching item", () => {
+  it.each([
+    ["filter[status][eq]=active", { status: "active" }, { status: "banned" }],
+    ["filter[status][ne]=banned", { status: "active" }, { status: "banned" }],
+    ["filter[age][gt]=18", { age: 19 }, { age: 18 }],
+    ["filter[age][gte]=18", { age: 18 }, { age: 17 }],
+    ["filter[age][lt]=65", { age: 64 }, { age: 65 }],
+    ["filter[age][lte]=65", { age: 65 }, { age: 66 }],
+    ["filter[status][in]=active,pending", { status: "pending" }, { status: "banned" }],
+    ["filter[status][notIn]=active,pending", { status: "banned" }, { status: "active" }],
+    ["filter[age][between]=18,65", { age: 40 }, { age: 66 }],
+    ["filter[name][isNull]=true", { name: null }, { name: "Ada" }],
+    ["filter[name][isNotNull]=true", { name: "Ada" }, { name: null }],
+  ])("'%s' matches the matching item and rejects the non-matching one", (query, matching, nonMatching) => {
+    const [key, value] = query.split("=") as [string, string];
+    const expression = filterOf({ [key]: value });
+    expect(evaluateFilter(expression, matching)).toBe(true);
+    expect(evaluateFilter(expression, nonMatching)).toBe(false);
+  });
+});
+
+describe("evaluateFilter — SQL-like null semantics", () => {
+  it.each(["eq", "ne", "gt", "gte", "lt", "lte", "in", "notIn"])(
+    "'%s' never matches a null/absent item value, including NE",
+    (token) => {
+      const raw = token === "in" || token === "notIn" ? "a,b" : "a";
+      const expression = filterOf({ [`filter[name][${token}]`]: raw });
+      expect(evaluateFilter(expression, { name: null })).toBe(false);
+      expect(evaluateFilter(expression, {})).toBe(false);
+    },
+  );
+
+  it("BETWEEN never matches a null/absent item value", () => {
+    const expression = filterOf({ "filter[age][between]": "18,65" });
+    expect(evaluateFilter(expression, { age: null })).toBe(false);
+    expect(evaluateFilter(expression, {})).toBe(false);
+  });
+
+  it("LIKE/ILIKE never match a null/absent item value", () => {
+    expect(evaluateFilter(filterOf({ "filter[name][like]": "%an%" }), { name: null })).toBe(false);
+    expect(evaluateFilter(filterOf({ "filter[name][ilike]": "%AN%" }), {})).toBe(false);
+  });
+
+  it("IS_NULL is the only operator that matches a null item value", () => {
+    const expression = filterOf({ "filter[name][isNull]": "true" });
+    expect(evaluateFilter(expression, { name: null })).toBe(true);
+    expect(evaluateFilter(expression, {})).toBe(true);
+    expect(evaluateFilter(expression, { name: "Ada" })).toBe(false);
+  });
+});
+
+describe("evaluateFilter — LIKE/ILIKE", () => {
+  it("translates '%' as zero-or-more and anchors the whole value", () => {
+    const expression = filterOf({ "filter[name][like]": "A%e" });
+    expect(evaluateFilter(expression, { name: "Ada Lovelace" })).toBe(true); // starts 'A', ends 'e'
+    expect(evaluateFilter(expression, { name: "Bob" })).toBe(false); // doesn't start with 'A'
+    expect(evaluateFilter(expression, { name: "Apple" })).toBe(true);
+  });
+
+  it("translates '_' as exactly one character, so length must match", () => {
+    const expression = filterOf({ "filter[name][like]": "A_a" });
+    expect(evaluateFilter(expression, { name: "Ada" })).toBe(true);
+    expect(evaluateFilter(expression, { name: "Alaska" })).toBe(false); // right shape, wrong length — anchored
+  });
+
+  it("ILIKE is case-insensitive, LIKE is case-sensitive", () => {
+    const like = filterOf({ "filter[name][like]": "%ada%" });
+    const ilike = filterOf({ "filter[name][ilike]": "%ada%" });
+    expect(evaluateFilter(like, { name: "Ada Lovelace" })).toBe(false);
+    expect(evaluateFilter(ilike, { name: "Ada Lovelace" })).toBe(true);
+  });
+
+  it("escapes regex metacharacters in the literal portion of the pattern", () => {
+    // A naive '%'/'_' -> regex translation with no escaping would treat
+    // '(', ')', '+' as regex syntax here rather than literal characters.
+    const expression = filterOf({ "filter[name][like]": "a+b(c)%" });
+    expect(evaluateFilter(expression, { name: "a+b(c)ANYTHING" })).toBe(true);
+    expect(evaluateFilter(expression, { name: "aXbXcXANYTHING" })).toBe(false);
+  });
+
+  it("honors a backslash-escaped literal '%'", () => {
+    const expression = filterOf({ "filter[name][like]": "100\\%" });
+    expect(evaluateFilter(expression, { name: "100%" })).toBe(true);
+    expect(evaluateFilter(expression, { name: "100x" })).toBe(false);
+  });
+});
+
+describe("evaluateFilter — dates", () => {
+  it("compares a Date item value against the coerced Date filter value", () => {
+    const expression = filterOf({ "filter[createdAt][gte]": "2026-01-01" });
+    expect(evaluateFilter(expression, { createdAt: new Date("2026-06-01") })).toBe(true);
+    expect(evaluateFilter(expression, { createdAt: new Date("2025-01-01") })).toBe(false);
+  });
+
+  it("parses an ISO string item value to compare against a Date filter value", () => {
+    // Not every item source hands the evaluator a real `Date` instance —
+    // an ORM adapter or a hand-built RealtimeTransport fixture might not.
+    const expression = filterOf({ "filter[createdAt][lt]": "2026-06-01" });
+    expect(evaluateFilter(expression, { createdAt: "2026-01-01T00:00:00.000Z" })).toBe(true);
+    expect(evaluateFilter(expression, { createdAt: "2026-12-01T00:00:00.000Z" })).toBe(false);
+  });
+});
+
+describe("evaluateFilter — logical operators", () => {
+  it("AND requires every child to match", () => {
+    const expression = filterOf({ "filter[status][eq]": "active", "filter[age][gte]": "18" });
+    expect(evaluateFilter(expression, { status: "active", age: 20 })).toBe(true);
+    expect(evaluateFilter(expression, { status: "active", age: 10 })).toBe(false);
+  });
+
+  it("OR requires at least one child to match", () => {
+    const expression = filterOf({
+      "filter[or][0][status][eq]": "active",
+      "filter[or][1][status][eq]": "pending",
+    });
+    expect(evaluateFilter(expression, { status: "pending" })).toBe(true);
+    expect(evaluateFilter(expression, { status: "banned" })).toBe(false);
+  });
+
+  it("NOT negates AND(children), including the wire parser's unary case", () => {
+    const expression = filterOf({ "filter[not][status][eq]": "banned" });
+    expect(evaluateFilter(expression, { status: "active" })).toBe(true);
+    expect(evaluateFilter(expression, { status: "banned" })).toBe(false);
+  });
+
+  it("nests AND and OR together", () => {
+    // status = 'active' AND (age >= 65 OR age < 18) — within the default
+    // maxFilterDepth (3); NOT-nesting is covered on its own above.
+    const expression = filterOf({
+      "filter[status][eq]": "active",
+      "filter[or][0][age][gte]": "65",
+      "filter[or][1][age][lt]": "18",
+    });
+    expect(evaluateFilter(expression, { status: "active", age: 70 })).toBe(true);
+    expect(evaluateFilter(expression, { status: "active", age: 10 })).toBe(true);
+    expect(evaluateFilter(expression, { status: "active", age: 40 })).toBe(false);
+    expect(evaluateFilter(expression, { status: "banned", age: 70 })).toBe(false);
+  });
+});

--- a/packages/core/tests/realtime.spec.ts
+++ b/packages/core/tests/realtime.spec.ts
@@ -259,6 +259,31 @@ describe("realtime — engine emit hook", () => {
   });
 });
 
+describe("realtime — collection-channel support (issue #160)", () => {
+  it("exposes the entity metadata a transport needs to parse a subscribe-time filter", () => {
+    // `event.entity` already doubles as the collection-channel name a
+    // transport routes to — no new `RealtimeEventDto` field — so the only
+    // new core surface issue #160 needs is a way for a transport to build a
+    // `DefaultFilterParser` for the same entity a `RealtimeTransport`
+    // publishes for.
+    const { crud } = makeCrud();
+    expect(crud.engine.metadata).toBe(userMetadata);
+  });
+
+  it("publishes an event whose 'entity' a transport can use as the collection-channel name, unchanged by any per-item channel", async () => {
+    const transport = new FakeTransport();
+    const { crud } = makeCrud({ realtime: { enabled: true, events: {} } } as never, [transport]);
+    await crud.createOne({ name: "Ada", email: "a@x.io", age: 36 } as never);
+    await crud.createOne({ name: "Grace", email: "g@x.io", age: 40 } as never);
+
+    // Two different item channels (`User.1`, `User.2`), the same
+    // collection channel (`entity: "User"`) — exactly what lets one
+    // transport instance route a single event to both kinds of subscriber.
+    expect(transport.events.map((event) => event.channel)).toEqual(["User.1", "User.2"]);
+    expect(transport.events.every((event) => event.entity === "User")).toBe(true);
+  });
+});
+
 describe("realtime — createKavo(options).realtimeTransports validation", () => {
   it("rejects a transport with no publish function", () => {
     expect(() => createKavo({ realtimeTransports: [{ name: "bad" }] } as never)).toThrowError(/publish/);

--- a/packages/realtime/sse/README.md
+++ b/packages/realtime/sse/README.md
@@ -19,7 +19,6 @@ import { createKavo } from "@kavo/core";
 let bookService: ReturnType<typeof kavo.createCrud<Book>>;
 
 const sse = createSseTransport({
-  verifyToken: (token) => verifyJwt(token), // returns a principal, or null
   subscribableFields: (entityName) => (entityName === "Book" ? ["title", "status", "price"] : undefined),
   // Enables subscribe-time filtering (issue #160) for an entity — omit an
   // entry and a `filter[...]` query param on that entity is rejected with
@@ -40,13 +39,11 @@ const kavo = createKavo({
 bookService = kavo.createCrud(Book);
 ```
 
-`verifyToken` is optional — omit it and `handleRequest` never authenticates
-a subscribe request at all (no `401`, no `token`/`Authorization` check),
-useful for an internal-only or already-perimeter-authenticated stream:
-
-```ts
-const sse = createSseTransport({}); // no verifyToken: every subscribe request is accepted
-```
+`@kavo/sse` has **no authentication of its own** — `handleRequest` accepts
+any subscribe request that otherwise validates. A deployment that needs to
+gate who may open a stream does so in front of it: a reverse proxy, or the
+host framework's own guard/middleware on the mounted route, since
+`handleRequest` is just an ordinary `(req, res)` handler.
 
 Mount `sse.handleRequest` on a plain Node HTTP route (or any host
 framework's request/response — Express, Nest, Fastify's raw
@@ -69,13 +66,13 @@ body):
 
 ```js
 // Item channel: every event for Book id 42.
-const one = new EventSource("/realtime?channel=Book.42&token=...");
+const one = new EventSource("/realtime?channel=Book.42");
 
 // Collection channel: every event for every Book (issue #160).
-const all = new EventSource("/realtime?channel=Book&token=...");
+const all = new EventSource("/realtime?channel=Book");
 
 // Collection channel, scoped with the same filter grammar REST uses.
-const published = new EventSource("/realtime?channel=Book&filter[status][eq]=published&token=...");
+const published = new EventSource("/realtime?channel=Book&filter[status][eq]=published");
 
 all.addEventListener("updated", (message) => {
   const event = JSON.parse(message.data); // RealtimeEventDto
@@ -93,14 +90,9 @@ silently ignoring it. See doc 18 §4.3 for what a filtered subscriber
 receives when a write moves a row across the filter boundary, and for the
 unconditional `"deleted"`-event bypass.
 
-`token` may be passed as a query param (what `EventSource` needs, since it
-cannot set custom headers) or as a normal `Authorization: Bearer <token>`
-header for any other client. An invalid or missing token gets a `401`
-_before_ any SSE frame is written — unless `verifyToken` was omitted from
-`createSseTransport`, in which case `token` is ignored entirely and every
-subscribe request is accepted. Once `subscribableFields` is configured
-for an entity, it bounds every outgoing `item` **unconditionally** — not
-only when a subscriber names `fields` — the same way `allowlists.selectable`
+Once `subscribableFields` is configured for an entity, it bounds every
+outgoing `item` **unconditionally** — not only when a subscriber names
+`fields` — the same way `allowlists.selectable`
 bounds a REST response whether or not the caller asked for a subset. An
 optional `fields` query param (comma-separated) narrows further within
 that bound; a field outside it (or outside `subscribableFields`, when no
@@ -130,9 +122,10 @@ closed rather than left to block delivery to every other subscriber.
 - **No filtering by which fields changed** — a subscribe-time filter
   matches row data (`RealtimeEventDto.item`), not the write's diff
   (`RealtimeEventDto.changed`).
-- **No subscriber-level authorization.** Every subscription within
-  `subscribableFields` is trusted once the connection is authenticated (or
-  unconditionally, if `verifyToken` was omitted); row-level/tenant scoping
-  of subscribers is a future issue (`authorize`, out of scope here — see
-  `RealtimeTransport`'s own doc). A `filter` narrows _which_ events a
-  subscriber receives, not _whether_ they were authorized to receive them.
+- **No authentication or authorization.** `@kavo/sse` accepts any subscribe
+  request that otherwise validates — gating who may open a stream is the
+  host app's job (a reverse proxy, or a guard on the mounted route), and
+  row/tenant-level subscriber scoping is a future issue (`authorize`, out
+  of scope here — see `RealtimeTransport`'s own doc). A `filter` narrows
+  _which_ events a subscriber receives, not _whether_ they were authorized
+  to receive them.

--- a/packages/realtime/sse/README.md
+++ b/packages/realtime/sse/README.md
@@ -14,9 +14,19 @@ or any other framework — same rule `packages/orms/*` follows.
 import { createSseTransport } from "@kavo/sse";
 import { createKavo } from "@kavo/core";
 
+// Filled in below, after `createCrud` — the callback only runs once a
+// subscribe request actually arrives, so the forward reference is fine.
+let bookService: ReturnType<typeof kavo.createCrud<Book>>;
+
 const sse = createSseTransport({
   verifyToken: (token) => verifyJwt(token), // returns a principal, or null
   subscribableFields: (entityName) => (entityName === "Book" ? ["title", "status", "price"] : undefined),
+  // Enables subscribe-time filtering (issue #160) for an entity — omit an
+  // entry and a `filter[...]` query param on that entity is rejected with
+  // 400 rather than silently ignored. Typically `service.engine.metadata`/
+  // `service.engine.config` off the `createCrud` service already returned.
+  filterableEntities: (entityName) =>
+    entityName === "Book" ? { metadata: bookService.engine.metadata, config: bookService.engine.config } : undefined,
 });
 
 const kavo = createKavo({
@@ -26,6 +36,16 @@ const kavo = createKavo({
     realtime: { enabled: true, events: { created: true, updated: true, patched: true, deleted: true } },
   },
 });
+
+bookService = kavo.createCrud(Book);
+```
+
+`verifyToken` is optional — omit it and `handleRequest` never authenticates
+a subscribe request at all (no `401`, no `token`/`Authorization` check),
+useful for an internal-only or already-perimeter-authenticated stream:
+
+```ts
+const sse = createSseTransport({}); // no verifyToken: every subscribe request is accepted
 ```
 
 Mount `sse.handleRequest` on a plain Node HTTP route (or any host
@@ -43,28 +63,49 @@ http.createServer((req, res) => {
 });
 ```
 
-A client subscribes to one entity/id with `EventSource`, or any HTTP
-client that reads a chunked `text/event-stream` body:
+A client subscribes to one entity/id, or to the whole entity, with
+`EventSource` (or any HTTP client that reads a chunked `text/event-stream`
+body):
 
 ```js
-const source = new EventSource("/realtime?channel=Book.42&token=...");
-source.addEventListener("updated", (message) => {
+// Item channel: every event for Book id 42.
+const one = new EventSource("/realtime?channel=Book.42&token=...");
+
+// Collection channel: every event for every Book (issue #160).
+const all = new EventSource("/realtime?channel=Book&token=...");
+
+// Collection channel, scoped with the same filter grammar REST uses.
+const published = new EventSource("/realtime?channel=Book&filter[status][eq]=published&token=...");
+
+all.addEventListener("updated", (message) => {
   const event = JSON.parse(message.data); // RealtimeEventDto
 });
 ```
 
-`channel` is required and always `<entity>.<id>` — entity-level
-subscriptions only; collection/view subscriptions are a future issue.
+`channel` is required: `<entity>.<id>` for an item-level subscription, or
+the bare `<entity>` for a collection-level one (every event for that
+entity). A collection-channel subscribe request may add a `filter` query
+string in the exact `filter[field][operator]=value` grammar REST list
+requests use (doc 18) — evaluated in memory per event, no DB round trip.
+Filtering is opt-in per entity via `filterableEntities`; an entity with no
+entry there rejects any `filter[...]` param with `400` rather than
+silently ignoring it. See doc 18 §4.3 for what a filtered subscriber
+receives when a write moves a row across the filter boundary, and for the
+unconditional `"deleted"`-event bypass.
+
 `token` may be passed as a query param (what `EventSource` needs, since it
 cannot set custom headers) or as a normal `Authorization: Bearer <token>`
 header for any other client. An invalid or missing token gets a `401`
-_before_ any SSE frame is written. An optional `fields` query param
-(comma-separated) is checked against that entity's configured
-`realtime.subscribableFields`, if any — a field outside the allowlist gets
-a `400`, the same way `allowlists.selectable` rejects an unlisted field
-over REST; the field list does not filter what a subscription receives yet
-(entity-level events are always the whole item), it only bounds what a
-future field-scoped subscription could reach.
+_before_ any SSE frame is written — unless `verifyToken` was omitted from
+`createSseTransport`, in which case `token` is ignored entirely and every
+subscribe request is accepted. Once `subscribableFields` is configured
+for an entity, it bounds every outgoing `item` **unconditionally** — not
+only when a subscriber names `fields` — the same way `allowlists.selectable`
+bounds a REST response whether or not the caller asked for a subset. An
+optional `fields` query param (comma-separated) narrows further within
+that bound; a field outside it (or outside `subscribableFields`, when no
+`fields` param is given) gets a `400` the same way `allowlists.selectable`
+rejects an unlisted field over REST.
 
 A connection that cannot keep up with its publish rate (the writable
 buffer on its response exceeds `bufferLimitBytes`, default 64 KiB) is
@@ -82,7 +123,16 @@ closed rather than left to block delivery to every other subscriber.
 - **No multi-node fan-out.** The channel registry is one process's
   in-memory `Map` — a subscriber connected to one instance of a
   horizontally-scaled app never sees a write handled by another instance.
+- **No "leave" event on an ordinary write.** A write that makes a row stop
+  matching a filtered subscriber's filter is not delivered at all — only a
+  genuine `"deleted"` reliably tells that subscriber a row is gone. See
+  doc 18 §4.3.
+- **No filtering by which fields changed** — a subscribe-time filter
+  matches row data (`RealtimeEventDto.item`), not the write's diff
+  (`RealtimeEventDto.changed`).
 - **No subscriber-level authorization.** Every subscription within
-  `subscribableFields` is trusted once the connection is authenticated;
-  row-level/tenant scoping of subscribers is a future issue (`authorize`,
-  out of scope here — see `RealtimeTransport`'s own doc).
+  `subscribableFields` is trusted once the connection is authenticated (or
+  unconditionally, if `verifyToken` was omitted); row-level/tenant scoping
+  of subscribers is a future issue (`authorize`, out of scope here — see
+  `RealtimeTransport`'s own doc). A `filter` narrows _which_ events a
+  subscriber receives, not _whether_ they were authorized to receive them.

--- a/packages/realtime/sse/src/index.ts
+++ b/packages/realtime/sse/src/index.ts
@@ -1,1 +1,6 @@
-export { createSseTransport, type SseTransport, type SseTransportOptions } from "./sse-transport.js";
+export {
+  createSseTransport,
+  type FilterableEntity,
+  type SseTransport,
+  type SseTransportOptions,
+} from "./sse-transport.js";

--- a/packages/realtime/sse/src/sse-transport.ts
+++ b/packages/realtime/sse/src/sse-transport.ts
@@ -43,26 +43,16 @@ export interface FilterableEntity {
   readonly config: ResolvedEntityConfig;
 }
 
-/** What `handleRequest` needs to authenticate and scope one subscription. */
+/**
+ * What `handleRequest` needs to scope one subscription. `@kavo/sse` has no
+ * authentication of its own — every subscribe request that otherwise
+ * validates is accepted. A deployment that needs to gate who may open a
+ * stream does so in front of `handleRequest` (a reverse proxy, a host
+ * framework's own guard/middleware on the mounted route, …) — see
+ * `RealtimeTransport`'s doc comment on why subscriber-level access control
+ * is out of this seam entirely.
+ */
 export interface SseTransportOptions {
-  /**
-   * Authenticates a subscribe request the same way REST does: a bearer
-   * token, read from the `Authorization` header or a `token` query param
-   * (`EventSource` cannot set custom headers, so the query param is the
-   * only option a browser client actually has). Returning `null` (or
-   * `undefined`) fails the request with `401` *before* any SSE frame is
-   * written — `handleRequest` never opens the stream on an invalid or
-   * missing token. The resolved value is only used to gate the connection;
-   * `@kavo/sse` carries no `authorize` seam (out of scope for this issue,
-   * see `RealtimeTransport`'s own doc on subscriber-level access control).
-   *
-   * **Optional.** Omitting it disables authentication entirely — every
-   * subscribe request is accepted regardless of `token`/`Authorization`,
-   * and no `401` is ever produced. That is a deliberate choice for a
-   * public/internal-only stream, not a fallback to guess at; nothing else
-   * in `@kavo/sse` gates a connection once this callback is absent.
-   */
-  verifyToken?(token: string): unknown | Promise<unknown>;
   /**
    * Per-entity `RealtimeSettings.subscribableFields`, the same allowlist an
    * app already configured via `createCrud` — this package has no config
@@ -177,13 +167,6 @@ function narrowItem(
   return narrowed;
 }
 
-function bearerToken(req: IncomingMessage): string | undefined {
-  const header = req.headers.authorization;
-  if (typeof header !== "string") return undefined;
-  const match = /^Bearer (.+)$/.exec(header);
-  return match?.[1];
-}
-
 function sendJson(res: ServerResponse, status: number, body: Record<string, unknown>): void {
   const payload = JSON.stringify(body);
   res.writeHead(status, { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) });
@@ -208,8 +191,8 @@ function frame(id: number, event: RealtimeEventDto): string {
  * `DefaultFilterParser` expects: one entry per literal key, repeated keys
  * (the `filter[status][in][]=a&filter[status][in][]=b` form) collapsed
  * into one array value under that key. Every other query param
- * (`channel`, `token`, `fields`, …) rides along harmlessly — the parser
- * only ever reads keys starting with `filter[` or the bare `filter` key.
+ * (`channel`, `fields`, …) rides along harmlessly — the parser only ever
+ * reads keys starting with `filter[` or the bare `filter` key.
  */
 function collectRawParams(searchParams: URLSearchParams): Record<string, unknown> {
   const raw: Record<string, unknown> = {};
@@ -374,22 +357,6 @@ export function createSseTransport(options: SseTransportOptions): SseTransport {
         return;
       }
       const entityName = dot === -1 ? channel : channel.slice(0, dot);
-
-      if (options.verifyToken !== undefined) {
-        const token = bearerToken(req) ?? url.searchParams.get("token") ?? undefined;
-        let principal: unknown = null;
-        if (token !== undefined) {
-          try {
-            principal = (await options.verifyToken(token)) ?? null;
-          } catch {
-            principal = null;
-          }
-        }
-        if (principal === null) {
-          sendJson(res, 401, { error: "unauthorized" });
-          return;
-        }
-      }
 
       const selector = options.subscribableFields?.(entityName);
       const fieldsParam = url.searchParams.get("fields");

--- a/packages/realtime/sse/src/sse-transport.ts
+++ b/packages/realtime/sse/src/sse-transport.ts
@@ -1,5 +1,14 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { RealtimeEventDto, RealtimeFieldSelector, RealtimeTransport } from "@kavo/core";
+import type {
+  EntityMetadata,
+  FilterExpression,
+  QueryIssueDto,
+  RealtimeEventDto,
+  RealtimeFieldSelector,
+  RealtimeTransport,
+  ResolvedEntityConfig,
+} from "@kavo/core";
+import { DefaultFilterParser, QueryValidationException, evaluateFilter } from "@kavo/core";
 
 /**
  * Bytes buffered in a connection's underlying socket before it is dropped
@@ -11,6 +20,28 @@ import type { RealtimeEventDto, RealtimeFieldSelector, RealtimeTransport } from 
  * stuck client quickly.
  */
 const DEFAULT_BUFFER_LIMIT_BYTES = 64 * 1024;
+
+/**
+ * What a subscribe request needs to parse and validate a `filter` query
+ * string for one entity — the same two pieces `DefaultFilterParser` and
+ * `Filter.parse` already need for REST: `metadata` for column-kind-aware
+ * value coercion, `config` for the `filterable` allowlist and the
+ * `query.maxFilterDepth`/`maxInValues` limits. `@kavo/sse` has no config
+ * resolution of its own (same reason `subscribableFields` is a callback,
+ * not a lookup this package performs itself), so the host app supplies
+ * both — typically `service.engine.metadata`/`service.engine.config` off
+ * the `DefaultKavoService` `createCrud` already returned for that entity.
+ * That property is concretely typed per entity (`ResolvedEntityConfig<
+ * Book>`), while this interface — serving every entity through one
+ * callback — is not; assigning the former to the latter needs the same
+ * erasure cast `kavo.ts`'s own `catalog.register` already uses internally
+ * (`config as unknown as ResolvedEntityConfig`), not a sign of a type
+ * mismatch.
+ */
+export interface FilterableEntity {
+  readonly metadata: EntityMetadata;
+  readonly config: ResolvedEntityConfig;
+}
 
 /** What `handleRequest` needs to authenticate and scope one subscription. */
 export interface SseTransportOptions {
@@ -24,8 +55,14 @@ export interface SseTransportOptions {
    * missing token. The resolved value is only used to gate the connection;
    * `@kavo/sse` carries no `authorize` seam (out of scope for this issue,
    * see `RealtimeTransport`'s own doc on subscriber-level access control).
+   *
+   * **Optional.** Omitting it disables authentication entirely — every
+   * subscribe request is accepted regardless of `token`/`Authorization`,
+   * and no `401` is ever produced. That is a deliberate choice for a
+   * public/internal-only stream, not a fallback to guess at; nothing else
+   * in `@kavo/sse` gates a connection once this callback is absent.
    */
-  verifyToken(token: string): unknown | Promise<unknown>;
+  verifyToken?(token: string): unknown | Promise<unknown>;
   /**
    * Per-entity `RealtimeSettings.subscribableFields`, the same allowlist an
    * app already configured via `createCrud` — this package has no config
@@ -35,8 +72,24 @@ export interface SseTransportOptions {
    * rejects an unlisted field over REST. Returning `undefined` (including
    * when the callback itself is omitted) means no allowlist is configured
    * for that entity, so any requested field is accepted.
+   *
+   * Once configured, this allowlist is also enforced **unconditionally** on
+   * every outgoing `item` for that entity — not only when a subscriber
+   * names `fields` — the same way `allowlists.selectable` bounds a REST
+   * response whether or not the caller asked for a subset. A `fields`
+   * query param narrows further *within* that bound; it can never widen
+   * past it.
    */
   subscribableFields?(entityName: string): RealtimeFieldSelector | undefined;
+  /**
+   * Enables subscribe-time filtering (`filter[field][operator]=value`,
+   * issue #160) for one entity. Returning `undefined` (including when the
+   * callback itself is omitted) means that entity does not support
+   * subscribe-time filtering — a request naming any `filter[...]`/`filter`
+   * query param for it is rejected with `400` before the stream opens,
+   * rather than silently ignoring the filter and delivering everything.
+   */
+  filterableEntities?(entityName: string): FilterableEntity | undefined;
   /** See `DEFAULT_BUFFER_LIMIT_BYTES`. */
   bufferLimitBytes?: number;
 }
@@ -44,13 +97,15 @@ export interface SseTransportOptions {
 /** A `RealtimeTransport` plus the HTTP entry point a host wires a route to. */
 export interface SseTransport extends RealtimeTransport {
   /**
-   * Handles one incoming SSE subscribe request: `GET ?channel=<entity>.<id>`
-   * with `Accept: text/event-stream`. Host-framework-agnostic — takes
-   * Node's own `IncomingMessage`/`ServerResponse`, which every Node HTTP
-   * framework's request/response either extends or wraps directly.
-   * Resolves once the response is settled (an error status was written, or
-   * the stream was opened) — the connection itself then lives for as long
-   * as the client keeps it open, torn down by the request's own `close`.
+   * Handles one incoming SSE subscribe request:
+   * `GET ?channel=<entity>.<id>` (item channel) or `GET ?channel=<entity>`
+   * (collection channel, issue #160) with `Accept: text/event-stream`.
+   * Host-framework-agnostic — takes Node's own
+   * `IncomingMessage`/`ServerResponse`, which every Node HTTP framework's
+   * request/response either extends or wraps directly. Resolves once the
+   * response is settled (an error status was written, or the stream was
+   * opened) — the connection itself then lives for as long as the client
+   * keeps it open, torn down by the request's own `close`.
    */
   handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void>;
   /** Number of currently open subscriptions, across every channel. */
@@ -62,6 +117,13 @@ export interface SseTransport extends RealtimeTransport {
 interface Connection {
   readonly res: ServerResponse;
   readonly channel: string;
+  readonly entityName: string;
+  /** `null` means "no filter configured" — every event on the channel matches. */
+  readonly filter: FilterExpression<object> | null;
+  /** Already validated against `subscribableFields`; `undefined` means no `fields` param was given. */
+  readonly fields: readonly string[] | undefined;
+  /** Captured once at subscribe time — see `subscribableFields`'s doc on why it applies unconditionally. */
+  readonly selector: RealtimeFieldSelector | undefined;
 }
 
 /**
@@ -85,6 +147,36 @@ function isFieldAllowed(selector: RealtimeFieldSelector | undefined, field: stri
   return selector.includes(field);
 }
 
+/**
+ * Bounds an outgoing `item` to `selector` (unconditional, once configured)
+ * and then further to `fields` (a subscriber-requested subset, already
+ * validated ⊆ the allowlist at subscribe time). `undefined` for both means
+ * no narrowing — the item is delivered whole, today's behavior for an
+ * entity that never configured `subscribableFields`.
+ */
+function narrowItem(
+  item: unknown,
+  selector: RealtimeFieldSelector | undefined,
+  fields: readonly string[] | undefined,
+): unknown {
+  if (item === null || typeof item !== "object") return item;
+  const record = item as Record<string, unknown>;
+
+  let allowed: readonly string[];
+  if (fields !== undefined) {
+    allowed = fields;
+  } else if (selector !== undefined) {
+    const keys = Object.keys(record);
+    allowed = "exclude" in selector ? keys.filter((key) => !selector.exclude.includes(key)) : selector;
+  } else {
+    return item;
+  }
+
+  const narrowed: Record<string, unknown> = {};
+  for (const key of allowed) if (key in record) narrowed[key] = record[key];
+  return narrowed;
+}
+
 function bearerToken(req: IncomingMessage): string | undefined {
   const header = req.headers.authorization;
   if (typeof header !== "string") return undefined;
@@ -102,19 +194,63 @@ function sendJson(res: ServerResponse, status: number, body: Record<string, unkn
  * `id:` set even though nothing consumes it yet (resume-on-reconnect is a
  * future issue) — a monotonically increasing counter, shared across every
  * channel on this transport instance, so it stays meaningful the day resume
- * is built instead of forcing a wire-format change then.
+ * is built instead of forcing a wire-format change then. Allocated once per
+ * `publish` call (not once per connection/frame) so every subscriber of one
+ * logical write sees the same `id:`, even though the `data:` they receive
+ * may differ once field-narrowing is applied.
  */
 function frame(id: number, event: RealtimeEventDto): string {
   return `id: ${id}\nevent: ${event.event}\ndata: ${JSON.stringify(event)}\n\n`;
 }
 
 /**
+ * Every `filter[...]`/`filter` query param, flattened the way
+ * `DefaultFilterParser` expects: one entry per literal key, repeated keys
+ * (the `filter[status][in][]=a&filter[status][in][]=b` form) collapsed
+ * into one array value under that key. Every other query param
+ * (`channel`, `token`, `fields`, …) rides along harmlessly — the parser
+ * only ever reads keys starting with `filter[` or the bare `filter` key.
+ */
+function collectRawParams(searchParams: URLSearchParams): Record<string, unknown> {
+  const raw: Record<string, unknown> = {};
+  for (const key of new Set(searchParams.keys())) {
+    const values = searchParams.getAll(key);
+    raw[key] = values.length > 1 ? values : values[0];
+  }
+  return raw;
+}
+
+function hasFilterParams(searchParams: URLSearchParams): boolean {
+  for (const key of searchParams.keys()) {
+    if (key === "filter" || key.startsWith("filter[")) return true;
+  }
+  return false;
+}
+
+/** Every field name a condition in `expression` compares against, deduplicated. */
+function collectConditionFields(expression: FilterExpression<object>): readonly string[] {
+  const fields = new Set<string>();
+  const visit = (node: FilterExpression<object>): void => {
+    if (node.kind === "condition") {
+      fields.add(node.field as string);
+      return;
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(expression);
+  return [...fields];
+}
+
+/**
  * The first real `RealtimeTransport` implementation (issue #155, over the
- * seam #154 added): plain HTTP `text/event-stream`, no client or server
- * library required. Entity-level subscriptions only — the channel a
- * connection opens is exactly the `<entity>.<id>` string `RealtimeEventDto.
- * channel` carries, and `publish` fans an event out to every connection
- * registered under that same string.
+ * seam #154 added; issue #160 / ADR-0024 added collection and filtered subscriptions):
+ * plain HTTP `text/event-stream`, no client or server library required.
+ * The channel a connection opens is either the item-level `<entity>.<id>`
+ * string `RealtimeEventDto.channel` carries, or the bare `<entity>` name
+ * (`RealtimeEventDto.entity`) for every event on that entity — `publish`
+ * fans an event out to every connection registered under either string, so
+ * one write reaches both an item-level and a collection-level subscriber
+ * from the same call.
  *
  * One process, one in-memory channel registry: a subscriber connected to
  * this instance never sees a write handled by another instance of a
@@ -141,6 +277,49 @@ export function createSseTransport(options: SseTransportOptions): SseTransport {
     if (subscribers.size === 0) channels.delete(connection.channel);
   }
 
+  /**
+   * `"deleted"` bypasses the filter unconditionally — `event.item` is
+   * `null`, so there is nothing to evaluate, and the alternative (silently
+   * excluding it) leaves a filtered subscriber with a row in its view that
+   * is permanently gone. See `RealtimeTransport`'s doc for the
+   * confidentiality tradeoff this implies. Every other event id evaluates
+   * normally: a write that makes a row start matching a filter is
+   * delivered as whatever its real event id is (`"entering" a filtered
+   * view reuses the ordinary event, not a synthesized `"created"`); a
+   * write that makes it stop matching simply is not delivered — there is
+   * no before-image available to detect that transition without an extra
+   * read the engine does not already do, so it is a documented limitation
+   * rather than a silently-wrong "leave" event.
+   */
+  function matches(connection: Connection, event: RealtimeEventDto): boolean {
+    if (event.event === "deleted") return true;
+    return evaluateFilter(connection.filter, (event.item ?? {}) as Record<string, unknown>);
+  }
+
+  function deliverTo(subscribers: Set<Connection> | undefined, event: RealtimeEventDto, id: number): void {
+    if (!subscribers || subscribers.size === 0) return;
+    // Direct `for...of` over the live `Set`, not a snapshot copy: deleting
+    // the current entry mid-iteration (the `unsubscribe` below, for a
+    // connection that can't keep up) is well-defined under the Set
+    // iteration protocol — already-visited and about-to-be-visited
+    // entries are unaffected.
+    for (const connection of subscribers) {
+      if (!matches(connection, event)) continue;
+      if (connection.res.writableLength > bufferLimitBytes) {
+        // Can't keep up: dropped rather than left to block publish to
+        // every other subscriber of this channel.
+        unsubscribe(connection);
+        connection.res.end();
+        continue;
+      }
+      const outgoing: RealtimeEventDto = {
+        ...event,
+        item: (narrowItem(event.item, connection.selector, connection.fields) ?? null) as never,
+      };
+      connection.res.write(frame(id, outgoing));
+    }
+  }
+
   return {
     name: "sse",
 
@@ -151,25 +330,21 @@ export function createSseTransport(options: SseTransportOptions): SseTransport {
     },
 
     async publish(event: RealtimeEventDto): Promise<void> {
-      const subscribers = channels.get(event.channel);
-      if (!subscribers || subscribers.size === 0) return;
-
-      const payload = frame(nextEventId++, event);
-      // Direct `for...of` over the live `Set`, not a snapshot copy: deleting
-      // the current entry mid-iteration (the `unsubscribe` below, for a
-      // connection that can't keep up) is well-defined under the Set
-      // iteration protocol — already-visited and about-to-be-visited
-      // entries are unaffected.
-      for (const connection of subscribers) {
-        if (connection.res.writableLength > bufferLimitBytes) {
-          // Can't keep up: dropped rather than left to block publish to
-          // every other subscriber of this channel.
-          unsubscribe(connection);
-          connection.res.end();
-          continue;
-        }
-        connection.res.write(payload);
+      const itemSubscribers = channels.get(event.channel);
+      const collectionSubscribers = channels.get(event.entity);
+      if (
+        (!itemSubscribers || itemSubscribers.size === 0) &&
+        (!collectionSubscribers || collectionSubscribers.size === 0)
+      ) {
+        return;
       }
+
+      // Allocated once per publish, not once per connection — every
+      // subscriber of one logical write shares the same `id:` even though
+      // the `data:` they receive may differ (field narrowing).
+      const id = nextEventId++;
+      deliverTo(itemSubscribers, event, id);
+      deliverTo(collectionSubscribers, event, id);
     },
 
     async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
@@ -185,30 +360,41 @@ export function createSseTransport(options: SseTransportOptions): SseTransport {
 
       const url = new URL(req.url ?? "", "http://kavo.invalid");
       const channel = url.searchParams.get("channel");
-      const dot = channel?.indexOf(".") ?? -1;
-      if (!channel || dot <= 0 || dot === channel.length - 1) {
-        sendJson(res, 400, { error: "a 'channel' query parameter of the form '<entity>.<id>' is required" });
+      if (!channel) {
+        sendJson(res, 400, {
+          error: "a 'channel' query parameter of the form '<entity>' or '<entity>.<id>' is required",
+        });
         return;
       }
+      const dot = channel.indexOf(".");
+      if (dot === 0 || dot === channel.length - 1) {
+        sendJson(res, 400, {
+          error: "a 'channel' query parameter of the form '<entity>' or '<entity>.<id>' is required",
+        });
+        return;
+      }
+      const entityName = dot === -1 ? channel : channel.slice(0, dot);
 
-      const token = bearerToken(req) ?? url.searchParams.get("token") ?? undefined;
-      let principal: unknown = null;
-      if (token !== undefined) {
-        try {
-          principal = (await options.verifyToken(token)) ?? null;
-        } catch {
-          principal = null;
+      if (options.verifyToken !== undefined) {
+        const token = bearerToken(req) ?? url.searchParams.get("token") ?? undefined;
+        let principal: unknown = null;
+        if (token !== undefined) {
+          try {
+            principal = (await options.verifyToken(token)) ?? null;
+          } catch {
+            principal = null;
+          }
+        }
+        if (principal === null) {
+          sendJson(res, 401, { error: "unauthorized" });
+          return;
         }
       }
-      if (principal === null) {
-        sendJson(res, 401, { error: "unauthorized" });
-        return;
-      }
 
-      const entityName = channel.slice(0, dot);
+      const selector = options.subscribableFields?.(entityName);
       const fieldsParam = url.searchParams.get("fields");
+      let fields: readonly string[] | undefined;
       if (fieldsParam !== null) {
-        const selector = options.subscribableFields?.(entityName);
         const requested = fieldsParam
           .split(",")
           .map((field) => field.trim())
@@ -217,6 +403,45 @@ export function createSseTransport(options: SseTransportOptions): SseTransport {
         if (disallowed.length > 0) {
           sendJson(res, 400, { error: `field(s) not subscribable: ${disallowed.join(", ")}` });
           return;
+        }
+        fields = requested;
+      }
+
+      let filter: FilterExpression<object> | null = null;
+      if (hasFilterParams(url.searchParams)) {
+        const filterable = options.filterableEntities?.(entityName);
+        if (filterable === undefined) {
+          sendJson(res, 400, { error: `entity '${entityName}' does not support subscribe-time filtering` });
+          return;
+        }
+        const parser = new DefaultFilterParser(filterable.metadata);
+        let parsed;
+        try {
+          parsed = parser.parse(collectRawParams(url.searchParams), filterable.config);
+        } catch (error) {
+          if (error instanceof QueryValidationException) {
+            sendJson(res, 400, { error: "invalid filter", issues: error.issues as QueryIssueDto[] });
+            return;
+          }
+          throw error;
+        }
+        filter = parsed.root as FilterExpression<object> | null;
+
+        if (filter !== null) {
+          const knownFields = new Set(filterable.metadata.fields.map((field) => field.name));
+          const conditionFields = collectConditionFields(filter);
+          const unevaluable = conditionFields.find((field) => !knownFields.has(field));
+          if (unevaluable !== undefined) {
+            sendJson(res, 400, {
+              error: `filter field '${unevaluable}' cannot be evaluated for a realtime subscription (relation and computed fields are not supported — only the entity's own columns)`,
+            });
+            return;
+          }
+          const disallowed = conditionFields.filter((field) => !isFieldAllowed(selector, field));
+          if (disallowed.length > 0) {
+            sendJson(res, 400, { error: `filter field(s) not subscribable: ${disallowed.join(", ")}` });
+            return;
+          }
         }
       }
 
@@ -227,7 +452,7 @@ export function createSseTransport(options: SseTransportOptions): SseTransport {
       });
       res.flushHeaders();
 
-      const connection: Connection = { res, channel };
+      const connection: Connection = { res, channel, entityName, filter, fields, selector };
       subscribe(connection);
       req.on("close", () => unsubscribe(connection));
       res.on("error", () => unsubscribe(connection));

--- a/packages/realtime/sse/tests/integration.spec.ts
+++ b/packages/realtime/sse/tests/integration.spec.ts
@@ -143,3 +143,35 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
     await waitForConnectionCount(transport, 0);
   });
 });
+
+describe("@kavo/sse — end-to-end, verifyToken omitted", () => {
+  let server: Server;
+  let baseUrl: string;
+  let transport: SseTransport;
+
+  beforeEach(async () => {
+    transport = createSseTransport({});
+    server = createServer((req, res) => {
+      void transport.handleRequest(req, res);
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    transport.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("opens the stream over a real socket with no token at all", async () => {
+    const response = await fetch(`${baseUrl}/realtime?channel=Book.1`, {
+      headers: { Accept: "text/event-stream" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(transport.connectionCount).toBe(1);
+    await response.body?.cancel();
+  });
+});

--- a/packages/realtime/sse/tests/integration.spec.ts
+++ b/packages/realtime/sse/tests/integration.spec.ts
@@ -61,7 +61,6 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
   beforeEach(async () => {
     adapter = new InMemoryBookAdapter();
     transport = createSseTransport({
-      verifyToken: (token) => (token === "good-token" ? { sub: "u1" } : null),
       subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
     });
 
@@ -78,18 +77,19 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 
-  it("rejects with 401 and never opens the stream when the token is missing or invalid", async () => {
+  it("opens the stream over a real socket with no authentication involved", async () => {
     const response = await fetch(`${baseUrl}/realtime?channel=Book.1`, {
       headers: { Accept: "text/event-stream" },
     });
 
-    expect(response.status).toBe(401);
-    expect(response.headers.get("content-type")).toContain("application/json");
-    expect(transport.connectionCount).toBe(0);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(transport.connectionCount).toBe(1);
+    await response.body?.cancel();
   });
 
   it("rejects a 'fields' request naming a field outside subscribableFields with 400", async () => {
-    const response = await fetch(`${baseUrl}/realtime?channel=Book.1&token=good-token&fields=title,price`, {
+    const response = await fetch(`${baseUrl}/realtime?channel=Book.1&fields=title,price`, {
       headers: { Accept: "text/event-stream" },
     });
 
@@ -107,7 +107,7 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
       metadata: bookMetadata,
     });
 
-    const response = await fetch(`${baseUrl}/realtime?channel=Book.1&token=good-token`, {
+    const response = await fetch(`${baseUrl}/realtime?channel=Book.1`, {
       headers: { Accept: "text/event-stream" },
     });
     expect(response.status).toBe(200);
@@ -141,37 +141,5 @@ describe("@kavo/sse — end-to-end over a real HTTP server", () => {
     // Proves the real disconnect path over a genuine socket, not just the
     // fake-driven mechanism sse-transport.spec.ts exercises.
     await waitForConnectionCount(transport, 0);
-  });
-});
-
-describe("@kavo/sse — end-to-end, verifyToken omitted", () => {
-  let server: Server;
-  let baseUrl: string;
-  let transport: SseTransport;
-
-  beforeEach(async () => {
-    transport = createSseTransport({});
-    server = createServer((req, res) => {
-      void transport.handleRequest(req, res);
-    });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
-    const address = server.address() as AddressInfo;
-    baseUrl = `http://127.0.0.1:${address.port}`;
-  });
-
-  afterEach(async () => {
-    transport.close();
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  });
-
-  it("opens the stream over a real socket with no token at all", async () => {
-    const response = await fetch(`${baseUrl}/realtime?channel=Book.1`, {
-      headers: { Accept: "text/event-stream" },
-    });
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toContain("text/event-stream");
-    expect(transport.connectionCount).toBe(1);
-    await response.body?.cancel();
   });
 });

--- a/packages/realtime/sse/tests/sse-transport.spec.ts
+++ b/packages/realtime/sse/tests/sse-transport.spec.ts
@@ -38,106 +38,27 @@ function bookFilterable(): FilterableEntity {
 
 describe("createSseTransport — name", () => {
   it("identifies itself as 'sse'", () => {
-    expect(createSseTransport({ verifyToken: () => ({}) }).name).toBe("sse");
+    expect(createSseTransport({}).name).toBe("sse");
   });
 });
 
-describe("createSseTransport — handleRequest auth", () => {
-  it("rejects with 401 before opening the stream when no token is supplied", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({ sub: "u1" }) });
-    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
-    const res = fakeResponse();
+describe("createSseTransport — no authentication of its own", () => {
+  it("accepts a subscribe request whether or not it carries a token or Authorization header", async () => {
+    const transport = createSseTransport({});
 
-    await transport.handleRequest(req, res);
+    for (const url of ["/realtime?channel=Book.1", "/realtime?channel=Book.1&token=whatever"]) {
+      const { req } = fakeRequest(url, { accept: "text/event-stream" });
+      const res = fakeResponse();
+      await transport.handleRequest(req, res);
+      expect(res.statusCode).toBe(200);
+    }
 
-    expect(res.statusCode).toBe(401);
-    expect(res.frames).toHaveLength(0);
-    expect(transport.connectionCount).toBe(0);
-  });
-
-  it("rejects with 401 when verifyToken returns null", async () => {
-    const transport = createSseTransport({ verifyToken: () => null });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=bad", { accept: "text/event-stream" });
-    const res = fakeResponse();
-
-    await transport.handleRequest(req, res);
-
-    expect(res.statusCode).toBe(401);
-    expect(res.jsonBody).toMatchObject({ error: expect.any(String) });
-  });
-
-  it("rejects with 401 when verifyToken rejects", async () => {
-    const transport = createSseTransport({
-      verifyToken: () => Promise.reject(new Error("token service down")),
-    });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=whatever", { accept: "text/event-stream" });
-    const res = fakeResponse();
-
-    await transport.handleRequest(req, res);
-
-    expect(res.statusCode).toBe(401);
-  });
-
-  it("rejects with 401 when verifyToken throws synchronously", async () => {
-    const transport = createSseTransport({
-      verifyToken: () => {
-        throw new Error("malformed token");
-      },
-    });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=whatever", { accept: "text/event-stream" });
-    const res = fakeResponse();
-
-    await transport.handleRequest(req, res);
-
-    expect(res.statusCode).toBe(401);
-  });
-
-  it("reads the token from a query param — what EventSource can actually set", async () => {
-    const verifyToken = vi.fn().mockReturnValue({ sub: "u1" });
-    const transport = createSseTransport({ verifyToken });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=abc123", { accept: "text/event-stream" });
-    const res = fakeResponse();
-
-    await transport.handleRequest(req, res);
-
-    expect(verifyToken).toHaveBeenCalledWith("abc123");
-    expect(res.statusCode).toBe(200);
-  });
-
-  it("prefers the Authorization header over a token query param when both are present", async () => {
-    const verifyToken = vi.fn().mockReturnValue({ sub: "u1" });
-    const transport = createSseTransport({ verifyToken });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=from-query", {
+    const { req } = fakeRequest("/realtime?channel=Book.1", {
       accept: "text/event-stream",
-      authorization: "Bearer from-header",
+      authorization: "Bearer whatever",
     });
     const res = fakeResponse();
-
     await transport.handleRequest(req, res);
-
-    expect(verifyToken).toHaveBeenCalledWith("from-header");
-  });
-});
-
-describe("createSseTransport — verifyToken omitted (authentication disabled)", () => {
-  it("accepts a subscribe request with no token at all", async () => {
-    const transport = createSseTransport({});
-    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
-    const res = fakeResponse();
-
-    await transport.handleRequest(req, res);
-
-    expect(res.statusCode).toBe(200);
-    expect(transport.connectionCount).toBe(1);
-  });
-
-  it("accepts a subscribe request that carries a token, without ever calling any verifier", async () => {
-    const transport = createSseTransport({});
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=whatever", { accept: "text/event-stream" });
-    const res = fakeResponse();
-
-    await transport.handleRequest(req, res);
-
     expect(res.statusCode).toBe(200);
   });
 
@@ -154,8 +75,8 @@ describe("createSseTransport — verifyToken omitted (authentication disabled)",
 
 describe("createSseTransport — handleRequest request shape", () => {
   it("rejects a non-GET method with 400 before opening the stream", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     (req as { method: string }).method = "POST";
     const res = fakeResponse();
 
@@ -165,8 +86,8 @@ describe("createSseTransport — handleRequest request shape", () => {
   });
 
   it("rejects a request with no 'Accept: text/event-stream' header with 400", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "application/json" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "application/json" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -175,8 +96,8 @@ describe("createSseTransport — handleRequest request shape", () => {
   });
 
   it("rejects a request with no 'channel' query parameter with 400", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -185,8 +106,8 @@ describe("createSseTransport — handleRequest request shape", () => {
   });
 
   it.each(["", ".42", "Book."])("rejects a malformed channel %j with 400", async (channel) => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest(`/realtime?channel=${encodeURIComponent(channel)}&token=t`, {
+    const transport = createSseTransport({});
+    const { req } = fakeRequest(`/realtime?channel=${encodeURIComponent(channel)}`, {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -197,8 +118,8 @@ describe("createSseTransport — handleRequest request shape", () => {
   });
 
   it("accepts a bare entity name as a collection-channel subscription (issue #160)", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -211,10 +132,9 @@ describe("createSseTransport — handleRequest request shape", () => {
 describe("createSseTransport — subscribableFields enforcement", () => {
   it("accepts a 'fields' request naming only allowlisted fields (array form)", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title,status", {
+    const { req } = fakeRequest("/realtime?channel=Book.1&fields=title,status", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -226,10 +146,9 @@ describe("createSseTransport — subscribableFields enforcement", () => {
 
   it("rejects a 'fields' request naming a field outside the allowlist (array form) with 400", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title,price", {
+    const { req } = fakeRequest("/realtime?channel=Book.1&fields=title,price", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -243,10 +162,9 @@ describe("createSseTransport — subscribableFields enforcement", () => {
 
   it("rejects a field named in an 'exclude' selector with 400", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: () => ({ exclude: ["price"] }),
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=price", { accept: "text/event-stream" });
+    const { req } = fakeRequest("/realtime?channel=Book.1&fields=price", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -256,10 +174,9 @@ describe("createSseTransport — subscribableFields enforcement", () => {
 
   it("accepts a field not named by an 'exclude' selector", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: () => ({ exclude: ["price"] }),
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title", { accept: "text/event-stream" });
+    const { req } = fakeRequest("/realtime?channel=Book.1&fields=title", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -268,8 +185,8 @@ describe("createSseTransport — subscribableFields enforcement", () => {
   });
 
   it("accepts any field when no subscribableFields callback is configured", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=anything", {
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1&fields=anything", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -281,10 +198,9 @@ describe("createSseTransport — subscribableFields enforcement", () => {
 
   it("accepts any field when the callback returns undefined for that entity", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: () => undefined,
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=anything", {
+    const { req } = fakeRequest("/realtime?channel=Book.1&fields=anything", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -296,8 +212,8 @@ describe("createSseTransport — subscribableFields enforcement", () => {
 
   it("skips 'fields'-list validation when no 'fields' param is given, but still resolves the allowlist for payload narrowing", async () => {
     const subscribableFields = vi.fn().mockReturnValue([]);
-    const transport = createSseTransport({ verifyToken: () => ({}), subscribableFields });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({ subscribableFields });
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -313,10 +229,9 @@ describe("createSseTransport — subscribableFields enforcement", () => {
 describe("createSseTransport — subscribableFields payload narrowing", () => {
   it("narrows the outgoing item to an array selector even when no 'fields' param was requested", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
     await transport.handleRequest(req, res);
 
@@ -328,10 +243,9 @@ describe("createSseTransport — subscribableFields payload narrowing", () => {
 
   it("narrows further to a requested 'fields' subset within the configured allowlist", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title", { accept: "text/event-stream" });
+    const { req } = fakeRequest("/realtime?channel=Book.1&fields=title", { accept: "text/event-stream" });
     const res = fakeResponse();
     await transport.handleRequest(req, res);
 
@@ -343,10 +257,9 @@ describe("createSseTransport — subscribableFields payload narrowing", () => {
 
   it("narrows to 'not excluded' for an exclude selector, with no 'fields' param", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: () => ({ exclude: ["price"] }),
     });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
     await transport.handleRequest(req, res);
 
@@ -357,8 +270,8 @@ describe("createSseTransport — subscribableFields payload narrowing", () => {
   });
 
   it("delivers the item unnarrowed when no subscribableFields callback is configured", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
     await transport.handleRequest(req, res);
 
@@ -371,8 +284,8 @@ describe("createSseTransport — subscribableFields payload narrowing", () => {
 
 describe("createSseTransport — opening a stream", () => {
   it("writes text/event-stream response headers and registers the connection", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -388,8 +301,8 @@ describe("createSseTransport — opening a stream", () => {
   });
 
   it("unsubscribes the connection once the underlying request closes", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req, close } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req, close } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -404,8 +317,8 @@ describe("createSseTransport — opening a stream", () => {
     // a broken pipe surfaces as an 'error' on the response, not a 'close' on
     // the request, and both must free the connection or a channel accumulates
     // dead subscribers forever.
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
 
     await transport.handleRequest(req, res);
@@ -418,8 +331,8 @@ describe("createSseTransport — opening a stream", () => {
 
 describe("createSseTransport — publish", () => {
   it("writes a spec-correct SSE frame (id/event/data) to a subscriber of the matching channel", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
     const res = fakeResponse();
     await transport.handleRequest(req, res);
 
@@ -435,8 +348,8 @@ describe("createSseTransport — publish", () => {
   });
 
   it("does not deliver to a connection subscribed to a different channel", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book.2&token=t", { accept: "text/event-stream" });
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.2", { accept: "text/event-stream" });
     const res = fakeResponse();
     await transport.handleRequest(req, res);
 
@@ -446,22 +359,16 @@ describe("createSseTransport — publish", () => {
   });
 
   it("is a no-op when no connection is subscribed to the event's channel", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const transport = createSseTransport({});
     await expect(transport.publish(createdEvent())).resolves.toBeUndefined();
   });
 
   it("fans one event out to every connection subscribed to the same channel", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const transport = createSseTransport({});
     const first = fakeResponse();
     const second = fakeResponse();
-    await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
-      first,
-    );
-    await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
-      second,
-    );
+    await transport.handleRequest(fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req, first);
+    await transport.handleRequest(fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req, second);
 
     await transport.publish(createdEvent());
 
@@ -474,15 +381,15 @@ describe("createSseTransport — publish", () => {
   });
 
   it("assigns increasing 'id:' values across successive publishes, shared across channels", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const transport = createSseTransport({});
     const bookRes = fakeResponse();
     const authorRes = fakeResponse();
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req,
       bookRes,
     );
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Author.5&token=t", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Author.5", { accept: "text/event-stream" }).req,
       authorRes,
     );
 
@@ -497,15 +404,12 @@ describe("createSseTransport — publish", () => {
   });
 
   it("drops a connection whose write buffer exceeds bufferLimitBytes instead of blocking other subscribers", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}), bufferLimitBytes: 10 });
+    const transport = createSseTransport({ bufferLimitBytes: 10 });
     const slow = fakeResponse();
     const healthy = fakeResponse();
+    await transport.handleRequest(fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req, slow);
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
-      slow,
-    );
-    await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req,
       healthy,
     );
     setWritableLength(slow, 1_000_000);
@@ -522,15 +426,15 @@ describe("createSseTransport — publish", () => {
 
 describe("createSseTransport — collection channel + dual routing", () => {
   it("delivers one write to both an item-channel and a collection-channel subscriber", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const transport = createSseTransport({});
     const itemSub = fakeResponse();
     const collectionSub = fakeResponse();
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req,
       itemSub,
     );
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book&token=t", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Book", { accept: "text/event-stream" }).req,
       collectionSub,
     );
 
@@ -541,10 +445,10 @@ describe("createSseTransport — collection channel + dual routing", () => {
   });
 
   it("does not deliver to a collection subscriber of a different entity", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const transport = createSseTransport({});
     const authorSub = fakeResponse();
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Author&token=t", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Author", { accept: "text/event-stream" }).req,
       authorSub,
     );
 
@@ -554,15 +458,15 @@ describe("createSseTransport — collection channel + dual routing", () => {
   });
 
   it("shares one 'id:' across every connection notified by one publish, even across item and collection channels", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const transport = createSseTransport({});
     const itemSub = fakeResponse();
     const collectionSub = fakeResponse();
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req,
       itemSub,
     );
     await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book&token=t&fields=title", { accept: "text/event-stream" }).req,
+      fakeRequest("/realtime?channel=Book&fields=title", { accept: "text/event-stream" }).req,
       collectionSub,
     );
 
@@ -579,8 +483,8 @@ describe("createSseTransport — collection channel + dual routing", () => {
 
 describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
   it("rejects filter query params with 400 when filterableEntities is not configured", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -593,10 +497,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("accepts a well-formed filter when filterableEntities is configured", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: (entity) => (entity === "Book" ? bookFilterable() : undefined),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -608,10 +511,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("rejects a malformed filter (unknown operator) with 400 before opening the stream", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][bogus]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][bogus]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -625,10 +527,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("rejects a filter naming a field the entity doesn't have, with 400", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[nope][eq]=x", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[nope][eq]=x", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -640,11 +541,10 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("rejects a filter field outside subscribableFields with 400", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[price][eq]=12", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[price][eq]=12", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -657,10 +557,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("delivers to a filtered collection subscriber only when the published item matches", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -675,10 +574,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("delivers an 'entering' write as its ordinary event id, not a synthesized one", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -694,10 +592,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("does not deliver a write that makes a row stop matching (leave is silent — documented limitation)", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -713,10 +610,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("delivers a 'deleted' event to a filtered subscriber unconditionally, item null (bypass policy)", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -732,10 +628,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("never delivers to a filtered subscriber across several writes that never match", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -751,10 +646,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
   it("delivers from creation when the created item already matches", async () => {
     const transport = createSseTransport({
-      verifyToken: () => ({}),
       filterableEntities: () => bookFilterable(),
     });
-    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+    const { req } = fakeRequest("/realtime?channel=Book&filter[status][eq]=published", {
       accept: "text/event-stream",
     });
     const res = fakeResponse();
@@ -768,12 +662,9 @@ describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
 
 describe("createSseTransport — close", () => {
   it("ends every open connection and clears the registry", async () => {
-    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const transport = createSseTransport({});
     const res = fakeResponse();
-    await transport.handleRequest(
-      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
-      res,
-    );
+    await transport.handleRequest(fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" }).req, res);
     expect(transport.connectionCount).toBe(1);
 
     transport.close();

--- a/packages/realtime/sse/tests/sse-transport.spec.ts
+++ b/packages/realtime/sse/tests/sse-transport.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import type { RealtimeEventDto } from "@kavo/core";
-import { createSseTransport } from "@kavo/sse";
+import type { EntityMetadata, RealtimeEventDto, ResolvedEntityConfig } from "@kavo/core";
+import { createKavo } from "@kavo/core";
+import { createSseTransport, type FilterableEntity } from "@kavo/sse";
 import { fakeRequest, fakeResponse, setWritableLength } from "./support/fake-http.js";
+import { Book, bookMetadata, InMemoryBookAdapter } from "./support/book-fixture.js";
 
 function createdEvent(overrides: Partial<RealtimeEventDto> = {}): RealtimeEventDto {
   return {
@@ -12,6 +14,25 @@ function createdEvent(overrides: Partial<RealtimeEventDto> = {}): RealtimeEventD
     occurredAt: "2026-01-01T00:00:00.000Z",
     item: { id: 1, title: "Dune" },
     ...overrides,
+  };
+}
+
+/**
+ * A real `ResolvedEntityConfig`/`EntityMetadata` pair for `Book`, the same
+ * way an app would obtain one — off `DefaultKavoService.engine` — rather
+ * than hand-building a fake that could drift from the real shape.
+ */
+function bookFilterable(): FilterableEntity {
+  const kavo = createKavo();
+  const crud = kavo.createCrud(Book, undefined, { adapter: new InMemoryBookAdapter(), metadata: bookMetadata });
+  // Same erasure cast `kavo.ts`'s own `catalog.register` uses to hand a
+  // concretely-typed `ResolvedEntityConfig<Book>` to a type-erased consumer
+  // — `Entity`'s variance in `ResolvedQueryAllowlists` makes a direct
+  // assignment to the `object`-parameterized shape fail structurally, even
+  // though it's sound at runtime.
+  return {
+    metadata: crud.engine.metadata as EntityMetadata,
+    config: crud.engine.config as unknown as ResolvedEntityConfig,
   };
 }
 
@@ -98,6 +119,39 @@ describe("createSseTransport — handleRequest auth", () => {
   });
 });
 
+describe("createSseTransport — verifyToken omitted (authentication disabled)", () => {
+  it("accepts a subscribe request with no token at all", async () => {
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(transport.connectionCount).toBe(1);
+  });
+
+  it("accepts a subscribe request that carries a token, without ever calling any verifier", async () => {
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=whatever", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("never produces a 401", async () => {
+    const transport = createSseTransport({});
+    const { req } = fakeRequest("/realtime?channel=Book", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).not.toBe(401);
+  });
+});
+
 describe("createSseTransport — handleRequest request shape", () => {
   it("rejects a non-GET method with 400 before opening the stream", async () => {
     const transport = createSseTransport({ verifyToken: () => ({}) });
@@ -130,7 +184,7 @@ describe("createSseTransport — handleRequest request shape", () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it.each(["", ".42", "Book.", "Book"])("rejects a malformed channel %j with 400", async (channel) => {
+  it.each(["", ".42", "Book."])("rejects a malformed channel %j with 400", async (channel) => {
     const transport = createSseTransport({ verifyToken: () => ({}) });
     const { req } = fakeRequest(`/realtime?channel=${encodeURIComponent(channel)}&token=t`, {
       accept: "text/event-stream",
@@ -140,6 +194,17 @@ describe("createSseTransport — handleRequest request shape", () => {
     await transport.handleRequest(req, res);
 
     expect(res.statusCode).toBe(400);
+  });
+
+  it("accepts a bare entity name as a collection-channel subscription (issue #160)", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(transport.connectionCount).toBe(1);
   });
 });
 
@@ -229,7 +294,7 @@ describe("createSseTransport — subscribableFields enforcement", () => {
     expect(res.statusCode).toBe(200);
   });
 
-  it("skips field validation entirely when no 'fields' param is given", async () => {
+  it("skips 'fields'-list validation when no 'fields' param is given, but still resolves the allowlist for payload narrowing", async () => {
     const subscribableFields = vi.fn().mockReturnValue([]);
     const transport = createSseTransport({ verifyToken: () => ({}), subscribableFields });
     const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
@@ -238,7 +303,69 @@ describe("createSseTransport — subscribableFields enforcement", () => {
     await transport.handleRequest(req, res);
 
     expect(res.statusCode).toBe(200);
-    expect(subscribableFields).not.toHaveBeenCalled();
+    // Called once, to capture the allowlist this connection narrows every
+    // outgoing item to (unconditionally, per `subscribableFields`'s doc) —
+    // not to validate a 'fields' list, since none was given.
+    expect(subscribableFields).toHaveBeenCalledWith("Book");
+  });
+});
+
+describe("createSseTransport — subscribableFields payload narrowing", () => {
+  it("narrows the outgoing item to an array selector even when no 'fields' param was requested", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", status: "published", price: 12 } }));
+
+    const body = JSON.parse(res.frames[0]!.match(/^data: (.*)$/m)![1]!) as RealtimeEventDto;
+    expect(body.item).toEqual({ title: "Dune", status: "published" });
+  });
+
+  it("narrows further to a requested 'fields' subset within the configured allowlist", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t&fields=title", { accept: "text/event-stream" });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", status: "published" } }));
+
+    const body = JSON.parse(res.frames[0]!.match(/^data: (.*)$/m)![1]!) as RealtimeEventDto;
+    expect(body.item).toEqual({ title: "Dune" });
+  });
+
+  it("narrows to 'not excluded' for an exclude selector, with no 'fields' param", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: () => ({ exclude: ["price"] }),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", price: 12 } }));
+
+    const body = JSON.parse(res.frames[0]!.match(/^data: (.*)$/m)![1]!) as RealtimeEventDto;
+    expect(body.item).toEqual({ id: 1, title: "Dune" });
+  });
+
+  it("delivers the item unnarrowed when no subscribableFields callback is configured", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", price: 12 } }));
+
+    const body = JSON.parse(res.frames[0]!.match(/^data: (.*)$/m)![1]!) as RealtimeEventDto;
+    expect(body.item).toEqual({ id: 1, title: "Dune", price: 12 });
   });
 });
 
@@ -390,6 +517,252 @@ describe("createSseTransport — publish", () => {
     expect(slow.ended).toBe(true);
     expect(healthy.frames).toHaveLength(1);
     expect(transport.connectionCount).toBe(1);
+  });
+});
+
+describe("createSseTransport — collection channel + dual routing", () => {
+  it("delivers one write to both an item-channel and a collection-channel subscriber", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const itemSub = fakeResponse();
+    const collectionSub = fakeResponse();
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      itemSub,
+    );
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book&token=t", { accept: "text/event-stream" }).req,
+      collectionSub,
+    );
+
+    await transport.publish(createdEvent());
+
+    expect(itemSub.frames).toHaveLength(1);
+    expect(collectionSub.frames).toHaveLength(1);
+  });
+
+  it("does not deliver to a collection subscriber of a different entity", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const authorSub = fakeResponse();
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Author&token=t", { accept: "text/event-stream" }).req,
+      authorSub,
+    );
+
+    await transport.publish(createdEvent());
+
+    expect(authorSub.frames).toHaveLength(0);
+  });
+
+  it("shares one 'id:' across every connection notified by one publish, even across item and collection channels", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const itemSub = fakeResponse();
+    const collectionSub = fakeResponse();
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book.1&token=t", { accept: "text/event-stream" }).req,
+      itemSub,
+    );
+    await transport.handleRequest(
+      fakeRequest("/realtime?channel=Book&token=t&fields=title", { accept: "text/event-stream" }).req,
+      collectionSub,
+    );
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", price: 12 } }));
+
+    const idOf = (frame: string) => Number(/^id: (\d+)/.exec(frame)![1]);
+    // The collection subscriber's payload is narrowed (differs from the
+    // item subscriber's), but both must carry the same event id — they are
+    // two views of the same logical write, not two publishes.
+    expect(itemSub.frames[0]).not.toBe(collectionSub.frames[0]);
+    expect(idOf(itemSub.frames[0]!)).toBe(idOf(collectionSub.frames[0]!));
+  });
+});
+
+describe("createSseTransport — subscribe-time filtering (issue #160)", () => {
+  it("rejects filter query params with 400 when filterableEntities is not configured", async () => {
+    const transport = createSseTransport({ verifyToken: () => ({}) });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(transport.connectionCount).toBe(0);
+  });
+
+  it("accepts a well-formed filter when filterableEntities is configured", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: (entity) => (entity === "Book" ? bookFilterable() : undefined),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("rejects a malformed filter (unknown operator) with 400 before opening the stream", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][bogus]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonBody).toMatchObject({ error: "invalid filter" });
+    expect(transport.connectionCount).toBe(0);
+  });
+
+  it("rejects a filter naming a field the entity doesn't have, with 400", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[nope][eq]=x", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a filter field outside subscribableFields with 400", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      subscribableFields: (entity) => (entity === "Book" ? ["title", "status"] : undefined),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[price][eq]=12", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+
+    await transport.handleRequest(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonBody).toMatchObject({ error: expect.stringContaining("price") });
+  });
+
+  it("delivers to a filtered collection subscriber only when the published item matches", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", status: "draft" } }));
+    expect(res.frames).toHaveLength(0);
+
+    await transport.publish(createdEvent({ event: "patched", item: { id: 1, title: "Dune", status: "published" } }));
+    expect(res.frames).toHaveLength(1);
+  });
+
+  it("delivers an 'entering' write as its ordinary event id, not a synthesized one", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    // Didn't match before (never delivered), matches now — delivered as the
+    // real "patched" event, per the documented enter policy.
+    await transport.publish(createdEvent({ event: "patched", item: { id: 1, title: "Dune", status: "published" } }));
+
+    expect(res.frames).toHaveLength(1);
+    expect(res.frames[0]).toContain("event: patched\n");
+  });
+
+  it("does not deliver a write that makes a row stop matching (leave is silent — documented limitation)", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ event: "patched", item: { id: 1, title: "Dune", status: "published" } }));
+    expect(res.frames).toHaveLength(1);
+
+    await transport.publish(createdEvent({ event: "patched", item: { id: 1, title: "Dune", status: "draft" } }));
+    // No second frame: the row left the filtered view silently.
+    expect(res.frames).toHaveLength(1);
+  });
+
+  it("delivers a 'deleted' event to a filtered subscriber unconditionally, item null (bypass policy)", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    // This row never matched the filter — never delivered a create/update —
+    // yet its delete is still delivered, per the documented bypass.
+    await transport.publish(createdEvent({ event: "deleted", item: null }));
+
+    expect(res.frames).toHaveLength(1);
+    expect(res.frames[0]).toContain("event: deleted\n");
+  });
+
+  it("never delivers to a filtered subscriber across several writes that never match", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", status: "draft" } }));
+    await transport.publish(
+      createdEvent({ event: "patched", item: { id: 1, title: "Dune 2nd ed.", status: "draft" } }),
+    );
+
+    expect(res.frames).toHaveLength(0);
+  });
+
+  it("delivers from creation when the created item already matches", async () => {
+    const transport = createSseTransport({
+      verifyToken: () => ({}),
+      filterableEntities: () => bookFilterable(),
+    });
+    const { req } = fakeRequest("/realtime?channel=Book&token=t&filter[status][eq]=published", {
+      accept: "text/event-stream",
+    });
+    const res = fakeResponse();
+    await transport.handleRequest(req, res);
+
+    await transport.publish(createdEvent({ item: { id: 1, title: "Dune", status: "published" } }));
+
+    expect(res.frames).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds two things realtime (#154/#155) didn't have yet: a way to subscribe to
every write on an entity, not just one row, and a way to scope that
subscription to a subset of rows.

- **Collection channel** — a subscriber can open `<entity>` (e.g.
  `channel=Book`) alongside the existing item channel `<entity>.<id>`. No new
  `RealtimeEventDto` field: `entity` already carries the collection-channel
  name, so one event, published once by the engine, fans out to both kinds of
  subscriber — the dual routing is the transport's job.
- **Subscribe-time filtering** — a collection-channel subscribe request may
  add the same `filter[field][operator]=value` grammar REST list requests
  use, parsed by the real `DefaultFilterParser` and evaluated in memory by a
  new core function, `evaluateFilter` (`packages/core/src/query/filter-evaluator.ts`).
  It follows SQL's three-valued-logic null semantics and safely escapes
  `LIKE`/`ILIKE` patterns before building a `RegExp`. Filtering is opt-in per
  entity via a new `SseTransportOptions.filterableEntities` callback (same
  pattern as the existing `subscribableFields`) — an entity with no entry
  rejects any `filter[...]` param with `400` rather than silently ignoring it.
- **`subscribableFields` payload narrowing is now actually enforced** on the
  outgoing item, unconditionally once configured — not only when a subscriber
  names `fields`.
- **Filter-boundary crossings, explicitly decided (ADR-0024, new architecture
  doc 18):** a row "entering" a filter is delivered as its real event id
  (never a synthesized `created`); "leaving" is silently not delivered
  (documented limitation — no before-image available without an extra read);
  `deleted` events always bypass the filter (`item` is `null`, nothing to
  evaluate), which is called out as a confidentiality tradeoff, not just a
  staleness one, in `RealtimeTransport`'s doc.
- **`SseTransportOptions.verifyToken` is now optional** — omitting it
  disables authentication entirely for that transport instance (an internal-
  only or already perimeter-authenticated deployment). Flagged in the docs
  that with no `verifyToken`, `subscribableFields`/filtering are the only
  things bounding what a connection can see, and neither is access control.

Closes #160

## Public API impact

- `@kavo/core` barrel: new export `evaluateFilter` (function). `KavoEngine`
  gained a `metadata` getter (alongside its existing `config`/`registry`
  ones). Both additive, non-breaking.
- `@kavo/sse`: `SseTransportOptions.verifyToken` changed from required to
  optional (widens the type — non-breaking for existing callers). New
  optional `SseTransportOptions.filterableEntities` and exported
  `FilterableEntity` type. `handleRequest` now also accepts a bare-`<entity>`
  `channel` value (previously rejected with `400`) — additive.
- `RealtimeEventDto` is unchanged (no new field) — see ADR-0024 for why.

## Testing

- New `packages/core/tests/filter-evaluator.spec.ts` — operator table, SQL
  null semantics, `LIKE`/`ILIKE` escaping, date comparisons, logical nesting.
- Extended `packages/core/tests/realtime.spec.ts` for the `metadata` getter
  and the entity/channel contract collection channels rely on.
- Extended `packages/realtime/sse/tests/sse-transport.spec.ts` — collection
  channel + dual routing, single event id per publish across narrowed
  payloads, filter parsing/validation 400s, the named transition cases
  (never-matches, matches-from-creation, enter, leave, delete-while-filtered),
  `subscribableFields` narrowing, and the new no-auth path.
- Extended `packages/realtime/sse/tests/integration.spec.ts` with a real-socket
  no-auth case.
- `pnpm check`: 96 test files, 2158 tests, all green (build + typecheck +
  depcruise + lint + test). `pnpm docs:links` and `pnpm docs:build` also
  clean.

## Review notes

- The "leave" transition (a write makes a row stop matching a filter) is not
  delivered at all today — detecting it needs a pre-write read the engine
  doesn't otherwise do, and adding one unconditionally was rejected as a cost
  paid by every write on a realtime-enabled entity. Worth a hard look: is the
  documented-limitation route the right call, or should this be revisited
  before merge?
- The `deleted`-event filter bypass is a deliberate confidentiality tradeoff
  (a filtered subscriber can learn the `id` of rows it never had visibility
  into) — flagged in `RealtimeTransport`'s doc and ADR-0024, not hidden.
- `verifyToken` going optional was a follow-up request during review, not
  part of the original issue #160 acceptance criteria — worth confirming
  scope is fine to bundle into this same PR rather than split out.