### PR TITLE
fix(core): refuse a custom operation result the entity projection empties

### DIFF
--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -390,6 +390,22 @@ Worth knowing before you reach for one:
 - **Custom routes are matched first.** Custom entries are registered ahead of the standard table, so `GET /orders/pending` reaches its own handler rather than `GET /orders/:id`. The flip side is that a custom entry whose `meta.routes` reproduces a standard route's shape takes that route.
 - **The handler is built at decoration time** ([ADR-0012](/internals/adr/0012-decoration-time-route-generation)), like everything else in a `@Kavo` config, so it is a plain object with nothing in scope but its arguments. Data access comes from `context.repository` (above), and anything else it needs has to be reachable from module scope.
 - **`If-Match` is refused, not ignored.** Nothing in the schema says which row a custom operation targets, so a conditional request against one answers `412 KAVO_PRECONDITION_UNSUPPORTED` rather than writing unguarded ([ADR-0020](/internals/adr/0020-content-hash-etags-and-the-engine-read-seam)).
+- **The result is projected through the entity, unless you say otherwise.** A custom operation goes through the whole pipeline, and that includes serialization: with no `dto.output`, the handler's return value is filtered to the entity's columns plus its computed fields, exactly as a `findOne` response would be. A result that is a narrower entity shape is served as-is. A result with its **own** shape needs a DTO:
+
+  ```ts
+  class ImportOutcomeDto {
+    applied = 0;
+    skus: string[] = [];
+  }
+
+  operations: {
+    importPricesMany: { handler, dto: { output: ImportOutcomeDto } },
+  }
+  ```
+
+  Every field needs a runtime initializer, since an uninitialized class field erases and the class then narrows nothing. A result sharing **no** field with the entity used to serialize to `{}` in silence; since v0.9 it raises `KAVO_CONFIG_INVALID` naming the operation and pointing here.
+
+- **The route defaults to `POST` and `201`.** A custom id is absent from the standard route table, so it falls back to `POST /<controller>/<operation id>` with a `201` — a custom operation is a write against the collection until its `meta.routes` says otherwise. A read that returns an existing row almost certainly wants `meta: { routes: { method: "GET", path: ":id/summary", successStatus: 200 } }`.
 
 Custom operations are a REST and programmatic feature only: the GraphQL and MCP bindings expose the standard operations.
 

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -399,11 +399,17 @@ Worth knowing before you reach for one:
   }
 
   operations: {
-    importPricesMany: { handler, dto: { output: ImportOutcomeDto } },
+    // `One`, not `Many`: cardinality names the *response*, and this one
+    // answers with a single outcome however many rows it wrote.
+    importPricesOne: { handler, dto: { output: ImportOutcomeDto } },
   }
   ```
 
-  Every field needs a runtime initializer, since an uninitialized class field erases and the class then narrows nothing. A result sharing **no** field with the entity used to serialize to `{}` in silence; since v0.9 it raises `KAVO_CONFIG_INVALID` naming the operation and pointing here.
+  Every field needs a runtime initializer, since an uninitialized class field erases and the class then narrows nothing.
+
+  A result the projection empties **raises** rather than serving `{}`. `KAVO_CONFIG_INVALID` names the operation and says which of the three mistakes it is: no DTO and no field in common with the entity, a registered DTO the handler's keys do not match, or a registered DTO with no runtime fields. It fires on a plain object, on a class instance whose values are accessors, and on an array — the last being what a handler that meant `cardinality: "many"` and left it at the default returns. It does **not** fire under an explicit `fields=`, which can empty a projection on its own.
+
+  Two things follow from it being a request-time refusal. The handler has already run, so a write it made through `context.repository` stands; and a partial strip — a result mixing entity fields with its own — is still silent, because that is what a projection is for.
 
 - **The route defaults to `POST` and `201`.** A custom id is absent from the standard route table, so it falls back to `POST /<controller>/<operation id>` with a `201` — a custom operation is a write against the collection until its `meta.routes` says otherwise. A read that returns an existing row almost certainly wants `meta: { routes: { method: "GET", path: ":id/summary", successStatus: 200 } }`.
 

--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -199,6 +199,15 @@ root `dto` slot of its own: `output` falls back to the entity's
 `item`/`list` slot and `input` to the entity's writable projection, which
 is what makes `dto` the only way to give it a shape of its own.
 
+That fallback is the right default for a result that _is_ a row, and a trap
+for one that is not: a handler returning `{ applied, skus }` against an
+entity with neither column serialized to `{}`, silently, while the static
+types promised the shape (#181). The engine now refuses a **custom**
+operation whose non-empty result projects to zero keys, naming the
+operation and pointing at `dto.output` (doc 07 §1a). A result that is a
+narrower entity shape is still served as-is; only zero intersection is
+treated as a declaration mistake.
+
 `query`'s effect is **typing only**, like the root `query` slot (§1): there
 is no validation subsystem, and the query normalizer parses wire params
 structurally against the allowlists regardless of which DTO class is

--- a/docs/internals/architecture/06-error-handling.md
+++ b/docs/internals/architecture/06-error-handling.md
@@ -18,7 +18,8 @@ KavoException (abstract; implements the KavoExceptionShape contract)
 ├─ BulkOperationException       carries items[] (reserved)
 ├─ PersistenceException
 ├─ TransactionException         carries retryable: boolean
-└─ ConfigurationException       bootstrap-only, never a wire response
+└─ ConfigurationException       mostly bootstrap; also a request-time refusal
+                                when a handler returns an unusable shape
 ```
 
 Every leaf binds exactly one catalog code; status, title, and the English
@@ -32,29 +33,29 @@ Codes are API surface — renaming one is a breaking change (semver
 policy). Source of truth: `ERROR_CATALOG` in
 `core/src/errors/error-catalog.ts`.
 
-| Code                            | HTTP | Fires when                                                                                                         | Payload extensions                |
-| ------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
-| `KAVO_QUERY_INVALID`            | 400  | Any query grammar/allowlist/limit violation (aggregate)                                                            | `errors[]` of the sub-codes below |
-| `KAVO_QUERY_INVALID_FIELD`      | 400  | Field not on the filter/sort/select allowlist                                                                      | issue-level                       |
-| `KAVO_QUERY_INVALID_OPERATOR`   | 400  | Unknown or misspelled wire operator                                                                                | issue-level                       |
-| `KAVO_QUERY_INVALID_VALUE`      | 400  | Coercion failure, malformed bounds, bad pagination value                                                           | issue-level                       |
-| `KAVO_QUERY_LIMIT_EXCEEDED`     | 400  | maxFilterDepth / maxInValues exceeded                                                                              | issue-level                       |
-| `KAVO_QUERY_UNSUPPORTED_PARAM`  | 400  | `withDeleted`/`onlyDeleted` on a hard-delete entity; `include` when no include resolver is wired                   | issue-level                       |
-| `KAVO_QUERY_CONFLICTING_PARAMS` | 400  | `withDeleted=true` and `onlyDeleted=true` set together                                                             | issue-level                       |
-| `KAVO_NOT_FOUND`                | 404  | Target row missing on findOne/update/patch/delete                                                                  | —                                 |
-| `KAVO_CONFLICT`                 | 409  | Unique/FK violation mapped by the adapter                                                                          | —                                 |
-| `KAVO_ALREADY_DELETED`          | 409  | Soft-deleting an already-deleted row                                                                               | —                                 |
-| `KAVO_NOT_DELETED`              | 409  | Restoring or purging a row that is not deleted                                                                     | —                                 |
-| `KAVO_PRECONDITION_FAILED`      | 412  | `If-Match` names no tag matching the target's current ETag (ADR-0020)                                              | —                                 |
-| `KAVO_PRECONDITION_UNSUPPORTED` | 412  | `If-Match` the engine cannot evaluate — untargeted operation, `caching.etag` off, `findOne` disabled (ADR-0020 §4) | —                                 |
-| `KAVO_OPERATION_DISABLED`       | 405  | Programmatic call to a disabled registry entry (no route exists over HTTP)                                         | —                                 |
-| `KAVO_OPERATION_NOT_REGISTERED` | 405  | Programmatic call naming an operation the registry has no entry for at all                                         | —                                 |
-| `KAVO_BULK_FAILED`              | 422  | Atomic bulk failure (reserved — bulk is not built)                                                                 | `items[]` per-index issues        |
-| `KAVO_PERSISTENCE_FAILED`       | 500  | Unrecognized adapter/driver error                                                                                  | `cause` kept internally           |
-| `KAVO_TRANSACTION_FAILED`       | 500  | Deadlock/serialization failure                                                                                     | `retryable` flag                  |
-| `KAVO_CONFIG_INVALID`           | 500  | Bootstrap config error (fails startup, not a response)                                                             | —                                 |
-| `KAVO_HTTP_ERROR`               | *    | Framework-level `HttpException` reaching the filter without ever going through `KavoEngine.execute` (§6)           | —                                 |
-| `KAVO_UNEXPECTED_ERROR`         | 500  | Any other error reaching the filter without ever going through `KavoEngine.execute` (§6)                           | `cause` kept internally           |
+| Code                            | HTTP | Fires when                                                                                                                                      | Payload extensions                |
+| ------------------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `KAVO_QUERY_INVALID`            | 400  | Any query grammar/allowlist/limit violation (aggregate)                                                                                         | `errors[]` of the sub-codes below |
+| `KAVO_QUERY_INVALID_FIELD`      | 400  | Field not on the filter/sort/select allowlist                                                                                                   | issue-level                       |
+| `KAVO_QUERY_INVALID_OPERATOR`   | 400  | Unknown or misspelled wire operator                                                                                                             | issue-level                       |
+| `KAVO_QUERY_INVALID_VALUE`      | 400  | Coercion failure, malformed bounds, bad pagination value                                                                                        | issue-level                       |
+| `KAVO_QUERY_LIMIT_EXCEEDED`     | 400  | maxFilterDepth / maxInValues exceeded                                                                                                           | issue-level                       |
+| `KAVO_QUERY_UNSUPPORTED_PARAM`  | 400  | `withDeleted`/`onlyDeleted` on a hard-delete entity; `include` when no include resolver is wired                                                | issue-level                       |
+| `KAVO_QUERY_CONFLICTING_PARAMS` | 400  | `withDeleted=true` and `onlyDeleted=true` set together                                                                                          | issue-level                       |
+| `KAVO_NOT_FOUND`                | 404  | Target row missing on findOne/update/patch/delete                                                                                               | —                                 |
+| `KAVO_CONFLICT`                 | 409  | Unique/FK violation mapped by the adapter                                                                                                       | —                                 |
+| `KAVO_ALREADY_DELETED`          | 409  | Soft-deleting an already-deleted row                                                                                                            | —                                 |
+| `KAVO_NOT_DELETED`              | 409  | Restoring or purging a row that is not deleted                                                                                                  | —                                 |
+| `KAVO_PRECONDITION_FAILED`      | 412  | `If-Match` names no tag matching the target's current ETag (ADR-0020)                                                                           | —                                 |
+| `KAVO_PRECONDITION_UNSUPPORTED` | 412  | `If-Match` the engine cannot evaluate — untargeted operation, `caching.etag` off, `findOne` disabled (ADR-0020 §4)                              | —                                 |
+| `KAVO_OPERATION_DISABLED`       | 405  | Programmatic call to a disabled registry entry (no route exists over HTTP)                                                                      | —                                 |
+| `KAVO_OPERATION_NOT_REGISTERED` | 405  | Programmatic call naming an operation the registry has no entry for at all                                                                      | —                                 |
+| `KAVO_BULK_FAILED`              | 422  | Atomic bulk failure (reserved — bulk is not built)                                                                                              | `items[]` per-index issues        |
+| `KAVO_PERSISTENCE_FAILED`       | 500  | Unrecognized adapter/driver error                                                                                                               | `cause` kept internally           |
+| `KAVO_TRANSACTION_FAILED`       | 500  | Deadlock/serialization failure                                                                                                                  | `retryable` flag                  |
+| `KAVO_CONFIG_INVALID`           | 500  | Bootstrap config error (fails startup), **and** a request-time refusal when a handler returns a shape the envelope or the projection cannot use | —                                 |
+| `KAVO_HTTP_ERROR`               | *    | Framework-level `HttpException` reaching the filter without ever going through `KavoEngine.execute` (§6)                                        | —                                 |
+| `KAVO_UNEXPECTED_ERROR`         | 500  | Any other error reaching the filter without ever going through `KavoEngine.execute` (§6)                                                        | `cause` kept internally           |
 
 ## 3. Error context & message strategy
 

--- a/docs/internals/architecture/07-crud-engine.md
+++ b/docs/internals/architecture/07-crud-engine.md
@@ -81,17 +81,44 @@ of any kind, while `CustomOperationResult` typed `run`'s return as the
 handler's own return type, so the static types promised the shape the wire
 did not carry (#181).
 
-`mapResponse` now refuses that case: a **custom** id whose non-empty result
-projects to zero keys raises `ConfigurationException`
-(`operations.<id>.dto.output`) naming the operation and the keys it
-returned. Zero intersection is the test, not "narrower than the result" — a
-genuine narrowing is exactly what the projection is for. The guard is
-skipped under an explicit `fields=`, which can empty a projection on its
-own and would make the message blame the wrong thing, and it is scoped to
-custom ids because a standard operation's empty projection is a different
-bug that `dto.output` does not fix. The pattern is `withListMeta`'s: a
-handler that returned a shape the envelope cannot use fails at request time,
-keyed to the operation, rather than assembling something broken.
+`mapResponse` now refuses that case: a **custom** id whose result carried
+something and projects to zero keys raises `ConfigurationException`
+(`operations.<id>.dto.output`). Four details decide what it catches and what
+the message says.
+
+**What counts as "carried something"** is deliberately wider than "has own
+enumerable keys", which was the first cut and let three shapes through in
+silence — the exact symptom the guard exists to end. `Object.keys` misses a
+class instance whose fields are accessors, while `DefaultSerializer.project`
+emits with `key in source` and does not; it also misses a `Date`. And a
+non-empty **array** is what a handler that meant `cardinality: "many"` and
+left it at the default returns. All three now raise. A literally empty `{}`
+is still exempt: returning nothing meaningful is not a shape mistake.
+
+**Zero intersection is the test**, not "narrower than the result" — a genuine
+narrowing is exactly what the projection is for, so a result mixing entity
+fields with its own is still stripped silently.
+
+**The message names what the result was projected _through_.** With no
+`dto.output` it names the entity and says to declare one. With one registered
+it names that class and its keys, because the entity's fields are irrelevant
+and telling an author to declare a DTO they already declared sends them to
+fix the thing they got right. With one registered that has **no runtime
+shape** — the declared-only class `@kavo/nest` supports on purpose, so
+Swagger's decorators can answer — it names the missing initializers, since
+the projection has silently fallen back to the entity.
+
+**Two scopings.** The guard is skipped under an explicit `fields=`, which can
+empty a projection on its own and would make the message blame the wrong
+thing; and it is scoped to custom ids, because a standard operation's empty
+projection is a different bug that `dto.output` does not fix.
+
+The pattern is `withListMeta`'s: a handler that returned a shape the envelope
+cannot use fails at request time, keyed to the operation, rather than
+assembling something broken. It is a request-time `KAVO_CONFIG_INVALID`,
+which is why doc 06's catalog row covers both that and the bootstrap case —
+and it fires _after_ the handler ran, so a write it made through
+`context.repository` stands.
 
 In code it is called through `service.run("markPaidOne", { id, body })`,
 which is the same `engine.execute` the eight named methods make, typed from

--- a/docs/internals/architecture/07-crud-engine.md
+++ b/docs/internals/architecture/07-crud-engine.md
@@ -71,6 +71,28 @@ response is serialized, ETagged and conditionally answered like any other.
 nothing in the schema says which row it targets, so the request is refused
 rather than performed unguarded (§3a).
 
+That DTO fallback is where the genericity has a sharp edge, and it is worth
+naming rather than leaving as an inference. A standard operation's result
+_is_ the entity, so falling back to the entity's projection loses nothing. A
+custom operation's result is whatever its handler returns, so the same
+fallback silently filters it to the entity's columns — and a result sharing
+no field with them survives as `{}`. That shipped with a 201 and no signal
+of any kind, while `CustomOperationResult` typed `run`'s return as the
+handler's own return type, so the static types promised the shape the wire
+did not carry (#181).
+
+`mapResponse` now refuses that case: a **custom** id whose non-empty result
+projects to zero keys raises `ConfigurationException`
+(`operations.<id>.dto.output`) naming the operation and the keys it
+returned. Zero intersection is the test, not "narrower than the result" — a
+genuine narrowing is exactly what the projection is for. The guard is
+skipped under an explicit `fields=`, which can empty a projection on its
+own and would make the message blame the wrong thing, and it is scoped to
+custom ids because a standard operation's empty projection is a different
+bug that `dto.output` does not fix. The pattern is `withListMeta`'s: a
+handler that returned a shape the envelope cannot use fails at request time,
+keyed to the operation, rather than assembling something broken.
+
 In code it is called through `service.run("markPaidOne", { id, body })`,
 which is the same `engine.execute` the eight named methods make, typed from
 the operation's own `dto` override or, failing that, from the registered

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -26,6 +26,7 @@ import {
   QueryValidationException,
 } from "../errors/exceptions.js";
 import { nameList } from "../errors/message-hints.js";
+import { isStandardOperationId } from "../operations/default-operation-registry.js";
 import { QueryNormalizer } from "../query/query-normalizer.js";
 import { hasKeyset, isSincePagination } from "../query/pagination.js";
 import { cursorValuesOf, encodeCursor } from "../query/cursor.js";
@@ -600,11 +601,16 @@ export class KavoEngine<Entity extends object> {
       const listDto = (descriptor.output as DtoClass<object> | null) ?? config.dto.resolve("list", descriptor.id);
       const pagination: Pagination<Entity> = context.query?.pagination ?? { limit: 0, offset: 0 };
       const listMeta = this.listMeta(listResult, context);
+      const items = serializer.serializeList(listResult.entities, listDto, context);
+      // First row only: this catches a declaration mistake, which is the
+      // same for every row, and checking all of them would be per-request
+      // work for a bootstrap-class error.
+      assertProjected(items[0], listResult.entities[0], descriptor, context, "list");
       return {
         operation: descriptor.id,
         item: null,
         list: {
-          items: serializer.serializeList(listResult.entities, listDto, context),
+          items,
           limit: pagination.limit,
           // A keyset page has no absolute position in the match set, and
           // `offset` is a non-nullable envelope field, so cursor pages report
@@ -638,6 +644,7 @@ export class KavoEngine<Entity extends object> {
 
     const itemDto = (descriptor.output as DtoClass<object> | null) ?? config.dto.resolve("item", descriptor.id);
     const item = serializer.serializeItem(result as Entity, itemDto, context);
+    assertProjected(item, result, descriptor, context, "item");
     // `context.config` is the per-call view, so `caching.etag` honors an
     // override at any scope down to this one request.
     const etag = context.config.settings.caching.etag ? await computeEtag(item) : null;
@@ -807,4 +814,62 @@ function compactMeta(meta: ListMetaDto | undefined): ListMetaDto | undefined {
  */
 function registeredIds<Entity extends object>(registry: OperationRegistry<Entity>): string {
   return nameList(registry.all().map((descriptor) => descriptor.id));
+}
+
+/**
+ * A custom operation whose handler returned a shape sharing **no** field
+ * with the response projection fails loudly instead of serving `{}`
+ * (#181).
+ *
+ * A custom operation is the one place a handler's result is not the entity
+ * by contract, so it is the one place the projection can empty a value
+ * entirely. `dto.output` is how a result with its own shape declares
+ * itself; with none, the result is filtered to the entity's columns plus
+ * its computed fields, and a result that shares none of them survives as an
+ * empty object. Nothing said so — not a type error, not a log line — and
+ * the static types actively disagreed: `CustomOperationResult` types
+ * `run`'s return as the handler's own return type when no `dto.output` is
+ * declared, so the signature promised the shape while the wire served `{}`.
+ *
+ * Scoped to custom ids deliberately. A standard operation's result *is* the
+ * entity by contract, so an empty projection there is a different bug with
+ * a different fix, and `dto.output` is not the answer to it.
+ *
+ * Zero intersection is the test, not "narrower than the result": a genuine
+ * narrowing — a handler returning a row with a subset of the entity's
+ * fields — is exactly what the projection is for and must stay silent.
+ *
+ * Skipped under an explicit `fields=`, because sparse selection can empty
+ * the projection on its own and the message would then blame the wrong
+ * thing. That request is the client's mistake, and a narrowed read of an
+ * operation whose shape is already wrong will trip this the moment the
+ * fieldset comes off.
+ *
+ * This is `withListMeta`'s pattern (`with-list-meta.ts`): a handler that
+ * returned a shape the envelope cannot use raises a request-time
+ * `ConfigurationException` keyed to the operation, rather than assembling
+ * something broken.
+ */
+function assertProjected<Entity>(
+  projected: unknown,
+  source: unknown,
+  descriptor: OperationDescriptor<Entity>,
+  context: KavoContext<Entity>,
+  slot: "item" | "list",
+): void {
+  if (isStandardOperationId(descriptor.id)) return;
+  if (context.query?.fields.root != null) return;
+  if (typeof source !== "object" || source === null || Array.isArray(source)) return;
+  if (Object.keys(source).length === 0) return;
+  if (typeof projected !== "object" || projected === null || Object.keys(projected).length > 0) return;
+  const served = slot === "list" ? "every row of the list" : "the response";
+  throw new ConfigurationException(
+    context.entityName,
+    `operations.${descriptor.id}.dto.output`,
+    `the '${descriptor.id}' handler returned an object whose keys are ${nameList(Object.keys(source))}, and ` +
+      `none of those are fields of '${context.entityName}', so ${served} serialized to {}. A custom operation's result is ` +
+      `projected through the entity's '${slot}' shape unless the operation registers one of its own — ` +
+      `declare 'dto: { output: <YourResultDto> }' on the operation, with every field initialized so the ` +
+      `class has a runtime shape`,
+  );
 }

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -26,6 +26,7 @@ import {
   QueryValidationException,
 } from "../errors/exceptions.js";
 import { nameList } from "../errors/message-hints.js";
+import { dtoShapeKeys } from "../dto/dto-shape.js";
 import { isStandardOperationId } from "../operations/default-operation-registry.js";
 import { QueryNormalizer } from "../query/query-normalizer.js";
 import { hasKeyset, isSincePagination } from "../query/pagination.js";
@@ -605,7 +606,14 @@ export class KavoEngine<Entity extends object> {
       // First row only: this catches a declaration mistake, which is the
       // same for every row, and checking all of them would be per-request
       // work for a bootstrap-class error.
-      assertProjected(items[0], listResult.entities[0], descriptor, context, "list");
+      validateProjectedResult(
+        items[0],
+        listResult.entities[0],
+        listDto as DtoClass | null,
+        descriptor,
+        context,
+        "list",
+      );
       return {
         operation: descriptor.id,
         item: null,
@@ -644,7 +652,7 @@ export class KavoEngine<Entity extends object> {
 
     const itemDto = (descriptor.output as DtoClass<object> | null) ?? config.dto.resolve("item", descriptor.id);
     const item = serializer.serializeItem(result as Entity, itemDto, context);
-    assertProjected(item, result, descriptor, context, "item");
+    validateProjectedResult(item, result, itemDto as DtoClass | null, descriptor, context, "item");
     // `context.config` is the per-call view, so `caching.etag` honors an
     // override at any scope down to this one request.
     const etag = context.config.settings.caching.etag ? await computeEtag(item) : null;
@@ -850,26 +858,99 @@ function registeredIds<Entity extends object>(registry: OperationRegistry<Entity
  * `ConfigurationException` keyed to the operation, rather than assembling
  * something broken.
  */
-function assertProjected<Entity>(
+function validateProjectedResult<Entity>(
   projected: unknown,
   source: unknown,
+  dto: DtoClass | null,
   descriptor: OperationDescriptor<Entity>,
   context: KavoContext<Entity>,
   slot: "item" | "list",
 ): void {
   if (isStandardOperationId(descriptor.id)) return;
   if (context.query?.fields.root != null) return;
-  if (typeof source !== "object" || source === null || Array.isArray(source)) return;
-  if (Object.keys(source).length === 0) return;
+  if (!carriesSomething(source)) return;
   if (typeof projected !== "object" || projected === null || Object.keys(projected).length > 0) return;
-  const served = slot === "list" ? "every row of the list" : "the response";
+  const served = slot === "list" ? "the first row of the list" : "the response";
   throw new ConfigurationException(
     context.entityName,
     `operations.${descriptor.id}.dto.output`,
-    `the '${descriptor.id}' handler returned an object whose keys are ${nameList(Object.keys(source))}, and ` +
-      `none of those are fields of '${context.entityName}', so ${served} serialized to {}. A custom operation's result is ` +
-      `projected through the entity's '${slot}' shape unless the operation registers one of its own — ` +
-      `declare 'dto: { output: <YourResultDto> }' on the operation, with every field initialized so the ` +
-      `class has a runtime shape`,
+    `the '${descriptor.id}' handler returned ${describeResult(source)}, so ${served} serialized to {}. ` +
+      projectedAgainst(dto, context.entityName, slot),
+  );
+}
+
+/**
+ * Whether the handler's result had anything for the projection to keep.
+ *
+ * Deliberately wider than `Object.keys(source).length > 0`, which was the
+ * first cut and let three shapes through in silence — the exact #181 symptom
+ * the guard exists to end:
+ *
+ * - a **class instance whose fields are accessors**, since getters live on
+ *   the prototype and `Object.keys` never sees them, while
+ *   `DefaultSerializer.project` emits with `key in source` and does;
+ * - a **`Date`**, or any other boxed value with no own enumerable keys;
+ * - a **non-empty array**, which is what a handler that meant
+ *   `cardinality: "many"` and left it at the default returns.
+ *
+ * A plain `{}` is still exempt: a handler that returns nothing meaningful is
+ * not making a declaration mistake about its shape.
+ */
+function carriesSomething(source: unknown): boolean {
+  if (typeof source !== "object" || source === null) return false;
+  if (Array.isArray(source)) return source.length > 0;
+  if (Object.keys(source).length > 0) return true;
+  // Anything that is not a plain object carries state somewhere the own-key
+  // check cannot see. `null` prototype means a bare dictionary, which the
+  // key check above already judged.
+  const prototype = Object.getPrototypeOf(source) as object | null;
+  return prototype !== Object.prototype && prototype !== null;
+}
+
+/** The result's shape, for the first half of the message. */
+function describeResult(source: unknown): string {
+  if (Array.isArray(source)) {
+    return `an array of ${source.length} item(s) — a collection result needs 'cardinality: "many"' on the operation`;
+  }
+  const keys = Object.keys(source as object);
+  if (keys.length > 0) return `an object whose keys are ${nameList(keys)}`;
+  const name = (source as { constructor?: { name?: string } }).constructor?.name;
+  return `a ${name === undefined || name === "" ? "non-plain object" : name} instance, whose values are not own enumerable properties`;
+}
+
+/**
+ * The second half: what the result was projected *through*, which decides
+ * what the reader has to change.
+ *
+ * Naming the entity unconditionally was wrong. Where a `dto.output` is
+ * registered, the entity's fields are irrelevant — the projection is the
+ * DTO's keys — and telling an author to "declare `dto: { output: … }`" when
+ * they already did sends them to fix the thing they got right. Where one is
+ * registered but has no runtime shape (a declared-only class, which
+ * `@kavo/nest` supports on purpose so Swagger's decorators can answer), the
+ * fallback is the entity's projection and the missing initializers are the
+ * actual fault.
+ */
+function projectedAgainst(dto: DtoClass | null, entityName: string, slot: "item" | "list"): string {
+  if (dto === null) {
+    return (
+      `A custom operation's result is projected through the entity's '${slot}' shape unless the operation ` +
+      `registers one of its own, and none of those keys are fields of '${entityName}' — declare ` +
+      `'dto: { output: <YourResultDto> }' on the operation, with every field initialized so the class has a ` +
+      `runtime shape`
+    );
+  }
+  const keys = dtoShapeKeys(dto);
+  if (keys === null) {
+    return (
+      `The registered '${dto.name || "(anonymous)"}' declares no runtime fields — TypeScript erases an ` +
+      `uninitialized class field, so 'applied!: number' declares nothing at runtime and the projection falls ` +
+      `back to '${entityName}'. Give each field an initializer ('applied = 0')`
+    );
+  }
+  return (
+    `The result was projected through the registered '${dto.name || "(anonymous)"}', which declares ` +
+    `${nameList(keys)} — none of which the handler returned. The DTO and the handler disagree about the ` +
+    `result's shape; change whichever is wrong`
   );
 }

--- a/packages/core/src/operations/default-operation-registry.ts
+++ b/packages/core/src/operations/default-operation-registry.ts
@@ -101,6 +101,18 @@ export const STANDARD_OPERATIONS: Readonly<Record<StandardOperationId, StandardO
 const STANDARD_IDS: ReadonlySet<string> = new Set(Object.keys(STANDARD_OPERATIONS));
 
 /**
+ * Whether an id is one of the standard eight — the same set the registry
+ * builds from, so the two can never drift.
+ *
+ * Internal to core (absent from the barrel, ADR-0010): the engine needs it
+ * to scope a guard to custom operations, and nothing outside the package
+ * has asked.
+ */
+export function isStandardOperationId(id: string): boolean {
+  return STANDARD_IDS.has(id);
+}
+
+/**
  * The same ids keyed by their lowercase spelling, which is how a custom id
  * is checked for being a standard one with the wrong case
  * (`createOperationRegistry`).

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -545,7 +545,64 @@ describe("KavoEngine — custom operations declared in config (issue #145)", () 
 
       const error = (await crud.run("probeMany").catch((thrown: unknown) => thrown)) as ConfigurationException;
       expect(error).toBeInstanceOf(ConfigurationException);
-      expect(error.message).toContain("every row of the list");
+      // "the first row", not "every row": the check reads index 0 only, and
+      // the message must not claim more than it verified.
+      expect(error.message).toContain("the first row of the list");
+      expect(error.messageParams).toMatchObject({ path: "operations.probeMany.dto.output" });
+    });
+
+    it("names the registered DTO, not the entity, when the DTO is what emptied the result", async () => {
+      // The message used to send an author who had already declared
+      // `dto.output` back to declare `dto.output`. With one registered, the
+      // entity's fields are irrelevant — the projection is the DTO's keys.
+      class OutcomeDto {
+        applied = 0;
+        skus: string[] = [];
+      }
+      const { crud } = withShape({ appliedCount: 3, skuList: ["a"] }, { dto: { output: OutcomeDto } });
+      const error = (await crud.run("probeOne").catch((thrown: unknown) => thrown)) as ConfigurationException;
+
+      expect(error).toBeInstanceOf(ConfigurationException);
+      expect(error.message).toContain("registered 'OutcomeDto'");
+      expect(error.message).toContain("applied, skus");
+      expect(error.message).not.toContain("declare 'dto: { output:");
+    });
+
+    it("names the missing initializers when a registered DTO has no runtime shape", async () => {
+      // The declared-only DTO `@kavo/nest` supports on purpose, so Swagger's
+      // own decorators can answer. The projection falls back to the entity,
+      // and the fault is the erased fields rather than a missing DTO.
+      class DeclaredOnlyDto {
+        declare applied: number;
+      }
+      const { crud } = withShape({ applied: 3 }, { dto: { output: DeclaredOnlyDto } });
+      const error = (await crud.run("probeOne").catch((thrown: unknown) => thrown)) as ConfigurationException;
+
+      expect(error.message).toContain("'DeclaredOnlyDto' declares no runtime fields");
+      expect(error.message).toContain("give each field an initializer".replace("give", "Give"));
+    });
+
+    it("refuses a class instance whose fields are accessors", async () => {
+      // `Object.keys` never sees a prototype getter, but the serializer
+      // emits with `key in source` and does — so this shape slipped through
+      // the first cut of the guard and served {} exactly as #181 reports.
+      class Outcome {
+        get applied(): number {
+          return 3;
+        }
+      }
+      const { crud } = withShape(new Outcome());
+      await expect(crud.run("probeOne")).rejects.toBeInstanceOf(ConfigurationException);
+    });
+
+    it("refuses a non-empty array from a cardinality-one operation", async () => {
+      // What a handler that meant `cardinality: "many"` and left it at the
+      // default returns. It projected to {} in silence.
+      const { crud } = withShape([{ applied: 1 }, { applied: 2 }]);
+      const error = (await crud.run("probeOne").catch((thrown: unknown) => thrown)) as ConfigurationException;
+
+      expect(error).toBeInstanceOf(ConfigurationException);
+      expect(error.message).toContain('cardinality: "many"');
     });
 
     it("leaves an empty list alone — there is no row to judge", async () => {

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -460,6 +460,130 @@ describe("KavoEngine — custom operations declared in config (issue #145)", () 
     expect(list).toMatchObject({ items: [expect.objectContaining({ name: "Ada" })], total: 1, offset: 0 });
   });
 
+  describe("a result the entity projection empties (#181)", () => {
+    /** A handler returning a shape with no field in common with `User`. */
+    function withShape(result: unknown, entry: Record<string, unknown> = {}) {
+      const { crud, adapter } = makeCrud({
+        operations: {
+          probeOne: {
+            handler: {
+              async execute() {
+                return result;
+              },
+            },
+            ...entry,
+          },
+        },
+      } as never);
+      return { crud, adapter };
+    }
+
+    it("refuses rather than serving {}", async () => {
+      // The silent version of this shipped `{}` with a 201, and the static
+      // types disagreed with it: `CustomOperationResult` types `run`'s
+      // return as the handler's own return type when no `dto.output` is
+      // declared, so the signature promised `{ probed, checkedAt }` while
+      // the wire served nothing at all.
+      const { crud } = withShape({ probed: true, checkedAt: "now" });
+      await expect(crud.run("probeOne")).rejects.toBeInstanceOf(ConfigurationException);
+    });
+
+    it("names the operation, what it returned, and dto.output as the fix", async () => {
+      const { crud } = withShape({ probed: true, checkedAt: "now" });
+      const error = (await crud.run("probeOne").catch((thrown: unknown) => thrown)) as ConfigurationException;
+
+      expect(error.code).toBe("KAVO_CONFIG_INVALID");
+      expect(error.messageParams).toMatchObject({ entity: "User", path: "operations.probeOne.dto.output" });
+      expect(error.message).toContain("keys are checkedAt, probed");
+      expect(error.message).toContain("dto: { output:");
+    });
+
+    it("leaves a genuine narrowing alone", async () => {
+      // A subset of the entity's fields is exactly what the projection is
+      // for. Only zero intersection is a mistake.
+      const { crud } = withShape({ id: 7, name: "Ada" });
+      expect(await crud.run("probeOne")).toEqual({ id: 7, name: "Ada" });
+    });
+
+    it("leaves a registered dto.output alone", async () => {
+      class ProbeResultDto {
+        probed = false;
+        checkedAt = "";
+      }
+      const { crud } = withShape({ probed: true, checkedAt: "now" }, { dto: { output: ProbeResultDto } });
+      expect(await crud.run("probeOne")).toEqual({ probed: true, checkedAt: "now" });
+    });
+
+    it("leaves a void result alone", async () => {
+      const { crud } = withShape(null);
+      await expect(crud.run("probeOne")).resolves.toBeNull();
+    });
+
+    it("does not blame the operation when it was fields= that emptied the projection", async () => {
+      // A sparse fieldset can empty a projection on its own, and the message
+      // would then point at a `dto.output` that is not the problem. The
+      // client's request is the mistake here, and the operation trips the
+      // real guard the moment the fieldset comes off.
+      const { crud } = withShape({ id: 7, name: "Ada" }, { kind: "read" });
+      expect(await crud.run("probeOne", { query: { fields: ["email"] } } as never)).toEqual({});
+    });
+
+    it("checks a many-cardinality operation on its first row", async () => {
+      const { crud } = makeCrud({
+        operations: {
+          probeMany: {
+            kind: "read",
+            cardinality: "many",
+            handler: {
+              async execute() {
+                return { entities: [{ probed: true }], total: 1 };
+              },
+            },
+          },
+        },
+      } as never);
+
+      const error = (await crud.run("probeMany").catch((thrown: unknown) => thrown)) as ConfigurationException;
+      expect(error).toBeInstanceOf(ConfigurationException);
+      expect(error.message).toContain("every row of the list");
+    });
+
+    it("leaves an empty list alone — there is no row to judge", async () => {
+      const { crud } = makeCrud({
+        operations: {
+          probeMany: {
+            kind: "read",
+            cardinality: "many",
+            handler: {
+              async execute() {
+                return { entities: [], total: 0 };
+              },
+            },
+          },
+        },
+      } as never);
+      expect(await crud.run("probeMany")).toMatchObject({ items: [], total: 0 });
+    });
+
+    it("leaves a standard operation alone, whatever its handler returns", async () => {
+      // A standard operation's result *is* the entity by contract, so an
+      // empty projection there is a different bug and `dto.output` is not
+      // its fix. Scoping the guard is what keeps the message honest.
+      const { crud } = makeCrud({
+        operations: {
+          findOne: {
+            handler: {
+              async execute() {
+                return { unrelated: true } as never;
+              },
+            },
+          },
+        },
+      } as never);
+      await expect(crud.findOne(1)).resolves.toEqual({});
+    });
+  });
+
   it("raises OperationDisabledException for a custom operation switched off", async () => {
     const { crud } = withPromote({ enabled: false });
     await expect(crud.run("promoteOne")).rejects.toBeInstanceOf(OperationDisabledException);


### PR DESCRIPTION
Closes #181.

A custom operation goes through the whole pipeline, serialization included, so with no `dto.output` its handler's return value is filtered to the entity's columns plus its computed fields. That is the right default for a result that *is* a row, and a trap for one that is not: a handler returning `{ applied, skus }` against an entity with neither column serialized to `{}`, shipped it with a `201`, and said nothing.

**The static types actively disagreed.** `CustomOperationResult` types `run`'s return as the handler's own return type when no `dto.output` is declared, so the signature promised `{ applied, skus }` while the wire carried `{}`. That divergence is the strongest argument for failing rather than documenting.

## The guard

`mapResponse` refuses it at request time, keyed to `operations.<id>.dto.output` and naming the keys the handler returned:

```
Invalid configuration for entity 'User' at 'operations.probeOne.dto.output': the 'probeOne'
handler returned an object whose keys are checkedAt, probed, and none of those are fields of
'User', so the response serialized to {}. A custom operation's result is projected through the
entity's 'item' shape unless the operation registers one of its own — declare
'dto: { output: <YourResultDto> }' on the operation, with every field initialized so the class
has a runtime shape
```

Four things scope it, each with a test:

- **Custom ids only.** A standard operation's result is the entity by contract, so an empty projection there is a different bug and `dto.output` is not its fix.
- **Zero intersection, not "narrower than the result".** A handler returning a subset of the entity's fields is exactly what the projection is for and stays silent.
- **Skipped under an explicit `fields=`**, which can empty a projection on its own and would make the message blame the wrong thing. The operation trips the real guard the moment the fieldset comes off.
- **The `many` branch checks the first row only.** This catches a declaration mistake, identical for every row; checking all of them would be per-request work for a bootstrap-class error.

The pattern is `withListMeta`'s — a handler that returned a shape the envelope cannot use raises a request-time `ConfigurationException` naming the operation, rather than assembling something broken. That is the established Kavo answer to this class of mistake, so this mints no new exception and touches no catalog entry.

## A correction to the issue

The reported repro returns `{ probed: true, id: "not-a-real-row" }`. **`id` is a metadata field**, so that case serialized to `{ id: "not-a-real-row" }`, not `{}` — the narrow rule would not have fired on the issue's own example. A literal `{}` needs a result whose keys intersect the projection at zero, which is what the tests use.

## What I did not do

The issue floats "warning once per operation at bootstrap when a handler's declared return type is known". **Not implementable**: TypeScript return types erase, and `createOperationRegistry` sees only an object with an `execute` function. Request time is the only place the shape exists.

## Also

`isStandardOperationId` is exported from `default-operation-registry` so the engine scopes the guard against the same set the registry builds from, rather than a second copy that could drift. Internal to core, absent from the barrel (ADR-0010).

The 201 default is documented alongside the serialization rule, per the issue's fourth criterion — same cause, same surprise: a custom id is absent from the standard route table, so it falls back to `POST /<controller>/<id>` with a `201`.

## Tests

Nine new in `packages/core/tests/engine.spec.ts`: the refusal, the message contents, a genuine narrowing, a registered `dto.output`, a void result, the `fields=` exemption, the many-cardinality case, an empty list (no row to judge), and a standard operation left alone whatever its handler returns.

No existing test pinned the silent strip — every custom-operation test in the repo returns a real entity — so nothing was changed to make this pass.

## Gate

`pnpm check` green: 2237 passed, 2 skipped, no dependency violations. `pnpm docs:links`, `pnpm docs:build` and `pnpm format:check` all pass.
