### PR TITLE
feat(nest): document per-entity allowlists in Swagger, extract shared boilerplate into KAVO_API_GUIDE

### DIFF
--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -250,6 +250,8 @@ What a request may filter, sort, and select on — including relation paths. Any
 
 `{ exclude: [...] }` means "every own column (plus, for `selectable`, every selectable computed field) except these", resolved at bootstrap against exactly the base set that key's plain default uses. Omit a key entirely and it derives from the `query` DTO or entity metadata instead.
 
+When `@nestjs/swagger` is installed, an explicit array here also names the generated `filter`/`sort`/`fields` `ApiQuery` descriptions with the entity's actual allowed fields. `{ exclude: [...] }` and an omitted key carry no per-route description at all — resolving either needs ORM metadata, which doesn't exist yet at `@Kavo` decoration time (see [ADR-0012](/internals/adr/0012-decoration-time-route-generation)). The generic `filter`/`sort`/`limit`/`offset`/`fields` syntax itself isn't repeated on every route — it's exported once as `KAVO_API_GUIDE` from `@kavo/nest`, for splicing into your own `DocumentBuilder().setDescription(...)` (see the reference apps' `main.ts`).
+
 **How to keep a column out of every response.** Name `selectable` and leave the column off it, or exclude it — both forms do the same thing:
 
 ```ts

--- a/docs/internals/adr/0012-decoration-time-route-generation.md
+++ b/docs/internals/adr/0012-decoration-time-route-generation.md
@@ -48,6 +48,9 @@ array.
   truth; the two can't drift.
 - Manual-method-wins is a one-line `hasOwnProperty` check at decoration
   time.
-- Limitation: decoration time has no ORM metadata, so Swagger docs can't
-  enumerate allowlist-derived per-field query params yet (doc 10 §4);
-  acceptable for now, revisited as a future DX option.
+- Limitation: decoration time has no ORM metadata, so Swagger docs can only
+  name an entity's allowlisted `filter`/`sort`/`fields` params when the
+  allowlist is an explicit array — which resolves identically with or
+  without metadata (issue #171); the unconfigured default and an
+  `{ exclude }` selector both need metadata to resolve and keep the
+  generic, unrestricted description (doc 10 §4).

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -379,9 +379,32 @@ surface (ADR-0020) — the `ETag` response header, `If-None-Match` + `304`
 on single-item reads, `If-Match` + `412` on single-row writes, gated on
 as much of `caching.etag` as decoration time can see (entity and
 operation scope; the global scope arrives later, with
-`KavoModule.forRoot`). Allowlist-derived
-per-field query documentation needs ORM metadata, which doesn't exist at
-decoration time — revisited in a future DX pass.
+`KavoModule.forRoot`).
+
+The generic syntax of `filter`/`sort`/`limit`/`offset`/`fields` (doc 5),
+`include`/`fields[relation]`, and `If-None-Match`/`If-Match` is documented
+**once**, in the exported `KAVO_API_GUIDE` string (`swagger.ts`) — not
+repeated as identical boilerplate on every route of every entity. An app
+splices it into its own top-level document description
+(`new DocumentBuilder().setDescription(...)`); the reference apps' `main.ts`
+do this. Per-route `ApiQuery`/`ApiHeader` descriptions then carry only what
+the guide can't say:
+
+- `filter`/`sort`/`fields` carry the entity's actual
+  `allowlists.filterable`/`sortable`/`selectable` fields, when decoration
+  time can tell (issue #171). An **explicit array** selector resolves to
+  exactly the same value `resolveAllowlists` would produce, with no ORM
+  metadata involved, so reading it straight off the raw `EntityConfig` is
+  not a guess. The unconfigured default and an `{ exclude }` selector both
+  resolve against the entity's own columns — ORM metadata that doesn't
+  exist yet at decoration time (ADR-0012) — so those params carry no
+  description at all, deferring entirely to the shared guide rather than
+  imply a narrower list than actually exists.
+- `include` carries which relations are actually includable on the entity,
+  the same way. `fields[relation]` carries no description at all — its
+  relation name is already the param name.
+- `limit`/`offset` and `If-None-Match`/`If-Match` carry no per-route
+  description at all, either way: none of the four ever varies by entity.
 
 The success-response schema is chosen by the descriptor's cardinality
 rather than by a list of operation ids, matching what `mapResponse`

--- a/examples/nest-mikroorm/src/main.ts
+++ b/examples/nest-mikroorm/src/main.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { KAVO_API_GUIDE } from "@kavo/nest";
 import { AppModule } from "./app.module.js";
 import { createPostgresOrm, createSqliteOrm } from "./database.js";
 
@@ -38,7 +39,8 @@ async function bootstrap(): Promise<void> {
           "sorting, pagination, layered config, RFC 9457 problem-details " +
           "errors, `?include=owner`/`?include=pets`/`?include=tags` " +
           "relations loaded by populate, filtering and sorting across a " +
-          "relation path, and soft delete with restore/purge on owners.",
+          "relation path, and soft delete with restore/purge on owners.\n\n" +
+          KAVO_API_GUIDE,
       )
       .setVersion("0.0.0")
       .build(),

--- a/examples/nest-mongoose/src/main.ts
+++ b/examples/nest-mongoose/src/main.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import mongoose from "mongoose";
 import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { KAVO_API_GUIDE } from "@kavo/nest";
 import { AppModule } from "./app.module.js";
 
 /**
@@ -24,7 +25,8 @@ async function bootstrap(): Promise<void> {
           "with filtering, sorting, pagination, layered config, RFC 9457 " +
           "problem-details errors, an `?include=author` relation loaded by " +
           "populate, and soft delete with restore/purge. Ids are MongoDB " +
-          "`_id` values, rendered as hex strings.",
+          "`_id` values, rendered as hex strings.\n\n" +
+          KAVO_API_GUIDE,
       )
       .setVersion("0.0.0")
       .build(),

--- a/examples/nest-typeorm/src/main.ts
+++ b/examples/nest-typeorm/src/main.ts
@@ -5,7 +5,7 @@ import { NestFactory } from "@nestjs/core";
 import type { NestExpressApplication } from "@nestjs/platform-express";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import type { DefaultKavoService, EntityMetadata, ResolvedEntityConfig } from "@kavo/core";
-import { getKavoServiceToken } from "@kavo/nest";
+import { KAVO_API_GUIDE, getKavoServiceToken } from "@kavo/nest";
 import { createTransport } from "@kavo/sse";
 import { AppModule } from "./app.module.js";
 import { Owner } from "./owner/owner.entity.js";
@@ -64,7 +64,8 @@ async function bootstrap(): Promise<void> {
           "(`?include=owner`, `?include=pets`) and soft delete on owners. " +
           "Owner writes also publish over SSE — see the realtime example " +
           "in the README (`GET /realtime?channel=Owner` or `Owner.<id>`, " +
-          "optionally `&filter[...]=...`).",
+          "optionally `&filter[...]=...`).\n\n" +
+          KAVO_API_GUIDE,
       )
       .setVersion("0.0.0")
       .build(),

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -14,7 +14,7 @@ import type { ComputedFieldDescriptor } from "./computed-field.js";
  * `exclude` is resolved against the entity's own columns at bootstrap
  * (`resolveAllowlists`), never evaluated eagerly here — the `@Kavo(...)`
  * config object is built at class-decoration time, before any ORM metadata
- * exists (ADR-0013), so there is nothing to resolve `exclude` against yet.
+ * exists (ADR-0012), so there is nothing to resolve `exclude` against yet.
  *
  * `Extra` widens both forms with names that are not paths on the entity —
  * only ever the entity's declared computed-field names, and only on

--- a/packages/frameworks/nest/src/index.ts
+++ b/packages/frameworks/nest/src/index.ts
@@ -20,6 +20,7 @@ export { KavoExceptionFilter } from "./kavo-exception.filter.js";
 export { KavoResponseInterceptor } from "./kavo-response.interceptor.js";
 export { ConditionalRequest, parseEntityTags } from "./conditional-request.decorator.js";
 export { flattenQuery } from "./flatten-query.js";
+export { KAVO_API_GUIDE } from "./swagger.js";
 export { enumProp, oneOfArray, type SchemaHint } from "./schema-hints.js";
 export type { KavoPrincipalExtractor, KavoPrincipalOption, KavoPrincipalRequest } from "./principal.js";
 export {

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -1,5 +1,12 @@
 import { createRequire } from "node:module";
-import type { ClassRef, DtoResolver, EntityConfig, OperationDescriptor, OperationDtoMap } from "@kavo/core";
+import type {
+  ClassRef,
+  DtoResolver,
+  EntityConfig,
+  OperationDescriptor,
+  OperationDtoMap,
+  QueryFieldSelector,
+} from "@kavo/core";
 import { DefaultDtoResolver } from "@kavo/core";
 import type { KavoHttpMethod } from "./operation-metadata.js";
 import { isSchemaHint, readSchemaHint, type SchemaHint } from "./schema-hints.js";
@@ -87,19 +94,89 @@ function cachingEnabled(config: EntityConfig<object> | undefined, operationId: s
   return perOperation ?? scoped?.caching?.etag ?? true;
 }
 
-const LIST_QUERY_PARAMS: readonly { name: string; description: string }[] = [
-  {
-    name: "filter",
-    description:
-      "Filter conditions: filter[field][operator]=value (operators: eq, ne, " +
-      "gt, gte, lt, lte, in, notIn, like, ilike, between, isNull, " +
-      "isNotNull; or/and/not groups; JSON escape hatch via filter={...}).",
-  },
-  { name: "sort", description: "Comma-separated fields; '-' prefix = descending." },
-  { name: "limit", description: "Page size (clamped to the configured maximum)." },
-  { name: "offset", description: "Zero-based index of the first returned row." },
-  { name: "fields", description: "Sparse fieldset: comma-separated field names." },
-];
+/**
+ * The generic syntax of every query param and conditional-request header a
+ * generated route can carry — identical on every route of every entity in
+ * every app, so it is documented **once** here rather than repeated as
+ * boilerplate across a Swagger document's routes (issue #171 follow-up).
+ * An app splices this into its own top-level document description, e.g.
+ * `new DocumentBuilder().setDescription(\`...\${KAVO_API_GUIDE}\`)`.
+ * Per-route `ApiQuery`/`ApiHeader` descriptions then carry only what this
+ * general guide *can't* say: which fields/relations this entity's config
+ * actually allows (see `listQueryParams` and the `include` block below).
+ * Conditional-request headers have nothing entity-specific to add at all —
+ * `If-None-Match`/`If-Match`'s semantics never vary by entity — so they
+ * carry no per-route description whatsoever, deferring entirely to this
+ * guide (ADR-0020).
+ */
+export const KAVO_API_GUIDE = `### List query parameters
+
+- \`filter\`: filter[field][operator]=value (operators: eq, ne, gt, gte, lt, lte, in, notIn, like, ilike, between, isNull, isNotNull; or/and/not groups; JSON escape hatch via filter={...}).
+- \`sort\`: comma-separated fields; '-' prefix = descending.
+- \`limit\`: page size (clamped to the configured maximum).
+- \`offset\`: zero-based index of the first returned row.
+- \`fields\`: sparse fieldset — comma-separated field names.
+
+Each list route's own \`filter\`/\`sort\`/\`fields\` parameter description names which fields are actually allowed, where the entity's config makes that known.
+
+### Relation includes (every read route)
+
+- \`include\`: comma-separated relation paths to embed, dot-separated for nesting (e.g. \`include=owner,pets.tags\`).
+- \`fields[relation]\`: sparse fieldset for an included relation node (e.g. \`fields[owner]=id,name\`).
+
+Each read route's own \`include\` parameter description names which relations are actually includable on that entity.
+
+### Conditional requests (single-row routes only)
+
+- \`If-None-Match\`: revalidate a cached copy — a matching entity-tag answers 304 with no body.
+- \`If-Match\`: apply this write only if the row's current ETag is one of these entity-tags. Take the tag from an unnarrowed read — a \`fields=\`/\`include=\`-narrowed one identifies a different representation and will not match.`;
+
+/**
+ * The `filter`/`sort`/`limit`/`offset`/`fields` params on a list route.
+ * `limit`/`offset` carry no per-route description at all — their syntax is
+ * always generic, so it lives only in `KAVO_API_GUIDE`.
+ * `filter`/`sort`/`fields` carry a description exactly when decoration
+ * time can name the entity's actual allowlisted fields (issue #171):
+ *
+ * `allowlists` sits outside `resolveEntityConfig`'s `SETTINGS_KEYS`
+ * (`packages/core/src/config/resolve-entity-config.ts`): it merges from
+ * nowhere but the entity's own `EntityConfig` — no global default, no
+ * per-operation override — so, unlike `cachingEnabled` above, there is no
+ * later-arriving scope this can miss. Only its **shape** limits what can be
+ * read here: an explicit array selector is used verbatim by
+ * `resolveFieldSelector`, with no ORM metadata involved, so it is exactly
+ * the value `ResolvedEntityConfig.allowlists` will carry — reading it off
+ * the raw config is not a guess. The unconfigured default and `{ exclude }`
+ * both resolve against the entity's own columns, which come from ORM
+ * metadata that does not exist yet at `@Kavo` decoration time (ADR-0012) —
+ * the same limitation `QueryFieldSelector`'s own doc comment names for
+ * `exclude` — so those carry no description, deferring entirely to the
+ * general guide, rather than imply a narrower list than actually exists.
+ */
+function listQueryParams(config: EntityConfig<object> | undefined): readonly { name: string; description?: string }[] {
+  const allowlists = config?.allowlists;
+  return [
+    { name: "filter", description: allowedFieldsDescription(allowlists?.filterable) },
+    { name: "sort", description: allowedFieldsDescription(allowlists?.sortable) },
+    { name: "limit" },
+    { name: "offset" },
+    { name: "fields", description: allowedFieldsDescription(allowlists?.selectable) },
+  ];
+}
+
+function allowedFieldsDescription(selector: QueryFieldSelector<object> | undefined): string | undefined {
+  const fields = explicitAllowlist(selector);
+  if (fields === null) return undefined;
+  // An explicit empty array is a real, allowed configuration ("nothing is
+  // filterable"), and must read as a closed door rather than as nothing to
+  // say at all — the same distinction `includableRelations` draws below.
+  return fields.length === 0 ? "No field is allowed." : `Allowed fields: ${fields.join(", ")}.`;
+}
+
+function explicitAllowlist(selector: QueryFieldSelector<object> | undefined): readonly string[] | null {
+  if (selector === undefined || "exclude" in selector) return null;
+  return selector;
+}
 
 export function applySwaggerMetadata(
   prototype: Record<string, unknown>,
@@ -134,13 +211,13 @@ export function applySwaggerMetadata(
   // same normalizer.
   const isList = descriptor.kind === "read" && descriptor.cardinality === "many";
   if (isList) {
-    for (const param of LIST_QUERY_PARAMS) {
+    for (const param of listQueryParams(config)) {
       apply(
         swagger.ApiQuery({
           name: param.name,
           required: false,
           type: String,
-          description: param.description,
+          ...(param.description !== undefined ? { description: param.description } : {}),
         }),
       );
     }
@@ -149,6 +226,12 @@ export function applySwaggerMetadata(
   // Includes are documented from the entity config's relation allowlist —
   // the only relation knowledge decoration time has (ADR-0012). Every read
   // supports `include` with identical semantics, single-item ones included.
+  // The generic `include`/`fields[relation]` syntax lives only in
+  // `KAVO_API_GUIDE`; per-route, `include` carries just which
+  // relations this entity actually allows (mirroring `listQueryParams`
+  // above), and `fields[relation]` carries no description at all — its
+  // relation name is already the param name, so there is nothing
+  // entity-specific left to add.
   if (descriptor.kind === "read") {
     const includable = includableRelations(config);
     apply(
@@ -158,9 +241,8 @@ export function applySwaggerMetadata(
         type: String,
         description:
           includable.length === 0
-            ? "Relation paths to embed. No relation is includable on this entity."
-            : `Comma-separated relation paths to embed, dot-separated for nesting. ` +
-              `Includable: ${includable.join(", ")}.`,
+            ? "No relation is includable on this entity."
+            : `Includable: ${includable.join(", ")}.`,
       }),
     );
     for (const relation of includable) {
@@ -169,7 +251,6 @@ export function applySwaggerMetadata(
           name: `fields[${relation}]`,
           required: false,
           type: String,
-          description: `Sparse fieldset for the included '${relation}' node.`,
         }),
       );
     }
@@ -191,7 +272,9 @@ export function applySwaggerMetadata(
   // precedence chain at bootstrap; decoration time can only see the entity
   // and operation scopes of it (ADR-0012), so a `false` at the global scope
   // leaves these documented and inert — the same limitation the query-param
-  // documentation above already lives with.
+  // documentation above already lives with. `If-None-Match`/`If-Match`'s own
+  // semantics never vary by entity, so their `ApiHeader` carries no
+  // description at all — the full explanation lives only in `KAVO_API_GUIDE`.
   const cached = cachingEnabled(config, descriptor.id);
   // Collection responses carry no ETag (ADR-0020) — which is a statement
   // about cardinality, not about one operation id.
@@ -206,25 +289,10 @@ export function applySwaggerMetadata(
   );
   if (cached && route.hasIdParam) {
     if (descriptor.kind === "read") {
-      apply(
-        swagger.ApiHeader({
-          name: "If-None-Match",
-          required: false,
-          description: "Revalidate a cached copy: a matching entity-tag answers 304 with no body.",
-        }),
-      );
+      apply(swagger.ApiHeader({ name: "If-None-Match", required: false }));
       apply(swagger.ApiResponse({ status: 304, description: "The client's cached representation is still current." }));
     } else {
-      apply(
-        swagger.ApiHeader({
-          name: "If-Match",
-          required: false,
-          description:
-            "Apply this write only if the row's current ETag is one of these entity-tags. " +
-            "Take the tag from an unnarrowed read — a 'fields='/'include='-narrowed one identifies " +
-            "a different representation and will not match.",
-        }),
-      );
+      apply(swagger.ApiHeader({ name: "If-Match", required: false }));
       apply(
         swagger.ApiResponse({
           status: 412,

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -20,6 +20,7 @@ import {
 } from "@kavo/core";
 import type { KavoModuleOptions } from "@kavo/nest";
 import {
+  KAVO_API_GUIDE,
   Kavo,
   KavoModule,
   Override,
@@ -1448,8 +1449,136 @@ describe("@Kavo relation includes", () => {
     const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
     const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
     const include = params.find((param) => param.name === "include");
-    expect(include?.description).toContain("Includable: list");
-    expect(params.map((param) => param.name)).toContain("fields[list]");
+    // The generic "comma-separated, dot-separated for nesting" syntax now
+    // lives only in `KAVO_API_GUIDE`; `include`'s own description
+    // carries just the entity-specific allowlist.
+    expect(include?.description).toBe("Includable: list.");
+    const fieldsList = params.find((param) => param.name === "fields[list]");
+    expect(fieldsList).toBeDefined();
+    // `fields[relation]`'s relation name is already the param name, so it
+    // carries no description at all.
+    expect(fieldsList?.description).toBeUndefined();
+  });
+
+  it("documents that no relation is includable, on an entity that opted nothing in", async () => {
+    @Kavo(Todo)
+    @Controller("todos")
+    class ClosedController {}
+
+    await app.close();
+    await bootstrap(ClosedController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const include = params.find((param) => param.name === "include");
+    expect(include?.description).toBe("No relation is includable on this entity.");
+  });
+});
+
+describe("@Kavo Swagger allowlist-aware query docs", () => {
+  @Kavo(Todo, { allowlists: { filterable: ["title", "priority"], sortable: ["priority"] } })
+  @Controller("todos")
+  class RestrictedController {}
+
+  beforeEach(async () => {
+    await bootstrap(RestrictedController);
+  });
+
+  it("names the entity's explicit filterable and sortable allowlists in the generated docs", async () => {
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const filter = params.find((param) => param.name === "filter");
+    const sort = params.find((param) => param.name === "sort");
+    // The generic filter/sort syntax now lives only in
+    // `KAVO_API_GUIDE`, so the per-route description carries
+    // nothing but what that shared guide can't say.
+    expect(filter?.description).toBe("Allowed fields: title, priority.");
+    expect(sort?.description).toBe("Allowed fields: priority.");
+  });
+
+  it("carries no description when an allowlist has no explicit array", async () => {
+    // `selectable` is unconfigured here, so its actual base set can only be
+    // resolved with ORM metadata — unavailable at decoration time. There is
+    // nothing entity-specific to say, so the param defers entirely to
+    // `KAVO_API_GUIDE` rather than claim a narrower list than the
+    // entity really allows.
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const fields = params.find((param) => param.name === "fields");
+    expect(fields?.description).toBeUndefined();
+  });
+
+  it("carries no description for an exclude-shaped allowlist", async () => {
+    @Kavo(Todo, { allowlists: { filterable: { exclude: ["id"] } } })
+    @Controller("todos")
+    class ExcludingController {}
+
+    await app.close();
+    await bootstrap(ExcludingController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const filter = params.find((param) => param.name === "filter");
+    expect(filter?.description).toBeUndefined();
+  });
+
+  it("documents an explicit empty allowlist as a closed door, not a blank description", async () => {
+    @Kavo(Todo, { allowlists: { sortable: [] } })
+    @Controller("todos")
+    class NoSortController {}
+
+    await app.close();
+    await bootstrap(NoSortController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const sort = params.find((param) => param.name === "sort");
+    expect(sort?.description).toBe("No field is allowed.");
+  });
+
+  it("carries no description at all on limit/offset — their syntax is always generic", async () => {
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    expect(params.find((param) => param.name === "limit")?.description).toBeUndefined();
+    expect(params.find((param) => param.name === "offset")?.description).toBeUndefined();
+  });
+});
+
+describe("KAVO_API_GUIDE", () => {
+  it("documents the generic filter/sort/limit/offset/fields syntax once, for apps to splice into their own document description", () => {
+    expect(KAVO_API_GUIDE).toContain("filter[field][operator]=value");
+    expect(KAVO_API_GUIDE).toContain("'-' prefix = descending");
+    expect(KAVO_API_GUIDE).toContain("clamped to the configured maximum");
+    expect(KAVO_API_GUIDE).toContain("zero-based index");
+    expect(KAVO_API_GUIDE).toContain("sparse fieldset");
+  });
+
+  it("documents the generic include/fields[relation] syntax", () => {
+    expect(KAVO_API_GUIDE).toContain("dot-separated for nesting");
+    expect(KAVO_API_GUIDE).toContain("sparse fieldset for an included relation node");
+  });
+
+  it("documents the generic If-None-Match/If-Match conditional-request semantics", () => {
+    expect(KAVO_API_GUIDE).toContain("a matching entity-tag answers 304 with no body");
+    expect(KAVO_API_GUIDE).toContain("Take the tag from an unnarrowed read");
+  });
+});
+
+describe("@Kavo Swagger conditional-request headers carry no per-route description", () => {
+  @Kavo(Todo)
+  @Controller("todos")
+  class ConditionalController {}
+
+  beforeEach(async () => {
+    await bootstrap(ConditionalController);
+  });
+
+  it("documents If-None-Match/If-Match with no description — the semantics live only in KAVO_API_GUIDE", async () => {
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    type HeaderParam = { name: string; in: string; description?: string };
+    const getParams = (document.paths["/todos/{id}"]?.get?.parameters ?? []) as HeaderParam[];
+    const putParams = (document.paths["/todos/{id}"]?.put?.parameters ?? []) as HeaderParam[];
+    const ifNoneMatch = getParams.find((p) => p.name === "If-None-Match" && p.in === "header");
+    const ifMatch = putParams.find((p) => p.name === "If-Match" && p.in === "header");
+    expect(ifNoneMatch?.description).toBeUndefined();
+    expect(ifMatch?.description).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What & why

`@kavo/nest`'s optional Swagger integration documented list-route query params (`filter`, `sort`, `fields`) with static, generic descriptions only — a consumer reading generated docs had no way to know an entity's actual `allowlists.filterable`/`sortable`/`selectable` sets without reading the source `@Kavo(Entity, config)` call.

Implementing that surfaced a second problem: `filter`/`sort`/`limit`/`offset`/`fields`, `include`/`fields[relation]`, and `If-None-Match`/`If-Match` all repeated identical generic boilerplate on every route of every entity — bloating a multi-entity API's generated OpenAPI document with the same paragraphs dozens of times over.

This PR does both:

- `filter`/`sort`/`fields`/`include` `ApiQuery` descriptions now name the entity's actual allowlisted fields/relations when decoration time can tell (an explicit array selector resolves identically with or without ORM metadata — `resolveFieldSelector` uses it verbatim), falling back to no per-route description when it can't (the unconfigured default or `{ exclude }`, which need ORM metadata unavailable at `@Kavo` decoration time, ADR-0012).
- The generic syntax that never varies by entity — `filter`/`sort`/`limit`/`offset`/`fields`, `include`/`fields[relation]`, `If-None-Match`/`If-Match` — is now documented **once**, via a new export `KAVO_API_GUIDE`, for an app to splice into its own `DocumentBuilder().setDescription(...)`. All three reference apps (`nest-typeorm`, `nest-mongoose`, `nest-mikroorm`) do this in their `main.ts`.

Closes #171
Closes #194

## Public API impact

New export from `@kavo/nest`: `KAVO_API_GUIDE` (a plain string constant), re-exported from the package barrel. Non-breaking — additive only. No other public API changes.

Behavioral note (not code-breaking, but consumer-visible): a `@kavo/nest` app that doesn't splice `KAVO_API_GUIDE` into its own Swagger document description now gets `limit`/`offset`/`If-None-Match`/`If-Match` with **no** description at all, and `filter`/`sort`/`fields`/`include` with no generic syntax explanation — only the entity-specific allowlist, when known. Previously every route always carried the full generic text inline. Worth a release note.

## Testing

- New/updated tests in `packages/frameworks/nest/tests/binding.e2e.spec.ts` covering: per-entity allowlist-aware `filter`/`sort`/`fields`/`include` descriptions, the empty-array ("closed door") case, the `{ exclude }`/unconfigured fallback case, `KAVO_API_GUIDE`'s content, and that `limit`/`offset`/`fields[relation]`/`If-None-Match`/`If-Match` carry no per-route description.
- Verified live against a running `nest-typeorm` instance (`/docs-json`): confirmed per-route descriptions and the top-level document description both render as expected.
- `pnpm check`: 99/99 test files, 2282/2282 tests passing; build/typecheck/depcruise/lint all clean.
- `pnpm docs:links`: clean.

## Review notes

- `packages/core/src/config/entity-config.ts` has one unrelated one-line fix bundled in (its own commit): a pre-existing doc-comment typo citing ADR-0013 (soft delete) instead of ADR-0012 (decoration-time routes) for the "no ORM metadata at decoration time" claim — directly adjacent to what this PR documents, so fixed in passing.
- `KAVO_API_GUIDE`'s naming was deliberated: it's a plain string constant, not a DI token, but uses the same `KAVO_`-prefixed SCREAMING_SNAKE form this repo otherwise reserves for tokens (`KAVO_INSTANCE`, `KAVO_MODULE_OPTIONS`). Flagging for a second opinion if a reviewer feels strongly.