### PR TITLE
docs: add http syntax highlighting to HTTP request examples

### DIFF
--- a/docs/features/caching-and-etags.md
+++ b/docs/features/caching-and-etags.md
@@ -2,7 +2,7 @@
 
 Every single-item response — `POST /books`, `GET /books/1`, `PUT`, `PATCH`, and `PATCH /books/1/restore` — carries a strong `ETag`:
 
-```
+```http
 ETag: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 ```
 
@@ -10,7 +10,7 @@ It is a hash of the exact representation being returned, so it changes whenever 
 
 ## `If-None-Match` — skip a body you already have
 
-```
+```http
 GET /books/1
 If-None-Match: "9f86d0…"
 ```
@@ -19,7 +19,7 @@ If your copy is still current you get `304 Not Modified` with an empty body and 
 
 ## `If-Match` — don't overwrite a version you never saw
 
-```
+```http
 PATCH /books/1
 If-Match: "9f86d0…"
 ```

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -47,7 +47,7 @@ That's it — no config object, no service, no repository wiring in the controll
 
 Requests and responses are shaped straight from `Book`'s own columns — there's no DTO to write until you want to narrow or reshape what's exposed. The list route (`GET /books`) already understands query-string filtering and sorting out of the box, for example:
 
-```
+```http
 GET /books?filter[author][eq]=Tolkien&sort=-title&limit=10&offset=0
 ```
 

--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -251,7 +251,7 @@ new `FilterOperator`, no adapter code — every `FilterTranslator` already
 handles an arbitrary `OR` group of `ILIKE` conditions, the exact shape a
 synthesized fragment produces.
 
-```
+```http
 GET /products?search[query]=blue+iphone&search[mode]=words&search[fields]=name,description
 ```
 

--- a/docs/querying/field-selection-and-includes.md
+++ b/docs/querying/field-selection-and-includes.md
@@ -2,7 +2,7 @@
 
 ## Field selection
 
-```
+```http
 GET /books?fields=id,title
 ```
 
@@ -12,7 +12,7 @@ Sparse fieldset for the root resource, validated against the `selectable` allowl
 
 ## Includes
 
-```
+```http
 GET /books?include=author,reviews.user
 ```
 

--- a/docs/querying/filtering.md
+++ b/docs/querying/filtering.md
@@ -1,12 +1,12 @@
 # Filtering
 
-```
+```http
 GET /books?filter[title][eq]=Dune
 ```
 
 `filter[<field>][<operator>]=<value>`. Multiple `filter[...]` params AND together implicitly, and multiple operators on the same field also AND:
 
-```
+```http
 GET /books?filter[pages][gte]=200&filter[pages][lt]=500
 ```
 
@@ -28,7 +28,7 @@ Wire tokens are exact-case (`gte`, not `GTE`) — a misspelled or wrong-case ope
 
 `in`/`notIn` also accept the repeated-key form instead of a comma list:
 
-```
+```http
 GET /books?filter[status][in][]=active&filter[status][in][]=pending
 ```
 
@@ -38,20 +38,20 @@ Only fields on the entity's `filterable` allowlist can be filtered on — see [A
 
 **OR / NOT / nested logic** uses the same bracket grammar and can be nested arbitrarily deep (up to `query.maxFilterDepth`, default 3):
 
-```
+```http
 GET /books?filter[or][0][author][eq]=Tolkien&filter[or][1][author][eq]=Herbert
 GET /books?filter[not][status][eq]=banned
 ```
 
 For anything the bracket grammar gets awkward at, `filter` also accepts one JSON-encoded value as a full-power escape hatch — it parses into the same filter tree as the bracket form, and if both are present on a request, they AND together:
 
-```
+```http
 GET /books?filter={"or":[{"author":{"eq":"Tolkien"}},{"not":{"status":{"eq":"banned"}}}]}
 ```
 
 **Relation-path filtering** uses dot notation and restricts root rows without loading the related collection — it never filters _what's inside_ an included relation, only which root rows come back:
 
-```
+```http
 GET /books?filter[author.country][eq]=UK
 ```
 

--- a/docs/querying/pagination.md
+++ b/docs/querying/pagination.md
@@ -1,6 +1,6 @@
 # Pagination
 
-```
+```http
 GET /books?limit=20&offset=40
 ```
 
@@ -10,7 +10,7 @@ A 1-indexed page-based alternative is also built in — `page[number]`/`page[siz
 
 ## Cursor (keyset) pagination
 
-```
+```http
 GET /books?limit=20
 GET /books?limit=20&cursor=WzE3MTIzNDU2Nzg5LDQyXQ
 ```
@@ -51,7 +51,7 @@ Finally, the **GraphQL and MCP bindings cannot page a cursor- or since-configure
 
 ## Since (seek-by-timestamp) pagination
 
-```
+```http
 GET /books?limit=20
 GET /books?limit=20&since=2024-03-01T10:00:00.000Z%7C41
 ```

--- a/docs/querying/search.md
+++ b/docs/querying/search.md
@@ -1,6 +1,6 @@
 # Search
 
-```
+```http
 GET /books?search[query]=dune
 ```
 
@@ -12,7 +12,7 @@ hasn't turned `query.search.enabled` on — and only searches fields on the
 entity's `searchable` allowlist (default: every own string column) — see
 [Allowlists & computed fields](/features/allowlists-and-computed-fields#allowlists).
 
-```
+```http
 GET /books?search[query]=blue+iphone&search[mode]=words&search[fields]=title,description
 ```
 

--- a/docs/querying/sorting.md
+++ b/docs/querying/sorting.md
@@ -1,6 +1,6 @@
 # Sorting
 
-```
+```http
 GET /books?sort=-publishedAt,title
 ```
 

--- a/docs/using-the-api.md
+++ b/docs/using-the-api.md
@@ -4,7 +4,7 @@
 
 ## Soft-deleted rows
 
-```
+```http
 GET /books?withDeleted=true
 ```
 


### PR DESCRIPTION
Fenced code blocks showing raw GET/PATCH requests and cache headers
were unlabeled; label them as http, matching docs/index.md.