### PR TITLE
Move includable from relations.edges.<name> into allowlists.includable

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -273,6 +273,10 @@ const config = defineConfig({
                 text: "0027 — An @Override inherits the ETag, but not the precondition",
                 link: "/internals/adr/0027-an-override-inherits-the-etag-but-not-the-precondition",
               },
+              {
+                text: "0028 — Relation inclusion permission moves into allowlists.includable",
+                link: "/internals/adr/0028-includable-relations-move-into-allowlists",
+              },
             ],
           },
         ],

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -119,20 +119,33 @@ This is the shape of `defaults` above, and also of every entity-scope, operation
 
 ### `relations`
 
-| Field              | Type                                             | Default | What it does                                                                                                                                                        |
-| ------------------ | ------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `maxIncludeDepth`  | `number`                                         | `2`     | Max nesting depth for `include=` chains (`include=owner.tags` is depth 2).                                                                                          |
-| `maxIncludedNodes` | `number`                                         | `10`    | Max total number of included relation nodes per request, across every branch of the include tree.                                                                   |
-| `edges`            | `Readonly<Record<string, RelationEdgeSettings>>` | `{}`    | Per-relation permissions, keyed by relation property name — see **`relations.edges`** below. Inclusion is opt-in: a relation absent here cannot be included at all. |
+| Field              | Type                                             | Default | What it does                                                                                                                                                                                                                                                                                                     |
+| ------------------ | ------------------------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxIncludeDepth`  | `number`                                         | `2`     | Max nesting depth for `include=` chains (`include=owner.tags` is depth 2).                                                                                                                                                                                                                                       |
+| `maxIncludedNodes` | `number`                                         | `10`    | Max total number of included relation nodes per request, across every branch of the include tree.                                                                                                                                                                                                                |
+| `edges`            | `Readonly<Record<string, RelationEdgeSettings>>` | `{}`    | Per-relation **loading tuning**, keyed by relation property name — see **`relations.edges`** below. Whether a relation may be included at all is `allowlists.includable`'s question, entity scope only — see **`allowlists`** below ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)). |
 
 **`relations.edges.<name>`** (`RelationEdgeSettings`):
 
 | Field            | Type                              | Default                                | What it does                                                                                                                                                              |
 | ---------------- | --------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `includable`     | `boolean`                         | `false`                                | Whether clients may `include=` this relation at all.                                                                                                                      |
-| `defaultInclude` | `boolean`                         | `false`                                | Include this relation even when the client doesn't ask for it.                                                                                                            |
+| `defaultInclude` | `boolean`                         | `false`                                | Include this relation even when the client doesn't ask for it. Requires the relation to also be named in `allowlists.includable` — a bootstrap error otherwise.           |
 | `maxDepth`       | `number`                          | (inherits `relations.maxIncludeDepth`) | Overrides the include-depth limit for the subtree below this relation only.                                                                                               |
 | `strategy`       | `"join"` \| `"batch"` \| `"auto"` | `"auto"`                               | How the relation loads: `join` (single query, correct for to-one), `batch` (per-level `WHERE parentId IN (...)`, correct for to-many), or `auto` (picks per cardinality). |
+
+An entry here tunes loading for a relation that is already includable; it
+grants no permission by itself — naming a relation in `edges` alone does not
+open it to `include=`.
+
+**Migrating from before v0.10 ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)):**
+`relations.edges.<name>.includable: true` was the opt-in — naming a relation
+here, with no `includable` key at all, opened it by default. That key is
+gone. Move each opted-in relation name to `allowlists.includable` (below);
+keep any `defaultInclude`/`maxDepth`/`strategy` on `relations.edges.<name>`
+exactly where it was. `allowlists.includable` is entity-scope-only config
+(no global `defaults`, no per-operation override), so a permission
+previously granted through a global default now needs its own
+`createCrud`/`@Kavo` registration per entity.
 
 ### `caching`
 
@@ -230,7 +243,7 @@ There's no `patch` DTO class to write on its own — it derives from `update`. S
 
 ### `allowlists`
 
-What a request may filter, sort, and select on — including relation paths. Anything outside an allowlist is rejected with a 400, never silently dropped:
+What a request may filter, sort, select, and include — including relation paths. Anything outside an allowlist is rejected with a 400, never silently dropped:
 
 ```ts
 @Kavo(Book, {
@@ -238,19 +251,23 @@ What a request may filter, sort, and select on — including relation paths. Any
     filterable: ["id", "title", "author"],
     sortable: ["id", "title"],
     selectable: ["id", "title", "author"],
+    includable: ["author"],
   },
 })
 ```
 
-| Field        | Type                                                          | What it does                                                 |
-| ------------ | ------------------------------------------------------------- | ------------------------------------------------------------ |
-| `filterable` | `readonly FieldPath[]` \| `{ exclude: readonly FieldPath[] }` | Fields usable in `filter[...]`.                              |
-| `sortable`   | same shape                                                    | Fields usable in `sort=`.                                    |
-| `selectable` | same shape                                                    | Fields usable in `fields=`, **and what a response carries**. |
+| Field        | Type                                                                                    | What it does                                                                                                                                          |
+| ------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `filterable` | `readonly FieldPath[]` \| `{ exclude: readonly FieldPath[] }`                           | Fields usable in `filter[...]`.                                                                                                                       |
+| `sortable`   | same shape                                                                              | Fields usable in `sort=`.                                                                                                                             |
+| `selectable` | same shape                                                                              | Fields usable in `fields=`, **and what a response carries**.                                                                                          |
+| `includable` | `readonly IncludePath<Entity, 1>[]` \| `{ exclude: readonly IncludePath<Entity, 1>[] }` | Relation names usable in `include=`, one segment at a time from the root ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)). |
 
-`{ exclude: [...] }` means "every own column (plus, for `selectable`, every selectable computed field) except these", resolved at bootstrap against exactly the base set that key's plain default uses. Omit a key entirely and it derives from the `query` DTO or entity metadata instead.
+`{ exclude: [...] }` means "every own column (plus, for `selectable`, every selectable computed field; for `includable`, every own relation) except these", resolved at bootstrap against exactly the base set that key's plain default uses.
 
-When `@nestjs/swagger` is installed, an explicit array here also names the generated `filter`/`sort`/`fields` `ApiQuery` descriptions with the entity's actual allowed fields. `{ exclude: [...] }` and an omitted key carry no per-route description at all — resolving either needs ORM metadata, which doesn't exist yet at `@Kavo` decoration time (see [ADR-0012](/internals/adr/0012-decoration-time-route-generation)). The generic `filter`/`sort`/`limit`/`offset`/`fields` syntax itself isn't repeated on every route — it's exported once as `KAVO_API_GUIDE` from `@kavo/nest`, for splicing into your own `DocumentBuilder().setDescription(...)` (see the reference apps' `main.ts`).
+**`includable` is the one key here that does not default to "everything".** Omit `filterable`/`sortable`/`selectable` and it derives from the `query` DTO or entity metadata — every own column. Omit `includable` and it resolves to `[]` — **no relation is includable** — the same opt-in posture `relations.edges` had before this key existed. Write `{ exclude: [] }` to opt every own relation in at once; that is the one spelling that crosses the fail-closed default rather than narrowing a fail-open one.
+
+When `@nestjs/swagger` is installed, an explicit array here also names the generated `filter`/`sort`/`fields`/`include` `ApiQuery` descriptions with the entity's actual allowed fields/relations. `{ exclude: [...] }` and an omitted `filterable`/`sortable`/`selectable` key carry no per-route description at all — resolving either needs ORM metadata, which doesn't exist yet at `@Kavo` decoration time (see [ADR-0012](/internals/adr/0012-decoration-time-route-generation)). `includable`'s omitted case is different: the empty-set default needs no ORM metadata, so an omitted `includable` still gets a description ("No relation is includable on this entity") — only its own `{ exclude: [...] }` form is undescribed, for the same decoration-time reason. The generic `filter`/`sort`/`limit`/`offset`/`fields`/`include` syntax itself isn't repeated on every route — it's exported once as `KAVO_API_GUIDE` from `@kavo/nest`, for splicing into your own `DocumentBuilder().setDescription(...)` (see the reference apps' `main.ts`).
 
 **How to keep a column out of every response.** Name `selectable` and leave the column off it, or exclude it — both forms do the same thing:
 

--- a/docs/integrations/nest/configuration.md
+++ b/docs/integrations/nest/configuration.md
@@ -141,11 +141,23 @@ open it to `include=`.
 `relations.edges.<name>.includable: true` was the opt-in — naming a relation
 here, with no `includable` key at all, opened it by default. That key is
 gone. Move each opted-in relation name to `allowlists.includable` (below);
-keep any `defaultInclude`/`maxDepth`/`strategy` on `relations.edges.<name>`
-exactly where it was. `allowlists.includable` is entity-scope-only config
-(no global `defaults`, no per-operation override), so a permission
-previously granted through a global default now needs its own
-`createCrud`/`@Kavo` registration per entity.
+keep any `maxDepth`/`strategy` on `relations.edges.<name>` exactly where it
+was. `allowlists.includable` is entity-scope-only config (no global
+`defaults`, no per-operation override), so a permission previously granted
+through a global default now needs its own `createCrud`/`@Kavo` registration
+per entity.
+
+**`defaultInclude` needs its own care if it was set at global (`defaults`)
+scope.** Before this change, naming a relation in a global
+`defaults.relations.edges.<name>` was itself the opt-in, so a global
+`defaultInclude: true` was safe by construction. It is not safe to leave
+where it was: `allowlists.includable` cannot be set globally, so a global
+`defaultInclude: true` with no _entity-level_ `allowlists.includable` naming
+that relation is now a **bootstrap crash** (`ConfigurationException`) on
+every entity that happens to have a relation of that name — not a silent
+no-op. Move `defaultInclude: true` down to each entity's own
+`relations.edges.<name>` alongside that entity's `allowlists.includable`
+grant, rather than leaving it at global scope.
 
 ### `caching`
 

--- a/docs/internals/adr/0028-includable-relations-move-into-allowlists.md
+++ b/docs/internals/adr/0028-includable-relations-move-into-allowlists.md
@@ -1,0 +1,144 @@
+# ADR-0028 — Relation inclusion permission moves into `allowlists.includable`
+
+**Status:** accepted
+
+## Context
+
+`QueryAllowlists` (`filterable`/`sortable`/`selectable`, entity-config.ts) is
+where every other request/response permission gate lives, and each key is
+typed against the entity's real paths (`FieldPath<Entity>`), so a typo fails
+at compile time. `include=` permission lived somewhere else entirely:
+`relations.edges.<name>.includable` (`RelationEdgeSettings`, settings.ts), a
+plain boolean buried alongside unrelated loading tuning
+(`defaultInclude`/`maxDepth`/`strategy`), and typed only as
+`Readonly<Record<string, RelationEdgeSettings>>` — a plain string-keyed map,
+because `KavoSettings` carries no `Entity` type parameter. A typo'd relation
+name there produced no compile error, only a bootstrap
+`ConfigurationException` (`DefaultRelationRegistry`).
+
+Two problems followed from where the key sat, not from what it did:
+
+1. **No compile-time typing.** Every other allowlist catches a typo before
+   the app runs; `includable` could not, because `RelationEdgeSettings` is
+   part of `KavoSettings`, which is deliberately entity-agnostic (it is the
+   same schema for global, entity, operation, and per-call scope).
+2. **One concept split across two unrelated categories.** `edges` mixed a
+   permission gate (`includable`) with pure loading tuning
+   (`defaultInclude`/`maxDepth`/`strategy`) in the same record, where naming a
+   relation there was itself sufficient to open it
+   (`includable: edge.includable ?? true`) — an easy default to get backwards
+   when skimming the shape.
+
+The alternative — leave `includable` on `relations.edges` but type its keys
+against the entity's real relation names in place, the same way `filterable`/
+`sortable` are typed against `FieldPath<Entity>` — was raised and rejected.
+It fixes problem 1 alone; it does nothing about problem 2, and a config
+schema is not the layer to fix half a documented inconsistency.
+
+## Decision
+
+**`includable` moves onto `QueryAllowlists`, typed against the entity's own
+top-level relation names.** `IncludePath<Entity, 1>` — `IncludePath` capped
+to depth 1 — is exactly that set: `include=` grants permission one relation
+segment at a time from the root (`blog` is the unit `includable` grants;
+`blog.name` is a filter/sort/select path, a different thing entirely), so
+depth 1 is not an arbitrary choice, it is the shape of the permission. The
+new type, `RelationFieldSelector<Entity>`, mirrors `QueryFieldSelector`'s
+array-or-`{ exclude }` shape.
+
+**`relations.edges` keeps only loading tuning.** `RelationEdgeSettings` drops
+`includable`; `defaultInclude`/`maxDepth`/`strategy` stay exactly where they
+were, because they are not a permission question — a relation `edges` tunes
+without also being named in `allowlists.includable` still validates and
+applies its tuning, but grants nothing. This is the same split ADR-0026 drew
+between `selectable` (a permission/projection gate) and everything else
+`KavoSettings` tunes.
+
+**The opt-in default is preserved across the move — deliberately the odd one
+out among the four allowlist keys.** `filterable`/`sortable`/`selectable`
+default to "every own column" when unconfigured (a validation posture: reject
+the unexpected, don't hide the expected). `includable` defaults to "no
+relation" when unconfigured (a disclosure posture: a client cannot even probe
+whether a relation exists until config says so — the same fail-closed
+reasoning `errors/message-hints.ts`'s disclosure rule documents for the
+rejection message itself). Moving the key does not get to also flip that
+default; `resolveAllowlists` (`resolve-entity-config.ts`) resolves
+`includable` through its own resolver, `resolveIncludableSelector`, returning
+`[]` on `undefined` where every other key's resolver returns its base set.
+
+**`{ exclude: [] }` is the one spelling that opts every relation in at
+once.** `{ exclude }` still resolves against the full base set (every
+relation), consistent with the other three keys — the asymmetry is in the
+_default_, not in how `{ exclude }` resolves once written.
+
+**The typo fail-fast moves with the permission, not with the tuning.**
+`DefaultRelationRegistry` now takes `includable` (resolved names) and `edges`
+(tuning) as two separate parameters. A name in `includable` that is not a
+real relation throws `ConfigurationException` at `allowlists.includable`; a
+name in `edges` that is not a real relation still throws too, at
+`relations.edges.<name>` — the tuning-only entry gets the same fail-fast
+treatment it always had, it just no longer doubles as a permission grant.
+
+**The `defaultInclude` vs. permission cross-check moves out of
+`validateSettings`.** `defaultInclude: true` on a relation the entity did not
+open (`allowlists.includable`) is still a bootstrap `ConfigurationException`
+— "it would load a relation clients cannot ask for" — but `validateSettings`
+only ever sees `KavoSettings`, which no longer carries permission at all. The
+check is now `validateIncludableRelations` in `resolve-entity-config.ts`, run
+after `allowlists` resolves, alongside `validateDefaultSort`/
+`validateSincePagination`, which already cross-check settings against a
+resolved allowlist for the same reason.
+
+## Consequences
+
+**This is a breaking change to `EntityConfig`/`RelationEdgeSettings`'s public
+shape.** Any app writing `relations.edges.<name>.includable` needs a
+migration: move the relation names to `allowlists.includable`, keep any
+`defaultInclude`/`maxDepth`/`strategy` on `relations.edges.<name>` as before.
+
+**`includable` can no longer be set at global (`createKavo`) or per-operation
+scope.** `allowlists` sits outside `resolveEntityConfig`'s `SETTINGS_KEYS` —
+it merges from nowhere but the entity's own `EntityConfig`, exactly like
+`filterable`/`sortable`/`selectable` already did (`swagger.ts` documents the
+same limitation for those three). A relation reachable only through
+`include=` and never given its own `createCrud`/`@Kavo` call — legitimate,
+and covered in doc 12 §2 — can no longer have that relation's own further
+relations opened by a caller-side global default; opening them now requires
+giving that target entity its own `createCrud`/`@Kavo` registration.
+
+**Swagger's `include`/`fields[relation]` docs read `allowlists.includable`
+instead of `relations.edges`, with one added case.** `{ exclude }` cannot be
+resolved at `@Kavo` decoration time (no ORM metadata exists yet, ADR-0012) —
+the same limitation the other three allowlist keys already have — so
+`includableRelations` (`packages/frameworks/nest/src/swagger.ts`) returns
+`null` for that shape, distinct from a known-empty array: the caller
+advertises the `include` parameter without a description rather than omitting
+a parameter that may well do something.
+
+**`{ exclude }` fails open on a name that matches nothing — the same hazard
+ADR-0026 §"Consequences" documents for `selectable`, but landing on a
+fail-closed gate this time.** `resolveIncludableSelector` does no existence
+check, so `{ exclude: ["ptes"] }` on an entity whose relation is actually
+named `pets` excludes nothing and opens **every** relation — the typo defeats
+the exclusion rather than producing a bootstrap error, because the base set
+subtracts a name that was never in it. `IncludePath<Entity, 1>` catches this
+at compile time for a properly typed config; it does not for a config built
+through `as never`/erasure, which every ORM adapter's own tests use for
+relation names that don't type-check cleanly against a marker class or a
+lean-document shape (ADR-0017, ADR-0018). Unlike `selectable`'s version of
+this hazard — which costs one served column — this one costs the entire
+relation surface, on the one allowlist whose whole posture is fail-closed. A
+bootstrap existence check on `{ exclude }`'s names, the same follow-up
+ADR-0026 left open for its own case, is the fix and is deliberately not
+bundled here.
+
+## References
+
+- ADR-0026 (`allowlists.selectable` narrows the response projection), the
+  precedent for treating `allowlists` as the request/response permission
+  surface and for splitting a permission gate out of unrelated tuning.
+- ADR-0008 (field-path recursion cap), whose depth counter `IncludePath`
+  reuses and this decision caps at 1.
+- ADR-0012 (decoration-time route generation), the reason Swagger's
+  `include` docs cannot resolve an `{ exclude }` selector.
+- `docs/internals/architecture/12-relations-and-includes.md` §1 and §2.

--- a/docs/internals/adr/0028-includable-relations-move-into-allowlists.md
+++ b/docs/internals/adr/0028-includable-relations-move-into-allowlists.md
@@ -94,17 +94,41 @@ resolved allowlist for the same reason.
 **This is a breaking change to `EntityConfig`/`RelationEdgeSettings`'s public
 shape.** Any app writing `relations.edges.<name>.includable` needs a
 migration: move the relation names to `allowlists.includable`, keep any
-`defaultInclude`/`maxDepth`/`strategy` on `relations.edges.<name>` as before.
+`maxDepth`/`strategy` on `relations.edges.<name>` as before. `defaultInclude`
+needs more care than a mechanical move if it was set at **global**
+(`defaults`) scope — see the next consequence.
 
 **`includable` can no longer be set at global (`createKavo`) or per-operation
-scope.** `allowlists` sits outside `resolveEntityConfig`'s `SETTINGS_KEYS` —
-it merges from nowhere but the entity's own `EntityConfig`, exactly like
+scope, and a global `defaultInclude` now fails loudly instead of silently.**
+`allowlists` sits outside `resolveEntityConfig`'s `SETTINGS_KEYS` — it merges
+from nowhere but the entity's own `EntityConfig`, exactly like
 `filterable`/`sortable`/`selectable` already did (`swagger.ts` documents the
-same limitation for those three). A relation reachable only through
-`include=` and never given its own `createCrud`/`@Kavo` call — legitimate,
-and covered in doc 12 §2 — can no longer have that relation's own further
-relations opened by a caller-side global default; opening them now requires
-giving that target entity its own `createCrud`/`@Kavo` registration.
+same limitation for those three). Before this change, a global
+`defaults.relations.edges.<name>.defaultInclude: true` was safe: naming the
+relation in `edges` at all was itself the opt-in, so it needed no companion
+grant. It is not safe to leave in place now — `validateIncludableRelations`
+cross-checks `defaultInclude` against `allowlists.includable`, which cannot
+be set at that same global scope, so a global `defaultInclude: true` with no
+matching entity-level grant is a bootstrap `ConfigurationException` on every
+entity that happens to have a relation of that name. This is deliberate
+(failing loudly at bootstrap is preferable to the alternative — silently
+dropping the setting, which would be `defaultInclude`'s own contract broken
+silently), but it means the migration is not purely mechanical for this one
+sub-key: `defaultInclude` set at global scope has to move down to each
+entity's own `relations.edges.<name>`, alongside that entity's
+`allowlists.includable` grant, not just have its host relation renamed.
+Separately: a relation reachable only through `include=` and never given its
+own `createCrud`/`@Kavo` call — legitimate, and covered in doc 12 §2 — can no
+longer have that relation's own further relations opened by a caller-side
+global default; opening them now requires giving that target entity its own
+`createCrud`/`@Kavo` registration.
+
+**`DefaultRelationRegistry`'s constructor signature changed, and it is a
+barrel export.** `(descriptors, edges, entityName)` became `(descriptors,
+includable, edges, entityName)` — a parameter inserted in the middle, not
+appended. Any caller constructing one directly (outside the
+`resolveEntityConfig` call this ADR's decision lives in) needs to add the new
+`includable: readonly string[]` argument in the right position.
 
 **Swagger's `include`/`fields[relation]` docs read `allowlists.includable`
 instead of `relations.edges`, with one added case.** `{ exclude }` cannot be
@@ -115,22 +139,27 @@ the same limitation the other three allowlist keys already have — so
 advertises the `include` parameter without a description rather than omitting
 a parameter that may well do something.
 
-**`{ exclude }` fails open on a name that matches nothing — the same hazard
-ADR-0026 §"Consequences" documents for `selectable`, but landing on a
-fail-closed gate this time.** `resolveIncludableSelector` does no existence
-check, so `{ exclude: ["ptes"] }` on an entity whose relation is actually
-named `pets` excludes nothing and opens **every** relation — the typo defeats
-the exclusion rather than producing a bootstrap error, because the base set
-subtracts a name that was never in it. `IncludePath<Entity, 1>` catches this
-at compile time for a properly typed config; it does not for a config built
+**`{ exclude }`'s own names are existence-checked, unlike the other three
+allowlist keys' `{ exclude }` form.** An earlier draft of this change left
+`resolveIncludableSelector` with no existence check on `{ exclude }`'s names,
+mirroring `resolveFieldSelector`'s behavior for `filterable`/`sortable`/
+`selectable` — a name that matches nothing there silently excludes nothing
+(the same hazard ADR-0026 §"Consequences" documents for `selectable`, left
+open as a follow-up). That mirroring was wrong for this key specifically:
+`{ exclude: ["ptes"] }` on an entity whose relation is actually named `pets`
+would have excluded nothing and opened **every** relation — the typo
+defeating the exclusion rather than producing a bootstrap error, on the one
+allowlist whose whole posture is fail-closed by default. Unlike
+`selectable`'s version of the hazard, which costs one served column, this one
+would have cost the entire relation surface. `resolveIncludableSelector`
+therefore checks `{ exclude }`'s names against the entity's real relations
+and throws `ConfigurationException` at `allowlists.includable.exclude` on a
+typo, the same fail-fast treatment the plain-array form already had.
+`IncludePath<Entity, 1>` still catches most typos at compile time for a
+properly typed config; this check is what catches the rest — a config built
 through `as never`/erasure, which every ORM adapter's own tests use for
 relation names that don't type-check cleanly against a marker class or a
-lean-document shape (ADR-0017, ADR-0018). Unlike `selectable`'s version of
-this hazard — which costs one served column — this one costs the entire
-relation surface, on the one allowlist whose whole posture is fail-closed. A
-bootstrap existence check on `{ exclude }`'s names, the same follow-up
-ADR-0026 left open for its own case, is the fix and is deliberately not
-bundled here.
+lean-document shape (ADR-0017, ADR-0018).
 
 ## References
 

--- a/docs/internals/architecture/08-configuration.md
+++ b/docs/internals/architecture/08-configuration.md
@@ -11,21 +11,21 @@ built-in defaults → global (createKavo) → entity (createCrud)
 
 `BUILT_IN_DEFAULTS` (`core/src/config/defaults.ts`):
 
-| Key                                                                     | Default                                        | Notes                                                                                            |
-| ----------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `pagination.defaultLimit` / `maxLimit`                                  | 20 / 100                                       | `defaultLimit ≤ maxLimit` enforced                                                               |
-| `pagination.strategy`                                                   | `"offset"`                                     | `"page"` built in; custom via `paginationStrategies`                                             |
-| `pagination.count`                                                      | `true`                                         | `false` skips the count query; envelope reports `total: null`                                    |
-| `query.maxFilterDepth` / `maxInValues`                                  | 3 / 100                                        |                                                                                                  |
-| `query.defaultSort`                                                     | `[]` (unset)                                   | order applied when a request supplies no `sort` (issue #56); see below                           |
-| `errors.exposeInternals`                                                | `false`                                        | leak driver detail into responses                                                                |
-| `relations.maxIncludeDepth` / `maxIncludedNodes`                        | 2 / 10                                         | include depth budget and total node cap                                                          |
-| `relations.edges.<name>`                                                | `{}`                                           | per-relation `includable` / `defaultInclude` / `maxDepth` / `strategy`                           |
-| `caching.etag`                                                          | `true`                                         | ETag on single-item responses + `If-None-Match`/`If-Match` (ADR-0020)                            |
-| `softDelete.field` / `strategy`                                         | `"deletedAt"` / `"auto"`                       | `auto` = soft when the entity has the marker field, `false` disables                             |
-| `realtime.enabled` / `events` / `subscribableFields` / `onPublishError` | `false` (unset) / `{}` (unset) / unset / unset | per-operation event toggles + field allowlist; registered transports are **not** here (ADR-0023) |
-| `operations.<id>`                                                       | `{}` (unset)                                   | global operation-enablement default (issue #38); see below                                       |
-| `bulk.mode` / `maxBatchSize`                                            | `"atomic"` / 500                               | reserved (bulk is not built)                                                                     |
+| Key                                                                     | Default                                        | Notes                                                                                                                                         |
+| ----------------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pagination.defaultLimit` / `maxLimit`                                  | 20 / 100                                       | `defaultLimit ≤ maxLimit` enforced                                                                                                            |
+| `pagination.strategy`                                                   | `"offset"`                                     | `"page"` built in; custom via `paginationStrategies`                                                                                          |
+| `pagination.count`                                                      | `true`                                         | `false` skips the count query; envelope reports `total: null`                                                                                 |
+| `query.maxFilterDepth` / `maxInValues`                                  | 3 / 100                                        |                                                                                                                                               |
+| `query.defaultSort`                                                     | `[]` (unset)                                   | order applied when a request supplies no `sort` (issue #56); see below                                                                        |
+| `errors.exposeInternals`                                                | `false`                                        | leak driver detail into responses                                                                                                             |
+| `relations.maxIncludeDepth` / `maxIncludedNodes`                        | 2 / 10                                         | include depth budget and total node cap                                                                                                       |
+| `relations.edges.<name>`                                                | `{}`                                           | per-relation loading tuning — `defaultInclude` / `maxDepth` / `strategy`; permission is `allowlists.includable`, entity scope only (ADR-0028) |
+| `caching.etag`                                                          | `true`                                         | ETag on single-item responses + `If-None-Match`/`If-Match` (ADR-0020)                                                                         |
+| `softDelete.field` / `strategy`                                         | `"deletedAt"` / `"auto"`                       | `auto` = soft when the entity has the marker field, `false` disables                                                                          |
+| `realtime.enabled` / `events` / `subscribableFields` / `onPublishError` | `false` (unset) / `{}` (unset) / unset / unset | per-operation event toggles + field allowlist; registered transports are **not** here (ADR-0023)                                              |
+| `operations.<id>`                                                       | `{}` (unset)                                   | global operation-enablement default (issue #38); see below                                                                                    |
+| `bulk.mode` / `maxBatchSize`                                            | `"atomic"` / 500                               | reserved (bulk is not built)                                                                                                                  |
 
 **Schema extensibility rule:** new features add keys to this schema —
 they never add a second config mechanism. The reserved keys above are
@@ -144,6 +144,17 @@ global/entity/operation scope, and when a per-call override is merged
 fast at the scope that introduced it instead of producing a broken
 `ORDER BY` on the first request that hits it. Doc 05 covers the
 request-time semantics (client `sort` vs. this fallback).
+
+### `relations.edges.<name>.defaultInclude`
+
+`defaultInclude: true` on a relation absent from `allowlists.includable` is a
+bootstrap `ConfigurationException` — it would load a relation clients cannot
+ask for ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)).
+`validateSettings` only ever sees `KavoSettings`, which does not carry
+`allowlists`, so this cross-check runs separately, in
+`validateIncludableRelations` (`resolve-entity-config.ts`), once `allowlists`
+has resolved — the same reason `query.defaultSort` and
+`pagination.since.field` are checked outside `validateSettings` too.
 
 ## 5. Root factory and framework skin
 

--- a/docs/internals/architecture/12-relations-and-includes.md
+++ b/docs/internals/architecture/12-relations-and-includes.md
@@ -5,31 +5,37 @@ query string and the SQL is documented here.
 
 ```ts
 @Kavo(Owner, {
-  relations: { edges: { pets: { includable: true } } },
+  allowlists: { includable: ["pets"] },
 })
 ```
 
 Inclusion is an **allowlist**, exactly like filtering and sorting: ORM
 metadata supplies the shape of a relation (name, target, cardinality) and
 config supplies permission, which metadata can never know. A relation
-nobody opted in is a 400, never a silent omission.
+nobody opted in is a 400, never a silent omission. Permission and loading
+tuning are two different config keys (ADR-0028): `allowlists.includable`
+(entity-config.ts) grants `include=` access, one relation segment at a time
+from the root; `relations.edges.<name>` (settings.ts) only tunes
+`defaultInclude`/`maxDepth`/`strategy` for a relation once it is already
+includable — naming a relation in `edges` grants nothing by itself.
 
 ## 1. The registry
 
-`DefaultRelationRegistry` merges the two sources at bootstrap into one
+`DefaultRelationRegistry` merges three sources at bootstrap into one
 `RelationDescriptor` per edge:
 
-| Key                             | Source   | Default                              |
-| ------------------------------- | -------- | ------------------------------------ |
-| `name`, `target`, `cardinality` | metadata | —                                    |
-| `includable`                    | config   | `false` — naming the edge opts it in |
-| `defaultInclude`                | config   | `false`                              |
-| `maxDepth`                      | config   | inherit `relations.maxIncludeDepth`  |
-| `strategy`                      | config   | `auto`                               |
+| Key                             | Source                  | Default                                                                                             |
+| ------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- |
+| `name`, `target`, `cardinality` | metadata                | —                                                                                                   |
+| `includable`                    | `allowlists.includable` | `false` — unconfigured means no relation is includable, unlike every other allowlist key (ADR-0028) |
+| `defaultInclude`                | `relations.edges`       | `false`                                                                                             |
+| `maxDepth`                      | `relations.edges`       | inherit `relations.maxIncludeDepth`                                                                 |
+| `strategy`                      | `relations.edges`       | `auto`                                                                                              |
 
-An edge naming a relation the entity does not have is a bootstrap
-`ConfigurationException`: an allowlist typo that silently permits nothing
-looks exactly like working config until the first client asks.
+A name in `allowlists.includable`, or in `relations.edges`, that the entity
+does not have is a bootstrap `ConfigurationException`: an allowlist typo
+that silently permits nothing looks exactly like working config until the
+first client asks.
 
 ## 2. Resolution (`DefaultIncludeResolver`)
 
@@ -93,7 +99,8 @@ and a second query is pure overhead:
 
 ```ts
 joinedBlogs = kavo.createCrud(Blog, {
-  relations: { edges: { articles: { includable: true, strategy: "join" } } },
+  allowlists: { includable: ["articles"] },
+  relations: { edges: { articles: { strategy: "join" } } },
 });
 ```
 

--- a/examples/nest-mikroorm/src/cat/cat.controller.ts
+++ b/examples/nest-mikroorm/src/cat/cat.controller.ts
@@ -30,8 +30,8 @@ import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.j
     filterable: ["id", "name", "age", "size", "owner.name"],
     sortable: ["id", "name", "age", "owner.name"],
     selectable: ["id", "name", "age", "size"],
+    includable: ["owner", "tags"],
   },
-  relations: { edges: { owner: { includable: true }, tags: { includable: true } } },
   operations: {
     patchOne: false,
   },

--- a/examples/nest-mikroorm/src/owner/owner.controller.ts
+++ b/examples/nest-mikroorm/src/owner/owner.controller.ts
@@ -37,11 +37,11 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
     filterable: { exclude: ["deletedAt"] },
     sortable: { exclude: ["deletedAt"] },
     selectable: { exclude: ["deletedAt"] },
+    // `include=pets` — opt-in per relation, and a to-many. `address` is the
+    // to-one counterpart. Neither disturbs root pagination: MikroORM
+    // resolves `populate` with its own queries either way (doc 17 §3).
+    includable: ["pets", "address"],
   },
-  // `include=pets` — opt-in per relation, and a to-many. `address` is the
-  // to-one counterpart. Neither disturbs root pagination: MikroORM resolves
-  // `populate` with its own queries either way (doc 17 §3).
-  relations: { edges: { pets: { includable: true }, address: { includable: true } } },
   operations: {
     purgeOne: true,
     restoreOne: true,

--- a/examples/nest-mongoose/src/article/article.controller.ts
+++ b/examples/nest-mongoose/src/article/article.controller.ts
@@ -33,8 +33,8 @@ import { CreateArticleDto, UpdateArticleDto, ArticleItemDto, ArticleListDto } fr
     filterable: ["_id", "title", "status", "tags", "author"],
     sortable: ["_id", "title", "createdAt"],
     selectable: ["_id", "title", "status", "tags", "body", "createdAt"],
+    includable: ["author"],
   },
-  relations: { edges: { author: { includable: true } } },
 })
 @Controller("articles")
 export class ArticleController {}

--- a/examples/nest-typeorm/src/cat/cat.controller.ts
+++ b/examples/nest-typeorm/src/cat/cat.controller.ts
@@ -30,11 +30,12 @@ import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.j
     filterable: ["id", "name", "age", "size"],
     sortable: ["id", "name", "age"],
     selectable: ["id", "name", "age", "size"],
+    includable: ["owner", "tags"],
   },
   // The to-one side of the owner edge joins; `tags` is a to-many (many-to-
-  // many) and batches. `fields[owner]=id,name` / `fields[tags]=id,name`
-  // narrow each embedded relation.
-  relations: { edges: { owner: { includable: true }, tags: { includable: true } } },
+  // many) and batches, both `auto`'s default — no `relations.edges` tuning
+  // needed. `fields[owner]=id,name` / `fields[tags]=id,name` narrow each
+  // embedded relation.
   operations: {
     patchOne: false,
   },

--- a/examples/nest-typeorm/src/owner/owner.controller.ts
+++ b/examples/nest-typeorm/src/owner/owner.controller.ts
@@ -43,12 +43,13 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
     filterable: { exclude: ["deletedAt"] },
     sortable: { exclude: ["deletedAt"] },
     selectable: { exclude: ["deletedAt"] },
+    // `include=pets` — opt-in per relation. Pets are a to-many, so they
+    // batch-load: one extra query per page of owners, never a joined row
+    // explosion under pagination. `address` is the to-one counterpart — it
+    // joins instead. Both are `auto`'s default, so no `relations.edges`
+    // tuning is needed.
+    includable: ["pets", "address"],
   },
-  // `include=pets` — opt-in per relation. Pets are a to-many,
-  // so they batch-load: one extra query per page of owners, never a joined
-  // row explosion under pagination. `address` is the to-one counterpart —
-  // it joins instead.
-  relations: { edges: { pets: { includable: true }, address: { includable: true } } },
   operations: {
     purgeOne: true,
     restoreOne: true,

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -1,6 +1,7 @@
 import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
 import type { FieldPath } from "../types/field-path.js";
+import type { IncludePath } from "../types/include-path.js";
 import type { QueryContext } from "../query/query-context.js";
 import type { OperationDtoMap, OperationDtoOverride } from "../dto/dto.js";
 import type { EntityInput } from "../types/utility.js";
@@ -24,11 +25,24 @@ export type QueryFieldSelector<Entity, Extra extends string = never> =
   readonly (FieldPath<Entity> | Extra)[] | { readonly exclude: readonly (FieldPath<Entity> | Extra)[] };
 
 /**
- * Security allowlists: what a request may filter, sort, and
- * select on — including relation paths. Anything outside an allowlist is
+ * One relation allowlist key's raw configuration — the same array-or-
+ * `{ exclude }` shape as {@link QueryFieldSelector}, but typed against the
+ * entity's own top-level relation names ({@link IncludePath} capped to
+ * depth 1) rather than every field path. `include=` addresses one relation
+ * segment at a time from the root, so permission is granted per relation,
+ * not per dotted path — `blog.name` is a `filterable`/`sortable` path but
+ * `blog` is the unit `includable` grants or withholds.
+ */
+export type RelationFieldSelector<Entity> =
+  readonly IncludePath<Entity, 1>[] | { readonly exclude: readonly IncludePath<Entity, 1>[] };
+
+/**
+ * Security allowlists: what a request may filter, sort, select, and
+ * include — including relation paths. Anything outside an allowlist is
  * rejected with a 400 (`QueryValidationException`), never silently
- * dropped. When omitted, the allowlists derive from the `query` DTO or
- * entity metadata at bootstrap.
+ * dropped. When omitted, `filterable`/`sortable`/`selectable` derive from
+ * the `query` DTO or entity metadata at bootstrap; `includable` does not
+ * — see its own note.
  *
  * `filterable` and `sortable` govern the request only. `selectable`
  * governs the request **and the response** (ADR-0026) — see its own note.
@@ -65,6 +79,25 @@ export interface QueryAllowlists<Entity = unknown, Computed extends string = nev
    * narrowing statement.
    */
   readonly selectable?: QueryFieldSelector<Entity, Computed>;
+  /**
+   * What a request may name in `include=` — which relations, one path
+   * segment at a time from the root, a client may embed at all
+   * (ADR-0028). `relations.edges.<name>` (`KavoSettings`, settings.ts)
+   * still tunes `defaultInclude`/`maxDepth`/`strategy` for a relation once
+   * it is includable, but grants no permission itself: naming a relation
+   * there without also naming it here does not open it.
+   *
+   * **Opt-in, unlike every other key on this interface.**
+   * `filterable`/`sortable`/`selectable` default to "every own
+   * column/field" when unconfigured — `includable` defaults the other way:
+   * an unconfigured `includable` means **no relation is includable**,
+   * mirroring the opt-in posture `relations.edges` had before this key
+   * existed. `{ exclude: [] }`, written explicitly, means the opposite —
+   * every relation includable — the same asymmetry `{ exclude }` already
+   * carries on the other three keys, just crossing a fail-closed default
+   * instead of a fail-open one.
+   */
+  readonly includable?: RelationFieldSelector<Entity>;
 }
 
 /**

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -296,7 +296,7 @@ function resolveAllowlists<Entity extends object>(
     filterable: resolveFieldSelector(ownColumns, configured?.filterable),
     sortable: resolveFieldSelector(ownColumns, configured?.sortable),
     selectable: resolveFieldSelector(selectableBase, configured?.selectable),
-    includable: resolveIncludableSelector(relationNames, configured?.includable),
+    includable: resolveIncludableSelector(metadata.name, relationNames, configured?.includable),
   };
   for (const key of ["filterable", "sortable"] as const) {
     for (const field of allowlists[key] as readonly string[]) {
@@ -484,16 +484,36 @@ function resolveFieldSelector<Entity>(
  * `includable`'s own resolver, not `resolveFieldSelector` reused: the
  * unconfigured default is `[]`, not `base` — the opt-in direction
  * `QueryAllowlists.includable`'s doc comment calls out (ADR-0028). An
- * explicit array is used verbatim; `{ exclude }` still resolves against
- * `base` (every relation), so `{ exclude: [] }` is the one spelling that
- * opts every relation in at once.
+ * explicit array is used verbatim (and is checked for typos later, when
+ * `DefaultRelationRegistry` builds the registry); `{ exclude }` still
+ * resolves against `base` (every relation), so `{ exclude: [] }` is the one
+ * spelling that opts every relation in at once.
+ *
+ * `{ exclude }`'s own names *are* checked here, unlike `resolveFieldSelector`'s
+ * — a name that matches nothing in `base` would otherwise silently exclude
+ * nothing, so `{ exclude: ["ptes"] }` on an entity whose relation is actually
+ * `pets` would open *every* relation instead of the one name meant to stay
+ * closed. That is a worse failure mode here than on `filterable`/`sortable`/
+ * `selectable`: this is the one allowlist that is fail-closed by default, so
+ * a typo silently flipping it wide open is exactly the mistake the opt-in
+ * default exists to prevent.
  */
 function resolveIncludableSelector<Entity>(
+  entityName: string,
   base: readonly IncludePath<Entity, 1>[],
   selector: RelationFieldSelector<Entity> | undefined,
 ): readonly IncludePath<Entity, 1>[] {
   if (selector === undefined) return [];
   if (!("exclude" in selector)) return selector;
+  const known = new Set<string>(base as readonly string[]);
+  for (const name of selector.exclude) {
+    if (known.has(name as string)) continue;
+    throw new ConfigurationException(
+      entityName,
+      "allowlists.includable.exclude",
+      `'${name}' is not a relation of ${entityName} (relations: ${[...known].join(", ") || "none"})`,
+    );
+  }
   const excluded = new Set(selector.exclude);
   return base.filter((path) => !excluded.has(path));
 }

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -1,11 +1,12 @@
 import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
 import type { ComputedFieldDescriptor, ComputedFieldMap } from "./computed-field.js";
-import type { EntityConfig, OperationConfig, QueryFieldSelector } from "./entity-config.js";
+import type { EntityConfig, OperationConfig, QueryFieldSelector, RelationFieldSelector } from "./entity-config.js";
 import type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./resolved-entity-config.js";
 import type { DtoClass } from "../dto/dto.js";
 import type { EntityMetadata } from "../metadata/entity-metadata.js";
 import type { FieldPath } from "../types/field-path.js";
+import type { IncludePath } from "../types/include-path.js";
 import type { OperationId, StandardOperationId } from "../operations/operation.js";
 import type { RealtimeTransport } from "../realtime/realtime-transport.js";
 import { BUILT_IN_DEFAULTS } from "./defaults.js";
@@ -79,6 +80,7 @@ export function resolveEntityConfig<Entity extends object>(
   validateSettings(entityName, entitySettings);
   validateDefaultSort(entityName, entitySettings, allowlists);
   validateSincePagination(entityName, metadata, entitySettings, allowlists);
+  validateIncludableRelations(entityName, entitySettings, allowlists);
 
   // Per-operation settings views, precomputed for every operation that
   // declares overrides. `false` (disabled) contributes no settings — the
@@ -97,6 +99,7 @@ export function resolveEntityConfig<Entity extends object>(
     validateSettings(scope, merged);
     validateDefaultSort(scope, merged, allowlists);
     validateSincePagination(scope, metadata, merged, allowlists);
+    validateIncludableRelations(scope, merged, allowlists);
     // Resolve for its validation side effect: a per-operation scope that
     // demands soft delete on an entity without a marker field must fail at
     // bootstrap, not on the first request (the engine recomputes the
@@ -116,7 +119,12 @@ export function resolveEntityConfig<Entity extends object>(
     softDelete: resolveSoftDelete(metadata, entitySettings),
     dto: new DefaultDtoResolver<Entity>(entityConfig?.dto),
     computed,
-    relations: new DefaultRelationRegistry<Entity>(metadata.relations, entitySettings.relations.edges, entityName),
+    relations: new DefaultRelationRegistry<Entity>(
+      metadata.relations,
+      allowlists.includable as readonly string[],
+      entitySettings.relations.edges,
+      entityName,
+    ),
     // Shallow-frozen: the array itself can't be mutated, but a transport's
     // own internal state is left alone (ADR-0023).
     realtimeTransports: Object.freeze([...realtimeTransports]),
@@ -279,11 +287,16 @@ function resolveAllowlists<Entity extends object>(
     ...(ownColumns as readonly string[]),
     ...Object.keys(computed).filter((name) => computed[name]?.selectable !== false),
   ] as unknown as readonly FieldPath<Entity>[];
+  const relationNames = metadata.relations.map((relation) => relation.name) as unknown as readonly IncludePath<
+    Entity,
+    1
+  >[];
   const configured = entityConfig?.allowlists;
   const allowlists = {
     filterable: resolveFieldSelector(ownColumns, configured?.filterable),
     sortable: resolveFieldSelector(ownColumns, configured?.sortable),
     selectable: resolveFieldSelector(selectableBase, configured?.selectable),
+    includable: resolveIncludableSelector(relationNames, configured?.includable),
   };
   for (const key of ["filterable", "sortable"] as const) {
     for (const field of allowlists[key] as readonly string[]) {
@@ -318,6 +331,32 @@ export function validateDefaultSort<Entity>(
         scope,
         "query.defaultSort",
         `field '${entry.field}' is not in the sortable allowlist`,
+      );
+    }
+  }
+}
+
+/**
+ * Cross-checks `relations.edges.<name>.defaultInclude` against
+ * `allowlists.includable` (ADR-0028): `defaultInclude: true` on a relation
+ * the entity never opted into `include=` would load something clients
+ * cannot ask for — the same rule `validate-settings.ts` enforced when
+ * `defaultInclude` and `includable` lived on the same `edges` entry, now
+ * checked against the allowlist that carries permission instead.
+ */
+function validateIncludableRelations<Entity>(
+  scope: string,
+  settings: KavoSettings,
+  allowlists: ResolvedQueryAllowlists<Entity>,
+): void {
+  const includable = new Set(allowlists.includable as readonly string[]);
+  for (const [name, edge] of Object.entries(settings.relations.edges)) {
+    if (edge.defaultInclude === true && !includable.has(name)) {
+      throw new ConfigurationException(
+        scope,
+        `relations.edges.${name}`,
+        `defaultInclude requires an includable relation — '${name}' is not on allowlists.includable, ` +
+          `so it would load a relation clients cannot ask for`,
       );
     }
   }
@@ -436,6 +475,24 @@ function resolveFieldSelector<Entity>(
   selector: QueryFieldSelector<Entity> | undefined,
 ): readonly FieldPath<Entity>[] {
   if (selector === undefined) return base;
+  if (!("exclude" in selector)) return selector;
+  const excluded = new Set(selector.exclude);
+  return base.filter((path) => !excluded.has(path));
+}
+
+/**
+ * `includable`'s own resolver, not `resolveFieldSelector` reused: the
+ * unconfigured default is `[]`, not `base` — the opt-in direction
+ * `QueryAllowlists.includable`'s doc comment calls out (ADR-0028). An
+ * explicit array is used verbatim; `{ exclude }` still resolves against
+ * `base` (every relation), so `{ exclude: [] }` is the one spelling that
+ * opts every relation in at once.
+ */
+function resolveIncludableSelector<Entity>(
+  base: readonly IncludePath<Entity, 1>[],
+  selector: RelationFieldSelector<Entity> | undefined,
+): readonly IncludePath<Entity, 1>[] {
+  if (selector === undefined) return [];
   if (!("exclude" in selector)) return selector;
   const excluded = new Set(selector.exclude);
   return base.filter((path) => !excluded.has(path));

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -1,17 +1,25 @@
 import type { KavoSettings } from "./settings.js";
 import type { ComputedFieldMap } from "./computed-field.js";
 import type { FieldPath } from "../types/field-path.js";
+import type { IncludePath } from "../types/include-path.js";
 import type { DtoResolver } from "../dto/dto.js";
 import type { OperationId } from "../operations/operation.js";
 import type { RelationRegistry } from "../relations/relation-registry.js";
 import type { ResolvedSoftDelete } from "../persistence/soft-delete.js";
 import type { RealtimeTransport } from "../realtime/realtime-transport.js";
 
-/** Allowlists after bootstrap resolution — complete, never optional. */
+/**
+ * Allowlists after bootstrap resolution — complete, never optional.
+ *
+ * `includable` resolves the opposite direction from the other three keys:
+ * unconfigured, it is `[]` rather than "every relation" (ADR-0028) — see
+ * `QueryAllowlists.includable`'s doc comment for why.
+ */
 export interface ResolvedQueryAllowlists<Entity = unknown> {
   readonly filterable: readonly FieldPath<Entity>[];
   readonly sortable: readonly FieldPath<Entity>[];
   readonly selectable: readonly FieldPath<Entity>[];
+  readonly includable: readonly IncludePath<Entity, 1>[];
 }
 
 /**

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -56,13 +56,14 @@ export interface ErrorSettings {
 }
 
 /**
- * Per-relation configuration — the config half of a
- * `RelationDescriptor`. ORM metadata supplies shape (name, target,
- * cardinality); this supplies *permission*, which metadata can never know.
+ * Per-relation *tuning* — the config half of a `RelationDescriptor` other
+ * than permission. ORM metadata supplies shape (name, target,
+ * cardinality); this supplies loading behavior once a relation is already
+ * includable. Permission itself lives on `allowlists.includable`
+ * (`EntityConfig`, entity-config.ts) instead, not here (ADR-0028) — naming
+ * a relation in `edges` no longer opts it in.
  */
 export interface RelationEdgeSettings {
-  /** Whether clients may `include=` this relation. Defaults to `false`. */
-  readonly includable?: boolean;
   /** Included even when the client doesn't ask. */
   readonly defaultInclude?: boolean;
   /** Overrides `maxIncludeDepth` for the subtree below this node. */
@@ -70,13 +71,17 @@ export interface RelationEdgeSettings {
   readonly strategy?: RelationLoadStrategy;
 }
 
-/** Relation inclusion limits and the per-relation allowlist. */
+/** Relation inclusion limits and per-relation loading tuning. */
 export interface RelationSettings {
   readonly maxIncludeDepth: number;
   readonly maxIncludedNodes: number;
   /**
-   * Per-relation overrides, keyed by relation property name. Inclusion is
-   * opt-in: a relation absent here is not includable.
+   * Per-relation loading overrides, keyed by relation property name —
+   * `defaultInclude`/`maxDepth`/`strategy` only. Whether a relation is
+   * includable at all is `allowlists.includable`'s question, not this
+   * one (ADR-0028); an entry here for a relation `allowlists.includable`
+   * never named still validates and applies its tuning, but grants no
+   * permission.
    */
   readonly edges: Readonly<Record<string, RelationEdgeSettings>>;
 }

--- a/packages/core/src/config/validate-settings.ts
+++ b/packages/core/src/config/validate-settings.ts
@@ -88,7 +88,6 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
     if (typeof edge !== "object" || edge === null) {
       throw new ConfigurationException(entityName, path, `expected an object, got ${JSON.stringify(edge)}`);
     }
-    if (edge.includable !== undefined) bool(`${path}.includable`, edge.includable);
     if (edge.defaultInclude !== undefined) bool(`${path}.defaultInclude`, edge.defaultInclude);
     if (edge.maxDepth !== undefined) positiveInt(`${path}.maxDepth`, edge.maxDepth);
     if (edge.strategy !== undefined && !["join", "batch", "auto"].includes(edge.strategy)) {
@@ -98,13 +97,10 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
         `expected "join", "batch", or "auto", got ${JSON.stringify(edge.strategy)}`,
       );
     }
-    if (edge.defaultInclude === true && edge.includable === false) {
-      throw new ConfigurationException(
-        entityName,
-        path,
-        "defaultInclude requires an includable relation — it would load a relation clients cannot ask for",
-      );
-    }
+    // `defaultInclude` vs. `allowlists.includable` (permission) is cross-
+    // checked in `resolve-entity-config.ts`'s `validateIncludableRelations`,
+    // not here — this function only sees `KavoSettings`, and `allowlists`
+    // is entity-typed config outside that schema (ADR-0028).
   }
 
   // `softDelete` is the one key in this schema that `false` disables

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,7 @@ export type {
   StandardOperationsConfig,
   QueryAllowlists,
   QueryFieldSelector,
+  RelationFieldSelector,
 } from "./config/entity-config.js";
 export type { ComputedFieldDescriptor, ComputedFieldMap } from "./config/computed-field.js";
 export type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./config/resolved-entity-config.js";

--- a/packages/core/src/relations/default-include-resolver.ts
+++ b/packages/core/src/relations/default-include-resolver.ts
@@ -89,12 +89,13 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
       // A name that is not a relation at all and a relation the config never
       // opted in are the same rejection to the client, deliberately: the
       // registry keeps every metadata relation and flips `includable` only
-      // for configured edges, so wording the two differently would confirm
-      // the existence of the edges `relations.edges` closed on purpose (the
-      // disclosure rule in `errors/message-hints.ts`). What issue #7 was
-      // actually about — the message never naming the config key that grants
-      // inclusion — is fixed without that split, by stating the key as a
-      // conditional the developer can act on and a prober learns nothing from.
+      // for names on `allowlists.includable` (ADR-0028), so wording the two
+      // differently would confirm the existence of the relations that
+      // allowlist closed on purpose (the disclosure rule in
+      // `errors/message-hints.ts`). What issue #7 was actually about — the
+      // message never naming the config key that grants inclusion — is
+      // fixed without that split, by stating the key as a conditional the
+      // developer can act on and a prober learns nothing from.
       if (relation === undefined || !relation.includable) {
         const includable = includableNames(owner);
         issues.push({
@@ -104,8 +105,8 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
             `Relation '${draft.name}' is not includable on ${owner.entityName}${inPath(draft)}.` +
             `${suggestion(draft.name, includable)}` +
             ` Includable relations on ${owner.entityName}: ${nameList(includable)}.` +
-            ` If ${owner.entityName} has a '${draft.name}' relation, opt in with` +
-            ` relations.edges.${draft.name}.includable = true on the ${owner.entityName} config.`,
+            ` If ${owner.entityName} has a '${draft.name}' relation, opt in by naming it in` +
+            ` allowlists.includable on the ${owner.entityName} config.`,
         });
         continue;
       }

--- a/packages/core/src/relations/default-relation-registry.ts
+++ b/packages/core/src/relations/default-relation-registry.ts
@@ -4,37 +4,53 @@ import type { RelationEdgeSettings } from "../config/settings.js";
 import { ConfigurationException } from "../errors/exceptions.js";
 
 /**
- * Map-backed relation registry, built once at bootstrap from two sources:
- * the adapter's ORM metadata supplies *shape* — name, target,
- * cardinality — and `relations.edges` config supplies *permission*, which
- * metadata can never know. Inclusion is opt-in, so a relation with no
- * config entry stays `includable: false`.
+ * Map-backed relation registry, built once at bootstrap from three
+ * sources: the adapter's ORM metadata supplies *shape* — name, target,
+ * cardinality; `allowlists.includable` (`EntityConfig`, entity-config.ts)
+ * supplies *permission*; `relations.edges` (`KavoSettings`, settings.ts)
+ * supplies loading *tuning* (`defaultInclude`/`maxDepth`/`strategy`) for a
+ * relation once it is includable (ADR-0028). Inclusion is opt-in, so a
+ * relation absent from `includable` stays `includable: false` no matter
+ * what `edges` says about it.
  */
 export class DefaultRelationRegistry<Entity = unknown> implements RelationRegistry<Entity> {
   private readonly relations: ReadonlyMap<string, RelationDescriptor>;
 
   constructor(
     descriptors: readonly RelationDescriptor[],
+    includable: readonly string[] = [],
     edges: Readonly<Record<string, RelationEdgeSettings>> = {},
     entityName = "entity",
   ) {
     const byName = new Map(descriptors.map((descriptor) => [descriptor.name, descriptor]));
-    for (const [name, edge] of Object.entries(edges)) {
+    for (const name of includable) {
       const descriptor = byName.get(name);
       if (descriptor === undefined) {
         // Fail fast: a typo in an allowlist that permits nothing looks
         // exactly like working config until the first client asks.
         throw new ConfigurationException(
           entityName,
+          "allowlists.includable",
+          `'${name}' is not a relation of ${entityName} (relations: ${[...byName.keys()].join(", ") || "none"})`,
+        );
+      }
+      byName.set(name, { ...descriptor, includable: true });
+    }
+    for (const [name, edge] of Object.entries(edges)) {
+      const descriptor = byName.get(name);
+      if (descriptor === undefined) {
+        throw new ConfigurationException(
+          entityName,
           `relations.edges.${name}`,
           `'${name}' is not a relation of ${entityName} (relations: ${[...byName.keys()].join(", ") || "none"})`,
         );
       }
+      // `edges` tunes loading only — it no longer touches `includable`
+      // (ADR-0028): a relation can be tuned here without being includable,
+      // and `defaultInclude: true` on one that isn't is rejected earlier,
+      // at bootstrap, by `validateIncludableRelations`.
       byName.set(name, {
         ...descriptor,
-        // Naming the relation in `edges` is itself the opt-in; spelling
-        // `includable: false` keeps the other keys usable while closed.
-        includable: edge.includable ?? true,
         ...(edge.defaultInclude !== undefined && { defaultInclude: edge.defaultInclude }),
         ...(edge.maxDepth !== undefined && { maxDepth: edge.maxDepth }),
         strategy: edge.strategy ?? descriptor.strategy,

--- a/packages/core/src/relations/relation-descriptor.ts
+++ b/packages/core/src/relations/relation-descriptor.ts
@@ -25,8 +25,9 @@ export interface RelationDescriptor {
   readonly cardinality: RelationCardinality;
   /**
    * Whether clients may `include=` this relation. Defaults to `false` —
-   * inclusion is an opt-in allowlist, consistent with the filter/sort
-   * posture.
+   * inclusion is an opt-in allowlist, granted by `allowlists.includable`
+   * (`EntityConfig`, entity-config.ts, ADR-0028), consistent with the
+   * filter/sort/select posture.
    */
   readonly includable: boolean;
   /** Included even when the client doesn't ask. */

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -174,6 +174,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "RelationCardinality",
   "RelationDescriptor",
   "RelationEdgeSettings",
+  "RelationFieldSelector",
   "RelationLoadStrategy",
   "RelationRegistry",
   "RelationSettings",

--- a/packages/core/tests/caching.spec.ts
+++ b/packages/core/tests/caching.spec.ts
@@ -176,7 +176,7 @@ describe("ETag generation", () => {
       },
     });
     const posts = kavo.createCrud(Post, {
-      relations: { edges: { author: { includable: true } } },
+      allowlists: { includable: ["author"] },
     } as never);
     kavo.createCrud(Author);
 
@@ -549,7 +549,8 @@ describe("a write response's tag describes that response, not the canonical read
       },
     });
     const crud = kavo.createCrud(Author, {
-      relations: { edges: { posts: { includable: true, defaultInclude: true } } },
+      allowlists: { includable: ["posts"] },
+      relations: { edges: { posts: { defaultInclude: true } } },
     } as never);
     kavo.createCrud(Post);
     return { crud, adapter };

--- a/packages/core/tests/computed-fields.spec.ts
+++ b/packages/core/tests/computed-fields.spec.ts
@@ -534,7 +534,7 @@ describe("computed fields — on an included relation target", () => {
           initials: { resolve: (author: Author) => author.name.slice(0, 2) },
           label: { resolve: (author: Author) => `author:${author.name}` },
         },
-        relations: { edges: { posts: { includable: true } } },
+        allowlists: { includable: ["posts"] },
       }) as never,
     ) as DefaultKavoService<Author>;
     kavo.createCrud(
@@ -547,7 +547,7 @@ describe("computed fields — on an included relation target", () => {
       Post,
       (configs.post ?? {
         computed: { label: { resolve: (post: Post) => `post:${post.title}` } },
-        relations: { edges: { author: { includable: true }, comments: { includable: true } } },
+        allowlists: { includable: ["author", "comments"] },
       }) as never,
     ) as DefaultKavoService<Post>;
     postAdapter.rows.push(

--- a/packages/core/tests/config-validation.spec.ts
+++ b/packages/core/tests/config-validation.spec.ts
@@ -178,14 +178,6 @@ describe("validateSettings — relation edges", () => {
     }
   });
 
-  it("rejects a non-boolean includable", () => {
-    expectRejected(
-      { relations: { edges: { posts: { includable: "yes" } } } },
-      "relations.edges.posts.includable",
-      "yes",
-    );
-  });
-
   it("rejects a non-boolean defaultInclude", () => {
     expectRejected(
       { relations: { edges: { posts: { defaultInclude: 1 } } } },
@@ -206,15 +198,12 @@ describe("validateSettings — relation edges", () => {
     }
   });
 
-  it("rejects defaultInclude on a relation clients cannot ask for", () => {
-    // The offending value here is the edge as a whole: neither key is
-    // wrong alone, the pair is.
-    const error = rejectionOf({
-      relations: { edges: { posts: { includable: false, defaultInclude: true } } },
-    });
-    expect(error.code).toBe("KAVO_CONFIG_INVALID");
-    expect(error.messageParams).toMatchObject({ entity: "User", path: "relations.edges.posts" });
-  });
+  // `defaultInclude` vs. permission (`allowlists.includable`) is no longer
+  // checkable by `validateSettings` alone — permission moved to entity-typed
+  // `EntityConfig.allowlists` (ADR-0028), outside the `KavoSettings` shape
+  // this file exercises. See `config.spec.ts`'s
+  // "resolveEntityConfig — allowlists.includable" describe block for that
+  // cross-check, now performed by `validateIncludableRelations`.
 
   it("accepts an edge that configures nothing — every sub-key is optional", () => {
     expect(() => accept({ relations: { edges: { posts: {} } } })).not.toThrow();
@@ -226,10 +215,10 @@ describe("validateSettings — relation edges", () => {
     }
   });
 
-  it("accepts defaultInclude on an includable relation", () => {
-    expect(() =>
-      accept({ relations: { edges: { posts: { includable: true, defaultInclude: true, maxDepth: 1 } } } }),
-    ).not.toThrow();
+  it("accepts defaultInclude/maxDepth shape regardless of includable permission", () => {
+    // `validateSettings` only checks shape now — whether `posts` is actually
+    // includable is `resolveEntityConfig`'s `allowlists`-aware cross-check.
+    expect(() => accept({ relations: { edges: { posts: { defaultInclude: true, maxDepth: 1 } } } })).not.toThrow();
   });
 });
 

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -225,6 +225,10 @@ describe("resolveEntityConfig — bootstrap", () => {
       expect.unreachable();
     } catch (error) {
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).messageParams).toMatchObject({
+        entity: "Author.operations.findMany",
+        path: "relations.edges.posts",
+      });
       expect((error as ConfigurationException).detail).toContain("posts");
     }
   });
@@ -243,8 +247,26 @@ describe("resolveEntityConfig — allowlists.includable", () => {
       expect.unreachable();
     } catch (error) {
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).messageParams).toMatchObject({
+        entity: "Author",
+        path: "relations.edges.posts",
+      });
       expect((error as ConfigurationException).detail).toContain("posts");
     }
+  });
+
+  it("rejects defaultInclude set at global scope when no entity opts the relation into allowlists.includable", () => {
+    // Migration hazard: `relations.edges.<name>.defaultInclude` at global
+    // `defaults` scope used to be safe — naming the relation at all was the
+    // opt-in before this PR. It is not safe now: `allowlists.includable` is
+    // entity-scope-only, so a global defaultInclude with no matching entity
+    // grant is a bootstrap crash on every entity sharing that relation name,
+    // not a silent no-op. Pinning the crash here so a future change to this
+    // cross-check doesn't silently turn it into the no-op adopters might
+    // expect.
+    expect(() =>
+      resolveEntityConfig(authorMetadata, undefined, { relations: { edges: { posts: { defaultInclude: true } } } }),
+    ).toThrow(ConfigurationException);
   });
 
   it("accepts defaultInclude on a relation allowlists.includable named", () => {
@@ -267,7 +289,31 @@ describe("resolveEntityConfig — allowlists.includable", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(ConfigurationException);
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).messageParams).toMatchObject({
+        entity: "Author",
+        path: "allowlists.includable",
+      });
       expect((error as ConfigurationException).detail).toContain("ghosts");
+    }
+  });
+
+  it("fails fast on a typo'd relation name in allowlists.includable's { exclude } form", () => {
+    // Unlike `resolveFieldSelector`'s `{ exclude }` (filterable/sortable/
+    // selectable), which silently excludes nothing on a name that matches
+    // nothing, `includable`'s `{ exclude }` checks its own names — a typo
+    // here would otherwise open every relation instead of leaving the
+    // intended one closed, the opposite of what the author wrote.
+    try {
+      resolveEntityConfig(authorMetadata, { allowlists: { includable: { exclude: ["ptes" as never] } } }, undefined);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigurationException);
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).messageParams).toMatchObject({
+        entity: "Author",
+        path: "allowlists.includable.exclude",
+      });
+      expect((error as ConfigurationException).detail).toContain("ptes");
     }
   });
 

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { BUILT_IN_DEFAULTS, ConfigurationException, createKavo, mergeSettings, resolveEntityConfig } from "@kavo/core";
 import { User, userMetadata } from "./support/user-fixture.js";
+import { authorMetadata } from "./support/blog-fixture.js";
 
 describe("mergeSettings — merge algebra", () => {
   it("replaces scalars key-by-key, nearer scope wins", () => {
@@ -207,6 +208,78 @@ describe("resolveEntityConfig — bootstrap", () => {
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
       expect((error as ConfigurationException).detail).toContain("email");
     }
+  });
+
+  it("rejects an operation-scope defaultInclude on a relation absent from allowlists.includable", () => {
+    // `validateIncludableRelations` runs for the per-operation settings view
+    // too, not only entity scope — an operation override can name
+    // `relations.edges` just as the entity config can.
+    try {
+      resolveEntityConfig(
+        authorMetadata,
+        {
+          operations: { findMany: { relations: { edges: { posts: { defaultInclude: true } } } } },
+        },
+        undefined,
+      );
+      expect.unreachable();
+    } catch (error) {
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).detail).toContain("posts");
+    }
+  });
+});
+
+/**
+ * ADR-0028: `defaultInclude` vs. permission is cross-checked against
+ * `allowlists.includable`, not `relations.edges`'s own (now-removed)
+ * `includable` key — `validateIncludableRelations` in
+ * resolve-entity-config.ts, run after `allowlists` is resolved.
+ */
+describe("resolveEntityConfig — allowlists.includable", () => {
+  it("rejects defaultInclude on a relation absent from allowlists.includable", () => {
+    try {
+      resolveEntityConfig(authorMetadata, { relations: { edges: { posts: { defaultInclude: true } } } }, undefined);
+      expect.unreachable();
+    } catch (error) {
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).detail).toContain("posts");
+    }
+  });
+
+  it("accepts defaultInclude on a relation allowlists.includable named", () => {
+    expect(() =>
+      resolveEntityConfig(
+        authorMetadata,
+        {
+          allowlists: { includable: ["posts"] },
+          relations: { edges: { posts: { defaultInclude: true, maxDepth: 1 } } },
+        },
+        undefined,
+      ),
+    ).not.toThrow();
+  });
+
+  it("fails fast on a typo'd relation name in allowlists.includable", () => {
+    try {
+      resolveEntityConfig(authorMetadata, { allowlists: { includable: ["ghosts" as never] } }, undefined);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigurationException);
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).detail).toContain("ghosts");
+    }
+  });
+
+  it("defaults to no relation includable when the key is unconfigured (opt-in, unlike the other allowlists)", () => {
+    const config = resolveEntityConfig(authorMetadata, undefined, undefined);
+    expect(config.allowlists.includable).toEqual([]);
+    expect(config.relations.get("posts")?.includable).toBe(false);
+  });
+
+  it("opts every own relation in via an explicit { exclude: [] }", () => {
+    const config = resolveEntityConfig(authorMetadata, { allowlists: { includable: { exclude: [] } } }, undefined);
+    expect(config.allowlists.includable).toEqual(["posts"]);
   });
 });
 

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -100,7 +100,7 @@ describe("include resolution", () => {
   });
 
   it("rejects an unknown relation with the same 400", async () => {
-    const fixture = blog({ author: { relations: { edges: { posts: { includable: true } } } } });
+    const fixture = blog({ author: { allowlists: { includable: ["posts"] } } });
     const { authors } = fixture;
     // `IncludePath` rejects 'ghosts' at compile time now, which is the point
     // of the type — but the *runtime* rejection is a separate guarantee and
@@ -110,16 +110,20 @@ describe("include resolution", () => {
     await expect(authors.findMany({ include: unknownPath })).rejects.toBeInstanceOf(QueryValidationException);
   });
 
-  it("fails at bootstrap when an edge names a relation the entity does not have", () => {
-    expect(() => blog({ author: { relations: { edges: { ghosts: { includable: true } } } } })).toThrow(
+  it("fails at bootstrap when allowlists.includable names a relation the entity does not have", () => {
+    expect(() => blog({ author: { allowlists: { includable: ["ghosts" as never] } } })).toThrow(ConfigurationException);
+  });
+
+  it("fails at bootstrap when relations.edges names a relation the entity does not have", () => {
+    expect(() => blog({ author: { relations: { edges: { ghosts: { strategy: "join" } } } } })).toThrow(
       ConfigurationException,
     );
   });
 
   it("merges overlapping paths into one tree", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
-      post: { relations: { edges: { comments: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
+      post: { allowlists: { includable: ["comments"] } },
     });
     const { authors, authorRows } = fixture;
     authorRows.push(authorWithPosts());
@@ -134,7 +138,7 @@ describe("include resolution", () => {
 
   it("resolves auto strategies from cardinality: to-one joins, to-many batches", async () => {
     const fixture = blog({
-      post: { relations: { edges: { author: { includable: true }, comments: { includable: true } } } },
+      post: { allowlists: { includable: ["author", "comments"] } },
     });
     const { posts, postRows } = fixture;
     postRows.push(Object.assign(new Post(), { id: 10, title: "First" }));
@@ -147,7 +151,10 @@ describe("include resolution", () => {
 
   it("honors an explicit strategy over the heuristic", async () => {
     const fixture = blog({
-      post: { relations: { edges: { comments: { includable: true, strategy: "join" } } } },
+      post: {
+        allowlists: { includable: ["comments"] },
+        relations: { edges: { comments: { strategy: "join" } } },
+      },
     });
     const { posts, postRows } = fixture;
     postRows.push(Object.assign(new Post(), { id: 10 }));
@@ -156,7 +163,7 @@ describe("include resolution", () => {
   });
 
   it("carries the target's delete strategy, not the root's", async () => {
-    const fixture = blog({ author: { relations: { edges: { posts: { includable: true } } } } });
+    const fixture = blog({ author: { allowlists: { includable: ["posts"] } } });
     const { authors, authorRows } = fixture;
     authorRows.push(authorWithPosts());
     await authors.findMany({ include: ["posts"] });
@@ -167,8 +174,8 @@ describe("include resolution", () => {
   it("enforces maxIncludeDepth", async () => {
     const fixture = blog(
       {
-        author: { relations: { edges: { posts: { includable: true } } } },
-        post: { relations: { edges: { comments: { includable: true } } } },
+        author: { allowlists: { includable: ["posts"] } },
+        post: { allowlists: { includable: ["comments"] } },
       },
       { defaults: { relations: { maxIncludeDepth: 1 } } },
     );
@@ -181,8 +188,11 @@ describe("include resolution", () => {
   it("lets a per-relation maxDepth override the budget below it", async () => {
     const fixture = blog(
       {
-        author: { relations: { edges: { posts: { includable: true, maxDepth: 3 } } } },
-        post: { relations: { edges: { comments: { includable: true } } } },
+        author: {
+          allowlists: { includable: ["posts"] },
+          relations: { edges: { posts: { maxDepth: 3 } } },
+        },
+        post: { allowlists: { includable: ["comments"] } },
       },
       { defaults: { relations: { maxIncludeDepth: 1 } } },
     );
@@ -195,7 +205,7 @@ describe("include resolution", () => {
 
   it("enforces maxIncludedNodes across the whole tree", async () => {
     const fixture = blog(
-      { post: { relations: { edges: { author: { includable: true }, comments: { includable: true } } } } },
+      { post: { allowlists: { includable: ["author", "comments"] } } },
       { defaults: { relations: { maxIncludedNodes: 1 } } },
     );
     const { posts, postRows } = fixture;
@@ -207,8 +217,8 @@ describe("include resolution", () => {
 
   it("bounds a self-revisiting path by depth, not by visited types", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
-      post: { relations: { edges: { author: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
+      post: { allowlists: { includable: ["author"] } },
     });
     const { authors, authorRows } = fixture;
     authorRows.push(authorWithPosts());
@@ -221,7 +231,10 @@ describe("include resolution", () => {
 
   it("adds defaultInclude relations with no include param at all", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true, defaultInclude: true } } } },
+      author: {
+        allowlists: { includable: ["posts"] },
+        relations: { edges: { posts: { defaultInclude: true } } },
+      },
     });
     const { authors, authorRows } = fixture;
     authorRows.push(authorWithPosts());
@@ -233,7 +246,7 @@ describe("include resolution", () => {
 describe("include serialization", () => {
   it("projects an included node through the target's own shape", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
       post: { allowlists: { selectable: ["id", "title"] } },
     });
     const { authors, authorRows } = fixture;
@@ -248,7 +261,7 @@ describe("include serialization", () => {
 
   it("narrows an included node with fields[path], validated against the target", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
     });
     const { authors, authorRows } = fixture;
     authorRows.push(authorWithPosts());
@@ -262,7 +275,7 @@ describe("include serialization", () => {
 
   it("accepts the relation-keyed fields spelling identically", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
     });
     const { authors, authorRows } = fixture;
     authorRows.push(authorWithPosts());
@@ -278,7 +291,7 @@ describe("include serialization", () => {
 
   it("rejects a fieldset the target does not allow", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
       post: { allowlists: { selectable: ["id"] } },
     });
     const { authors } = fixture;
@@ -295,7 +308,7 @@ describe("include serialization", () => {
     // to carry. This must fail the same way a malformed top-level `fields`
     // value does: one issue, never an uncaught error that surfaces as 500.
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
     });
     const { authors } = fixture;
     await expect(
@@ -306,7 +319,7 @@ describe("include serialization", () => {
   });
 
   it("omits relation keys that were not included", async () => {
-    const fixture = blog({ author: { relations: { edges: { posts: { includable: true } } } } });
+    const fixture = blog({ author: { allowlists: { includable: ["posts"] } } });
     const { authors, authorRows } = fixture;
     authorRows.push(authorWithPosts());
     const list = await authors.findMany();
@@ -315,7 +328,7 @@ describe("include serialization", () => {
 
   it("emits an empty list / null for a relation with nothing loaded", async () => {
     const fixture = blog({
-      post: { relations: { edges: { author: { includable: true }, comments: { includable: true } } } },
+      post: { allowlists: { includable: ["author", "comments"] } },
     });
     const { posts, postRows } = fixture;
     postRows.push(Object.assign(new Post(), { id: 10, title: "Lonely", author: null, comments: [] }));
@@ -328,7 +341,7 @@ describe("include serialization", () => {
     // `[]` or `null`; the envelope must not leak that difference, or a
     // client would have to null-check a field the schema types as a list.
     const fixture = blog({
-      post: { relations: { edges: { comments: { includable: true } } } },
+      post: { allowlists: { includable: ["comments"] } },
     });
     const { posts, postRows } = fixture;
     postRows.push(Object.assign(new Post(), { id: 11, title: "Null comments", comments: null as never }));
@@ -400,7 +413,7 @@ describe("include rejection messages", () => {
   it("names the config key that opts a real relation in", async () => {
     const { authors } = blog();
     const detail = await detailOf(() => authors.findMany({ include: ["posts"] }));
-    expect(detail).toContain("relations.edges.posts.includable = true");
+    expect(detail).toContain("allowlists.includable");
     expect(detail).toContain("on the Author config");
   });
 
@@ -413,7 +426,7 @@ describe("include rejection messages", () => {
   });
 
   it("suggests the near miss, drawn only from relations already opted in", async () => {
-    const { authors } = blog({ author: { relations: { edges: { posts: { includable: true } } } } });
+    const { authors } = blog({ author: { allowlists: { includable: ["posts"] } } });
     const detail = await detailOf(() =>
       authors.findMany({ include: ["postz"] as unknown as readonly IncludePath<Author>[] }),
     );
@@ -425,7 +438,7 @@ describe("include rejection messages", () => {
     // already permitted to ask for. `Post.author` exists in metadata but no
     // edge names it, so it must not appear.
     const { authors } = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
     });
     const detail = await detailOf(() =>
       authors.findMany({ include: ["posts.authr"] as unknown as readonly IncludePath<Author>[] }),
@@ -436,7 +449,7 @@ describe("include rejection messages", () => {
 
   it("blames the entity that owns the failing segment, not the root", async () => {
     const { authors } = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
     });
     const detail = await detailOf(() =>
       authors.findMany({ include: ["posts.comments"] as unknown as readonly IncludePath<Author>[] }),
@@ -449,7 +462,7 @@ describe("include rejection messages", () => {
 
   it("names the target entity's allowlist when a relation fieldset is rejected", async () => {
     const { authors } = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
       post: { allowlists: { selectable: ["id", "title"] } },
     });
     const detail = await detailOf(() =>
@@ -467,8 +480,11 @@ describe("defaultInclude", () => {
     // round: a `defaultInclude` node carries no children, so clobbering
     // would silently drop `posts.comments` from the response.
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true, defaultInclude: true } } } },
-      post: { relations: { edges: { comments: { includable: true } } } },
+      author: {
+        allowlists: { includable: ["posts"] },
+        relations: { edges: { posts: { defaultInclude: true } } },
+      },
+      post: { allowlists: { includable: ["comments"] } },
     } as never);
 
     return fixture.authors.findMany({ include: ["posts.comments"] } as never).then(() => {
@@ -482,8 +498,11 @@ describe("defaultInclude", () => {
     // `path` is what `fields[...]` and every issue message key off, so a
     // nested default that reported a bare name would be unaddressable.
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
-      post: { relations: { edges: { comments: { includable: true, defaultInclude: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
+      post: {
+        allowlists: { includable: ["comments"] },
+        relations: { edges: { comments: { defaultInclude: true } } },
+      },
     } as never);
 
     await fixture.authors.findMany({ include: ["posts"] } as never);
@@ -493,35 +512,69 @@ describe("defaultInclude", () => {
   });
 });
 
-describe("relations.edges — naming an edge is the opt-in", () => {
-  it("treats an edge that omits includable as includable", async () => {
-    // The registry documents this default; every other test in the file
-    // spells `includable: true`, which would leave it free to regress.
+/**
+ * ADR-0028: permission moved out of `relations.edges` into
+ * `allowlists.includable`. `relations.edges` naming a relation used to be
+ * the opt-in itself (`includable: edge.includable ?? true`); it no longer
+ * grants anything — it only tunes `defaultInclude`/`maxDepth`/`strategy`
+ * for a relation `allowlists.includable` has already opened.
+ */
+describe("allowlists.includable — where inclusion permission now lives", () => {
+  it("does not open a relation that relations.edges only tunes", async () => {
     const fixture = blog({
       author: { relations: { edges: { posts: { strategy: "join" } } } },
-    } as never);
+    });
 
-    await fixture.authors.findMany({ include: ["posts"] } as never);
+    await expect(fixture.authors.findMany({ include: ["posts"] })).rejects.toBeInstanceOf(QueryValidationException);
+  });
+
+  it("opens a relation named in allowlists.includable alone, with no relations.edges entry", async () => {
+    const fixture = blog({
+      author: { allowlists: { includable: ["posts"] } },
+    });
+
+    await fixture.authors.findMany({ include: ["posts"] });
 
     expect(Object.keys(includeTree(fixture.authorAdapter))).toEqual(["posts"]);
   });
 
-  it("still honours an explicit includable: false", async () => {
+  it("still applies relations.edges tuning to a relation also opened by allowlists.includable", async () => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: false, strategy: "join" } } } },
-    } as never);
+      author: {
+        allowlists: { includable: ["posts"] },
+        relations: { edges: { posts: { strategy: "join" } } },
+      },
+    });
 
-    await expect(fixture.authors.findMany({ include: ["posts"] } as never)).rejects.toBeInstanceOf(
-      QueryValidationException,
-    );
+    await fixture.authors.findMany({ include: ["posts"] });
+
+    expect(includeTree(fixture.authorAdapter)["posts"]!.strategy).toBe("join");
+  });
+
+  it("opts every own relation in via an explicit { exclude: [] }", async () => {
+    const fixture = blog({
+      post: { allowlists: { includable: { exclude: [] } } },
+    });
+
+    await fixture.posts.findMany({ include: ["author", "comments"] });
+
+    expect(Object.keys(includeTree(fixture.postAdapter))).toEqual(["author", "comments"]);
+  });
+
+  it("excludes a named relation via { exclude }, leaving the rest includable", async () => {
+    const fixture = blog({
+      post: { allowlists: { includable: { exclude: ["comments"] } } },
+    });
+
+    await expect(fixture.posts.findMany({ include: ["comments"] })).rejects.toBeInstanceOf(QueryValidationException);
+    await fixture.posts.findMany({ include: ["author"] });
+    expect(Object.keys(includeTree(fixture.postAdapter))).toEqual(["author"]);
   });
 
   it("says 'none' rather than trailing a bare colon when the entity has no relations at all", () => {
     // `Comment` declares no relations, so the message has an empty list to
     // render — the one case where the join would produce nothing.
-    expect(() => blog({ comment: { relations: { edges: { ghosts: { includable: true } } } } } as never)).toThrow(
-      /relations: none/,
-    );
+    expect(() => blog({ comment: { allowlists: { includable: ["ghosts" as never] } } })).toThrow(/relations: none/);
   });
 });
 
@@ -533,8 +586,8 @@ describe("malformed include paths", () => {
     ["an empty string", ""],
   ])("rejects %s as a query issue rather than building an empty-named node", async (_label, path) => {
     const fixture = blog({
-      author: { relations: { edges: { posts: { includable: true } } } },
-      post: { relations: { edges: { comments: { includable: true } } } },
+      author: { allowlists: { includable: ["posts"] } },
+      post: { allowlists: { includable: ["comments"] } },
     } as never);
 
     const issues = await fixture.authors
@@ -572,9 +625,9 @@ describe("an includable relation whose target is unknown to this instance", () =
       },
     });
     const authors = kavo.createCrud(Author, {
-      relations: { edges: { posts: { includable: true } } },
+      allowlists: { includable: ["posts"] },
     } as never) as DefaultKavoService<Author>;
-    kavo.createCrud(Post, { relations: { edges: { comments: { includable: true } } } } as never);
+    kavo.createCrud(Post, { allowlists: { includable: ["comments"] } } as never);
 
     const issues = await authors.findMany({ include: ["posts.comments"] } as never).then(
       () => {

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -115,9 +115,20 @@ describe("include resolution", () => {
   });
 
   it("fails at bootstrap when relations.edges names a relation the entity does not have", () => {
-    expect(() => blog({ author: { relations: { edges: { ghosts: { strategy: "join" } } } } })).toThrow(
-      ConfigurationException,
-    );
+    try {
+      blog({ author: { relations: { edges: { ghosts: { strategy: "join" } } } } });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigurationException);
+      // A distinct path from the sibling allowlists.includable typo check
+      // above — edges (tuning) and includable (permission) are two
+      // different config keys that both fail fast on the same kind of
+      // typo, and the path is what tells them apart.
+      expect((error as ConfigurationException).messageParams).toMatchObject({
+        entity: "Author",
+        path: "relations.edges.ghosts",
+      });
+    }
   });
 
   it("merges overlapping paths into one tree", async () => {

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -31,11 +31,7 @@ const postCatalog = new DefaultEntityCatalog((entity: ClassRef) => {
   if (entity === Author) return authorMetadata as unknown as EntityMetadata<object>;
   return undefined;
 });
-const postConfig = resolveEntityConfig(
-  postMetadata,
-  { relations: { edges: { comments: { includable: true } } } },
-  undefined,
-);
+const postConfig = resolveEntityConfig(postMetadata, { allowlists: { includable: ["comments"] } }, undefined);
 const postNormalizer = new QueryNormalizer<Post>(postMetadata, [], new DefaultIncludeResolver<Post>(postCatalog));
 
 describe("QueryNormalizer — wire params", () => {

--- a/packages/core/tests/selectable-projection.spec.ts
+++ b/packages/core/tests/selectable-projection.spec.ts
@@ -165,7 +165,7 @@ describe("allowlists.selectable narrows the response projection", () => {
       kavo.createCrud(Author, authorConfig as never);
       kavo.createCrud(Comment);
       return kavo.createCrud(Post, {
-        relations: { edges: { author: { includable: true } } },
+        allowlists: { includable: ["author"] },
       } as never) as DefaultKavoService<Post>;
     }
 

--- a/packages/core/tests/types/include-path.test-d.ts
+++ b/packages/core/tests/types/include-path.test-d.ts
@@ -78,3 +78,26 @@ expectTypeOf<IncludePath<Tagged>>().toEqualTypeOf<"reviews">();
 // scalar field is.
 const primitiveArray: IncludePath<Tagged> = "tags";
 void primitiveArray;
+
+/**
+ * `IncludePath<Entity, 1>` is what `RelationFieldSelector` (entity-config.ts,
+ * ADR-0028) types `allowlists.includable` against: exactly the entity's own
+ * top-level relation names, with no dotted nesting — `include=` grants
+ * permission one relation segment at a time from the root, the same unit
+ * `relations.edges` keyed on before this change.
+ */
+expectTypeOf<IncludePath<Author, 1>>().toEqualTypeOf<"posts">();
+expectTypeOf<IncludePath<Post, 1>>().toEqualTypeOf<"author" | "comments">();
+expectTypeOf<IncludePath<Comment, 1>>().toEqualTypeOf<never>();
+
+// @ts-expect-error — a dotted nested path is not a top-level relation name.
+const nestedAtDepthOne: IncludePath<Author, 1> = "posts.comments";
+void nestedAtDepthOne;
+
+// @ts-expect-error — a scalar field is still not a relation, at any depth.
+const scalarAtDepthOne: IncludePath<Author, 1> = "name";
+void scalarAtDepthOne;
+
+// @ts-expect-error — a typo'd relation name still fails at depth 1.
+const typoAtDepthOne: IncludePath<Author, 1> = "postz";
+void typoAtDepthOne;

--- a/packages/core/tests/types/usage-full.test-d.ts
+++ b/packages/core/tests/types/usage-full.test-d.ts
@@ -55,8 +55,7 @@ const authors = kavo.createCrud(Author, {
     item: AuthorItemDto,
     list: AuthorListDto,
   },
-  allowlists: { filterable: ["name"], sortable: ["name"], selectable: ["id", "name"] },
-  relations: { edges: { posts: { includable: true } } },
+  allowlists: { filterable: ["name"], sortable: ["name"], selectable: ["id", "name"], includable: ["posts"] },
   operations: {
     findMany: { handler: promote },
   },

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -6,6 +6,7 @@ import type {
   OperationDescriptor,
   OperationDtoMap,
   QueryFieldSelector,
+  RelationFieldSelector,
 } from "@kavo/core";
 import { DefaultDtoResolver } from "@kavo/core";
 import type { KavoHttpMethod } from "./operation-metadata.js";
@@ -221,13 +222,17 @@ export function applySwaggerMetadata(
         name: "include",
         required: false,
         type: String,
-        description:
-          includable.length === 0
-            ? "No relation is includable on this entity."
-            : `Includable: ${includable.join(", ")}.`,
+        ...(includable !== null
+          ? {
+              description:
+                includable.length === 0
+                  ? "No relation is includable on this entity."
+                  : `Includable: ${includable.join(", ")}.`,
+            }
+          : {}),
       }),
     );
-    for (const relation of includable) {
+    for (const relation of includable ?? []) {
       apply(
         swagger.ApiQuery({
           name: `fields[${relation}]`,
@@ -541,14 +546,25 @@ function schemaForHint(hint: SchemaHint): object {
   }
 }
 
-/** Relation names this entity's config opens to `include=`. */
-function includableRelations(config: EntityConfig<object> | undefined): readonly string[] {
-  const edges = (config as { relations?: { edges?: Record<string, { includable?: boolean }> } } | undefined)?.relations
-    ?.edges;
-  if (edges === undefined) return [];
-  return Object.entries(edges)
-    .filter(([, edge]) => edge.includable !== false)
-    .map(([name]) => name);
+/**
+ * Relation names this entity's config opens to `include=`
+ * (`allowlists.includable`, ADR-0028) — or `null` when decoration time
+ * cannot know the set at all.
+ *
+ * Unlike `filterable`/`sortable`/`selectable`, `includable` is opt-in: an
+ * unconfigured key resolves to `[]`, not "every relation" (`resolveAllowlists`
+ * in core), and that default needs no ORM metadata to compute — so `undefined`
+ * here is a real, known empty set, not an unknown one. Only an `{ exclude }`
+ * selector is unresolvable without ORM metadata (same limitation
+ * `listQueryParams` documents for the other three keys); `null` signals that
+ * case so the caller advertises `include` rather than omitting a parameter
+ * that may well do something.
+ */
+function includableRelations(config: EntityConfig<object> | undefined): readonly string[] | null {
+  const selector = (config?.allowlists as { includable?: RelationFieldSelector<object> } | undefined)?.includable;
+  if (selector === undefined) return [];
+  if ("exclude" in selector) return null;
+  return selector;
 }
 
 function bodyDtoFor(descriptor: OperationDescriptor<object>, dtoResolver: DtoResolver<object>): ClassRef | null {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1362,7 +1362,7 @@ describe("@Kavo soft-delete routes", () => {
 });
 
 describe("@Kavo relation includes", () => {
-  @Kavo(Todo, { relations: { edges: { list: { includable: true } } } })
+  @Kavo(Todo, { allowlists: { includable: ["list"] } })
   @Controller("todos")
   class IncludingController {}
 
@@ -1471,6 +1471,25 @@ describe("@Kavo relation includes", () => {
     const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
     const include = params.find((param) => param.name === "include");
     expect(include?.description).toBe("No relation is includable on this entity.");
+  });
+
+  it("carries no description for an exclude-shaped includable allowlist, and no fields[relation] params", async () => {
+    // `{ exclude }` cannot be resolved at decoration time — no ORM metadata
+    // exists yet (ADR-0012) — so `include` is still emitted (the set may be
+    // non-empty) but undescribed, the same treatment `filterable`/`sortable`/
+    // `selectable` already get for their own `{ exclude }` form.
+    @Kavo(Todo, { allowlists: { includable: { exclude: [] } } })
+    @Controller("todos")
+    class ExcludingIncludableController {}
+
+    await app.close();
+    await bootstrap(ExcludingIncludableController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const include = params.find((param) => param.name === "include");
+    expect(include).toBeDefined();
+    expect(include?.description).toBeUndefined();
+    expect(params.find((param) => param.name.startsWith("fields["))).toBeUndefined();
   });
 });
 

--- a/packages/frameworks/nest/tests/settings.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/settings.e2e.spec.ts
@@ -7,7 +7,7 @@ import { withListMeta } from "@kavo/core";
 import type { DefaultKavoService, RealtimeEventDto, RealtimeTransport } from "@kavo/core";
 import type { KavoModuleOptions } from "@kavo/nest";
 import { Kavo, KavoModule, getKavoServiceToken } from "@kavo/nest";
-import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+import { InMemoryTodoAdapter, Todo, TodoList, fakeInfrastructure } from "./support/fake-infrastructure.js";
 import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
 
 /**
@@ -32,7 +32,7 @@ interface BootstrapOptions {
   readonly realtimeTransports?: KavoModuleOptions["realtimeTransports"];
 }
 
-async function bootstrap(controller: unknown, options: BootstrapOptions = {}): Promise<void> {
+async function bootstrap(controller: unknown | readonly unknown[], options: BootstrapOptions = {}): Promise<void> {
   adapter = new InMemoryTodoAdapter();
   const infrastructure = fakeInfrastructure(adapter);
   const rootModule =
@@ -50,8 +50,9 @@ async function bootstrap(controller: unknown, options: BootstrapOptions = {}): P
           ...(options.paginationStrategies !== undefined && { paginationStrategies: options.paginationStrategies }),
           ...(options.realtimeTransports !== undefined && { realtimeTransports: options.realtimeTransports }),
         });
+  const controllers = Array.isArray(controller) ? controller : [controller];
   const moduleRef = await Test.createTestingModule({
-    imports: [rootModule, KavoModule.forFeature([controller as never])],
+    imports: [rootModule, KavoModule.forFeature(controllers as never)],
   }).compile();
   app = moduleRef.createNestApplication();
   httpServer = await listen(app);
@@ -110,17 +111,25 @@ describe("@Kavo allowlists — filterable/sortable/selectable enforced over HTTP
 
 describe("@Kavo relation include budgets (maxIncludeDepth/maxIncludedNodes)", () => {
   // `Todo.list` and `TodoList.list` deliberately share the relation name,
-  // so one global `edges.list` entry opts both levels in at once (see
-  // `fake-infrastructure.ts`) — an `include=list.list` request is a
-  // genuine two-level tree, which a single relation can never produce
-  // once a positive integer is the smallest legal budget.
-  @Kavo(Todo)
+  // so `include=list.list` is a genuine two-level tree, which a single
+  // relation can never exceed once a positive integer is the smallest legal
+  // budget (see `fake-infrastructure.ts`). `includable` is entity-scope-only
+  // config (ADR-0028: `allowlists` merges from nowhere but the entity's own
+  // `EntityConfig`, no global default) — unlike before, when one global
+  // `relations.edges.list.includable` opened both levels at once, each
+  // level now needs its own `createCrud`/`@Kavo` registration, even though
+  // `TodoList` is never routed, only included.
+  @Kavo(Todo, { allowlists: { includable: ["list"] } })
   @Controller("todos")
   class NestedIncludeController {}
 
+  @Kavo(TodoList, { allowlists: { includable: ["list"] } })
+  @Controller("todolists")
+  class TodoListController {}
+
   it("rejects an include deeper than the configured maxIncludeDepth", async () => {
-    await bootstrap(NestedIncludeController, {
-      defaults: { relations: { maxIncludeDepth: 1, edges: { list: { includable: true } } } },
+    await bootstrap([NestedIncludeController, TodoListController], {
+      defaults: { relations: { maxIncludeDepth: 1 } },
     });
 
     const response = await request(server()).get("/todos?include=list.list").expect(400);
@@ -131,8 +140,8 @@ describe("@Kavo relation include budgets (maxIncludeDepth/maxIncludedNodes)", ()
   });
 
   it("rejects an include tree exceeding the configured maxIncludedNodes", async () => {
-    await bootstrap(NestedIncludeController, {
-      defaults: { relations: { maxIncludedNodes: 1, edges: { list: { includable: true } } } },
+    await bootstrap([NestedIncludeController, TodoListController], {
+      defaults: { relations: { maxIncludedNodes: 1 } },
     });
 
     const response = await request(server()).get("/todos?include=list.list").expect(400);
@@ -144,11 +153,12 @@ describe("@Kavo relation include budgets (maxIncludeDepth/maxIncludedNodes)", ()
 
   it("accepts an include within both budgets", async () => {
     @Kavo(Todo, {
-      relations: { maxIncludeDepth: 1, maxIncludedNodes: 1, edges: { list: { includable: true } } },
+      allowlists: { includable: ["list"] },
+      relations: { maxIncludeDepth: 1, maxIncludedNodes: 1 },
     })
     @Controller("todos")
     class RoomyController {}
-    await bootstrap(RoomyController);
+    await bootstrap([RoomyController, TodoListController]);
 
     await request(server()).get("/todos?include=list").expect(200);
   });

--- a/packages/orms/mikroorm/tests/cursor-pagination.spec.ts
+++ b/packages/orms/mikroorm/tests/cursor-pagination.spec.ts
@@ -73,7 +73,7 @@ beforeAll(async () => {
   });
   posts = kavo.createCrud(Post, {
     softDelete: { field: "deletedAt" },
-    relations: { edges: { comments: { includable: true } } },
+    allowlists: { includable: ["comments"] },
   } as never) as DefaultKavoService<Post>;
 });
 

--- a/packages/orms/mikroorm/tests/includes.spec.ts
+++ b/packages/orms/mikroorm/tests/includes.spec.ts
@@ -62,18 +62,20 @@ beforeAll(async () => {
   orm = await newTestOrm([Blog, Article, Note]);
   kavo = createMikroOrmKavo(orm);
   blogs = kavo.createCrud(Blog, {
-    relations: { edges: { articles: { includable: true } } },
+    allowlists: { includable: ["articles"] },
   }) as DefaultKavoService<Blog>;
   articles = kavo.createCrud(Article, {
     softDelete: { strategy: "soft", field: "deletedAt" },
-    relations: { edges: { blog: { includable: true }, notes: { includable: true } } },
-    // Filtering across a relation path is its own allowlist decision,
-    // independent of whether the relation may be included.
-    allowlists: { filterable: ["id", "title", "blog.name"] },
+    allowlists: {
+      includable: ["blog", "notes"],
+      // Filtering across a relation path is its own allowlist decision,
+      // independent of whether the relation may be included.
+      filterable: ["id", "title", "blog.name"],
+    },
   } as never) as DefaultKavoService<Article>;
   notes = kavo.createCrud(Note, {
     softDelete: { strategy: "soft", field: "deletedAt" },
-    relations: { edges: { article: { includable: true } } },
+    allowlists: { includable: ["article"] },
   }) as DefaultKavoService<Note>;
 });
 

--- a/packages/orms/mongoose/tests/cursor-pagination.spec.ts
+++ b/packages/orms/mongoose/tests/cursor-pagination.spec.ts
@@ -69,7 +69,7 @@ beforeAll(async () => {
   });
   posts = kavo.createCrud(models.Post, {
     softDelete: { field: "deletedAt" },
-    relations: { edges: { comments: { includable: true } } },
+    allowlists: { includable: ["comments"] },
   } as never) as unknown as DefaultKavoService<Post>;
 });
 

--- a/packages/orms/mongoose/tests/includes.spec.ts
+++ b/packages/orms/mongoose/tests/includes.spec.ts
@@ -67,11 +67,11 @@ beforeAll(async () => {
   // string. The interfaces above are the shape the service actually
   // returns, which is what these tests assert.
   blogs = kavo.createCrud(models.Blog, {
-    relations: { edges: { articles: { includable: true } } },
+    allowlists: { includable: ["articles"] },
   }) as unknown as DefaultKavoService<Blog>;
   articles = kavo.createCrud(models.Article, {
     softDelete: { field: "deletedAt" },
-    relations: { edges: { blog: { includable: true }, notes: { includable: true } } },
+    allowlists: { includable: ["blog", "notes"] },
   } as never) as unknown as DefaultKavoService<Article>;
   kavo.createCrud(models.Note);
 });

--- a/packages/orms/prisma/tests/adapter.spec.ts
+++ b/packages/orms/prisma/tests/adapter.spec.ts
@@ -388,7 +388,7 @@ describe("PrismaRepositoryAdapter — query translation", () => {
 
   it("associates a relation by writing its scalar foreign-key field (ADR-0014)", async () => {
     const books = kavo.createCrud(Book, {
-      relations: { edges: { author: { includable: true } } },
+      allowlists: { includable: ["author"] },
     } as never) as DefaultKavoService<Book>;
     const author = (await authors.createOne({ email: "assoc@x.io", name: "Assoc", age: 1 } as never)) as Author;
 

--- a/packages/orms/prisma/tests/cursor-pagination.spec.ts
+++ b/packages/orms/prisma/tests/cursor-pagination.spec.ts
@@ -50,7 +50,7 @@ beforeAll(() => {
   );
   posts = kavo.createCrud(Post, {
     softDelete: { field: "deletedAt" },
-    relations: { edges: { comments: { includable: true } } },
+    allowlists: { includable: ["comments"] },
   } as never) as DefaultKavoService<Post>;
 });
 

--- a/packages/orms/prisma/tests/includes.spec.ts
+++ b/packages/orms/prisma/tests/includes.spec.ts
@@ -38,14 +38,13 @@ beforeAll(() => {
     caseInsensitiveFilters: false,
   });
   blogs = kavo.createCrud(Blog, {
-    relations: { edges: { articles: { includable: true } } },
+    allowlists: { includable: ["articles"] },
   }) as DefaultKavoService<Blog>;
   articles = kavo.createCrud(Article, {
     softDelete: { field: "deletedAt" },
-    relations: { edges: { blog: { includable: true }, notes: { includable: true } } },
-    allowlists: { filterable: ["id", "title", "blog.name"] },
+    allowlists: { includable: ["blog", "notes"], filterable: ["id", "title", "blog.name"] },
   } as never) as DefaultKavoService<Article>;
-  kavo.createCrud(Note, { relations: { edges: { article: { includable: true } } } });
+  kavo.createCrud(Note, { allowlists: { includable: ["article"] } } as never);
 });
 
 afterAll(async () => {

--- a/packages/orms/typeorm/tests/cursor-pagination.spec.ts
+++ b/packages/orms/typeorm/tests/cursor-pagination.spec.ts
@@ -86,7 +86,7 @@ beforeAll(async () => {
     },
   });
   posts = kavo.createCrud(Post, {
-    relations: { edges: { comments: { includable: true } } },
+    allowlists: { includable: ["comments"] },
   } as never) as DefaultKavoService<Post>;
 });
 

--- a/packages/orms/typeorm/tests/includes.spec.ts
+++ b/packages/orms/typeorm/tests/includes.spec.ts
@@ -80,26 +80,30 @@ beforeAll(async () => {
   await dataSource.initialize();
   kavo = createTypeOrmKavo(dataSource);
   blogs = kavo.createCrud(Blog, {
-    relations: { edges: { articles: { includable: true } } },
+    allowlists: { includable: ["articles"] },
   }) as DefaultKavoService<Blog>;
   articles = kavo.createCrud(Article, {
     softDelete: { strategy: "soft" },
-    relations: { edges: { blog: { includable: true }, notes: { includable: true } } },
-    // Filtering across a relation path is its own allowlist decision,
-    // independent of whether the relation may be included.
-    allowlists: { filterable: ["id", "title", "blog.name"] },
+    allowlists: {
+      includable: ["blog", "notes"],
+      // Filtering across a relation path is its own allowlist decision,
+      // independent of whether the relation may be included.
+      filterable: ["id", "title", "blog.name"],
+    },
   } as never) as DefaultKavoService<Article>;
-  kavo.createCrud(Note, { relations: { edges: { article: { includable: true } } } });
+  kavo.createCrud(Note, { allowlists: { includable: ["article"] } });
   // The same entity with the to-many forced to `join`: the case the
   // normative pagination rule exists for.
   joinedBlogs = createTypeOrmKavo(dataSource).createCrud(Blog, {
-    relations: { edges: { articles: { includable: true, strategy: "join" } } },
+    allowlists: { includable: ["articles"] },
+    relations: { edges: { articles: { strategy: "join" } } },
   }) as DefaultKavoService<Blog>;
   // A *to-one* forced to `batch`. Left on `auto` a to-one joins, so the
   // batched to-one path only exists when a config asks for it.
   batchedArticles = createTypeOrmKavo(dataSource).createCrud(Article, {
     softDelete: { strategy: "soft" },
-    relations: { edges: { blog: { includable: true, strategy: "batch" } } },
+    allowlists: { includable: ["blog"] },
+    relations: { edges: { blog: { strategy: "batch" } } },
   } as never) as DefaultKavoService<Article>;
 });
 


### PR DESCRIPTION
## What & why

Issue #196: `include=` permission moves out of `relations.edges.<name>.includable` and into a new `allowlists.includable`, typed against the entity's own relation names (`IncludePath<Entity, 1>`) — the same compile-time typing `filterable`/`sortable`/`selectable` already have. `relations.edges` keeps only loading tuning (`defaultInclude`/`maxDepth`/`strategy`); naming a relation there no longer grants permission by itself.

The issue itself flagged an open design question — move the key vs. just type `relations.edges` in place — which was surfaced to and resolved by the user before implementation: proceed with the move as specified in the acceptance criteria.

The opt-in default is preserved deliberately: an unconfigured `allowlists.includable` resolves to `[]` (no relation includable), the opposite direction from the other three allowlist keys. See ADR-0028 for the full decision, including a documented `{ exclude }` fail-open hazard on this fail-closed gate (same class of issue ADR-0026 records for `selectable`), left as a follow-up rather than bundled in.

## Public API impact

**Breaking.** `RelationEdgeSettings.includable` is removed; `QueryAllowlists.includable` and the new `RelationFieldSelector<Entity>` type are added to the core barrel. `ResolvedQueryAllowlists` gains a required `includable` member. Any app configuring `relations.edges.<name>.includable` needs to move that relation name to `allowlists.includable` — see the migration note in `docs/integrations/nest/configuration.md` and ADR-0028's Consequences. `allowlists.includable` is entity-scope-only config (no global `defaults`, no per-operation override), so a permission previously granted through a global default now needs its own `createCrud`/`@Kavo` registration per entity.

## Testing

- New coverage: opt-in default preserved, typo'd relation name fails fast (entity and `{ exclude }` shapes), `defaultInclude` vs. permission cross-check (both entity and per-operation scope), `{ exclude: [] }` opt-everything-in, Swagger's `{ exclude }` doc path (undescribed `include` param, no `fields[relation]` entries).
- Migrated existing tests (not weakened) across `@kavo/core`, all four ORM adapters, `@kavo/nest`, and the three example apps to the new config shape.
- `pnpm check`: build, typecheck, `depcruise`, and lint all pass; 2100 tests pass. The only failures are 5 pre-existing Docker-container-backed e2e suites (`app-postgres`/`app-mariadb`/`app-cockroach`/`app-mongo`) that can't start in this sandbox — confirmed via `docker ps` that the daemon is unreachable here, unrelated to this change. `pnpm docs:links` and `pnpm docs:build` both pass.

## Review notes

- Left issue #197's separate "omit the Swagger `include` param when nothing is includable" fix out of scope — it touches the same `swagger.ts` hunk this PR also edits (`includableRelations`/`descriptor.kind === "read"`), so whichever of #196/#197 merges second will need a small conflict resolution there. If #197 lands after this, its own omit-behavior will also need to reconcile with this PR's new `configuration.md` sentence about an omitted `includable` still emitting a description.
- `examples/nest-mongoose/src/article/article.controller.ts`'s only test file needs the Mongo container, so that one edit never actually executed locally — it typechecks and mirrors the typeorm/mikroorm edits exactly, but CI is what will actually run it.
- ADR-0028 documents the `{ exclude }` fail-open hazard (a typo'd exclude name opens every relation rather than none) as a known, deliberately unfixed follow-up — flagging for the security auditor.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcM65A74S2zb2rQTz2pcZN
