### PR TITLE
chore(docs): fix prettier formatting in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -268,7 +268,12 @@ GET /books
 ```json
 {
   "items": [
-    { "id": 42, "title": "The Left Hand of Darkness", "status": "published", "author": { "id": 7, "name": "Ursula K. Le Guin" } },
+    {
+      "id": 42,
+      "title": "The Left Hand of Darkness",
+      "status": "published",
+      "author": { "id": 7, "name": "Ursula K. Le Guin" }
+    },
     { "id": 41, "title": "Kindred", "status": "published", "author": { "id": 3, "name": "Octavia E. Butler" } }
   ],
   "limit": 20,


### PR DESCRIPTION
## Summary
- \`docs/index.md\` was failing \`pnpm format:check\` on \`main\`, which was blocking CI (the \`format\` job) for unrelated PRs. Re-run prettier to fix.

## Test plan
- [x] \`pnpm format:check\` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)