### PR TITLE
style: reformat the book list example in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -268,7 +268,12 @@ GET /books
 ```json
 {
   "items": [
-    { "id": 42, "title": "The Left Hand of Darkness", "status": "published", "author": { "id": 7, "name": "Ursula K. Le Guin" } },
+    {
+      "id": 42,
+      "title": "The Left Hand of Darkness",
+      "status": "published",
+      "author": { "id": 7, "name": "Ursula K. Le Guin" }
+    },
     { "id": 41, "title": "Kindred", "status": "published", "author": { "id": 3, "name": "Octavia E. Butler" } }
   ],
   "limit": 20,


### PR DESCRIPTION
`main` is red on the `format` job and has been since 0fd9b54.

That commit added a nested `author` object to the `GET /books?include=author` response sample in `docs/index.md`, which pushed one line inside the JSON block to 128 characters. `.prettierrc` sets `printWidth: 120`, so Prettier wants that object broken across lines.

This is `prettier --write docs/index.md` and nothing else. No content change, no hand edits.

Worth noting how it got through. `format` is its own CI job and is deliberately not part of `pnpm check`, so the gate a contributor runs locally stays green while `main` goes red. Every open PR then inherits the failure, because a PR run checks out a merge with `main`. #172 is currently red for this and nothing else.

```
$ npx prettier --check .
Checking formatting...
All matched files use Prettier code style!
```
