### PR TITLE
feat(core)!: allowlists.selectable narrows the response projection

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -265,6 +265,10 @@ const config = defineConfig({
                 text: "0025 — Handlers reach persistence through the request context",
                 link: "/internals/adr/0025-handlers-reach-persistence-through-the-context",
               },
+              {
+                text: "0026 — selectable narrows the response projection",
+                link: "/internals/adr/0026-selectable-narrows-the-response-projection",
+              },
             ],
           },
         ],

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -235,13 +235,25 @@ What a request may filter, sort, and select on — including relation paths. Any
 })
 ```
 
-| Field        | Type                                                          | What it does                    |
-| ------------ | ------------------------------------------------------------- | ------------------------------- |
-| `filterable` | `readonly FieldPath[]` \| `{ exclude: readonly FieldPath[] }` | Fields usable in `filter[...]`. |
-| `sortable`   | same shape                                                    | Fields usable in `sort=`.       |
-| `selectable` | same shape                                                    | Fields usable in `fields=`.     |
+| Field        | Type                                                          | What it does                                                 |
+| ------------ | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| `filterable` | `readonly FieldPath[]` \| `{ exclude: readonly FieldPath[] }` | Fields usable in `filter[...]`.                              |
+| `sortable`   | same shape                                                    | Fields usable in `sort=`.                                    |
+| `selectable` | same shape                                                    | Fields usable in `fields=`, **and what a response carries**. |
 
 `{ exclude: [...] }` means "every own column (plus, for `selectable`, every selectable computed field) except these", resolved at bootstrap against exactly the base set that key's plain default uses. Omit a key entirely and it derives from the `query` DTO or entity metadata instead.
+
+**How to keep a column out of every response.** Name `selectable` and leave the column off it, or exclude it — both forms do the same thing:
+
+```ts
+@Kavo(User, {
+  allowlists: { selectable: { exclude: ["apiKey"] } },
+})
+```
+
+`apiKey` is then absent from `findOne`, `findMany`, and the row echoed back by `createOne`/`updateOne`/`patchOne`, and naming it in `fields=` is a 400. Writing the key at all is what turns it on: omit `selectable` entirely and the projection is every column plus every declared computed field, exactly as before ([ADR-0026](/internals/adr/0026-selectable-narrows-the-response-projection)).
+
+Two things to know about the edges. A registered `dto.item`/`dto.list` **wins outright** where both are present, rather than intersecting — the DTO is the narrower, more specific statement, so use it when the response shape is more than a subset of columns. And an included relation is projected by its **own** target's `selectable`, never the root's, so hiding a column on `User` keeps it hidden everywhere `user` is included.
 
 ### `computed`
 
@@ -273,7 +285,9 @@ Keep it a pure function of the entity as well (plus `context.principal` where a 
 
 **`resolve` receives the full fetched row**, not the projected object — selection is "kept internally, stripped late", so every column is present regardless of `fields=` or the registered `item` DTO. A computed field can therefore surface a value a narrowed DTO or `selectable` list deliberately hides. That is deliberate (`resolve` is server-authored code, the same trust level as `exposeInternals`), but it makes the resolver part of the exposure decision: narrowing the DTO does not narrow what the resolver can see.
 
-**What `selectable: false` does and does not mean.** It removes the name from the allowlist, so `?fields=auditNote` is a 400. It does **not** pin the field into every response: selection narrows the projection uniformly, so any request that sends `fields=` at all still drops it, and the client has no way to ask for it back. Read it as "not individually selectable", not "always present". An explicit `allowlists.selectable` list naming the field overrides the flag — an explicit list is always the deliberate answer.
+**What `selectable: false` does and does not mean.** It removes the name from the allowlist, so `?fields=auditNote` is a 400. It does **not** pin the field into every response: selection narrows the projection uniformly, so any request that sends `fields=` at all still drops it, and the client has no way to ask for it back. Read it as "not individually selectable", not "always present".
+
+The flag and an explicit `allowlists.selectable` list say different things, deliberately. The flag is a default about _nameability_ and leaves the projection alone. An explicit list is a statement about the **response**, so a list that omits the field — or excludes it — drops it from responses too. Where both are present the explicit list wins, as it always has ([ADR-0026](/internals/adr/0026-selectable-narrows-the-response-projection)).
 
 On an **included relation target**, `resolve` receives the _root_ request's `KavoContext` — serving `GET /posts/1?include=author` hands an `Author` computed field a context whose `entityName`, `operation`, `config`, `query` and `repository` describe Post. Only `principal`, `correlationId`, `transaction` and `state` mean what they say from a relation target — `principal` being whatever the module's [`principal`](#the-principal) option extracted for the root request, or `null` when no option is set.
 

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -251,9 +251,22 @@ What a request may filter, sort, and select on — including relation paths. Any
 })
 ```
 
-`apiKey` is then absent from `findOne`, `findMany`, and the row echoed back by `createOne`/`updateOne`/`patchOne`, and naming it in `fields=` is a 400. Writing the key at all is what turns it on: omit `selectable` entirely and the projection is every column plus every declared computed field, exactly as before ([ADR-0026](/internals/adr/0026-selectable-narrows-the-response-projection)).
+`apiKey` is then absent from `findOne`, `findMany`, `restoreOne`, any custom operation's result, and the row echoed back by `createOne`/`updateOne`/`patchOne`; naming it in `fields=` is a 400. Writing the key at all is what turns it on: omit `selectable` entirely and the projection is every column plus every declared computed field, exactly as before ([ADR-0026](/internals/adr/0026-selectable-narrows-the-response-projection)).
 
-Two things to know about the edges. A registered `dto.item`/`dto.list` **wins outright** where both are present, rather than intersecting — the DTO is the narrower, more specific statement, so use it when the response shape is more than a subset of columns. And an included relation is projected by its **own** target's `selectable`, never the root's, so hiding a column on `User` keeps it hidden everywhere `user` is included.
+::: danger `selectable` alone is not a credential control
+It closes the **response body**. Three other doors stay open, and a column you actually need to protect has to close all four.
+
+| Door                      | Still open after `selectable`                                                                                                             | Close it with                                                       |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `filter[apiKey][like]=a%` | yes — `filterable` defaults to every column, and `LIKE`/`GT`/`LT` binary-search the value in `O(log n)` requests                          | name `filterable` explicitly, without the column                    |
+| `sort=apiKey`             | yes — `sortable` defaults to every column, and ordering leaks the column across pages                                                     | name `sortable` explicitly, without the column                      |
+| `PATCH {"apiKey":"…"}`    | yes — writable columns are derived separately, and after this change the write is **invisible**, because the response no longer echoes it | register `dto.update` (`patch` falls back to it) without the column |
+| response body             | no                                                                                                                                        | `selectable`                                                        |
+
+The filter and sort doors are the same oracle [ADR-0021](/internals/adr/0021-cursor-pagination-is-an-opaque-keyset-union) refuses for cursor sort keys. Narrow all three allowlists together, and add the write DTO.
+:::
+
+Two more edges. A registered `dto.item`/`dto.list` with a runtime shape **replaces** the projection rather than intersecting with it, so `selectable` does not fence a column the DTO names — even where the DTO is _wider_. Register the DTO as the narrowing statement when you use one. And an included relation is projected by its **own** target's `selectable`, never the root's, so hiding a column on `User` keeps it hidden wherever `user` is included — provided `User` itself went through `@Kavo`/`createCrud`. A relation target that never did gets a derived config, which configures nothing and serves its full column set.
 
 ### `computed`
 

--- a/docs/internals/adr/0026-selectable-narrows-the-response-projection.md
+++ b/docs/internals/adr/0026-selectable-narrows-the-response-projection.md
@@ -1,0 +1,151 @@
+# ADR-0026 — `allowlists.selectable` narrows the response, not only the request
+
+**Status:** accepted
+
+## Context
+
+`allowlists.selectable` gated what a request could **name** in `fields=` and
+nothing else. What a response actually carried came from somewhere else
+entirely: a registered `item`/`list` DTO if there was one, otherwise every
+scalar column plus every declared computed field.
+
+So a column left off `selectable`, or explicitly excluded from it, was still
+serialized into every response that did not send `fields=`.
+
+An application on 0.7.2 found this the way it gets found (#149). A `User`
+entity had an `apiKey` credential column, `selectable` was written to omit
+it, and `GET /users` returned it to every caller:
+
+| Request                      | Result                         |
+| ---------------------------- | ------------------------------ |
+| `GET /users`                 | 200, every item has `apiKey`   |
+| `GET /users/:id`             | 200, has `apiKey`              |
+| `GET /users?fields=apiKey`   | 400 `KAVO_QUERY_INVALID_FIELD` |
+| `GET /users?fields=id,email` | 200, narrowed correctly        |
+
+The narrow path was guarded and the wide path was open. As a confidentiality
+control the key was **vacuous**: a client that could not ask for `apiKey`
+received it by not asking for anything.
+
+Three things made this worse than an ordinary gap.
+
+**The documentation asserted the opposite**, in three places, and only one
+table cell in `docs/integrations/nest/configuration.md` had it right:
+
+- `QueryAllowlists`' own doc comment: "what a request may filter, sort, and
+  **select** on".
+- ADR-0019 §1: "a computed field can surface a column that a narrowed `item`
+  DTO **or `selectable` list hides**".
+- ADR-0021 §2, arguing why a cursor needs `selectable` as well as `sortable`:
+  "excluding `passwordHash` **via `selectable` or an item DTO** while leaving
+  `sortable` at its default — **the natural configuration**".
+
+That last one inverts its own outcome. A reader who followed ADR-0021's
+advice, and excluded `passwordHash` via `selectable` alone, got the column in
+plaintext in the body of every list response. The mitigation for a
+binary-search oracle pointed at a configuration that dumped the column
+outright.
+
+**The failure was silent and failed open.** No bootstrap warning, no
+request-time warning. The 400 reinforced the wrong reading, because it
+enumerates the list as though it described what is served:
+
+```
+Field 'apiKey' cannot be used for selection. Selectable fields on User:
+createdAt, email, id, isMe, name, role, storeId, updatedAt.
+```
+
+Every field it named was served. The one it refused to name was served too.
+
+**The only mechanism that did work is easy to get silently wrong.** A
+registered DTO projects by the own enumerable properties of `new Dto()`, and
+TypeScript erases an uninitialized field, so `id!: string` declares nothing
+at runtime and the class falls back to the full entity. That is documented
+and deliberate (`docs/internals/architecture/04-dto-system.md`
+§4), and it is the same failure direction: the config looks like narrowing,
+nothing complains, the response is wide.
+
+## Decision
+
+**1. An explicitly configured `allowlists.selectable` narrows the default
+response projection.** Both spellings, the plain list and `{ exclude }`. The
+entity-derived key set is intersected with it, so a column off the list is
+not serialized by `findOne`, `findMany`, `createOne`, `updateOne` or
+`patchOne`.
+
+This is the resolution that makes the name, the doc comment, ADR-0019 §1 and
+ADR-0021 §2 all true as written, rather than correcting four passages to
+match a behavior nobody wants. It turns one config key into the one-line
+answer to "keep this column out of every response", which is a question
+every adopter with a credential column has.
+
+**2. Explicit configuration is the trigger, and the provenance is
+load-bearing.** `ResolvedEntityConfig` carries a `projection` that is `null`
+unless `allowlists.selectable` was written. It is not read back off
+`allowlists.selectable`, because unconfigured that list resolves to a base
+set which is _almost_ the derived projection and not quite: it drops computed
+fields declaring `selectable: false`, whose documented contract is to stay in
+the projection while being unnameable in `fields=`. Narrowing by a list
+nobody wrote would silently retire that contract, and would break apps that
+never configured the key — the one group this change must not touch.
+
+The flag and the explicit list therefore now say different things, which is
+the point of having both. `selectable: false` is a default about
+_nameability_. An explicit list is a statement about the _response_.
+
+**3. A registered `item`/`list` DTO wins outright; the two are not
+intersected.** Both narrow, and the DTO is the more specific statement.
+Intersecting would mean a DTO that deliberately exposes a field silently
+failed to, which is the exact failure this ADR exists to remove.
+
+**4. A relation is projected by its own target's `selectable`, never the
+root's.** An include never widens what its target exposes, and that has to
+hold for the projection allowlist as it already does for the DTO. Without
+it, hiding a credential on `User` would leak it again the moment any other
+entity included `user`.
+
+**5. The `fields=` 400 message is left alone.** It enumerates the selectable
+list as though that described what is served — which, after decision 1, it
+does.
+
+## Consequences
+
+**This is a breaking change**, and it is scoped to configurations that asked
+for it: an entity that configured `selectable` narrower than its columns
+_and_ depends on the omitted columns still being served. That combination is
+far more likely to be an unnoticed leak than an intended contract, which is
+why it lands as a behavior change rather than a new opt-in key. Pre-1.0, and
+in a minor bump with a changelog note.
+
+**The empty-DTO bootstrap check was proposed and rejected.** #149 asked for a
+`ConfigurationException` when a registered `item`/`list` DTO has an empty
+runtime key set, on the same fail-open reasoning. It cannot ship: a
+declared-only DTO is a **supported, tested path** in `@kavo/nest`, which
+hands the class to Swagger so its own `@ApiProperty` decorators answer
+instead of publishing an empty inline schema
+(`packages/frameworks/nest/tests/binding.e2e.spec.ts`). Rejecting the shape
+in core would break the idiomatic NestJS DTO, which does not initialize its
+fields. The trap is real and stays documented in doc 04 §4; what changes is
+that it is no longer the _only_ way to keep a column out of a response, so an
+adopter reaching for a credential control is now pointed at `selectable`,
+which fails loudly on a misspelling and narrows for real.
+
+**Adopters get one sentence instead of a decision.** "Keep a column out of
+every response" was previously answerable only by "register an `item` DTO,
+and remember to initialize every field, and remember to name every computed
+field you still want". It is now `allowlists.selectable`, with the DTO still
+available for shapes that are more than a subset of columns.
+
+**`fields=` still narrows further and never wider**, unchanged: selection is
+applied after the projection resolves, so it can only subset what
+`selectable` already allows.
+
+## References
+
+- #149, and the application that found it.
+- ADR-0019 (computed fields are serializer-evaluated), whose §1 claim this
+  makes true.
+- ADR-0021 §2 (cursor sort keys must be on `selectable`), whose security
+  argument depended on this being true.
+- `docs/internals/architecture/04-dto-system.md` §4, on DTO
+  runtime shapes.

--- a/docs/internals/adr/0026-selectable-narrows-the-response-projection.md
+++ b/docs/internals/adr/0026-selectable-narrows-the-response-projection.md
@@ -89,6 +89,16 @@ the projection while being unnameable in `fields=`. Narrowing by a list
 nobody wrote would silently retire that contract, and would break apps that
 never configured the key — the one group this change must not touch.
 
+The same reasoning applies one level down, and the first cut of this change
+got it wrong. The two spellings resolve against **different bases**: a plain
+array is the author's own list and is used verbatim, while `{ exclude }`
+resolves against the _readable projection_ — every column plus **every**
+declared computed field — not against the selectable base. Resolving
+`{ exclude }` against the narrower base meant `{ exclude: ["email"] }`
+silently deleted an unrelated `selectable: false` audit field from every
+response, which is "narrowing by a list nobody wrote" wearing a different
+hat.
+
 The flag and the explicit list therefore now say different things, which is
 the point of having both. `selectable: false` is a default about
 _nameability_. An explicit list is a statement about the _response_.
@@ -105,8 +115,30 @@ it, hiding a credential on `User` would leak it again the moment any other
 entity included `user`.
 
 **5. The `fields=` 400 message is left alone.** It enumerates the selectable
-list as though that described what is served — which, after decision 1, it
-does.
+list as though that described what is served, and after decision 1 that is
+accurate in the case the message actually fires in: an explicitly configured
+list with no runtime-shaped `item` DTO. It stays inaccurate in two others —
+where a DTO wins (decision 3), and where the list is unconfigured and omits
+`selectable: false` computed fields that _are_ served. Rewording it to cover
+those would make it longer and less useful in the case it is for.
+
+**6. What this does not close.** `selectable` bounds the **response body**,
+and a column worth hiding has three other doors, none of which this decision
+touches:
+
+| Door                      | Why it stays open                                                                                                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `filter[apiKey][like]=a%` | `filterable` defaults to every column, independently. `LIKE`/`GT`/`LT` binary-search a value in `O(log n)` requests — the same oracle ADR-0021 §2 refuses for cursor sort keys |
+| `sort=apiKey`             | `sortable` defaults the same way; ordering leaks the column across pages                                                                                                       |
+| `PATCH {"apiKey":"…"}`    | the writable projection is derived separately, and this change makes the write **invisible** by removing the echo                                                              |
+
+They are left open because closing them from `selectable` would mean one key
+silently rewriting three others, which is the opposite of the explicitness
+this ADR is built on. What changes is the documentation: the adopter-facing
+answer to "keep this column out of every response" is now stated as all four
+doors, not one. Calling `selectable` "the one-line answer to keeping a
+credential out of a response" — as an earlier draft of this ADR did — was
+the same overstatement that produced #149 in the first place.
 
 ## Consequences
 
@@ -130,11 +162,39 @@ that it is no longer the _only_ way to keep a column out of a response, so an
 adopter reaching for a credential control is now pointed at `selectable`,
 which fails loudly on a misspelling and narrows for real.
 
-**Adopters get one sentence instead of a decision.** "Keep a column out of
+**`ResolvedEntityConfig` gains a required member.** It is barrel-exported, so
+anyone hand-constructing one — through a cast, which is how the in-repo tests
+do it — now has an incomplete object with no compile error. ADR-0019 recorded
+the same break for `computed`; this is its sibling.
+
+**An `If-Match` guard is exactly as wide as the projection.** `canonicalEtag`
+hashes the _served_ representation, so a concurrent change confined to a
+column off `selectable` no longer changes the tag and no longer trips a 412.
+That was already true for a registered `item` DTO; this extends it to a
+config key adopters are steered toward. The confidentiality win and the
+integrity loss are the same mechanism, and ADR-0020 should be read alongside
+this.
+
+**Decision 4 holds only for registered entities.** A relation target that
+never went through `createCrud`/`@Kavo` gets a config derived from metadata
+alone, which configures nothing — so its full column set is served through
+an `include`, however the root is narrowed.
+
+**`{ exclude }` still fails open on a name that matches nothing.**
+`resolveFieldSelector` does no existence check, so `{ exclude: ["apikey"] }`
+excludes nothing and serves the column. `FieldPath` catches this at compile
+time for a properly typed entity and degrades to bare `string` for
+`any`/index-signature ones, and is defeated by a cast. The plain-list
+spelling fails closed (the field vanishes); the exclude spelling does not.
+A bootstrap existence check is the obvious follow-up and is deliberately not
+bundled here.
+
+**Adopters get a shorter answer, not a one-line one.** "Keep a column out of
 every response" was previously answerable only by "register an `item` DTO,
 and remember to initialize every field, and remember to name every computed
-field you still want". It is now `allowlists.selectable`, with the DTO still
-available for shapes that are more than a subset of columns.
+field you still want". The response half is now one key; the filter, sort and
+write halves are still three more, and decision 6 is where that is stated
+rather than glossed.
 
 **`fields=` still narrows further and never wider**, unchanged: selection is
 applied after the projection resolves, so it can only subset what

--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -42,11 +42,17 @@ The metadata seam (`EntityMetadata`, doc 09 §1) supplies the field list
 the defaults derive from:
 
 - **Readable projection** (`item`/`list` default): every scalar column,
-  plus every computed field the entity declares (§7). Relation properties
+  plus every computed field the entity declares (§7), **intersected with
+  `allowlists.selectable` when that key is configured explicitly**
+  ([ADR-0026](/internals/adr/0026-selectable-narrows-the-response-projection)) —
+  which is how a column is kept out of every response without registering a
+  DTO at all. Relation properties
   are excluded unless the request includes them deliberately; a class
   getter or method never appears on its own — it is not a column, and an
   entity-class getter that seems to work is an accident of the ORM handing
   the engine class instances ([ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated)).
+  A registered DTO wins outright over the allowlist rather than
+  intersecting with it: it is the narrower, more specific statement.
 - **Writable projection** (`create`/`update`/`patch` default): every
   scalar column with `generated: false`. Generated columns (auto ids,
   `@CreateDateColumn`, versions) can never be written from a request

--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -126,7 +126,7 @@ The rules, all governed by
 
 | Aspect                  | Behavior                                                                                                                         |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Default projection      | Included in `item`/`list` automatically — no DTO registration needed                                                             |
+| Default projection      | Included in `item`/`list` automatically — unless an explicit `allowlists.selectable` omits it (ADR-0026)                         |
 | Explicit DTO            | Narrows it like any other field (omit it to hide it; name it to keep it, still evaluated)                                        |
 | `selectable`            | Joined by default, so `fields=fullName` works; `selectable: false` opts out                                                      |
 | `filterable`/`sortable` | **Never** — naming one is a bootstrap `ConfigurationException`, and a type error besides                                         |

--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -247,6 +247,13 @@ LOWER(:v)`), identical on every driver. Both operators apply to string
   (`KAVO_QUERY_INVALID_FIELD`), never a silent drop. Programmatic
   callers (`findMany({ filter })`) pass through the **same** allowlist
   and limit checks — typed input skips coercion, not security.
+- **`selectable` governs the response as well as the request:** where
+  `filterable` and `sortable` only gate what a request may name, an
+  _explicitly configured_ `selectable` also narrows the default projection,
+  so a column left off it is not serialized at all. That is what makes it a
+  confidentiality control rather than a validation list. Omit the key and
+  the projection is unchanged
+  ([ADR-0026](/internals/adr/0026-selectable-narrows-the-response-projection)).
 - **Computed fields are selectable only:** a declared computed field
   (doc 04 §7) joins the _selectable_ default and never the filterable or
   sortable one — it has no column to translate to `WHERE`/`ORDER BY`, so

--- a/docs/internals/architecture/08-configuration.md
+++ b/docs/internals/architecture/08-configuration.md
@@ -81,7 +81,10 @@ All merging happens **once at bootstrap** (`resolveEntityConfig`) into a
 deep-frozen `ResolvedEntityConfig`: entity-scope settings, precomputed
 per-operation views behind `settingsFor(operation)`, resolved allowlists
 (explicit, or derived from own scalar columns plus any selectable computed
-fields), the cached `DtoResolver`, the validated `computed` map, and the
+fields), the default response `projection` (`null` unless
+`allowlists.selectable` was configured explicitly —
+[ADR-0026](/internals/adr/0026-selectable-narrows-the-response-projection)),
+the cached `DtoResolver`, the validated `computed` map, and the
 relation registry. There is no runtime mutation API — per-call
 overrides (`KavoCallOptions.settings`) are merged as _parameters_ onto
 the operation view inside the engine, validated, and discarded with the

--- a/docs/using-the-api.md
+++ b/docs/using-the-api.md
@@ -160,6 +160,8 @@ GET /books?fields=id,title
 
 Sparse fieldset for the root resource, validated against the `selectable` allowlist. Narrow an included relation the same way: `fields[author]=id,name`.
 
+`selectable` also decides what a response carries when no `fields=` is sent, so it is the one place to keep a column out of every response — see [Allowlists](/integrations/nest/configuration#allowlists).
+
 ## Computed fields
 
 A response can carry fields that have no database column behind them — a `fullName` built from two columns, a formatted total, a flag that depends on who is asking. They are declared once on the entity's config:

--- a/packages/core/src/config/computed-field.ts
+++ b/packages/core/src/config/computed-field.ts
@@ -70,9 +70,14 @@ export interface ComputedFieldDescriptor<Entity = unknown> {
    * Note what that does *not* buy: a request that sends any `fields=` at
    * all still drops the field, because selection narrows the projection
    * uniformly and there is no way to ask for it back. `false` means "not
-   * individually selectable", not "always present". An explicit
-   * `allowlists.selectable` list naming the field overrides this — an
-   * explicit list is always the deliberate answer.
+   * individually selectable", not "always present".
+   *
+   * This flag and an explicit `allowlists.selectable` now say different
+   * things, and the difference is deliberate (ADR-0026). The flag is a
+   * default about *nameability* and leaves the projection alone; an
+   * explicit list is a statement about the **response**, so a list that
+   * omits (or `exclude`s) the field drops it from responses too. Where
+   * both are present the explicit list wins, as it always has.
    */
   readonly selectable?: boolean;
 }

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -47,13 +47,22 @@ export interface QueryAllowlists<Entity = unknown, Computed extends string = nev
    * when it sends no `fields=` at all (ADR-0026).
    *
    * The second half is what makes this a confidentiality control rather
-   * than a validation list: a column left off is not served, so
-   * `selectable` is the one-line way to keep a credential out of every
-   * response. Omit the key and the projection is unchanged — every column
-   * plus every declared computed field.
+   * than a validation list: a column left off is not served. Omit the key
+   * and the projection is unchanged — every column plus every declared
+   * computed field.
    *
-   * A registered `dto.item`/`dto.list` wins outright where both are
-   * present: the DTO is the narrower, more specific statement.
+   * **It closes the response body and nothing else.** `filterable` and
+   * `sortable` default to every column independently, so
+   * `filter[apiKey][like]=a%` binary-searches the value and `sort=apiKey`
+   * leaks its ordering; the writable projection is derived separately, so
+   * the column is still writable — and this key makes that write
+   * *invisible* by removing the echo. Hiding a credential means narrowing
+   * all three allowlists and registering a write DTO (ADR-0026 §6).
+   *
+   * A registered `dto.item`/`dto.list` with a runtime shape **replaces**
+   * the projection rather than intersecting with it, so it wins even where
+   * it is *wider*. Where you register one, it — not this key — is the
+   * narrowing statement.
    */
   readonly selectable?: QueryFieldSelector<Entity, Computed>;
 }

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -30,6 +30,9 @@ export type QueryFieldSelector<Entity, Extra extends string = never> =
  * dropped. When omitted, the allowlists derive from the `query` DTO or
  * entity metadata at bootstrap.
  *
+ * `filterable` and `sortable` govern the request only. `selectable`
+ * governs the request **and the response** (ADR-0026) — see its own note.
+ *
  * `selectable` is the only key computed-field names may appear in:
  * `filterable`/`sortable` stay typed to real paths, because a computed
  * field has no column to translate to `WHERE`/`ORDER BY` (ADR-0019). The
@@ -39,6 +42,19 @@ export type QueryFieldSelector<Entity, Extra extends string = never> =
 export interface QueryAllowlists<Entity = unknown, Computed extends string = never> {
   readonly filterable?: QueryFieldSelector<Entity>;
   readonly sortable?: QueryFieldSelector<Entity>;
+  /**
+   * What a request may name in `fields=`, **and** what a response carries
+   * when it sends no `fields=` at all (ADR-0026).
+   *
+   * The second half is what makes this a confidentiality control rather
+   * than a validation list: a column left off is not served, so
+   * `selectable` is the one-line way to keep a credential out of every
+   * response. Omit the key and the projection is unchanged — every column
+   * plus every declared computed field.
+   *
+   * A registered `dto.item`/`dto.list` wins outright where both are
+   * present: the DTO is the narrower, more specific statement.
+   */
   readonly selectable?: QueryFieldSelector<Entity, Computed>;
 }
 

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -70,10 +70,7 @@ export function resolveEntityConfig<Entity extends object>(
   const computed = resolveComputedFields(metadata, entityConfig);
   rejectComputedWriteDtoKeys(entityName, entityConfig, computed);
   const allowlists = resolveAllowlists(metadata, entityConfig, computed);
-  // Explicit configuration is what turns `selectable` into a projection
-  // (ADR-0026); an unwritten list narrows nothing. See
-  // `ResolvedEntityConfig.projection` for why the provenance is load-bearing.
-  const projection = entityConfig?.allowlists?.selectable === undefined ? null : allowlists.selectable;
+  const projection = resolveProjection(metadata, entityConfig, computed, allowlists);
   const entitySettings = mergeSettings(
     BUILT_IN_DEFAULTS,
     globalDefaults,
@@ -398,6 +395,42 @@ function validateSincePagination<Entity extends object>(
  * outside `base` can never appear via `exclude` and stays fail-closed like
  * the plain default.
  */
+/**
+ * The default response projection, or `null` for "leave it derived"
+ * (ADR-0026).
+ *
+ * Explicit configuration is the trigger: an unwritten `selectable` narrows
+ * nothing, which is what keeps this change confined to entities that asked
+ * for it.
+ *
+ * The two spellings resolve against **different bases**, and that asymmetry
+ * is the whole point rather than an oversight. A plain array is the author's
+ * own list and is used verbatim. `{ exclude }` means "everything except
+ * these", and *everything* here has to be the readable projection — every
+ * column plus **every** declared computed field — not `selectableBase`,
+ * which drops computed fields declaring `selectable: false`.
+ *
+ * Resolving `{ exclude }` against the narrower base retires a contract the
+ * author never touched: `selectable: false` is documented as keeping a field
+ * in the projection while making its name a 400 in `fields=`, so
+ * `{ exclude: ["email"] }` would silently delete an unrelated audit field
+ * from every response. That is the same "narrowing by a list nobody wrote"
+ * this function exists to prevent, one level down.
+ */
+function resolveProjection<Entity extends object>(
+  metadata: EntityMetadata<Entity>,
+  entityConfig: EntityConfig<Entity> | undefined,
+  computed: ComputedFieldMap<Entity>,
+  allowlists: ResolvedQueryAllowlists<Entity>,
+): readonly FieldPath<Entity>[] | null {
+  const selector = entityConfig?.allowlists?.selectable;
+  if (selector === undefined) return null;
+  if (!("exclude" in selector)) return allowlists.selectable;
+  const readable = [...metadata.fields.map((field) => field.name), ...Object.keys(computed)];
+  const excluded = new Set(selector.exclude as readonly string[]);
+  return readable.filter((name) => !excluded.has(name)) as unknown as readonly FieldPath<Entity>[];
+}
+
 function resolveFieldSelector<Entity>(
   base: readonly FieldPath<Entity>[],
   selector: QueryFieldSelector<Entity> | undefined,

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -70,6 +70,10 @@ export function resolveEntityConfig<Entity extends object>(
   const computed = resolveComputedFields(metadata, entityConfig);
   rejectComputedWriteDtoKeys(entityName, entityConfig, computed);
   const allowlists = resolveAllowlists(metadata, entityConfig, computed);
+  // Explicit configuration is what turns `selectable` into a projection
+  // (ADR-0026); an unwritten list narrows nothing. See
+  // `ResolvedEntityConfig.projection` for why the provenance is load-bearing.
+  const projection = entityConfig?.allowlists?.selectable === undefined ? null : allowlists.selectable;
   const entitySettings = mergeSettings(
     BUILT_IN_DEFAULTS,
     globalDefaults,
@@ -111,6 +115,7 @@ export function resolveEntityConfig<Entity extends object>(
       return perOperation.get(operation) ?? entitySettings;
     },
     allowlists,
+    projection,
     softDelete: resolveSoftDelete(metadata, entitySettings),
     dto: new DefaultDtoResolver<Entity>(entityConfig?.dto),
     computed,

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -31,6 +31,23 @@ export interface ResolvedEntityConfig<Entity = unknown> {
   settingsFor(operation: OperationId): KavoSettings;
   readonly allowlists: ResolvedQueryAllowlists<Entity>;
   /**
+   * The default response projection: what a read serves when the request
+   * sends no `fields=` and no `item`/`list` DTO is registered.
+   *
+   * `null` means "the entity-derived default" — every scalar column plus
+   * every declared computed field. A non-null value is
+   * {@link ResolvedQueryAllowlists.selectable}, and it is non-null exactly
+   * when `allowlists.selectable` was configured explicitly (ADR-0026).
+   *
+   * The provenance is the whole point, and is why this is not simply read
+   * off `allowlists.selectable`. Unconfigured, that list resolves to a base
+   * set that is *almost* the derived projection but drops computed fields
+   * declaring `selectable: false` — fields whose documented contract is to
+   * stay in the projection while being unnameable in `fields=`. Narrowing
+   * by a list nobody wrote would silently retire that contract.
+   */
+  readonly projection: readonly FieldPath<Entity>[] | null;
+  /**
    * The delete strategy resolved for this scope — `hard` with
    * a `null` field for everything that isn't soft-deletable, so adapters
    * branch on one object instead of re-deriving the decision.

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -494,6 +494,11 @@ export class KavoEngine<Entity extends object> {
       settings,
       settingsFor: () => settings,
       allowlists: config.allowlists,
+      // Structural, like `computed` below: the projection is derived from
+      // `allowlists.selectable` at bootstrap (ADR-0026), and allowlists are
+      // outside the settings precedence chain, so a per-call override
+      // cannot widen what a response serves.
+      projection: config.projection,
       // A narrowed scope may change the delete strategy (an operation that
       // forces `hard` on a soft-deletable entity, say), so it is resolved
       // against the settings actually in force for this call.

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -151,7 +151,12 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
         metadata: metadata as EntityMetadata<Entity>,
         config: resolved,
         registry,
-        serializer: new DefaultSerializer(metadata as EntityMetadata<Entity>, catalog, resolved.computed),
+        serializer: new DefaultSerializer(
+          metadata as EntityMetadata<Entity>,
+          catalog,
+          resolved.computed,
+          resolved.projection as readonly string[] | null,
+        ),
         deserializer: new DefaultDeserializer(metadata as EntityMetadata<Entity>, catalog, resolved.computed),
         normalizer: new QueryNormalizer(
           metadata as EntityMetadata<Entity>,

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -51,7 +51,11 @@ function selectionSet(selection: readonly string[] | null | undefined): Readonly
  * Projection sources, in order:
  * 1. An explicit DTO class with initialized fields → its key set.
  * 2. Otherwise the entity-derived default: every scalar column from
- *    adapter metadata, plus every declared computed field (ADR-0019).
+ *    adapter metadata, plus every declared computed field (ADR-0019),
+ *    **intersected with an explicitly configured `allowlists.selectable`**
+ *    (ADR-0026). A DTO wins outright: it is the narrower, more specific
+ *    statement, and intersecting the two would make a DTO that deliberately
+ *    exposes a field silently not do so.
  *
  * A key that names a computed field is produced by calling the
  * descriptor's `resolve`, never by reading it off the row — which is what
@@ -71,9 +75,10 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
     metadata: EntityMetadata<Entity>,
     private readonly catalog?: EntityCatalog,
     computed: ComputedFieldMap<Entity> = {},
+    projection: readonly string[] | null = null,
   ) {
     this.rootProjection = {
-      keys: [...metadata.fields.map((field) => field.name), ...Object.keys(computed)],
+      keys: narrowToProjection([...metadata.fields.map((field) => field.name), ...Object.keys(computed)], projection),
       relations: new Set(metadata.relations.map((relation) => relation.name)),
       computed,
     };
@@ -182,12 +187,38 @@ export class DefaultSerializer<Entity = unknown> implements Serializer<Entity> {
     if (info === undefined) return { keys: null, relations: NO_RELATIONS, computed: NO_COMPUTED_FIELDS };
     const dto = info.config.dto.resolve(node.relation.cardinality === "many" ? "list" : "item", "findMany");
     const computed: ErasedComputedFields = info.config.computed;
+    // The target's own `selectable`, not the root's: an include never
+    // widens what its target exposes, and that has to hold for the
+    // projection allowlist as well as for the DTO (ADR-0026). Without it,
+    // hiding a credential on `User` would leak it again the moment some
+    // other entity included `user`.
     return {
-      keys: dtoShapeKeys(dto) ?? [...info.metadata.fields.map((field) => field.name), ...Object.keys(computed)],
+      keys:
+        dtoShapeKeys(dto) ??
+        narrowToProjection(
+          [...info.metadata.fields.map((field) => field.name), ...Object.keys(computed)],
+          info.config.projection as readonly string[] | null,
+        ),
       relations: new Set(info.metadata.relations.map((relation) => relation.name)),
       computed,
     };
   }
+}
+
+/**
+ * The entity-derived key set, narrowed to an explicitly configured
+ * `allowlists.selectable` (ADR-0026). `null` leaves it alone, which is what
+ * an entity that never configured the key gets.
+ *
+ * Filtering the derived list rather than using the allowlist directly keeps
+ * the derived order and, more importantly, keeps the projection a subset of
+ * what the entity actually has: an explicit `selectable` may legitimately
+ * name a relation path, which is not a key this projection ever emits.
+ */
+function narrowToProjection(derived: readonly string[], projection: readonly string[] | null): readonly string[] {
+  if (projection === null) return derived;
+  const allowed = new Set(projection);
+  return derived.filter((key) => allowed.has(key));
 }
 
 /**

--- a/packages/core/tests/computed-fields.spec.ts
+++ b/packages/core/tests/computed-fields.spec.ts
@@ -227,12 +227,22 @@ describe("computed fields — selection", () => {
     await expect(crud.findOne(1, { fields: ["email"] } as never)).rejects.toBeInstanceOf(QueryValidationException);
   });
 
-  it("can be excluded by name, without leaving the default projection", async () => {
+  it("leaves the default projection when excluded by name, not just the allowlist", async () => {
+    // Changed by ADR-0026, deliberately. This used to assert the opposite:
+    // that `{ exclude: ["shout"] }` narrowed the allowlist and left the
+    // field in every response anyway. That is #149 — a config that states
+    // an intent to hide and does not hide.
+    //
+    // The descriptor flag and the explicit list now say different things,
+    // which is the point of having both: `selectable: false` still keeps
+    // the field in the projection (the test above), because it is a default
+    // about *nameability*; an explicit list is a statement about the
+    // response.
     const { crud } = await seeded({
       computed: { shout },
       allowlists: { selectable: { exclude: ["shout"] } },
     } as never);
-    expect(await crud.findOne(1)).toMatchObject({ shout: "ADA" });
+    expect(await crud.findOne(1)).not.toHaveProperty("shout");
     await expect(crud.findOne(1, { fields: ["shout"] } as never)).rejects.toMatchObject({
       code: "KAVO_QUERY_INVALID",
       issues: [{ field: "shout", code: "KAVO_QUERY_INVALID_FIELD" }],

--- a/packages/core/tests/computed-fields.spec.ts
+++ b/packages/core/tests/computed-fields.spec.ts
@@ -249,6 +249,23 @@ describe("computed fields — selection", () => {
     });
   });
 
+  it("keeps a `selectable: false` field when an { exclude } list names something else", async () => {
+    // The interaction ADR-0026 §2 promises and the first cut of it broke.
+    // `{ exclude }` resolves against the *readable* projection — every
+    // column plus every declared computed field — not against the selectable
+    // base, which drops `selectable: false` fields. Resolving against the
+    // narrower base deleted an audit field the author never named, from
+    // every response, because they excluded an unrelated column.
+    const { crud } = await seeded({
+      computed: { shout: { ...shout, selectable: false } },
+      allowlists: { selectable: { exclude: ["email"] } },
+    } as never);
+
+    const item = (await crud.findOne(1)) as unknown as Record<string, unknown>;
+    expect(item["shout"]).toBe("ADA");
+    expect(item).not.toHaveProperty("email");
+  });
+
   it("lets an explicit selectable list override the descriptor's `selectable: false`", async () => {
     // The descriptor's flag governs the *derived* default; naming the field
     // in an explicit list is the same deliberate opt-in that an explicit

--- a/packages/core/tests/selectable-projection.spec.ts
+++ b/packages/core/tests/selectable-projection.spec.ts
@@ -91,6 +91,16 @@ describe("allowlists.selectable narrows the response projection", () => {
         COLUMNS.filter((name) => name !== "email").sort(),
       );
     });
+
+    it("echoes the full allowed key set from createOne, not merely one absence", async () => {
+      // The five tests above assert `not.toHaveProperty("email")`, which
+      // would also pass if the projection collapsed entirely. The create
+      // echo is the case worth pinning positively: it is the argument for
+      // why a read-only fix would have been worthless.
+      const crud = crudFor(HIDES_EMAIL);
+      const created = await crud.createOne({ name: "Grace", email: "g@x.io", age: 45 } as never);
+      expect(Object.keys(created as object).sort()).toEqual(COLUMNS.filter((name) => name !== "email").sort());
+    });
   });
 
   describe("the spellings", () => {

--- a/packages/core/tests/selectable-projection.spec.ts
+++ b/packages/core/tests/selectable-projection.spec.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import type { DefaultKavoService, EntityConfig, ListResultDto } from "@kavo/core";
+import { createKavo } from "@kavo/core";
+import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
+import {
+  Author,
+  Comment,
+  Post,
+  SeededAdapter,
+  authorMetadata,
+  commentMetadata,
+  postMetadata,
+} from "./support/blog-fixture.js";
+
+/**
+ * `allowlists.selectable` narrows the response projection (ADR-0026).
+ *
+ * Before that decision it gated only what `fields=` could *name*, which
+ * made it vacuous as a confidentiality control: a client that could not ask
+ * for `email` received it anyway by sending no `fields=` at all. #149 found
+ * this with a real credential column.
+ *
+ * The three axes that matter are the ones these tests are organized around:
+ * **which operations** it covers (all reads and all writes, since every one
+ * of them serves a representation), **which spellings** trigger it (the
+ * plain list, the `{ exclude }` form, and no key at all), and **how far it
+ * reaches** (an included relation is projected by its own target's list,
+ * not the root's).
+ */
+
+const COLUMNS = ["id", "name", "email", "age", "status", "createdAt"];
+
+function crudFor(config: EntityConfig<User>) {
+  const adapter = new InMemoryUserAdapter();
+  const kavo = createKavo();
+  return kavo.createCrud(User, config as never, { adapter, metadata: userMetadata }) as DefaultKavoService<User>;
+}
+
+async function seeded(config: EntityConfig<User>) {
+  const crud = crudFor(config);
+  const created = await crud.createOne({ name: "Ada", email: "ada@example.com", age: 36 } as never);
+  return { crud, id: (created as User).id };
+}
+
+/** `email` stands in for #149's `apiKey`: present on the entity, off the list. */
+const HIDES_EMAIL: EntityConfig<User> = {
+  allowlists: { selectable: ["id", "name", "age", "status", "createdAt"] },
+} as EntityConfig<User>;
+
+const EXCLUDES_EMAIL: EntityConfig<User> = {
+  allowlists: { selectable: { exclude: ["email"] } },
+} as EntityConfig<User>;
+
+describe("allowlists.selectable narrows the response projection", () => {
+  describe("every operation that serves a representation", () => {
+    // A read-only fix would have been worthless: `createOne` echoes the row
+    // it just wrote, so a credential omitted from every GET still leaves on
+    // the 201. All five are asserted rather than sampled for that reason.
+    it("hides the column on findOne", async () => {
+      const { crud, id } = await seeded(HIDES_EMAIL);
+      expect(await crud.findOne(id)).not.toHaveProperty("email");
+    });
+
+    it("hides the column on findMany", async () => {
+      const { crud } = await seeded(HIDES_EMAIL);
+      const list = (await crud.findMany()) as ListResultDto<User>;
+      expect(list.items).toHaveLength(1);
+      expect(list.items[0]).not.toHaveProperty("email");
+    });
+
+    it("hides the column on the createOne echo", async () => {
+      const crud = crudFor(HIDES_EMAIL);
+      const created = await crud.createOne({ name: "Grace", email: "grace@example.com", age: 45 } as never);
+      expect(created).not.toHaveProperty("email");
+    });
+
+    it("hides the column on updateOne", async () => {
+      const { crud, id } = await seeded(HIDES_EMAIL);
+      const updated = await crud.updateOne(id, { name: "Ada L", email: "new@example.com", age: 36 } as never);
+      expect(updated).not.toHaveProperty("email");
+    });
+
+    it("hides the column on patchOne", async () => {
+      const { crud, id } = await seeded(HIDES_EMAIL);
+      expect(await crud.patchOne(id, { name: "Ada L" } as never)).not.toHaveProperty("email");
+    });
+
+    it("still serves everything the list does allow", async () => {
+      const { crud, id } = await seeded(HIDES_EMAIL);
+      expect(Object.keys((await crud.findOne(id)) as object).sort()).toEqual(
+        COLUMNS.filter((name) => name !== "email").sort(),
+      );
+    });
+  });
+
+  describe("the spellings", () => {
+    it("treats the { exclude } form identically", async () => {
+      // The form that states the intent most plainly, and the one #149
+      // singled out as the clearest evidence the old behavior was wrong.
+      const { crud, id } = await seeded(EXCLUDES_EMAIL);
+      expect(await crud.findOne(id)).not.toHaveProperty("email");
+    });
+
+    it("leaves the projection alone when the key is not configured at all", async () => {
+      // The compatibility guarantee. An app that never wrote `selectable`
+      // sees exactly what it saw before, which is what makes this change
+      // affect only configurations that asked for it.
+      const { crud, id } = await seeded({});
+      expect(Object.keys((await crud.findOne(id)) as object).sort()).toEqual([...COLUMNS].sort());
+    });
+
+    it("keeps rejecting an unlisted field in fields=, rather than dropping it", async () => {
+      // The old behavior that was already correct, and has to survive: the
+      // 400 is what tells a client it asked for something it cannot have.
+      const { crud, id } = await seeded(HIDES_EMAIL);
+      await expect(crud.findOne(id, { fields: ["email"] } as never)).rejects.toMatchObject({
+        code: "KAVO_QUERY_INVALID",
+        issues: [{ field: "email", code: "KAVO_QUERY_INVALID_FIELD" }],
+      });
+    });
+
+    it("narrows further, never wider, when fields= is sent as well", async () => {
+      const { crud, id } = await seeded(HIDES_EMAIL);
+      expect(await crud.findOne(id, { fields: ["id", "name"] } as never)).toEqual({ id, name: "Ada" });
+    });
+  });
+
+  describe("an included relation is projected by its own target", () => {
+    // The leak this closes is indirect and would otherwise undo the whole
+    // fix: hiding a column on `Author` means nothing if `Post` can include
+    // `author` and serve it back.
+    function blog(authorConfig: EntityConfig<Author>) {
+      const metadata = new Map<unknown, unknown>([
+        [Author, authorMetadata],
+        [Post, postMetadata],
+        [Comment, commentMetadata],
+      ]);
+      const postRow = Object.assign(new Post(), {
+        id: 10,
+        title: "First",
+        authorId: 1,
+        author: Object.assign(new Author(), { id: 1, name: "Ada" }),
+      });
+      const adapters = new Map<unknown, unknown>([
+        [Author, new SeededAdapter<Author>([])],
+        [Post, new SeededAdapter<Post>([postRow])],
+        [Comment, new SeededAdapter<Comment>([])],
+      ]);
+      const kavo = createKavo({
+        infrastructure: {
+          metadataFor: (entity) => metadata.get(entity) as never,
+          adapterFor: (entity) => adapters.get(entity) as never,
+        },
+      });
+      kavo.createCrud(Author, authorConfig as never);
+      kavo.createCrud(Comment);
+      return kavo.createCrud(Post, {
+        relations: { edges: { author: { includable: true } } },
+      } as never) as DefaultKavoService<Post>;
+    }
+
+    async function includedAuthor(authorConfig: EntityConfig<Author>): Promise<Record<string, unknown>> {
+      const list = (await blog(authorConfig).findMany({ include: ["author"] } as never)) as ListResultDto<Post>;
+      const author = (list.items[0] as unknown as { author?: Record<string, unknown> }).author;
+      expect(author).toBeDefined();
+      return author as Record<string, unknown>;
+    }
+
+    it("applies the target's own selectable to the included rows", async () => {
+      expect(Object.keys(await includedAuthor({ allowlists: { selectable: ["id"] } } as EntityConfig<Author>))).toEqual(
+        ["id"],
+      );
+    });
+
+    it("leaves the target alone when the target configured nothing", async () => {
+      // The root's own config must not reach across the edge in either
+      // direction: each entity answers for its own columns.
+      expect(Object.keys(await includedAuthor({} as EntityConfig<Author>))).toEqual(["id", "name"]);
+    });
+  });
+
+  it("lets a registered item DTO win outright rather than intersecting", async () => {
+    // Two narrowing statements, and the more specific one answers. An
+    // intersection would make a DTO that deliberately exposes a field
+    // silently fail to, which is the failure mode this whole ADR is about.
+    class UserItemDto {
+      id = 0;
+      email = "";
+    }
+    const { crud, id } = await seeded({
+      allowlists: { selectable: ["id", "name"] },
+      dto: { item: UserItemDto },
+    } as never);
+    expect(await crud.findOne(id)).toEqual({ id, email: "ada@example.com" });
+  });
+});


### PR DESCRIPTION
Closes #149.

`allowlists.selectable` gated what a request could **name** in `fields=` and nothing else. A column left off it — or explicitly excluded from it — was still serialized into every response that sent no `fields=` at all.

As a confidentiality control the key was **vacuous**: a client that could not ask for `apiKey` received it by not asking for anything. That is how a real application on 0.7.2 shipped a credential column to every caller.

## The part that makes it more than a gap

Three doc passages asserted the opposite, and one is load-bearing. ADR-0021 §2 argues that a cursor sort key must be on `selectable` so `?sort=passwordHash,id` cannot base64 a secret into `nextCursor`, and it names **excluding `passwordHash` via `selectable`** as "the natural configuration" it is protecting. A reader who followed that advice got the column in plaintext in the body of every list response. The mitigation for a binary-search oracle pointed at a configuration that dumped the column outright.

The `fields=` 400 reinforced the misreading, since it enumerates the list as though it described what is served. Every field it named was served; the one it refused to name was served too.

## What changes

An explicitly configured `selectable` intersects the entity-derived projection, in both spellings, across `findOne`, `findMany`, and the row echoed back by `createOne`/`updateOne`/`patchOne`. Four rules make it safe:

- **Explicit configuration is the trigger**, tracked as `ResolvedEntityConfig.projection` rather than read back off the resolved allowlist. Unconfigured, that list is *almost* the derived projection and not quite: it drops computed fields declaring `selectable: false`, whose documented contract is to stay in the projection while being unnameable in `fields=`. Narrowing by a list nobody wrote would retire that contract and break the one group this change must not touch.
- **A registered `item`/`list` DTO wins outright**, not intersected. Both narrow; the DTO is the more specific statement. Intersecting would mean a DTO that deliberately exposes a field silently failed to, which is the exact failure being removed.
- **A relation is projected by its own target's `selectable`**, never the root's. Otherwise hiding a column on `User` leaks it again wherever `user` is included.
- **Per-call settings cannot reach it.** Allowlists sit outside the settings precedence chain, so no override widens a response.

## What was rejected, and why

#149's second acceptance criterion asked for a bootstrap `ConfigurationException` when a registered `item`/`list` DTO has an empty runtime key set. **It cannot ship.** A declared-only DTO is a supported, tested path in `@kavo/nest` (`binding.e2e.spec.ts` — "defers to Swagger's own introspection for a DTO with no runtime own properties"): the binding hands the class to Swagger so its `@ApiProperty` decorators answer, instead of publishing an empty inline schema. Rejecting that shape in core would break the idiomatic NestJS DTO, which does not initialize its fields.

I implemented it first and the Nest suite caught it, which is the useful version of finding out. The trap stays documented in doc 04 §4; what changes is that it is no longer the *only* way to keep a column out of a response, so an adopter reaching for a credential control is now pointed at `selectable` — which fails loudly on a misspelling and narrows for real.

## Breaking change

An entity that configures `selectable` narrower than its columns **and** depends on the omitted columns still being served will see them disappear. That combination is far more likely to be an unnoticed leak than an intended contract, which is why it lands as a behavior change rather than a new opt-in key. Entities that never configured `selectable` are unaffected, and there is a test pinning exactly that.

One existing test changed rather than being weakened: `computed-fields.spec.ts` asserted that `{ exclude: ["shout"] }` narrowed the allowlist and left the field in every response anyway. That assertion **is** #149. It now asserts the field is gone, with a comment saying what changed and why the descriptor's `selectable: false` flag still behaves the old way — the flag is a default about nameability, an explicit list is a statement about the response.

## Tests

13 new in `packages/core/tests/selectable-projection.spec.ts`, organized on the three axes that matter: which operations it covers (all five that serve a representation — a read-only fix would have been worthless, since `createOne` echoes the row it just wrote), which spellings trigger it (plain list, `{ exclude }`, and no key at all), and how far it reaches (the included-relation case).

## Gate

`pnpm check` green: 2241 passed, 2 skipped, no dependency violations. `pnpm docs:links`, `pnpm docs:build` and `pnpm format:check` all pass.
