### PR TITLE
refactor(examples): break out SSE into its own Swagger doc subsection

### DIFF
--- a/examples/nest-typeorm/src/main.ts
+++ b/examples/nest-typeorm/src/main.ts
@@ -61,7 +61,8 @@ async function bootstrap(): Promise<void> {
           "sorting, pagination, layered config, and RFC 9457 problem-details " +
           "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
           "model the schema, with opt-in relation includes " +
-          "(`?include=owner`, `?include=pets`) and soft delete on owners. " +
+          "(`?include=owner`, `?include=pets`) and soft delete on owners.\n\n" +
+          "### Realtime (SSE)\n\n" +
           "Owner writes also publish over SSE — see the realtime example " +
           "in the README (`GET /realtime?channel=Owner` or `Owner.<id>`, " +
           "optionally `&filter[...]=...`).\n\n" +


### PR DESCRIPTION
## What & why

The `nest-typeorm` example's top-level Swagger document description folded the SSE realtime mention into the same paragraph as the CRUD overview. This gives it its own `### Realtime (SSE)` heading, matching the section style `KAVO_API_GUIDE` already uses for its own subsections (List query parameters, Relation includes, Conditional requests).

## Test plan

- [x] `pnpm check` (build/typecheck/depcruise/lint/test) — passes except the 5 Docker-testcontainer e2e specs, which fail only because this sandbox has no container runtime, unrelated to this change