### PR TITLE
feat(docs): tint text selection with kavo primary color

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -14,6 +14,16 @@
   --vp-c-brand-3: #7c5cff;
 }
 
+::selection {
+  background: rgba(124, 92, 255, 0.28);
+  color: inherit;
+}
+
+.dark ::selection {
+  background: rgba(167, 139, 250, 0.35);
+  color: inherit;
+}
+
 .VPHero {
   position: relative;
   overflow: visible;

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -3,6 +3,7 @@
   --vp-c-brand-2: #6a45e6;
   --vp-c-brand-3: #5c3dc0;
   --vp-c-brand-soft: rgba(124, 92, 255, 0.14);
+  --vp-c-brand-selection: rgba(124, 92, 255, 0.28);
 
   --vp-home-hero-name-color: transparent;
   --vp-home-hero-name-background: linear-gradient(120deg, #9b7fe0 20%, #6a45e6);
@@ -12,16 +13,11 @@
   --vp-c-brand-1: #a78bfa;
   --vp-c-brand-2: #8b6fe0;
   --vp-c-brand-3: #7c5cff;
+  --vp-c-brand-selection: rgba(167, 139, 250, 0.32);
 }
 
 ::selection {
-  background: #a98bff;
-  color: #000;
-}
-
-.dark ::selection {
-  background: #b282ff;
-  color: #14101f;
+  background-color: var(--vp-c-brand-selection);
 }
 
 .VPHero {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -16,7 +16,7 @@
 
 ::selection {
   background: #a98bff;
-  color: #14101f;
+  color: #000;
 }
 
 .dark ::selection {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -15,13 +15,13 @@
 }
 
 ::selection {
-  background: rgba(130, 87, 255, 0.55);
-  color: inherit;
+  background: #8257ff;
+  color: #14101f;
 }
 
 .dark ::selection {
-  background: rgba(178, 130, 255, 0.6);
-  color: inherit;
+  background: #b282ff;
+  color: #14101f;
 }
 
 .VPHero {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -15,7 +15,7 @@
 }
 
 ::selection {
-  background: #8257ff;
+  background: #a98bff;
   color: #14101f;
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -15,12 +15,12 @@
 }
 
 ::selection {
-  background: rgba(124, 92, 255, 0.28);
+  background: rgba(130, 87, 255, 0.55);
   color: inherit;
 }
 
 .dark ::selection {
-  background: rgba(167, 139, 250, 0.35);
+  background: rgba(178, 130, 255, 0.6);
   color: inherit;
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -268,7 +268,12 @@ GET /books
 ```json
 {
   "items": [
-    { "id": 42, "title": "The Left Hand of Darkness", "status": "published", "author": { "id": 7, "name": "Ursula K. Le Guin" } },
+    {
+      "id": 42,
+      "title": "The Left Hand of Darkness",
+      "status": "published",
+      "author": { "id": 7, "name": "Ursula K. Le Guin" }
+    },
     { "id": 41, "title": "Kindred", "status": "published", "author": { "id": 3, "name": "Octavia E. Butler" } }
   ],
   "limit": 20,


### PR DESCRIPTION
## Summary
- Add a `::selection` rule (light and dark) using a lighter tint of the kavo brand color (`--vp-c-brand-1`) instead of the browser default selection highlight.

## Test plan
- [ ] Visually confirm selection highlight in docs site, light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)