### PR TITLE
fix(nest): omit the Swagger include query param when nothing is includable

### DIFF
--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -214,32 +214,44 @@ export function applySwaggerMetadata(
   // relations this entity actually allows (mirroring `listQueryParams`
   // above), and `fields[relation]` carries no description at all — its
   // relation name is already the param name, so there is nothing
-  // entity-specific left to add.
+  // entity-specific left to add. When no relation is includable, the
+  // parameter could never do anything, so it is omitted entirely rather
+  // than advertised with a "nothing is includable" description.
   if (descriptor.kind === "read") {
     const includable = includableRelations(config);
-    apply(
-      swagger.ApiQuery({
-        name: "include",
-        required: false,
-        type: String,
-        ...(includable !== null
-          ? {
-              description:
-                includable.length === 0
-                  ? "No relation is includable on this entity."
-                  : `Includable: ${includable.join(", ")}.`,
-            }
-          : {}),
-      }),
-    );
-    for (const relation of includable ?? []) {
+    // `null` means decoration time cannot know the set (an `{ exclude }`
+    // selector) — the parameter may still do something, so it is emitted
+    // undescribed, the same treatment `filterable`/`sortable`/`selectable`
+    // get for their own `{ exclude }` form. An empty array is a known,
+    // closed set — the parameter could never do anything, so it is omitted
+    // entirely rather than advertised with a "nothing is includable"
+    // description.
+    if (includable === null) {
       apply(
         swagger.ApiQuery({
-          name: `fields[${relation}]`,
+          name: "include",
           required: false,
           type: String,
         }),
       );
+    } else if (includable.length > 0) {
+      apply(
+        swagger.ApiQuery({
+          name: "include",
+          required: false,
+          type: String,
+          description: `Includable: ${includable.join(", ")}.`,
+        }),
+      );
+      for (const relation of includable) {
+        apply(
+          swagger.ApiQuery({
+            name: `fields[${relation}]`,
+            required: false,
+            type: String,
+          }),
+        );
+      }
     }
   }
 

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1460,7 +1460,7 @@ describe("@Kavo relation includes", () => {
     expect(fieldsList?.description).toBeUndefined();
   });
 
-  it("documents that no relation is includable, on an entity that opted nothing in", async () => {
+  it("omits the include query parameter on an entity that opted nothing in", async () => {
     @Kavo(Todo)
     @Controller("todos")
     class ClosedController {}
@@ -1469,8 +1469,8 @@ describe("@Kavo relation includes", () => {
     await bootstrap(ClosedController);
     const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
     const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
-    const include = params.find((param) => param.name === "include");
-    expect(include?.description).toBe("No relation is includable on this entity.");
+    expect(params.find((param) => param.name === "include")).toBeUndefined();
+    expect(params.find((param) => param.name.startsWith("fields["))).toBeUndefined();
   });
 
   it("carries no description for an exclude-shaped includable allowlist, and no fields[relation] params", async () => {


### PR DESCRIPTION
## What & why

`packages/frameworks/nest/src/swagger.ts` added an `include` `ApiQuery` to every generated `read` route unconditionally, falling back to a "No relation is includable on this entity" description when `includableRelations(config)` was empty. That advertised a query parameter callers could send but which could never do anything. The `include` (and per-relation `fields[<relation>]`) `ApiQuery` params are now only emitted when at least one relation is includable; behavior is unchanged when at least one relation is includable.

Closes #197

## Public API impact

None — this is Swagger-doc generation only. Runtime `include` query parsing/validation is untouched.

## Testing

- Updated `packages/frameworks/nest/tests/binding.e2e.spec.ts`: the test for an entity with nothing includable now asserts the `include` and any `fields[...]` params are absent from the generated OpenAPI doc (previously asserted the old fallback description). The existing positive-case test (entity with an includable relation) is unchanged and still passes.
- `pnpm check`: build, typecheck, depcruise, lint all green. `vitest run`: 2091 passed, 194 skipped. The only failing suites are the 5 Postgres/MariaDB/CockroachDB/Mongo Testcontainers e2e suites, which fail with "Could not find a working container runtime strategy" — no Docker daemon in this environment, unrelated to this change (same failure on `main`).
- `pnpm docs:links`: OK.

## Review notes

Scoped exactly to `swagger.ts` per the issue's constraints — `includableRelations`'s data source and core's relation-registry logic are untouched.