### PR TITLE
chore: mark the protocol bindings' peers optional

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,16 +65,18 @@ Kavo never bundles your framework or your ORM. Each package declares what it exp
 - **`@kavo/prisma`** — `@prisma/client` (`^5.0.0 || ^6.0.0`).
 - **`@kavo/mongoose`** — `mongoose` (`^7.0.0 || ^8.0.0`).
 - **`@kavo/mikroorm`** — `@mikro-orm/core` (`^7.0.0`), plus the MikroORM driver package your database needs.
-- **`@kavo/graphql`** — `graphql` (`^17.0.0`).
-- **`@kavo/mcp`** — `@modelcontextprotocol/sdk` (`^1.0.0`).
+- **`@kavo/graphql`** — `graphql` (`^17.0.0`), optional.
+- **`@kavo/mcp`** — `@modelcontextprotocol/sdk` (`^1.0.0`), optional.
 
-Three of `@kavo/nest`'s own peers are declared **optional** — `@nestjs/swagger` (`^8.0.0 || ^11.0.0`) for generated OpenAPI docs, `graphql` (`^17.0.0`) for the GraphQL controller, and `@modelcontextprotocol/sdk` (`^1.0.0`) for the MCP controller — so nothing makes you configure a protocol you don't serve. They may still land in your dependency tree either way: `@kavo/nest` depends on `@kavo/graphql` and `@kavo/mcp`, and those two declare `graphql` and `@modelcontextprotocol/sdk` as _required_ peers. npm, pnpm, and bun install required peers automatically, so both arrive even in a REST-only app; yarn does not, and reports them as unmet peers instead. Optional here means you never have to import or wire them.
+Three of `@kavo/nest`'s own peers are declared **optional** — `@nestjs/swagger` (`^8.0.0 || ^11.0.0`) for generated OpenAPI docs, `graphql` (`^17.0.0`) for the GraphQL controller, and `@modelcontextprotocol/sdk` (`^1.0.0`) for the MCP controller — so nothing makes you configure a protocol you don't serve.
+
+**Both hops say optional**, which is what keeps them out of the tree. `@kavo/nest` depends on `@kavo/graphql` and `@kavo/mcp` outright, so your package manager resolves the binding and then the binding's peer; while those two declared theirs required, npm, pnpm and bun installed `graphql` and the MCP SDK into every REST-only app anyway. Both are optional on both hops now, so a REST-only install gets neither, and you add the protocol library when you opt into the protocol.
 
 ### GraphQL and MCP
 
 The same entities can be served over GraphQL and the Model Context Protocol, through the same engine.
 
-Inside a Nest app you never install the Kavo bindings directly — `@kavo/nest` depends on `@kavo/graphql`, and on `@kavo/mcp` as of the next release. Add only the protocol library you intend to use:
+Inside a Nest app you never install the Kavo bindings directly — `@kavo/nest` depends on both `@kavo/graphql` and `@kavo/mcp`. Add only the protocol library you intend to use:
 
 ::: code-group
 

--- a/docs/internals/architecture/02-monorepo-and-packages.md
+++ b/docs/internals/architecture/02-monorepo-and-packages.md
@@ -270,10 +270,21 @@ uninstallable — and npm does not allow republishing a version to correct it.
 | `@kavo/mongoose` | `@kavo/core`                               | `mongoose`                                                                                                                         |
 | `@kavo/mikroorm` | `@kavo/core`                               | `@mikro-orm/core`                                                                                                                  |
 | `@kavo/sse`      | `@kavo/core`                               | — (none)                                                                                                                           |
-| `@kavo/graphql`  | `@kavo/core`                               | `graphql`                                                                                                                          |
-| `@kavo/mcp`      | `@kavo/core`                               | `@modelcontextprotocol/sdk`                                                                                                        |
+| `@kavo/graphql`  | `@kavo/core`                               | `graphql` (optional)                                                                                                               |
+| `@kavo/mcp`      | `@kavo/core`                               | `@modelcontextprotocol/sdk` (optional)                                                                                             |
 | `@kavo/nest`     | `@kavo/core`, `@kavo/graphql`, `@kavo/mcp` | `@nestjs/common`, `@nestjs/core`, `graphql`, `@modelcontextprotocol/sdk` (+ `@nestjs/swagger`, all three protocol peers, optional) |
 
 Peers, not dependencies, because the consumer's app owns the TypeORM/Prisma/
 Mongoose/MikroORM/Nest instance — a second copy via a nested dependency would fracture
 `instanceof` checks and DI tokens.
+
+**Optional where the peer is optional to _install_, required to _use_.** An
+ORM adapter's peer is not: `@kavo/typeorm` without `typeorm` does nothing, so
+marking it optional would trade an install-time error for a runtime one. A
+protocol binding's is, and both hops have to say so. `@kavo/nest` depends on
+`@kavo/graphql` and `@kavo/mcp` outright (ADR-0016's sanctioned sideways
+edge), so npm resolves the binding and then the binding's peer — marking only
+`@kavo/nest`'s copy left `graphql`, the MCP SDK and its `zod` subtree in
+every REST-only install (#148). `tests/release-workflow.spec.ts` asserts both
+hops, since the failure is silent: the manifest still installs, the tree is
+just bigger.

--- a/docs/internals/architecture/02-monorepo-and-packages.md
+++ b/docs/internals/architecture/02-monorepo-and-packages.md
@@ -262,29 +262,46 @@ uninstallable — and npm does not allow republishing a version to correct it.
 
 ## 8. Dependency classification (decided now, executed later)
 
-| Package          | `dependencies`                             | `peerDependencies`                                                                                                                 |
-| ---------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `@kavo/core`     | — (none, ever)                             | —                                                                                                                                  |
-| `@kavo/typeorm`  | `@kavo/core`                               | `typeorm`                                                                                                                          |
-| `@kavo/prisma`   | `@kavo/core`                               | `@prisma/client`                                                                                                                   |
-| `@kavo/mongoose` | `@kavo/core`                               | `mongoose`                                                                                                                         |
-| `@kavo/mikroorm` | `@kavo/core`                               | `@mikro-orm/core`                                                                                                                  |
-| `@kavo/sse`      | `@kavo/core`                               | — (none)                                                                                                                           |
-| `@kavo/graphql`  | `@kavo/core`                               | `graphql` (optional)                                                                                                               |
-| `@kavo/mcp`      | `@kavo/core`                               | `@modelcontextprotocol/sdk` (optional)                                                                                             |
-| `@kavo/nest`     | `@kavo/core`, `@kavo/graphql`, `@kavo/mcp` | `@nestjs/common`, `@nestjs/core`, `graphql`, `@modelcontextprotocol/sdk` (+ `@nestjs/swagger`, all three protocol peers, optional) |
+| Package          | `dependencies`                             | `peerDependencies`                                                                                                                                  |
+| ---------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@kavo/core`     | — (none, ever)                             | —                                                                                                                                                   |
+| `@kavo/typeorm`  | `@kavo/core`                               | `typeorm`                                                                                                                                           |
+| `@kavo/prisma`   | `@kavo/core`                               | `@prisma/client`                                                                                                                                    |
+| `@kavo/mongoose` | `@kavo/core`                               | `mongoose`                                                                                                                                          |
+| `@kavo/mikroorm` | `@kavo/core`                               | `@mikro-orm/core`                                                                                                                                   |
+| `@kavo/sse`      | `@kavo/core`                               | — (none)                                                                                                                                            |
+| `@kavo/graphql`  | `@kavo/core`                               | `graphql` (optional)                                                                                                                                |
+| `@kavo/mcp`      | `@kavo/core`                               | `@modelcontextprotocol/sdk` (optional)                                                                                                              |
+| `@kavo/nest`     | `@kavo/core`, `@kavo/graphql`, `@kavo/mcp` | `@nestjs/common`, `@nestjs/core`, `reflect-metadata`, `rxjs`; plus `graphql`, `@modelcontextprotocol/sdk` and `@nestjs/swagger`, all three optional |
 
 Peers, not dependencies, because the consumer's app owns the TypeORM/Prisma/
 Mongoose/MikroORM/Nest instance — a second copy via a nested dependency would fracture
 `instanceof` checks and DI tokens.
 
-**Optional where the peer is optional to _install_, required to _use_.** An
-ORM adapter's peer is not: `@kavo/typeorm` without `typeorm` does nothing, so
-marking it optional would trade an install-time error for a runtime one. A
-protocol binding's is, and both hops have to say so. `@kavo/nest` depends on
-`@kavo/graphql` and `@kavo/mcp` outright (ADR-0016's sanctioned sideways
-edge), so npm resolves the binding and then the binding's peer — marking only
-`@kavo/nest`'s copy left `graphql`, the MCP SDK and its `zod` subtree in
-every REST-only install (#148). `tests/release-workflow.spec.ts` asserts both
-hops, since the failure is silent: the manifest still installs, the tree is
-just bigger.
+**Optional where the package is somebody's transitive dependency.** The rule
+is topological, not about how badly the package needs its peer — every peer
+here is required to _use_ the package that declares it, `graphql` and
+`typeorm` alike.
+
+What separates them is who ends up installing it. An ORM adapter is nobody's
+dependency: `@kavo/typeorm` only ever reaches a tree because someone asked
+for it, so a required peer is a clear install-time error for a user who
+already opted in. A protocol binding is a hard `dependency` of `@kavo/nest`
+(ADR-0016's sanctioned sideways edge), so a required peer there is
+force-installed on every user who never opted into the protocol at all —
+which is #148: `graphql`, the MCP SDK and its `zod` subtree in every
+REST-only install.
+
+Both hops have to say optional, because a package manager resolves the
+binding and then the binding's own peer; marking only `@kavo/nest`'s copy
+changed nothing. `tests/release-workflow.spec.ts` asserts both, since the
+failure is silent — the manifest still installs, the tree is just bigger.
+
+The two bindings sit at different points on the trade. `@kavo/mcp` is free:
+it references the SDK as a type only, so it runs without it. `@kavo/graphql`
+value-imports `graphql` at module scope, so installing that package alone
+without its peer throws `ERR_MODULE_NOT_FOUND` on first import — a runtime
+error where a required peer would have given an install-time one. That is
+the deliberate half of the trade, and it is acceptable because the person
+who installed `@kavo/graphql` is by definition someone who opted in; the
+person it protects is the REST-only adopter who never touched it.

--- a/docs/internals/architecture/13-graphql-binding.md
+++ b/docs/internals/architecture/13-graphql-binding.md
@@ -179,8 +179,12 @@ graphql: true })` mounts `POST /graphql`; `{ graphql: { path: "api/graphql"
 
 ## 6. Lazy-loading an optional protocol dependency
 
-`graphql` is an _optional_ peer of `@kavo/nest` (`peerDependenciesMeta.graphql.optional: true`)
-— an app that never touches GraphQL shouldn't need it installed. That
+`graphql` is an _optional_ peer of `@kavo/nest` **and of `@kavo/graphql`
+itself** (`peerDependenciesMeta.graphql.optional: true` on both) — an app
+that never touches GraphQL shouldn't need it installed. Both hops matter:
+`@kavo/nest` depends on `@kavo/graphql` outright, so npm resolves the
+binding and then the binding's peer, and marking only the outer one left
+`graphql` in every REST-only install (#148). That
 guarantee only holds if nothing `@kavo/nest`'s always-loaded module graph
 (`index.ts`, `kavo.module.ts`) reaches at import time ever statically
 imports `@kavo/graphql` or `graphql`. A static top-level `import` is
@@ -227,6 +231,18 @@ Node cannot `require()` an ES module synchronously — only a dynamic
 `BaseKavoGraphQLController.onModuleInit`/`execute` are `async` for
 exactly this reason; a future binding lazily loading another first-party
 ESM package should expect the same.
+
+**The lazy path is `@kavo/nest`'s, not `@kavo/graphql`'s.** Now that
+`graphql` is optional on `@kavo/graphql` too, installing that package alone
+without `graphql` is a reachable state, and it does not get the friendly
+`ConfigurationException`: `json-scalar.ts` and `schema.ts` import
+`GraphQLScalarType`/`Kind`/`valueFromASTUntyped` as **values** at the top
+level, so the first import throws a raw `ERR_MODULE_NOT_FOUND`. That is the
+honest outcome — a package whose whole job is building a GraphQL schema
+cannot run without `graphql`, and "optional" here means optional to
+_install_, required to _use_. The friendly error exists on the `@kavo/nest`
+path because that is the one where an app can plausibly have never asked for
+GraphQL at all.
 
 ## 7. What's out of scope (by design, for now)
 

--- a/docs/internals/architecture/16-mcp-binding.md
+++ b/docs/internals/architecture/16-mcp-binding.md
@@ -213,11 +213,24 @@ via `KavoModule`'s `mcp` option — never from `index.ts`, `kavo.module.ts`,
 or `base-kavo-mcp.controller.ts` directly.
 
 `@modelcontextprotocol/sdk` is listed as an optional peer of both
-`@kavo/mcp` and `@kavo/nest` (`peerDependenciesMeta`) so a consumer's own
-typecheck resolves the `Tool`/`CallToolResult` types even if they never
-install the SDK (a hand-written `BaseKavoMcpController` subclass reusing
-only the plain data shapes) — and so it's actually present for `mcp: true`
-to work at runtime.
+`@kavo/mcp` and `@kavo/nest` (`peerDependenciesMeta`). A **peer**, so the
+supported version range is declared and a package manager links the
+consumer's own copy rather than nesting a second one. **Optional**, because
+`@kavo/mcp` never executes the SDK — its only reference is
+`import type { CallToolResult, Tool }` in `tools.ts`, fully erased — so
+`@kavo/nest`'s eager `import { resolveKavoMcpTools } from "@kavo/mcp"`
+resolves with the SDK absent, and a REST-only app is not made to install it
+(#148). Marking it on both hops is what makes that true: `@kavo/nest`
+depends on `@kavo/mcp` outright, so a required peer on the inner hop
+force-installs the SDK regardless of the outer marking.
+
+Note what optional does **not** buy: it has no bearing on type resolution.
+A consumer who never installs the SDK loses the `Tool`/`CallToolResult`
+declarations `tools.d.ts` re-exports, which surfaces as `TS2307` only under
+`skipLibCheck: false` — `tsconfig.base.json` and Nest's own scaffold both
+set it `true`, so the blast radius is narrow, but a hand-written
+`BaseKavoMcpController` subclass that wants those types should install the
+SDK as a devDependency.
 
 ## 6. What's out of scope (by design, for now)
 

--- a/packages/protocols/graphql/package.json
+++ b/packages/protocols/graphql/package.json
@@ -35,6 +35,11 @@
   "peerDependencies": {
     "graphql": "^17.0.0"
   },
+  "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "graphql": "^17.0.0"
   }

--- a/packages/protocols/mcp/package.json
+++ b/packages/protocols/mcp/package.json
@@ -35,6 +35,11 @@
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"
   }

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -35,6 +35,7 @@ interface Manifest {
   engines?: Record<string, string>;
   dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   optionalDependencies?: Record<string, string>;
 }
 
@@ -320,6 +321,46 @@ describe("engines field lockstep", () => {
     for (const [dir, node] of Object.entries(actual)) {
       expect(node, `${dir} engines.node`).toBe(expectedNode);
     }
+  });
+});
+
+/**
+ * A protocol binding's peer is **optional to install, required to use**, and
+ * only `peerDependenciesMeta` says so to a package manager. Without it,
+ * `@kavo/nest` — which depends on both bindings — drags `graphql`, the MCP
+ * SDK and its `zod` subtree into every REST-only install (#148).
+ *
+ * `@kavo/nest` already marks its own three. These two are the transitive
+ * hop that made the marking on `@kavo/nest` insufficient, and the pairing is
+ * exactly the kind of thing that regresses silently when a package is added:
+ * the manifest still installs, the tree is just bigger.
+ *
+ * Deliberately **not** generalized to "every peer of every package". An ORM
+ * adapter's peer is genuinely required — `@kavo/typeorm` without `typeorm`
+ * does nothing — so marking those optional would trade a real install-time
+ * error for a runtime one.
+ */
+describe("optional protocol peers", () => {
+  const optionalPeers: readonly [dir: string, peer: string][] = [
+    ["packages/protocols/graphql", "graphql"],
+    ["packages/protocols/mcp", "@modelcontextprotocol/sdk"],
+  ];
+
+  it.each(optionalPeers)("marks %s's %s peer optional", (dir, peer) => {
+    const manifest = readManifest(dir);
+
+    expect(manifest.peerDependencies?.[peer], `${dir} must still declare ${peer} as a peer`).toBeTruthy();
+    expect(manifest.peerDependenciesMeta?.[peer]?.optional, `${dir} peerDependenciesMeta.${peer}.optional`).toBe(true);
+  });
+
+  it("keeps @kavo/nest's own marking, since both hops have to say optional", () => {
+    // Marking only the leaf does not help: npm resolves `@kavo/nest`'s
+    // dependency on the binding, then the binding's peer. Either hop
+    // declaring the peer required pulls it in.
+    const nest = readManifest("packages/frameworks/nest").peerDependenciesMeta;
+
+    expect(nest?.["graphql"]?.optional).toBe(true);
+    expect(nest?.["@modelcontextprotocol/sdk"]?.optional).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #148.

`@kavo/nest` already marked `graphql`, `@modelcontextprotocol/sdk` and `@nestjs/swagger` optional, and it was not enough.

**Both hops have to say optional.** `@kavo/nest` depends on `@kavo/graphql` and `@kavo/mcp` outright (ADR-0016's sanctioned sideways edge), so npm resolves the binding first and then the binding's own peer — and both bindings declared theirs required. A REST-only app installing `@kavo/nest` got `graphql`, the MCP SDK and its `zod` subtree anyway.

## The change

Two `peerDependenciesMeta` entries:

- `packages/protocols/graphql/package.json` → `graphql` optional
- `packages/protocols/mcp/package.json` → `@modelcontextprotocol/sdk` optional

Nothing else changes, and I verified why from the code rather than assuming:

- **`@kavo/mcp` only ever imports the SDK as a type** — `import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js"` in `tools.ts`, fully erased at compile time. So `@kavo/nest`'s eager value-import of `@kavo/mcp` (`index.ts` → `base-kavo-mcp.controller.ts`) resolves fine with the SDK absent, which is exactly why the SDK *can* be optional.
- **`@kavo/graphql` is reached only through a lazy `import()`** from `load-graphql.ts`; the controller carries only `import type … from "graphql"`.

Neither package's runtime behaviour depends on the peer being present at install time.

## Deliberately not generalized

Not "mark every peer of every package optional". An ORM adapter's peer is genuinely required — `@kavo/typeorm` without `typeorm` does nothing — so marking those optional would trade a clear install-time error for a runtime one.

## Test

`tests/release-workflow.spec.ts` asserts both hops, because this regresses silently: the manifest still installs, the tree is just bigger. It also asserts `@kavo/nest` keeps its own marking, since dropping either hop restores the bug. `Manifest` gains a `peerDependenciesMeta` field so the test reads it typed.

## Docs

`docs/internals/architecture/16-mcp-binding.md` already stated the SDK was "an optional peer of both `@kavo/mcp` and `@kavo/nest` (`peerDependenciesMeta`)". That was **false when written**; it is true now. Docs 02 and 13 are updated to match, and doc 02 gains the rule behind it — optional where the peer is optional to *install* and required to *use*, which is the line an ORM peer falls on the wrong side of.

One newly reachable state is documented rather than left to be discovered: installing `@kavo/graphql` alone without `graphql` now throws a raw `ERR_MODULE_NOT_FOUND` on first import, because `json-scalar.ts` and `schema.ts` import `graphql` values at the top level. The friendly `ConfigurationException` exists on the `@kavo/nest` path because that is where an app can plausibly never have asked for GraphQL at all.

## Gate

`pnpm check` green: 2231 passed, 2 skipped, no dependency violations. `pnpm docs:links`, `pnpm docs:build` and `pnpm format:check` all pass. `pnpm install` reports the lockfile unchanged — `peerDependenciesMeta` alters resolution for consumers, not for this workspace.
