### PR TITLE
fix(nest): give an @Override'd route the ETag a generated one carries

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -265,6 +265,10 @@ const config = defineConfig({
                 text: "0025 — Handlers reach persistence through the request context",
                 link: "/internals/adr/0025-handlers-reach-persistence-through-the-context",
               },
+              {
+                text: "0027 — An @Override inherits the ETag, but not the precondition",
+                link: "/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition",
+              },
             ],
           },
         ],

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -146,7 +146,14 @@ See [ETags and conditional requests](/using-the-api#etags-and-conditional-reques
 
 **Redaction belongs in the DTO, not in an interceptor.** Kavo's `KavoResponseInterceptor` is method-scoped and therefore innermost: it sets the `ETag` before any controller- or app-level interceptor runs. An outer interceptor that strips fields per role would ship a hash of the _unredacted_ representation next to a redacted body — and a client's `If-Match` built from it would never match. Shape the response with a per-operation `item` DTO, which the engine serializes through before hashing.
 
-**An `@Override`'d method enforces `If-Match` only if it forwards it.** The check lives in the engine, so a method you wrote in place of a generated one bypasses it. `@Kavo` still hands the tokens to the method as its last parameter; pass them on with `{ preconditions }` on the typed service, or return `service.engine.execute({ …, preconditions })` to also get the `ETag` header back.
+**An `@Override`'d method gets the `ETag` for free, and enforces `If-Match` only if it forwards it.** The split is worth reading carefully, because the two halves come from different places ([ADR-0027](/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition)):
+
+- **The tag is automatic.** An override on a single-item operation can return the typed service's item — `this.base.patchOne(id, body, { principal })` — and `@Kavo` hashes it into the same strong `ETag` a generated route would serve. Nothing to opt into.
+- **The precondition is not.** `If-Match` is evaluated inside the engine, against a canonical read, so it only runs if the method passes its `preconditions` parameter on: either as `{ preconditions }` on the typed service, or by returning `service.engine.execute({ …, preconditions })`.
+
+Before v0.9 the tag was not automatic, and the host framework filled in its own weak one instead. That is the failure worth recognizing if you are on an older version: reads carried an `ETag`, `If-None-Match` answered `304`, and the tag changed with the body — everything except the `412` that protects data, so a route could look fully conditional while every guarded write was a silent lost update. Assert the tag's **shape** (`/^"[0-9a-f]{64}"$/`), not its presence.
+
+One limit survives. The engine compares `If-Match` against what `findOne` would serve for that id, so an override serving a **reshaped** representation hands out a tag the check can never match, and every conditional write answers `412`. Serve the canonical shape, or set `caching: { etag: false }` for that operation and own the concurrency control yourself.
 
 ### `softDelete`
 

--- a/docs/internals/adr/0020-content-hash-etags-and-the-engine-read-seam.md
+++ b/docs/internals/adr/0020-content-hash-etags-and-the-engine-read-seam.md
@@ -186,3 +186,26 @@ Only the name and the declared type changed. `createCrud` always passed the
 whole adapter, and the pre-read described above is unchanged; the engine
 also hands that adapter to every handler on the request context (ADR-0025),
 which is a use the narrower name no longer described.
+
+**Amendment (issue #186, ADR-0027):** point 7's rule — "it acts only on an
+engine envelope, so an override returning its own value is untouched" — no
+longer holds, and the consequence bullet excluding `computeEtag` from the
+core barrel is withdrawn.
+
+`@Kavo` now promotes an `@Override`'d single-item route's bare return into an
+envelope carrying the tag, so the header is set on both paths and
+`computeEtag` is exported for it. What point 7 got right and ADR-0027 keeps
+is the split: the **precondition** is still only evaluated when the override
+forwards it, because that needs a canonical read from inside `execute`.
+
+The barrel exclusion was argued here on two grounds. The consumer ground is
+spent — there is one now. The offline-hash-oracle ground does not transfer:
+it is about disclosing a tag to a remote client, which is unchanged, not
+about whether an in-process package can compute one. `@kavo/nest` could
+already read any tag it liked off `KavoResponse`.
+
+What ADR-0027 does not change is the reasoning behind the exclusion's
+_other_ half: `canonicalize` stays unexported, and the export promises "the
+tag Kavo would set for this representation" rather than the algorithm, so
+this ADR's option to supersede the content hash with a version column stays
+open.

--- a/docs/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition.md
+++ b/docs/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition.md
@@ -1,0 +1,129 @@
+# ADR-0027 — An `@Override` inherits the `ETag`, but not the precondition
+
+**Status:** accepted
+
+## Context
+
+`KavoResponseInterceptor` turns the engine's `KavoResponse` into an HTTP
+response: it sets `ETag` from the envelope, answers a not-modified read with
+a bodyless `304`, and unwraps the rest. `@Kavo` applies it to every method it
+routes, generated and `@Override`'d alike, and it acts only on an envelope
+(`isKavoResponse`), so an override returning its own value is left alone.
+
+That guard was meant to be permissive. In practice it was the bug, because
+the natural way to write an override is to delegate to the typed service:
+
+```ts
+@Override()
+async patchOne(id: EntityId, body: Partial<Todo>, _p: RequestPreconditions | null, request: Request) {
+  const principal = boundKavoPrincipal(this, request);
+  return this.base.patchOne(id, body, { principal });
+}
+```
+
+`DefaultKavoService` is `execute` plus an unwrap. The unwrap discards the
+envelope — that is its entire purpose — so the override returns a bare item,
+the interceptor sees no envelope, and the route sets no `ETag`.
+
+**The host framework then fills one in, and that is what made this
+dangerous.** Express's default weak tag is convincing:
+
+- reads carry an `ETag` header;
+- `If-None-Match` on an unchanged row answers `304`;
+- the tag changes when the representation changes.
+
+Three of the four observable behaviours are right. The missing one is the
+`412`, and it is the only one that protects data. An application checking
+"do conditional requests work?" by hand sees ETags and 304s and concludes
+yes, while every `If-Match` write is a silent lost update.
+
+An application on 0.8.0 found it (#186) with all six of an entity's routes
+overridden — which is not exotic: overriding is the documented answer to
+row scoping having no seam (#138). Taking the recommended workaround for one
+gap silently disabled a shipped feature across every entity, with no type
+error, no bootstrap error, and no log line.
+
+It also found the trap in the obvious repair. Forwarding `preconditions`
+from the override makes it **worse**: the engine then evaluates `If-Match`
+against its content hash while the client is holding Express's weak tag, so
+every conditional write answers `412`. Silently-ignored becomes
+permanently-refused.
+
+## Decision
+
+**1. `@Kavo` promotes an override's bare return to an envelope, so the route
+carries Kavo's `ETag`.** The wrapper runs on the controller instance, which
+is the one place that can see both the operation's resolved settings and the
+value actually being served. It is a no-op when the override already returns
+an engine envelope, when the operation's cardinality is `many` (a collection
+has no tag, ADR-0020), when the result is `null`/`undefined` (a void
+operation), when the controller is unbound, and when
+`caching.etag` is off for that operation.
+
+`computeEtag` is exported from `@kavo/core` for it. The barrel note held it
+back while nothing in the workspace needed it; this is the consumer ADR-0010
+asks for. What the export promises is "the tag Kavo would set for this
+representation", not the algorithm, so ADR-0020's option to supersede the
+content hash with a version column stays open.
+
+**2. `If-Match` stays the override's to forward, and is documented as
+such.** Evaluating it is engine work: it needs a canonical read of the row
+before the write, which is inside `execute`, past the point the override
+replaced. A wrapper cannot do it after the fact, and doing it before would
+mean a second read on every conditional request whether or not the override
+delegates.
+
+What changes is that **forwarding now works**. The client holds Kavo's tag
+rather than the host framework's, so the strong comparison can succeed. The
+dead end #186 hit was a consequence of decision 1 being missing, not an
+independent defect.
+
+**3. A bootstrap refusal was considered and rejected.** #186 offered it as
+the cheap option, and it is: refuse when `caching.etag` is on for an
+operation whose route is overridden. But `caching.etag` defaults to `true`
+and overriding is the documented workaround for #138, so the check would
+fire on essentially every multi-tenant application and force a config change
+to keep starting — including on overrides that already return the envelope
+and were always correct. A rule that cannot tell a correct program from an
+incorrect one is not a guard.
+
+**4. What an override inherits is stated in one table**, on `@Override`
+itself, because "it keeps the route wiring and loses the engine behavior"
+is the distinction nobody derives unprompted.
+
+## Consequences
+
+**An `@Override`'d single-item route now sets an `ETag` where it previously
+set none**, or where the host framework's weak tag stood in. Conditional
+reads against those routes start answering with a strong tag; a client that
+cached the framework's weak tag revalidates once and gets a `200`.
+
+**A reshaping override still cannot use `If-Match`.** The tag on the way out
+describes what the override served; the check on the way in compares against
+what `findOne` would serve. If those differ, every conditional write is a
+`412`. That is the honest outcome — a precondition on a representation the
+engine cannot reconstruct is not a precondition — and it is documented on
+`@Override` with the two ways out: serve the canonical shape, or turn
+`caching.etag` off for the operation and own the concurrency control.
+
+**One existing test changed.** `caching.e2e.spec.ts` asserted that an
+override dropping its `preconditions` parameter served no `ETag`. That was
+true of the framework and false of the wire, since the suite turns Express's
+own tag off; with it on, the route served a weak tag and looked protected.
+The test now asserts Kavo's tag shape, and a new one runs with Express's tag
+enabled — the configuration #186 actually hit, and the one the rest of the
+file could not see.
+
+**"An ETag exists" is not a test.** #186 was caught only because the
+assertion was written against Kavo's documented tag shape
+(`/^"[0-9a-f]{64}"$/`) rather than against the header's presence. The tests
+added here keep that standard.
+
+## References
+
+- #186, and the application that found it.
+- ADR-0020 (content-hash ETags and `If-Match`), whose guarantees this
+  restores on overridden routes.
+- #138, on why so many routes are overridden in the first place.
+- ADR-0012 (routes are generated at decoration time), which is why the
+  wrapper is applied by `@Kavo` rather than resolved per request.

--- a/docs/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition.md
+++ b/docs/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition.md
@@ -64,7 +64,50 @@ operation), when the controller is unbound, and when
 back while nothing in the workspace needed it; this is the consumer ADR-0010
 asks for. What the export promises is "the tag Kavo would set for this
 representation", not the algorithm, so ADR-0020's option to supersede the
-content hash with a version column stays open.
+content hash with a version column stays open. **This ADR amends ADR-0020**,
+whose point 7 states the opposite rule and whose consequences give a second,
+separate reason for keeping `computeEtag` off the barrel; the amendment is
+recorded there.
+
+**1a. Replacing the method copies its metadata, or the promotion is a
+security regression.** Nest keys method-level metadata on the **function
+object** — `SetMetadata`, `UseGuards`, `UseInterceptors`, `UseFilters`,
+`UsePipes`, `Version`, `Header` and every `@nestjs/swagger` method decorator
+all write to `descriptor.value`, and `PathsExplorer` reflects off whatever
+function is on the prototype at scan time. Method decorators run before the
+`@Kavo` class decorator, so a bare swap drops everything the application
+attached.
+
+Measured, against this repo's Nest: an `@Override` carrying
+`@UseGuards(DenyGuard)` went from `403` to `200`, and `Reflector.get("roles",
+handler)` from `["admin"]` to `undefined`. Overriding is the documented
+answer to row scoping having no seam (#138), so overridden routes are
+precisely the ones carrying an app's authorization — the fix would have
+introduced a worse bug than the one it closed. `applyOverrideEtag` copies
+every metadata key onto the replacement before the route decorators run,
+which is what `RouterExplorer.copyMetadataToCallback` does, and the order
+matters: copying first lets Kavo's own `UseInterceptors` append rather than
+overwrite, so `KavoResponseInterceptor` stays innermost.
+
+**1b. Values Nest resolves after the handler returns are not promoted.**
+`InterceptorsConsumer.transformDeferred` flattens a handler result that _is_
+a Promise or an Observable; one nested a level down inside an envelope is
+flattened by nothing, and the body ships as `{}`. So an `Observable` return
+is passed through untouched — this is the one way the promotion could break
+a working route outright. `StreamableFile` is passed through for a milder
+reason: it would survive, but hashing a file handle's internals is
+meaningless work and a plausible cycle for `canonicalize`, which has no cycle
+guard.
+
+**1c. `If-None-Match` becomes the host framework's answer, not Kavo's.** The
+promotion reports `notModified: false`, because it never saw the request's
+preconditions. Express then answers `304` anyway — `req.fresh` reads the
+`ETag` header this now sets, independently of the app's own `etag` setting —
+so an overridden read gains conditional-read behaviour it did not have, from
+the host rather than from the engine, and another adapter may not do the
+same. That is a real asymmetry and it is documented on `@Override` rather
+than papered over. An override that wants the `304` to be Kavo's answer
+returns `service.engine.execute(...)`.
 
 **2. `If-Match` stays the override's to forward, and is documented as
 such.** Evaluating it is engine work: it needs a canonical read of the row

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -317,10 +317,23 @@ Two pieces, both applied programmatically at decoration time:
   needs no DI registration. It sets the `ETag` header from the
   envelope, turns `notModified` into a bodyless `304`, and unwraps to
   `item`/`list` — being the innermost interceptor, nothing downstream
-  ever sees the envelope. It acts only on an engine envelope, so an
-  override returning its own value is untouched; an override returning
-  `service.engine.execute(...)` gets the identical treatment rather
-  than silently losing the header.
+  ever sees the envelope. It acts only on an engine envelope, and an
+  `@Override` reaches it holding one either way: `applyOverrideEtag`
+  runs first and promotes a bare return into an envelope carrying the
+  tag ([ADR-0027](/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition)).
+  What an override returning `service.engine.execute(...)` additionally
+  gets is the `304`, since `notModified` is the engine's answer against
+  the request's own `If-None-Match`.
+- **`applyOverrideEtag`** (`kavo.decorator.ts`), applied only on the
+  `@Override` path and only for `cardinality: "one"`. It replaces the
+  method with one that awaits the original and, unless the result is
+  already an envelope, is `null`/`undefined`, is an `Observable` or a
+  `StreamableFile`, or the operation has `caching.etag` off, returns a
+  `KavoResponse` carrying `computeEtag(result)`. It **copies every
+  `Reflect` metadata key from the original onto the replacement** —
+  Nest keys method metadata on the function object, so without that an
+  `@Override` carrying `@UseGuards` or a `SetMetadata`-based decorator
+  would be routed with it silently dropped.
 
 `If-Match` enforcement is the engine's, not the binding's, so a method
 that replaces a generated one bypasses it — `@Override`'d or plain

--- a/docs/using-the-api.md
+++ b/docs/using-the-api.md
@@ -262,7 +262,9 @@ Kavo refuses rather than quietly proceeds. A `412 KAVO_PRECONDITION_UNSUPPORTED`
 
 `If-Match` on a `GET` is the one case Kavo ignores instead of refusing: a read cannot overwrite anything, and `If-None-Match` above is the read-side conditional.
 
-**A hand-written or `@Override`'d route enforces nothing by itself.** The check runs inside Kavo's engine, so a controller method you wrote replaces it along with everything else — it receives the `If-Match` tokens as its last parameter and must pass them on (`this.base.updateOne(id, data, { preconditions })`) for the guard to apply. See [`caching`](/integrations/nest/configuration#caching).
+**A hand-written or `@Override`'d route enforces nothing by itself.** The check runs inside Kavo's engine, so a controller method you wrote replaces it — it receives the `If-Match` tokens as its last parameter and must pass them on (`this.base.updateOne(id, data, { preconditions })`) for the guard to apply.
+
+The `ETag` is the exception: an `@Override` on a single-item operation gets it without asking, because `@Kavo` hashes whatever the method returns. A plain hand-written route (no `@Override`) is outside that and carries no Kavo tag at all. See [`caching`](/integrations/nest/configuration#caching).
 
 ### Two things to know
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,12 +117,17 @@ export type { KavoRequest } from "./context/kavo-request.js";
 export type { KavoResponse } from "./context/kavo-response.js";
 
 // ── HTTP caching (ADR-0020) ───────────────────────────────────────────
-// The *type* only. `computeEtag` stays internal on purpose: exporting it
-// would make "SHA-256 of the canonicalized representation" a public
-// promise, and ADR-0020's own consequences say a version-column scheme may
-// supersede it. Nothing in the workspace needs it — `@kavo/nest` consumes
-// the tag off `KavoResponse` — so the barrel keeps to what has a consumer
-// (ADR-0010).
+// `computeEtag` was held back while nothing in the workspace needed it —
+// `@kavo/nest` read the tag off `KavoResponse` and that was enough. It is
+// no longer enough: an `@Override`'d route that returns the typed service's
+// unwrapped item has no envelope to read a tag from, so the binding has to
+// compute one itself or let the host framework's weak default stand in for
+// Kavo's (ADR-0027). That is a consumer, which is the bar ADR-0010 sets.
+//
+// What the export promises is "the tag Kavo would set for this
+// representation", not the algorithm behind it — so ADR-0020's option to
+// supersede the content hash with a version column stays open.
+export { computeEtag } from "./caching/etag.js";
 export type { RequestPreconditions } from "./caching/etag.js";
 
 // ── Serialization ─────────────────────────────────────────────────────

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -204,6 +204,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "assertNever",
   "builtInHandlers",
   "builtInPaginationStrategies",
+  "computeEtag",
   "createCrud",
   "createKavoContext",
   "createKavo",

--- a/packages/frameworks/nest/src/kavo-response.interceptor.ts
+++ b/packages/frameworks/nest/src/kavo-response.interceptor.ts
@@ -24,10 +24,13 @@ const NOT_MODIFIED = 304;
  *
  * Applied method-scoped, by `@Kavo`, to every method it routes —
  * generated and `@Override`'d alike. It acts only on an engine envelope
- * (`isKavoResponse`), so an override returning its own value is left
- * untouched, while one returning `service.engine.execute(...)` gets the
- * identical `ETag`/`304` treatment instead of silently losing it. Being
- * the innermost interceptor, it unwraps before any controller- or
+ * (`isKavoResponse`), and an override reaches it holding one either way:
+ * `applyOverrideEtag` promotes a bare return into an envelope carrying the
+ * tag before this runs (ADR-0027). What an override returning
+ * `service.engine.execute(...)` gets that a bare return does not is the
+ * `304`, since `notModified` is the engine's answer against the request's
+ * own `If-None-Match` and the promotion has no preconditions to consult.
+ * Being the innermost interceptor, it unwraps before any controller- or
  * app-level interceptor sees the result, so nothing downstream ever meets
  * the envelope.
  *
@@ -61,7 +64,18 @@ function unwrap(context: ExecutionContext, value: unknown): unknown {
   return value.list ?? value.item;
 }
 
-function isKavoResponse(value: unknown): value is KavoResponse {
+/**
+ * Whether a handler's return value is an engine envelope.
+ *
+ * Exported because `@Kavo` needs the same question answered before it
+ * promotes a bare `@Override` return (ADR-0027), and two copies with
+ * different key sets would drift: the looser one would treat a value as an
+ * envelope, skip the promotion, and then this one would pass the raw object
+ * through as the response body, envelope keys and all.
+ *
+ * @internal
+ */
+export function isKavoResponse(value: unknown): value is KavoResponse {
   return (
     typeof value === "object" &&
     value !== null &&

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -1,4 +1,18 @@
-import { Body, Delete, Get, HttpCode, Param, Patch, Post, Put, Query, Req, UseInterceptors } from "@nestjs/common";
+import {
+  Body,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Query,
+  Req,
+  StreamableFile,
+  UseInterceptors,
+} from "@nestjs/common";
+import { isObservable } from "rxjs";
 import type {
   ClassRef,
   DefaultKavoService,
@@ -18,7 +32,7 @@ import type { KavoHttpMethod, KavoRouteOptions } from "./operation-metadata.js";
 import type { OverrideMetadata } from "./override.decorator.js";
 import type { KavoPrincipalExtractor, KavoPrincipalRequest } from "./principal.js";
 import { ConditionalRequest } from "./conditional-request.decorator.js";
-import { KavoResponseInterceptor } from "./kavo-response.interceptor.js";
+import { KavoResponseInterceptor, isKavoResponse } from "./kavo-response.interceptor.js";
 import {
   KAVO_CONTROLLER_METADATA,
   KAVO_OVERRIDE_METADATA,
@@ -159,7 +173,7 @@ interface ResolvedRoute {
  * `service.<op>(…, { preconditions })` on the typed surface or by
  * returning `service.engine.execute({ …, preconditions })`.
  *
- * The `ETag` half is *not* the method's to arrange: `wrapOverrideForEtag`
+ * The `ETag` half is *not* the method's to arrange: `applyOverrideEtag`
  * hashes a bare return, so an override delegating to the typed service
  * still serves the tag a generated route would (ADR-0027). Before that,
  * the header simply went missing and the host framework's own weak tag
@@ -247,7 +261,7 @@ export function Kavo<
         applySwaggerMetadata(controller.prototype, methodName, descriptor, route, entity, erasedConfig);
       } else {
         assertNoOwnParamMetadata(controller.prototype, overrideMethodName, entity.name, descriptor.id);
-        wrapOverrideForEtag(controller.prototype, overrideMethodName, descriptor);
+        applyOverrideEtag(controller.prototype, overrideMethodName, descriptor);
         applyRouteDecorators(controller.prototype, overrideMethodName, descriptor, route);
         applySwaggerMetadata(controller.prototype, overrideMethodName, descriptor, route, entity, erasedConfig);
       }
@@ -324,7 +338,7 @@ function collectOverrides(
  * equal the engine's content hash, so forwarding turned a silent no-op into
  * a permanent `412`.
  */
-function wrapOverrideForEtag(
+function applyOverrideEtag(
   prototype: Record<string, unknown>,
   methodName: string,
   descriptor: OperationDescriptor<object>,
@@ -333,11 +347,21 @@ function wrapOverrideForEtag(
   // pagination, sort and filter, which ADR-0020 leaves out of scope.
   if (descriptor.cardinality === "many") return;
   const original = prototype[methodName] as (this: unknown, ...args: unknown[]) => unknown;
-  async function wrapped(this: Partial<BoundController>, ...args: unknown[]): Promise<unknown> {
+  async function promoted(this: Partial<BoundController>, ...args: unknown[]): Promise<unknown> {
     const result = (await original.apply(this, args)) as unknown;
     // An envelope is already tagged; `null`/`undefined` is a void operation
     // (`deleteOne`), which has no representation to hash.
     if (result === null || result === undefined || isKavoResponse(result)) return result;
+    // Values Nest resolves *after* the handler returns. Wrapping an
+    // Observable in an envelope is the one way this function can break a
+    // working route outright: `InterceptorsConsumer.transformDeferred`
+    // flattens a handler result that *is* a Promise or an Observable, and an
+    // Observable nested one level down inside a plain object is not
+    // flattened by anything — the body ships as `{}`. `StreamableFile`
+    // survives the round trip but would be hashed, which is meaningless work
+    // over a file handle's internals and a plausible cycle for
+    // `canonicalize`. Neither is a representation, so neither is tagged.
+    if (isObservable(result) || result instanceof StreamableFile) return result;
     const service = this[KAVO_SERVICE_PROPERTY];
     // Unbound (a controller outside `KavoModule`'s discovery) means there
     // is no config to consult, and guessing `etag: true` would add a header
@@ -352,17 +376,44 @@ function wrapOverrideForEtag(
       // `If-None-Match` is answered by the engine against its own
       // representation. This wrapper never saw the request's preconditions
       // — they went to the override — so it reports the tag and nothing more.
+      // The host framework may still answer `304` off the header this sets;
+      // ADR-0027 records that as the deliberate limit.
       notModified: false,
     } satisfies KavoResponse;
   }
-  Object.defineProperty(wrapped, "name", { value: methodName });
-  Object.defineProperty(prototype, methodName, { value: wrapped, writable: true, configurable: true });
+  Object.defineProperty(promoted, "name", { value: methodName });
+  copyFunctionMetadata(original, promoted);
+  Object.defineProperty(prototype, methodName, { value: promoted, writable: true, configurable: true });
 }
 
-function isKavoResponse(value: unknown): boolean {
-  return (
-    typeof value === "object" && value !== null && "operation" in value && "etag" in value && "notModified" in value
-  );
+/**
+ * Move every `Reflect` metadata key from the original method to the
+ * replacement, which is what makes replacing it safe.
+ *
+ * Nest keys method-level metadata on the **function object**, not on the
+ * prototype-and-name pair: `SetMetadata` writes to `descriptor.value`, and so
+ * do `UseGuards`, `UseInterceptors`, `UseFilters`, `UsePipes`, `Version`,
+ * `Header`, `Sse` and every `@nestjs/swagger` method decorator. The read side
+ * matches — `PathsExplorer` takes `instance[methodName]` and reflects off
+ * whatever function is there now.
+ *
+ * Method decorators run at class-definition time, before the `@Kavo` class
+ * decorator, so an app's metadata is already on the original. Swapping in a
+ * bare function drops all of it, and the failure is silent and severe: an
+ * `@Override` carrying `@UseGuards(TenantGuard)` — which is exactly the
+ * shape #186's own reproduction describes, since overriding is the
+ * documented workaround for row scoping having no seam (#138) — would serve
+ * the route with its guard removed.
+ *
+ * This is `RouterExplorer.copyMetadataToCallback`'s approach, and the call
+ * order around it matters: copying *before* `applyRouteDecorators` means
+ * Kavo's own `UseInterceptors` appends onto the copied array through
+ * `extendArrayMetadata`, so `KavoResponseInterceptor` stays innermost.
+ */
+function copyFunctionMetadata(from: object, to: object): void {
+  for (const key of Reflect.getMetadataKeys(from)) {
+    Reflect.defineMetadata(key, Reflect.getMetadata(key, from) as unknown, to);
+  }
 }
 
 /**
@@ -440,12 +491,13 @@ function applyRouteDecorators(
   // The envelope unwrap / `ETag` / `304` interceptor (ADR-0020), applied
   // to **both** paths. On a generated handler it is the only thing that
   // turns the engine's `KavoResponse` into an HTTP response. On an
-  // `@Override`'d one it is a no-op unless that method returns an engine
-  // envelope of its own — `isKavoResponse` guards it — which is exactly
-  // how an override opts back in to the header: return
-  // `service.engine.execute(...)` rather than the typed service's
-  // unwrapped item. An *instance* rather than a class, so it needs no DI
-  // registration in whatever module the controller ends up in.
+  // `@Override`'d one it sees an envelope either way, because
+  // `applyOverrideEtag` ran first and promoted a bare return into one
+  // (ADR-0027) — so the `ETag` is set on both paths, and the `304` is not,
+  // since only an override returning `service.engine.execute(...)` carries a
+  // `notModified` the engine actually computed. An *instance* rather than a
+  // class, so it needs no DI registration in whatever module the controller
+  // ends up in.
   UseInterceptors(new KavoResponseInterceptor())(prototype, methodName, propertyDescriptor);
 }
 

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -5,6 +5,7 @@ import type {
   EntityConfig,
   EntityInput,
   KavoCallOptions,
+  KavoResponse,
   OperationDescriptor,
   OperationId,
   OperationsConfig,
@@ -12,7 +13,7 @@ import type {
   RequestPreconditions,
   StandardOperationId,
 } from "@kavo/core";
-import { ConfigurationException, createOperationRegistry } from "@kavo/core";
+import { ConfigurationException, computeEtag, createOperationRegistry } from "@kavo/core";
 import type { KavoHttpMethod, KavoRouteOptions } from "./operation-metadata.js";
 import type { OverrideMetadata } from "./override.decorator.js";
 import type { KavoPrincipalExtractor, KavoPrincipalRequest } from "./principal.js";
@@ -147,7 +148,7 @@ interface ResolvedRoute {
  * function backing it changes — resolved first, ahead of manual-method-wins,
  * so a decorated method never falls through to plain name-matching.
  *
- * **A replaced method owns its own conditional-request handling.** Kavo
+ * **A replaced method owns the precondition, but not the `ETag`.** Kavo
  * enforces `If-Match` inside the engine (ADR-0020), so a method that does
  * not reach the engine cannot have it enforced for it: a hand-written or
  * `@Override`'d `updateOne` that ignores its `preconditions` parameter
@@ -156,8 +157,14 @@ interface ResolvedRoute {
  * `ConditionalRequest` parameter is applied to overrides too, so the
  * tokens are handed to the method. Forward them, either as
  * `service.<op>(…, { preconditions })` on the typed surface or by
- * returning `service.engine.execute({ …, preconditions })`, which
- * additionally puts the `ETag` back on the response. The same goes for the
+ * returning `service.engine.execute({ …, preconditions })`.
+ *
+ * The `ETag` half is *not* the method's to arrange: `wrapOverrideForEtag`
+ * hashes a bare return, so an override delegating to the typed service
+ * still serves the tag a generated route would (ADR-0027). Before that,
+ * the header simply went missing and the host framework's own weak tag
+ * stood in for it — which looked like working conditional requests and
+ * guarded nothing (#186). The same goes for the
  * principal: a generated route resolves it from the module's `principal`
  * extractor per request, a replaced method must pass it on itself, and
  * `boundKavoPrincipal(this, request)` is how it reaches the extractor the
@@ -240,6 +247,7 @@ export function Kavo<
         applySwaggerMetadata(controller.prototype, methodName, descriptor, route, entity, erasedConfig);
       } else {
         assertNoOwnParamMetadata(controller.prototype, overrideMethodName, entity.name, descriptor.id);
+        wrapOverrideForEtag(controller.prototype, overrideMethodName, descriptor);
         applyRouteDecorators(controller.prototype, overrideMethodName, descriptor, route);
         applySwaggerMetadata(controller.prototype, overrideMethodName, descriptor, route, entity, erasedConfig);
       }
@@ -285,6 +293,76 @@ function collectOverrides(
     }
   }
   return overrides;
+}
+
+/**
+ * Gives an `@Override`'d single-item route the `ETag` a generated one
+ * carries (ADR-0027).
+ *
+ * The interceptor that sets the header only acts on an engine envelope, and
+ * the natural way to write an override is to delegate to the typed service
+ * — `this.base.patchOne(id, body, { principal })` — which discards the
+ * envelope by design. So the override returned a bare item, the interceptor
+ * left it alone, and **the host framework filled in its own weak tag**.
+ * Express's default is convincing: reads carry an `ETag`, `If-None-Match`
+ * answers `304`, and the tag changes when the body does. Three of the four
+ * observable behaviours are right. The missing one is the `412`, which is
+ * the only one that protects data, so an application checking "do
+ * conditional requests work?" by hand saw them pass while every `If-Match`
+ * write was a silent lost update (#186).
+ *
+ * Promoting a bare return to an envelope here fixes that at the one point
+ * that can see both the operation's config and the value actually being
+ * served. An override that already returns `service.engine.execute(...)` is
+ * untouched, and so is one on a `many` operation, since a collection has no
+ * ETag (ADR-0020).
+ *
+ * **What this does not do is evaluate `If-Match`.** That happens inside the
+ * engine, against a canonical read, and only when the override forwards its
+ * `preconditions` parameter. What changes is that forwarding now *works*:
+ * previously the client held the host framework's tag, which could never
+ * equal the engine's content hash, so forwarding turned a silent no-op into
+ * a permanent `412`.
+ */
+function wrapOverrideForEtag(
+  prototype: Record<string, unknown>,
+  methodName: string,
+  descriptor: OperationDescriptor<object>,
+): void {
+  // A collection response has no tag to give: a list's identity spans
+  // pagination, sort and filter, which ADR-0020 leaves out of scope.
+  if (descriptor.cardinality === "many") return;
+  const original = prototype[methodName] as (this: unknown, ...args: unknown[]) => unknown;
+  async function wrapped(this: Partial<BoundController>, ...args: unknown[]): Promise<unknown> {
+    const result = (await original.apply(this, args)) as unknown;
+    // An envelope is already tagged; `null`/`undefined` is a void operation
+    // (`deleteOne`), which has no representation to hash.
+    if (result === null || result === undefined || isKavoResponse(result)) return result;
+    const service = this[KAVO_SERVICE_PROPERTY];
+    // Unbound (a controller outside `KavoModule`'s discovery) means there
+    // is no config to consult, and guessing `etag: true` would add a header
+    // the app may have turned off. Leave it exactly as the override wrote it.
+    if (service === undefined) return result;
+    if (!service.engine.config.settingsFor(descriptor.id).caching.etag) return result;
+    return {
+      operation: descriptor.id,
+      item: result,
+      list: null,
+      etag: await computeEtag(result),
+      // `If-None-Match` is answered by the engine against its own
+      // representation. This wrapper never saw the request's preconditions
+      // — they went to the override — so it reports the tag and nothing more.
+      notModified: false,
+    } satisfies KavoResponse;
+  }
+  Object.defineProperty(wrapped, "name", { value: methodName });
+  Object.defineProperty(prototype, methodName, { value: wrapped, writable: true, configurable: true });
+}
+
+function isKavoResponse(value: unknown): boolean {
+  return (
+    typeof value === "object" && value !== null && "operation" in value && "etag" in value && "notModified" in value
+  );
 }
 
 /**

--- a/packages/frameworks/nest/src/override.decorator.ts
+++ b/packages/frameworks/nest/src/override.decorator.ts
@@ -42,6 +42,52 @@ export interface OverrideMetadata {
  * }
  * ```
  *
+ * ## What an override inherits, and what it does not
+ *
+ * Everything about the *route* is inherited by construction — method, path,
+ * success status, param wiring, Swagger metadata — because both paths go
+ * through the same `applyRouteDecorators` call. What is not inherited is
+ * anything the **engine** does, because the override is what replaced the
+ * call into it:
+ *
+ * | Behavior                    | Inherited | Why                                                                       |
+ * | --------------------------- | --------- | ------------------------------------------------------------------------- |
+ * | Route, params, Swagger      | yes       | same wiring as a generated route                                          |
+ * | `ETag` on a single item     | yes       | supplied for a bare return by `@Kavo` (ADR-0027)                          |
+ * | `If-Match` → `412`          | **no**    | evaluated in the engine; reaches it only if you forward `preconditions`   |
+ * | `If-None-Match` → `304`     | **no**    | same                                                                      |
+ * | Row scoping, auth           | n/a       | never Kavo's; that is why you are overriding                              |
+ *
+ * So an override that only needs the tag can ignore all of this: return the
+ * typed service's item and `@Kavo` hashes it. One that needs the
+ * **precondition** must pass `preconditions` on, which reaches the engine
+ * either through `KavoCallOptions` or by calling `execute` directly:
+ *
+ * ```ts
+ * @Override()
+ * async updateOne(id: EntityId, body: Partial<Todo>, preconditions: RequestPreconditions | null) {
+ *   return this.base.engine.execute({
+ *     operation: "updateOne",
+ *     id,
+ *     body: body as never,
+ *     query: null,
+ *     options: null,
+ *     preconditions,
+ *   });
+ * }
+ * ```
+ *
+ * That form returns the engine envelope, which `KavoResponseInterceptor`
+ * unwraps and tags exactly as it would a generated route's.
+ *
+ * One caveat worth knowing before relying on `If-Match` from an override:
+ * the engine evaluates it against a **canonical read** — what `findOne`
+ * would serve for that id — so an override that serves a *reshaped*
+ * representation hands the client a tag the check can never match, and
+ * every conditional write answers `412`. Serve the canonical shape, or set
+ * `caching: { etag: false }` for that operation and own the concurrency
+ * control yourself.
+ *
  * Distinct from plain manual-method-wins: an undecorated method whose name
  * matches an operation id suppresses that route entirely — no method/path/
  * status/Swagger wiring happens for it. `@Override` keeps all of that,

--- a/packages/frameworks/nest/src/override.decorator.ts
+++ b/packages/frameworks/nest/src/override.decorator.ts
@@ -54,9 +54,18 @@ export interface OverrideMetadata {
  * | --------------------------- | --------- | ------------------------------------------------------------------------- |
  * | Route, params, Swagger      | yes       | same wiring as a generated route                                          |
  * | `ETag` on a single item     | yes       | supplied for a bare return by `@Kavo` (ADR-0027)                          |
+ * | Method decorators you added | yes       | `@UseGuards`, `@SetMetadata`, `@Version`, … are copied onto the wrapper   |
  * | `If-Match` → `412`          | **no**    | evaluated in the engine; reaches it only if you forward `preconditions`   |
- * | `If-None-Match` → `304`     | **no**    | same                                                                      |
+ * | `If-None-Match` → `304`     | not Kavo's | the host framework answers it off the tag above; see below               |
  * | Row scoping, auth           | n/a       | never Kavo's; that is why you are overriding                              |
+ *
+ * The `304` row is the one worth reading twice. Kavo reports
+ * `notModified: false` for a promoted return, because the promotion never
+ * saw the request's `If-None-Match` — those went to your method. Express
+ * then answers `304` anyway, from `req.fresh`, because a strong `ETag` is
+ * now on the response; another adapter may not. If you need the `304` to be
+ * Kavo's answer rather than the host's, return `service.engine.execute(...)`
+ * so the engine evaluates the precondition itself.
  *
  * So an override that only needs the tag can ignore all of this: return the
  * typed service's item and `@Kavo` hashes it. One that needs the

--- a/packages/frameworks/nest/tests/caching.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/caching.e2e.spec.ts
@@ -1,8 +1,17 @@
 import "reflect-metadata";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import request from "supertest";
-import { Controller, Inject, type INestApplication } from "@nestjs/common";
+import {
+  type CanActivate,
+  Controller,
+  Inject,
+  Injectable,
+  SetMetadata,
+  UseGuards,
+  type INestApplication,
+} from "@nestjs/common";
 import { Test } from "@nestjs/testing";
+import { from, type Observable } from "rxjs";
 import type { DefaultKavoService, RequestPreconditions } from "@kavo/core";
 import type { KavoModuleOptions } from "@kavo/nest";
 import { Kavo, KavoModule, Override, getKavoServiceToken, parseEntityTags } from "@kavo/nest";
@@ -347,6 +356,18 @@ describe("If-Match through a replaced controller method", () => {
   class ForwardingTodoController {
     constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
 
+    /**
+     * The read has to be overridden too, or the round-trip test below is
+     * reading a *generated* route's tag and proving nothing new — which is
+     * what it did when first written. #186's shape is every route
+     * overridden, so the tag the client holds must come from the override
+     * path for the test to mean anything.
+     */
+    @Override()
+    async findOne(id: string, query: unknown): Promise<unknown> {
+      return this.base.findOne(id as never, query as never);
+    }
+
     @Override()
     async updateOne(id: string, body: Partial<Todo>, preconditions: RequestPreconditions | null): Promise<unknown> {
       return this.base.engine.execute({
@@ -378,12 +399,11 @@ describe("If-Match through a replaced controller method", () => {
     expect(applied.headers["etag"]).toMatch(/^"[0-9a-f]{64}"$/);
   });
 
-  it("serves a tag a forwarding override will actually accept", async () => {
-    // The round trip #186 could not close. A client reads, holds the tag,
-    // and writes with it; if the read served the host framework's weak tag
-    // and the write compared against the engine's content hash, the two
-    // could never match and forwarding `preconditions` turned a silent
-    // no-op into a permanent 412.
+  it("serves a tag from an overridden read that a forwarding override then accepts", async () => {
+    // The round trip #186 could not close, and it only tests the fix
+    // because BOTH routes are overridden: the tag comes off the promoted
+    // return, not off a generated route. Pre-fix this fails on the shape
+    // assertion, since the read carried no Kavo tag at all.
     await bootstrap(ForwardingTodoController);
     await seed();
 
@@ -395,9 +415,167 @@ describe("If-Match through a replaced controller method", () => {
     expect(adapter.rows[0]).toMatchObject({ title: "accepted" });
   });
 
-  it("leaves the override's return alone when caching is off for the operation", async () => {
-    // The wrapper reads the operation's own resolved settings, so an app
-    // that turned ETags off does not get one bolted back on.
+  it("issues the same tag an unoverridden route would for the same row", async () => {
+    // Shape alone would pass for a wrapper that hashed the envelope, or the
+    // pre-serialization entity. The promise is "the same strong ETag a
+    // generated route would serve", so the two are compared directly.
+    await bootstrap(CachedTodoController);
+    const generated = await seed();
+
+    await app.close();
+    await bootstrap(ForwardingTodoController);
+    await seed();
+    const overridden = (await request(server()).get("/todos/1").expect(200)).headers["etag"];
+
+    expect(overridden).toBe(generated);
+  });
+
+  it("keeps a method-level guard on an override, which replacing the method used to drop", async () => {
+    // The regression that mattered most, and the one the rest of this suite
+    // was structurally blind to: every other @UseGuards in these tests is
+    // class-level, which is the placement that survives a prototype swap.
+    // Nest keys method metadata on the FUNCTION, so an @Override carrying
+    // @UseGuards(...) lost it — and overriding is the documented workaround
+    // for row scoping (#138), so those are exactly the routes carrying an
+    // app's authorization.
+    @Injectable()
+    class DenyGuard implements CanActivate {
+      canActivate(): boolean {
+        return false;
+      }
+    }
+
+    @Kavo(Todo)
+    @Controller("todos")
+    class GuardedTodoController {
+      constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
+
+      @Override()
+      @UseGuards(DenyGuard)
+      @SetMetadata("roles", ["admin"])
+      async findOne(id: string, query: unknown): Promise<unknown> {
+        return this.base.findOne(id as never, query as never);
+      }
+    }
+
+    await bootstrap(GuardedTodoController);
+    await seed();
+
+    await request(server()).get("/todos/1").expect(403);
+    // And the SetMetadata half, which a Reflector-based @Roles decorator
+    // reads the same way — asserted off the routed function, since that is
+    // the object Nest reflects on.
+    const routed = GuardedTodoController.prototype["findOne"] as object;
+    expect(Reflect.getMetadata("roles", routed)).toEqual(["admin"]);
+  });
+
+  it("leaves an Observable return alone rather than sealing it inside an envelope", async () => {
+    // Nest flattens a handler result that IS an Observable. One nested a
+    // level down inside an envelope is flattened by nothing, and the body
+    // ships as {} — the wrapper's one way to break a working route.
+    @Kavo(Todo)
+    @Controller("todos")
+    class StreamingTodoController {
+      constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
+
+      @Override()
+      findOne(id: string, query: unknown): Observable<unknown> {
+        return from(this.base.findOne(id as never, query as never));
+      }
+    }
+
+    await bootstrap(StreamingTodoController);
+    await seed();
+
+    const read = await request(server()).get("/todos/1").expect(200);
+    expect(read.body).toMatchObject({ title: "write docs" });
+    // No tag: an Observable is not a representation to hash.
+    expect(read.headers["etag"]).toBeUndefined();
+  });
+
+  it("sets no tag on an overridden collection read", async () => {
+    // ADR-0020 leaves collection ETags out of scope, and the wrapper's
+    // cardinality skip is what keeps that true on the override path.
+    @Kavo(Todo)
+    @Controller("todos")
+    class ListingTodoController {
+      constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
+
+      @Override()
+      async findMany(query: unknown): Promise<unknown> {
+        return this.base.findMany(query as never);
+      }
+    }
+
+    await bootstrap(ListingTodoController);
+    await seed();
+
+    expect((await request(server()).get("/todos").expect(200)).headers["etag"]).toBeUndefined();
+  });
+
+  it("sets no tag on an overridden bodyless delete", async () => {
+    @Kavo(Todo)
+    @Controller("todos")
+    class DeletingTodoController {
+      constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
+
+      @Override()
+      async deleteOne(id: string): Promise<unknown> {
+        return this.base.deleteOne(id as never);
+      }
+    }
+
+    await bootstrap(DeletingTodoController);
+    await seed();
+
+    expect((await request(server()).delete("/todos/1").expect(204)).headers["etag"]).toBeUndefined();
+  });
+
+  it("does not unwrap an override that already returns an engine envelope", async () => {
+    // The pass-through branch. Shape assertions alone would stay green if
+    // the wrapper double-wrapped, so the body is checked for envelope keys.
+    await bootstrap(ForwardingTodoController);
+    await seed();
+
+    const written = await request(server()).put("/todos/1").send({ title: "enveloped" }).expect(200);
+    expect(written.body).not.toHaveProperty("operation");
+    expect(written.body).not.toHaveProperty("notModified");
+    expect(written.body).toMatchObject({ title: "enveloped" });
+  });
+
+  it("reads caching.etag at the operation scope, not just the entity's", async () => {
+    // `settingsFor` falls back to entity settings, so configuring the
+    // entity would pass even if per-operation resolution were bypassed.
+    // One operation off and its sibling on is what actually pins it.
+    @Kavo(Todo, { operations: { updateOne: { caching: { etag: false } } } })
+    @Controller("todos")
+    class MixedTodoController {
+      constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
+
+      @Override()
+      async updateOne(id: string, body: Partial<Todo>): Promise<unknown> {
+        return this.base.updateOne(id as never, body as never);
+      }
+
+      @Override()
+      async patchOne(id: string, body: Partial<Todo>): Promise<unknown> {
+        return this.base.patchOne(id as never, body as never);
+      }
+    }
+
+    await bootstrap(MixedTodoController);
+    await seed();
+
+    expect((await request(server()).put("/todos/1").send({ title: "a" }).expect(200)).headers["etag"]).toBeUndefined();
+    expect((await request(server()).patch("/todos/1").send({ title: "b" }).expect(200)).headers["etag"]).toMatch(
+      /^"[0-9a-f]{64}"$/,
+    );
+  });
+
+  it("leaves the override's return alone when caching is off entity-wide", async () => {
+    // The entity scope, which `settingsFor` falls back to. The test above
+    // is the per-operation half; both matter because the fallback is what
+    // makes an app-wide opt-out work at all.
     @Kavo(Todo, { caching: { etag: false } })
     @Controller("todos")
     class UncachedTodoController {

--- a/packages/frameworks/nest/tests/caching.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/caching.e2e.spec.ts
@@ -129,6 +129,31 @@ describe("ETag alongside the host framework's own", () => {
 
     expect(created.headers["etag"]).toMatch(/^"[0-9a-f]{64}"$/);
   });
+
+  it("wins over Express's weak ETag on an @Override'd route too", async () => {
+    // #186's actual scenario, and the one the rest of this file could not
+    // see because it turns Express's tag off. An override delegating to the
+    // typed service used to serve no tag of its own, so Express's weak one
+    // stood in — and a weak tag can never satisfy `If-Match`, which uses the
+    // strong comparison. The route looked cached and protected nothing.
+    @Kavo(Todo)
+    @Controller("todos")
+    class DelegatingTodoController {
+      constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
+
+      @Override()
+      async findOne(id: string, query: unknown): Promise<unknown> {
+        return this.base.findOne(id as never, query as never);
+      }
+    }
+
+    await bootstrap(DelegatingTodoController, { expressEtag: true });
+    await seed();
+
+    const read = await request(server()).get("/todos/1").expect(200);
+    expect(read.headers["etag"]).toMatch(/^"[0-9a-f]{64}"$/);
+    expect(read.headers["etag"]).not.toMatch(/^W\//);
+  });
 });
 
 describe("If-None-Match → 304", () => {
@@ -335,7 +360,7 @@ describe("If-Match through a replaced controller method", () => {
     }
   }
 
-  it("drops the guard when the override drops its preconditions parameter", async () => {
+  it("drops the guard when the override drops its preconditions parameter, but keeps the ETag", async () => {
     await bootstrap(BypassingTodoController);
     await seed();
     await request(server()).patch("/todos/1").send({ priority: 5 }).expect(200);
@@ -344,8 +369,49 @@ describe("If-Match through a replaced controller method", () => {
     const applied = await request(server()).put("/todos/1").set("If-Match", '"stale"').send({ title: "overwritten" });
     expect(applied.status).toBe(200);
     expect(adapter.rows[0]).toMatchObject({ title: "overwritten" });
-    // And no ETag either: this override returns the typed service's
-    // unwrapped item, which is where the envelope's tag was discarded.
+    // The tag, though, is Kavo's (ADR-0027). This used to assert
+    // `toBeUndefined()`, which was true of the framework and false of the
+    // wire: Express filled in its own weak tag, so the route looked like it
+    // had conditional requests while every If-Match write was a silent lost
+    // update (#186). Asserting the shape is the point — "an ETag exists" is
+    // exactly the check that missed this.
+    expect(applied.headers["etag"]).toMatch(/^"[0-9a-f]{64}"$/);
+  });
+
+  it("serves a tag a forwarding override will actually accept", async () => {
+    // The round trip #186 could not close. A client reads, holds the tag,
+    // and writes with it; if the read served the host framework's weak tag
+    // and the write compared against the engine's content hash, the two
+    // could never match and forwarding `preconditions` turned a silent
+    // no-op into a permanent 412.
+    await bootstrap(ForwardingTodoController);
+    await seed();
+
+    const read = await request(server()).get("/todos/1").expect(200);
+    const tag = read.headers["etag"] as string;
+    expect(tag).toMatch(/^"[0-9a-f]{64}"$/);
+
+    await request(server()).put("/todos/1").set("If-Match", tag).send({ title: "accepted" }).expect(200);
+    expect(adapter.rows[0]).toMatchObject({ title: "accepted" });
+  });
+
+  it("leaves the override's return alone when caching is off for the operation", async () => {
+    // The wrapper reads the operation's own resolved settings, so an app
+    // that turned ETags off does not get one bolted back on.
+    @Kavo(Todo, { caching: { etag: false } })
+    @Controller("todos")
+    class UncachedTodoController {
+      constructor(@Inject(getKavoServiceToken(Todo)) private readonly base: DefaultKavoService<Todo>) {}
+
+      @Override()
+      async updateOne(id: string, body: Partial<Todo>): Promise<unknown> {
+        return this.base.updateOne(id as never, body as never);
+      }
+    }
+
+    await bootstrap(UncachedTodoController);
+    await seed();
+    const applied = await request(server()).put("/todos/1").send({ title: "no tag" }).expect(200);
     expect(applied.headers["etag"]).toBeUndefined();
   });
 


### PR DESCRIPTION
Closes #186.

`KavoResponseInterceptor` acts only on an engine envelope, so an override returning its own value is left alone. That guard was meant to be permissive and was the bug, because the natural way to write an override is to delegate to the typed service:

```ts
return this.base.patchOne(id, body, { principal });
```

`DefaultKavoService` is `execute` plus an unwrap, and the unwrap discards the envelope — that is its purpose. So the override returned a bare item, the interceptor saw no envelope, and the route set no `ETag`.

**The host framework then filled one in, and that is what made it dangerous.** Express's weak tag gives reads an `ETag`, answers `If-None-Match` with a `304`, and changes when the body changes. Three of the four observable behaviours are right. The missing one is the `412`, and it is the only one that protects data — so a route looked fully conditional while every `If-Match` write was a silent lost update.

Not exotic, either: overriding is the documented answer to row scoping having no seam (#138), so taking the recommended workaround for one gap silently disabled a shipped feature across every entity of the application that found this.

## What changes

`@Kavo` promotes an override's bare return to an envelope carrying Kavo's tag. The wrapper runs on the controller instance — the one place that can see both the operation's resolved settings and the value actually being served — and is a no-op for:

- a return that is already an engine envelope;
- a `many`-cardinality operation (a collection has no tag, ADR-0020);
- a `null`/`undefined` result (a void operation);
- an unbound controller (no config to consult, and guessing `etag: true` would add a header the app may have turned off);
- an operation with `caching.etag` off.

`computeEtag` is exported from `@kavo/core` for it. The barrel note held it back while nothing in the workspace needed it; this is the consumer ADR-0010 asks for, and the export promises "the tag Kavo would set for this representation", not the algorithm, so ADR-0020's option to supersede the content hash with a version column stays open.

## What stays the override's job

**`If-Match` is still only enforced if the method forwards `preconditions`.** Evaluating it needs a canonical read from inside `execute`, past the point the override replaced; a wrapper cannot do it after the fact, and doing it before would mean a second read on every conditional request whether or not the override delegates.

What changes is that **forwarding now works**. The dead end #186 documented — forwarding `preconditions` turned a silent no-op into a permanent `412` — was a consequence of the client holding the framework's weak tag, which can never satisfy the strong comparison. It was not an independent defect.

## The option I rejected

#186 offered a bootstrap refusal as the cheap fix ("the second alone would have saved this"), and it cannot ship. `caching.etag` defaults to `true` and overriding is the documented workaround for #138, so the check would fire on essentially every multi-tenant application and force a config change to keep starting — including on overrides that already return the envelope and were always correct. A rule that cannot tell a correct program from an incorrect one is not a guard. Recorded in the ADR rather than left unsaid.

## The limit that survives

The engine compares `If-Match` against what `findOne` would serve for that id, so an override serving a **reshaped** representation hands out a tag the check can never match, and every conditional write answers `412`. That is the honest outcome — a precondition on a representation the engine cannot reconstruct is not a precondition — and it is documented on `@Override` with the two ways out: serve the canonical shape, or set `caching: { etag: false }` for that operation and own the concurrency control.

## Tests

One existing test changed rather than being weakened. `caching.e2e.spec.ts` asserted an override dropping its `preconditions` parameter served no `ETag`. That was true of the framework and false of the wire: the suite turns Express's own tag off, so it could not see the substitution. It now asserts Kavo's tag shape, and three tests are added:

- the same route under `expressEtag: true` — the configuration #186 actually hit — asserting a strong 64-hex tag and no `W/` prefix;
- the round trip the issue could not close: read the tag, write with it, `200`;
- `caching: { etag: false }` on the operation, asserting no tag is bolted back on.

**"An ETag exists" is not a test.** #186 was caught only because the assertion was written against Kavo's documented shape (`/^"[0-9a-f]{64}"$/`). The new tests keep that standard.

## Gate

`pnpm check` green: 2231 passed, 2 skipped, no dependency violations. `pnpm docs:links`, `pnpm docs:build` and `pnpm format:check` all pass.
