### PR TITLE
fix(nest): defer conditional-request Swagger docs until the global caching.etag scope resolves

### DIFF
--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -377,9 +377,22 @@ routes (doc 5), registered DTO classes as body schemas (`ApiBody`),
 problem-details response schemas for 400/404, and the conditional-request
 surface (ADR-0020) — the `ETag` response header, `If-None-Match` + `304`
 on single-item reads, `If-Match` + `412` on single-row writes, gated on
-as much of `caching.etag` as decoration time can see (entity and
-operation scope; the global scope arrives later, with
-`KavoModule.forRoot`).
+`caching.etag`.
+
+Unlike the rest of this list, that gate can't be applied at decoration
+time (ADR-0012): whether it's on depends on `caching.etag` resolved
+through the _full_ precedence chain, and the global scope only arrives
+later, with `KavoModule.forRoot`/`forRootAsync` (issue #198). So
+`applySwaggerMetadata` documents everything else immediately but stashes
+the route (`prototype`, `methodName`, `descriptor`, `route`) under
+`KAVO_CONDITIONAL_DOCS_METADATA`; `KavoModule`'s discovery binder
+(`KavoBinder`, the same `onModuleInit` pass that binds each entity's
+service) reads it back once `service.engine.config.settingsFor(id)`
+carries the entity's fully resolved settings, and calls
+`applyConditionalRequestDocs` with the true `caching.etag`. A module
+graph with no `KavoModule.forRoot`/`forRootAsync` — and so no working
+`@Kavo` service either — never reaches this pass, so no route is left
+half-documented.
 
 The generic syntax of `filter`/`sort`/`limit`/`offset`/`fields` (doc 5),
 `include`/`fields[relation]`, and `If-None-Match`/`If-Match` is documented

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -34,6 +34,7 @@ import type { KavoPrincipalExtractor, KavoPrincipalRequest } from "./principal.j
 import { ConditionalRequest } from "./conditional-request.decorator.js";
 import { KavoResponseInterceptor, isKavoResponse } from "./kavo-response.interceptor.js";
 import {
+  KAVO_CONDITIONAL_DOCS_METADATA,
   KAVO_CONTROLLER_METADATA,
   KAVO_OVERRIDE_METADATA,
   KAVO_PRINCIPAL_PROPERTY,
@@ -41,6 +42,19 @@ import {
 } from "./tokens.js";
 import { WireQueryPipe } from "./wire-query.pipe.js";
 import { applySwaggerMetadata } from "./swagger.js";
+
+/**
+ * One route whose conditional-request Swagger docs (ADR-0020) `@Kavo`
+ * couldn't finish at decoration time — see `applyConditionalRequestDocs`'s
+ * doc comment in `swagger.ts`. Stashed under `KAVO_CONDITIONAL_DOCS_METADATA`
+ * for `KavoModule`'s discovery binder to finish once the entity's config is
+ * fully resolved.
+ */
+export interface KavoConditionalDocEntry {
+  readonly methodName: string;
+  readonly descriptor: OperationDescriptor<object>;
+  readonly route: ResolvedRoute;
+}
 
 /** What `@Kavo` records on the controller for `KavoModule.forFeature`. */
 export interface KavoControllerMetadata {
@@ -236,6 +250,7 @@ export function Kavo<
 
     const registry = createOperationRegistry(erasedConfig, undefined, undefined, entity.name);
     const overrides = collectOverrides(controller.prototype, entity.name, registry);
+    const conditionalDocs: KavoConditionalDocEntry[] = [];
 
     for (const descriptor of registry.all()) {
       if (!descriptor.enabled) continue;
@@ -259,13 +274,16 @@ export function Kavo<
         }
         defineRoute(controller.prototype, methodName, descriptor, route);
         applySwaggerMetadata(controller.prototype, methodName, descriptor, route, entity, erasedConfig);
+        conditionalDocs.push({ methodName, descriptor, route });
       } else {
         assertNoOwnParamMetadata(controller.prototype, overrideMethodName, entity.name, descriptor.id);
         applyOverrideEtag(controller.prototype, overrideMethodName, descriptor);
         applyRouteDecorators(controller.prototype, overrideMethodName, descriptor, route);
         applySwaggerMetadata(controller.prototype, overrideMethodName, descriptor, route, entity, erasedConfig);
+        conditionalDocs.push({ methodName: overrideMethodName, descriptor, route });
       }
     }
+    Reflect.defineMetadata(KAVO_CONDITIONAL_DOCS_METADATA, conditionalDocs, target);
   };
 }
 

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -4,15 +4,17 @@ import { APP_FILTER, DiscoveryModule, DiscoveryService } from "@nestjs/core";
 import type { ClassRef, KavoInstance } from "@kavo/core";
 import { ConfigurationException, createKavo } from "@kavo/core";
 import type { KavoModuleOptions } from "./kavo-options.js";
-import type { KavoControllerMetadata } from "./kavo.decorator.js";
+import type { KavoConditionalDocEntry, KavoControllerMetadata } from "./kavo.decorator.js";
 import { getRegisteredKavoControllers } from "./kavo.decorator.js";
 import { KavoExceptionFilter } from "./kavo-exception.filter.js";
 import { createDefaultGraphQLController, DEFAULT_GRAPHQL_PATH } from "./graphql/default-graphql.controller.js";
 import { createDefaultMcpController, DEFAULT_MCP_PATH } from "./mcp/default-mcp.controller.js";
 import { resolvePrincipalExtractor } from "./principal.js";
+import { applyConditionalRequestDocs } from "./swagger.js";
 import {
   KAVO_INSTANCE,
   KAVO_MODULE_OPTIONS,
+  KAVO_CONDITIONAL_DOCS_METADATA,
   KAVO_CONTROLLER_METADATA,
   KAVO_PRINCIPAL_PROPERTY,
   KAVO_SERVICE_PROPERTY,
@@ -299,8 +301,23 @@ class KavoBinder implements OnModuleInit {
       if (metatype === null || instance === undefined) continue;
       const metadata = Reflect.getMetadata(KAVO_CONTROLLER_METADATA, metatype) as KavoControllerMetadata | undefined;
       if (metadata === undefined) continue;
-      instance[KAVO_SERVICE_PROPERTY] = this.kavo.createCrud(metadata.entity, metadata.config);
+      const service = this.kavo.createCrud(metadata.entity, metadata.config);
+      instance[KAVO_SERVICE_PROPERTY] = service;
       instance[KAVO_PRINCIPAL_PROPERTY] = extractPrincipal;
+
+      // The conditional-request Swagger docs (ADR-0020) decoration time
+      // couldn't finish — see `applyConditionalRequestDocs`'s doc comment
+      // in swagger.ts — now that `service.engine.config` carries the
+      // entity's fully resolved settings, global scope included.
+      const conditionalDocs = Reflect.getMetadata(KAVO_CONDITIONAL_DOCS_METADATA, metatype) as
+        readonly KavoConditionalDocEntry[] | undefined;
+      if (conditionalDocs !== undefined) {
+        const prototype = metatype.prototype as Record<string, unknown>;
+        for (const { methodName, descriptor, route } of conditionalDocs) {
+          const cached = service.engine.config.settingsFor(descriptor.id).caching.etag;
+          applyConditionalRequestDocs(prototype, methodName, descriptor, route, cached);
+        }
+      }
     }
   }
 }

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -76,25 +76,6 @@ const ETAG_RESPONSE_HEADER = {
 } as const;
 
 /**
- * Whether `caching.etag` is on for this operation, as far as decoration
- * time can tell (ADR-0012): the entity and operation scopes of the config
- * `@Kavo` was handed. The global scope arrives with
- * `KavoModule.forRoot`, long after this runs, so `true` is the answer when
- * neither scope says otherwise — matching the built-in default.
- */
-function cachingEnabled(config: EntityConfig<object> | undefined, operationId: string): boolean {
-  const scoped = config as
-    | {
-        caching?: { etag?: boolean };
-        operations?: Record<string, { caching?: { etag?: boolean } } | boolean | undefined>;
-      }
-    | undefined;
-  const operation = scoped?.operations?.[operationId];
-  const perOperation = typeof operation === "object" ? operation.caching?.etag : undefined;
-  return perOperation ?? scoped?.caching?.etag ?? true;
-}
-
-/**
  * The generic syntax of every query param and conditional-request header a
  * generated route can carry — identical on every route of every entity in
  * every app, so it is documented **once** here rather than repeated as
@@ -141,8 +122,9 @@ Each read route's own \`include\` parameter description names which relations ar
  * `allowlists` sits outside `resolveEntityConfig`'s `SETTINGS_KEYS`
  * (`packages/core/src/config/resolve-entity-config.ts`): it merges from
  * nowhere but the entity's own `EntityConfig` — no global default, no
- * per-operation override — so, unlike `cachingEnabled` above, there is no
- * later-arriving scope this can miss. Only its **shape** limits what can be
+ * per-operation override — so, unlike `caching.etag` (see
+ * `applyConditionalRequestDocs`), there is no later-arriving scope this can
+ * miss. Only its **shape** limits what can be
  * read here: an explicit array selector is used verbatim by
  * `resolveFieldSelector`, with no ORM metadata involved, so it is exactly
  * the value `ResolvedEntityConfig.allowlists` will carry — reading it off
@@ -267,41 +249,19 @@ export function applySwaggerMetadata(
     apply(swagger.ApiBody(bodyOptionsFor(bodyDto)));
   }
 
-  // Conditional requests (ADR-0020). Whether a *response* actually carries
-  // an `ETag` depends on `caching.etag`, which is resolved through the full
-  // precedence chain at bootstrap; decoration time can only see the entity
-  // and operation scopes of it (ADR-0012), so a `false` at the global scope
-  // leaves these documented and inert — the same limitation the query-param
-  // documentation above already lives with. `If-None-Match`/`If-Match`'s own
-  // semantics never vary by entity, so their `ApiHeader` carries no
-  // description at all — the full explanation lives only in `KAVO_API_GUIDE`.
-  const cached = cachingEnabled(config, descriptor.id);
-  // Collection responses carry no ETag (ADR-0020) — which is a statement
-  // about cardinality, not about one operation id.
-  const tagged = cached && route.status !== 204 && descriptor.cardinality !== "many";
+  // The success response's ETag header and the conditional-request
+  // headers/304/412 responses (ADR-0020) are applied later, by
+  // `applyConditionalRequestDocs` — see its doc comment for why: whether
+  // they belong on this route depends on `caching.etag` resolved through
+  // the *full* precedence chain, which decoration time cannot see
+  // (ADR-0012).
   apply(
     swagger.ApiResponse({
       status: route.status,
       description: "Success",
-      ...(tagged ? { headers: { ETag: ETAG_RESPONSE_HEADER } } : {}),
       ...successBodyFor(descriptor, route, entity, dtoResolver),
     }),
   );
-  if (cached && route.hasIdParam) {
-    if (descriptor.kind === "read") {
-      apply(swagger.ApiHeader({ name: "If-None-Match", required: false }));
-      apply(swagger.ApiResponse({ status: 304, description: "The client's cached representation is still current." }));
-    } else {
-      apply(swagger.ApiHeader({ name: "If-Match", required: false }));
-      apply(
-        swagger.ApiResponse({
-          status: 412,
-          description: "The If-Match precondition failed or cannot be evaluated (RFC 9457 problem details).",
-          schema: PROBLEM_DETAILS_SCHEMA,
-        }),
-      );
-    }
-  }
   apply(
     swagger.ApiResponse({
       status: 400,
@@ -326,6 +286,98 @@ export function applySwaggerMetadata(
         schema: PROBLEM_DETAILS_SCHEMA,
       }),
     );
+  }
+}
+
+/**
+ * The conditional-request surface of one route (ADR-0020): the `ETag`
+ * response header, and — on single-row routes — the `If-None-Match`/
+ * `If-Match` request header plus its `304`/`412` response. Applied
+ * separately from `applySwaggerMetadata`, and later, because whether any of
+ * this belongs on the route depends on `caching.etag` resolved through the
+ * *full* precedence chain (built-in default → global → entity →
+ * operation), and the global scope only arrives with
+ * `KavoModule.forRoot`/`forRootAsync` — long after `@Kavo` decoration runs
+ * (ADR-0012).
+ *
+ * `KavoModule`'s discovery binder (`KavoBinder`, `kavo.module.ts`) is what
+ * calls this: by `onModuleInit` it already resolved the entity's full
+ * config to bind the service, so it re-derives the true `cached` value from
+ * that resolution — `resolveEntityConfig`'s own precedence merge, not a
+ * second guess at it here — and calls this once per route the entity
+ * decorated, standard and `@Override`d alike. A caller with no
+ * `KavoModule.forRoot`/`forRootAsync` in its module graph never reaches
+ * this, so its routes carry no conditional-request docs at all, rather
+ * than the entity/operation-scope answer decoration time could have
+ * given — the same graph shape leaves them with no working `@Kavo`
+ * service either, so nothing about that app actually works yet.
+ *
+ * `If-None-Match`/`If-Match`'s own semantics never vary by entity, so
+ * their `ApiHeader` carries no description at all — the full explanation
+ * lives only in `KAVO_API_GUIDE`.
+ *
+ * Idempotent per method function: `KavoBinder`'s `onModuleInit` runs once
+ * per app *bootstrap*, but a decorated method's function object is shared
+ * process-wide (the controller class outlives any one app instance — the
+ * same reason `registeredKavoControllers` is process-scoped), and
+ * `@nestjs/swagger`'s own `ApiHeader`/`ApiResponse` decorators only ever
+ * append or merge, never replace. A second app bootstrapping the same
+ * class — deliberately common in `@kavo/nest`'s own tests — would
+ * otherwise double up every conditional-request header on every rebind.
+ * `alreadyDocumented` guards against exactly that; it freezes the first
+ * *positive* answer for a given method. Once a `cached: true` bootstrap has
+ * applied these docs and recorded the method, a later bootstrap of the same
+ * class that resolves `cached: false` returns at the `!cached` check above
+ * without ever consulting the set, so it cannot retract what the earlier
+ * bootstrap applied. A real app never notices, since it bootstraps exactly
+ * once.
+ */
+const alreadyDocumented = new WeakSet<object>();
+
+export function applyConditionalRequestDocs(
+  prototype: Record<string, unknown>,
+  methodName: string,
+  descriptor: OperationDescriptor<object>,
+  route: RouteShape,
+  cached: boolean,
+): void {
+  if (!cached) return;
+  const swagger = loadSwagger();
+  if (swagger === null) return;
+
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, methodName) as PropertyDescriptor;
+  const method = propertyDescriptor.value as object;
+  if (alreadyDocumented.has(method)) return;
+  alreadyDocumented.add(method);
+  const apply = (decorator: MethodDecorator): void => {
+    decorator(prototype, methodName, propertyDescriptor);
+  };
+
+  // Collection responses carry no ETag (ADR-0020) — which is a statement
+  // about cardinality, not about one operation id.
+  const tagged = route.status !== 204 && descriptor.cardinality !== "many";
+  if (tagged) {
+    // No `description` here: `mergeResponseEntry` (`@nestjs/swagger`)
+    // concatenates a non-empty incoming description onto the existing one
+    // rather than replacing it, and the "Success" description was already
+    // applied at decoration time — repeating it here would render as
+    // "Success\n\nSuccess".
+    apply(swagger.ApiResponse({ status: route.status, headers: { ETag: ETAG_RESPONSE_HEADER } }));
+  }
+  if (route.hasIdParam) {
+    if (descriptor.kind === "read") {
+      apply(swagger.ApiHeader({ name: "If-None-Match", required: false }));
+      apply(swagger.ApiResponse({ status: 304, description: "The client's cached representation is still current." }));
+    } else {
+      apply(swagger.ApiHeader({ name: "If-Match", required: false }));
+      apply(
+        swagger.ApiResponse({
+          status: 412,
+          description: "The If-Match precondition failed or cannot be evaluated (RFC 9457 problem details).",
+          schema: PROBLEM_DETAILS_SCHEMA,
+        }),
+      );
+    }
   }
 }
 

--- a/packages/frameworks/nest/src/tokens.ts
+++ b/packages/frameworks/nest/src/tokens.ts
@@ -14,6 +14,15 @@ export const KAVO_CONTROLLER_METADATA = "kavo:controller";
 /** Reflect metadata key the `@Override` method decorator writes. */
 export const KAVO_OVERRIDE_METADATA = "kavo:override";
 
+/**
+ * Reflect metadata key the `@Kavo` decorator writes on controllers: the
+ * routes whose conditional-request Swagger docs (ADR-0020) couldn't be
+ * decided at decoration time, for `KavoModule`'s discovery binder to finish
+ * once the entity's config is fully resolved — see
+ * `applyConditionalRequestDocs`'s doc comment in `swagger.ts`.
+ */
+export const KAVO_CONDITIONAL_DOCS_METADATA = "kavo:conditionalDocs";
+
 /** Property the generated route methods read the injected service from. */
 export const KAVO_SERVICE_PROPERTY = "__kavoService";
 

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1965,7 +1965,7 @@ describe("@Kavo Swagger request-body schemas", () => {
 
   type Operation = {
     parameters?: readonly { name: string; in: string }[];
-    responses?: Record<string, { headers?: Record<string, unknown> }>;
+    responses?: Record<string, { headers?: Record<string, unknown>; description?: string }>;
   };
   const operation = (path: string, verb: string): Operation | undefined =>
     (document.paths[path] as Record<string, Operation> | undefined)?.[verb];
@@ -1992,6 +1992,16 @@ describe("@Kavo Swagger request-body schemas", () => {
     expect(operation("/todos/{id}", "delete")?.responses?.["204"]?.headers).toBeUndefined();
   });
 
+  it("stays idempotent across the repeated bootstraps `beforeEach` gives DocumentedController (issue #198)", () => {
+    // `applyConditionalRequestDocs` runs again on every `onModuleInit`, but
+    // `DocumentedController`'s decorated methods are the same function
+    // objects across every `it` in this block — a second boot must not
+    // double up the header/response metadata `@nestjs/swagger` only ever
+    // appends or merges onto them.
+    expect(headerNames("/todos/{id}", "get").filter((name) => name === "If-None-Match")).toHaveLength(1);
+    expect(operation("/todos/{id}", "get")?.responses?.["200"]?.description).toBe("Success");
+  });
+
   it("documents nothing conditional when caching.etag is off for the entity", async () => {
     @Kavo(Todo, { caching: { etag: false } })
     @Controller("todos")
@@ -2004,6 +2014,38 @@ describe("@Kavo Swagger request-body schemas", () => {
     expect((patch?.parameters ?? []).filter((p) => p.in === "header")).toHaveLength(0);
     expect(patch?.responses?.["412"]).toBeUndefined();
     expect(patch?.responses?.["200"]?.headers).toBeUndefined();
+  });
+
+  it("documents nothing conditional when caching.etag is off at the global scope (issue #198)", async () => {
+    @Kavo(Todo)
+    @Controller("todos")
+    class GlobalUncachedController {}
+    await app.close();
+    await bootstrap(GlobalUncachedController, { defaults: { caching: { etag: false } } });
+    const uncached = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+    const get = (uncached.paths["/todos/{id}"] as Record<string, Operation>)["get"];
+    const patch = (uncached.paths["/todos/{id}"] as Record<string, Operation>)["patch"];
+
+    expect((get?.parameters ?? []).filter((p) => p.in === "header")).toHaveLength(0);
+    expect(get?.responses?.["304"]).toBeUndefined();
+    expect(get?.responses?.["200"]?.headers).toBeUndefined();
+    expect((patch?.parameters ?? []).filter((p) => p.in === "header")).toHaveLength(0);
+    expect(patch?.responses?.["412"]).toBeUndefined();
+    expect(patch?.responses?.["200"]?.headers).toBeUndefined();
+  });
+
+  it("an entity-scoped caching.etag still wins over a global default (issue #198)", async () => {
+    @Kavo(Todo, { caching: { etag: true } })
+    @Controller("todos")
+    class ReenabledCachingController {}
+    await app.close();
+    await bootstrap(ReenabledCachingController, { defaults: { caching: { etag: false } } });
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+    const get = (document.paths["/todos/{id}"] as Record<string, Operation>)["get"];
+
+    expect((get?.parameters ?? []).filter((p) => p.in === "header").map((p) => p.name)).toContain("If-None-Match");
+    expect(get?.responses?.["304"]).toBeDefined();
+    expect(get?.responses?.["200"]?.headers).toHaveProperty("ETag");
   });
 });
 


### PR DESCRIPTION
## What & why

`@kavo/nest`'s Swagger generation decided whether to document `If-Match`/`If-None-Match` and the `304`/`412`/`ETag` response shapes from `cachingEnabled(config, descriptor.id)`, which could only see the **entity** and **operation** scopes of `caching.etag` — the config `@Kavo(Entity, config)` was handed at class-decoration time. The **global** scope only arrives later, with `KavoModule.forRoot`/`forRootAsync`. So an app that disabled ETags only at the global scope (`defaults: { caching: { etag: false } }`) still got docs advertising conditional-request support the routes never actually served.

Fix: split the Swagger doc application in two. `applySwaggerMetadata` (decoration time) now documents everything except the conditional-request surface, and stashes each route's `(prototype, methodName, descriptor, route)` under a new `KAVO_CONDITIONAL_DOCS_METADATA` key. `KavoBinder.onModuleInit` (`kavo.module.ts`) — the same pass that already binds each entity's service from its fully-resolved config — reads that back and calls the new `applyConditionalRequestDocs`, using `service.engine.config.settingsFor(id).caching.etag` (the true, fully-merged value) to decide whether to document the ETag surface. Routes still generate at decoration time (ADR-0012 is unaffected); only this one gated Swagger doc surface is deferred to bootstrap.

Two correctness issues surfaced during self-review and are folded into this change:
- A duplicate `description: "Success"` on the merged response entry (`@nestjs/swagger` concatenates rather than replaces non-empty descriptions).
- Repeated bootstraps of the same controller class in one process (a real pattern in this package's own test suite) would otherwise double up the deferred docs on every rebind — guarded with a `WeakSet` keyed on the method function object.

Closes #198

## Public API impact

None. `applyConditionalRequestDocs` and `KAVO_CONDITIONAL_DOCS_METADATA` are new exports internal to `@kavo/nest`'s own decoration/binding wiring, not part of the package's documented public surface.

## Testing

- New test: global-scope `caching.etag: false` (no entity/operation override) documents nothing conditional.
- New test: an entity-scoped `caching.etag: true` still wins over a conflicting global default.
- New test: repeated bootstraps of the same controller class don't double up the conditional-request docs (regression guard for the `WeakSet` fix).
- Existing entity-scope test ("documents nothing conditional when caching.etag is off for the entity") still passes unchanged.
- `pnpm check`: build, typecheck, depcruise, and lint all pass; 2091/2091 runnable tests pass. The 5 failing suites (`examples/nest-typeorm/*`, `examples/nest-mongoose/*`, `examples/nest-mikroorm/*`) fail only because this sandbox has no working container runtime for `testcontainers` — identical failures on unmodified `main`.
- `pnpm docs:links`: passes.

## Review notes

`docs/internals/architecture/10-nestjs-integration.md` §4 was updated to describe the new deferred-application design and the no-`forRoot` degenerate case (no working `@Kavo` service either, so no conditional docs — same limitation the config resolution already has).
