### PR TITLE
chore: stop /publish reading a 0.x breaking change as 1.0.0

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -45,6 +45,20 @@ workflow.
    to 0, minor resets patch to 0). State the computed version and _why_
    (which commits triggered the bump level) before touching any files.
 
+   **While the current version is `0.x`, cap the computed bump at minor.**
+   Before 1.0 a breaking change bumps the minor (`0.7.2` → `0.8.0`), and the
+   `!` still matters: it is what makes the release a minor rather than a
+   patch. What it must not do is decide `1.0.0`. Declaring 1.0 says the
+   public API is now stable and that breaking it needs a major, which is a
+   deliberate call about the project rather than a fact about one commit
+   subject — and it retires the standing latitude to break APIs and revise
+   accepted ADRs that pre-1.0 work relies on. Ship 1.0.0 only when
+   `$ARGUMENTS` is explicitly `major`, and confirm it with the user as its
+   own decision rather than folding it into the release.
+
+   This rule is why v0.8.0 is 0.8.0: it carried two `feat!` commits (#151
+   and #172), both of which used that pre-1.0 latitude on purpose.
+
 3. **Apply the version, in lockstep** (ADR-0004 — [`docs/internals/adr/0004-lockstep-versioning.md`](../../docs/internals/adr/0004-lockstep-versioning.md)):
    set the new version in the `package.json` of **every** published package.
    `PACKAGE_DIRS` in `.github/workflows/publish.yml` is the single source of


### PR DESCRIPTION
`/publish` classifies the version bump from Conventional Commit prefixes, and maps a `!` in the subject straight to major. That is correct from 1.0 onward. Before it, the rule and semver disagree: under 0.x a breaking change bumps the minor, and 1.0.0 is a statement that the public API is stable, not a consequence of a commit prefix.

v0.8.0 is the first release to hit this. It carried two `feat!` commits, #151 and #172, so the rule as written computed 1.0.0. Both of those commits used the standing pre-1.0 latitude to break APIs and revise accepted ADRs on purpose, which made releasing them as 1.0.0 self-contradicting: the same release that exercised the freedom to destabilize the API would have declared it stable. It shipped as 0.8.0 with the rule applied by hand.

Left alone, the trap stays armed. The next release with a `!` in range computes 1.0.0 again, and retiring the pre-1.0 latitude becomes a side effect of running a command rather than a decision anyone made.

This caps the computed bump at minor while the current version is `0.x`. The `!` still matters there, it is what makes the release a minor rather than a patch. Shipping 1.0.0 now needs an explicit `major` argument and its own confirmation.

Nothing else in the command changes, and no code changes.
