### PR TITLE
chore: give each example its own .gitignore, scope prisma db ignores to its package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,3 @@ dist/
 .todo
 api.rest
 docs/.vitepress/cache
-packages/orms/prisma/prisma/*.db
-packages/orms/prisma/prisma/*.db-journal
-packages/orms/prisma/prisma/*.db-wal
-packages/orms/prisma/prisma/*.db-shm

--- a/examples/nest-mikroorm/.gitignore
+++ b/examples/nest-mikroorm/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/examples/nest-mongoose/.gitignore
+++ b/examples/nest-mongoose/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/examples/nest-typeorm/.gitignore
+++ b/examples/nest-typeorm/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/packages/orms/prisma/.gitignore
+++ b/packages/orms/prisma/.gitignore
@@ -1,0 +1,4 @@
+prisma/*.db
+prisma/*.db-journal
+prisma/*.db-wal
+prisma/*.db-shm


### PR DESCRIPTION
## Summary
- Add a \`.gitignore\` to each \`examples/*\` app (\`node_modules/\`, \`dist/\`, \`*.tsbuildinfo\`) so each example is self-contained rather than relying solely on the root file.
- Move the prisma-specific SQLite db/journal/wal/shm ignore patterns out of the root \`.gitignore\` into \`packages/orms/prisma/.gitignore\`, since they only ever applied there.

Closes #203

## Test plan
- [x] \`git check-ignore -v packages/orms/prisma/prisma/template.db\` resolves via the new \`packages/orms/prisma/.gitignore\`
- [x] \`git status --ignored\` still shows example \`dist/\`, \`node_modules/\`, and \`tsconfig.tsbuildinfo\` as ignored