### PR TITLE
Add a 'none' pagination strategy to opt a resource out entirely

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -346,6 +346,10 @@ const config = defineConfig({
                 text: "0029 — Array relations may opt into replace writes",
                 link: "/internals/adr/0029-array-relations-may-opt-into-replace-writes",
               },
+              {
+                text: "0030 — 'none' pagination strategy opts a resource out entirely",
+                link: "/internals/adr/0030-none-pagination-strategy-opts-a-resource-out-entirely",
+              },
             ],
           },
         ],

--- a/docs/guides/configuration/settings.md
+++ b/docs/guides/configuration/settings.md
@@ -6,12 +6,13 @@ The app-wide `KavoSettings` shape — the same schema at every scope (global `de
 
 `defaultLimit` (default `20`) is the page size when a request supplies no `limit`. `maxLimit` (default `100`) is a hard ceiling on `limit` — a request asking for more is clamped, not rejected.
 
-`strategy` (default `"offset"`) picks which pagination strategy computes the page — `"offset"`, `"page"`, `"cursor"`, `"since"`, or a registered name (see `paginationStrategies` in [Module setup](/guides/configuration/module-setup#global-config-kavomodule-forroot-forrootasync) for adding your own):
+`strategy` (default `"offset"`) picks which pagination strategy computes the page — `"offset"`, `"page"`, `"cursor"`, `"since"`, `"none"`, or a registered name (see `paginationStrategies` in [Module setup](/guides/configuration/module-setup#global-config-kavomodule-forroot-forrootasync) for adding your own):
 
 - `offset` is flat `limit`/`offset`.
 - `page` is `page[number]`/`page[size]`.
 - `cursor` is keyset paging over an opaque `?cursor=` token, which requires the effective sort to end in the entity's id field — with every sort key on `allowlists.filterable` and `allowlists.selectable` as well as `sortable` — and reports the next token as `meta.nextCursor`.
 - `since` is polling by a plain, compound `?since=<value>|<id>` token against `since.field`, with the sort forced to `[since.field, id]`, exactly-once delivery (the id half breaks ties on `since.field`), and the next token reported as `meta.nextSince`.
+- `none` opts the entity out of pagination altogether: `findMany` always serves the whole match set, `defaultLimit`/`maxLimit` go unused, and a client-sent `limit`/`offset` is rejected as an unsupported param rather than silently ignored. See [No pagination](/querying/pagination#no-pagination) for the caveats.
 
 Pair either keyset strategy with `count: false`, and index the sort tuple; both are refused by the GraphQL and MCP bindings, which cannot page a keyset (see [Cursor pagination](/querying/pagination#cursor-keyset-pagination), [Since pagination](/querying/pagination#since-seek-by-timestamp-pagination), [ADR-0021](/internals/adr/0021-cursor-pagination-is-an-opaque-keyset-union), and [ADR-0022](/internals/adr/0022-since-pagination-composes-a-value-id-keyset)).
 

--- a/docs/internals/adr/0030-none-pagination-strategy-opts-a-resource-out-entirely.md
+++ b/docs/internals/adr/0030-none-pagination-strategy-opts-a-resource-out-entirely.md
@@ -1,0 +1,122 @@
+# ADR-0030 — `pagination.strategy: "none"` opts a resource out of pagination entirely
+
+**Status:** accepted
+
+## Context
+
+`pagination.maxLimit` always clamps `findMany`, and `PaginationSettings` had
+no escape hatch — unlike `softDelete`, `realtime`, and `arrayMutation`, which
+each accept `false` at entity scope to switch the whole subtree off
+(`packages/core/src/config/settings.ts`). A resource that genuinely never
+wants a page boundary (a small lookup/reference table) could only raise
+`defaultLimit`/`maxLimit` to some large number — still a clamp, still an
+arbitrary ceiling the OpenAPI docs would advertise (issue #225).
+
+The `false`-disables-the-subtree convention does not transfer directly here.
+`softDelete`/`realtime`/`arrayMutation` are each a whole top-level
+`KavoSettings` key that can be `SomeSettings | false`; `pagination` itself is
+never optional — every `findMany` response still needs a `limit`/`offset`
+pair for the envelope, so there is no whole subtree to switch off. The two
+candidate shapes were a new field, `pagination.maxLimit: number | false`, or
+a new value for the field that already selects behavior,
+`pagination.strategy: "none"`.
+
+`maxLimit: false` was rejected for three reasons. First, it collides with
+`PaginationLimits`, the public interface every third-party `PaginationStrategy`
+receives (`{ defaultLimit: number, maxLimit: number }`) — widening `maxLimit`
+to `number | false` there means every existing strategy's
+`Math.min(limit, limits.maxLimit)` silently clamps to `0` the moment `false`
+reaches it, unless every strategy author updates first. Second, it only
+answers "how big can a page be", not "should there even be a boundary" — a
+plain `GET /widgets` would still be `defaultLimit`-sized unless `defaultLimit`
+were _also_ unbounded, which the issue's own examples call for ("a resource
+that legitimately wants to serve its whole table in one call"). Reaching that
+means resolving two settings together as one concept, which is what a
+dedicated strategy name already is. Third, `pagination.strategy` is already
+the seam this exact kind of behavioral choice lives on — `cursor` and `since`
+each change what a page even means (ADR-0021, ADR-0022); "no page at all" is
+a third variant of the same question, not a modifier on `offset`.
+
+## Decision
+
+**1. `"none"` is a fifth built-in `PaginationStrategy`.** Registered in
+`builtInPaginationStrategies()` alongside `offset`/`page`/`cursor`/`since`,
+so `strategyFor`'s "unknown strategy" error still enumerates it and nothing
+about strategy resolution needs to know it is special.
+
+**2. `limit`/`offset` are rejected outright, never silently ignored.**
+Accepting a client-sent `limit` and quietly not applying it would leave the
+client believing paging took effect when it didn't — the same "wrong
+strategy, told" treatment `cursor`/`since` params already get under any
+other strategy (`keysetParamUnsupportedIssue`). Both issues are collected
+into **one** `QueryValidationException` when both `limit` and `offset` are
+sent, matching `QueryNormalizer`'s own documented contract ("all issues from
+all sections … collected into a single exception, so a client fixes its
+request in one round trip") — a strategy raising its own exception is not
+exempt from that contract just because it lives outside the normalizer's own
+issue-collection loop.
+
+**3. The reported `limit` is `2^31 - 1` (`2147483647`), not
+`Number.MAX_SAFE_INTEGER`.** The envelope's shape is fixed (`items`, `limit`,
+`offset`, `total`, `meta`), so `limit` has to report _something_ even though
+there is no real page size — the same reasoning that leaves a cursor page's
+`offset` at `0` (ADR-0021 §6). `Number.MAX_SAFE_INTEGER` (`2^53 - 1`)
+overflows a signed 32-bit integer, which is what this value has to survive
+unchanged through every consumer in the workspace: every SQL driver's
+`LIMIT`/`.take()` (fine up to 64-bit), `@kavo/graphql`'s `GraphQLInt` envelope
+field (`graphql-js` throws serializing above `2^31 - 1`), and MongoDB's wire
+`limit`, which is int32. `2^31 - 1` is the ceiling every one of those can
+carry without a second, adapter-specific ceiling — and it is not a real limit
+for any table this strategy is a reasonable fit for.
+
+**4. The programmatic path (`QueryNormalizer.normalizeInput`) knows `"none"`
+by name, not by the shape it produces.** ADR-0021 §4 established
+`paginationShape`'s probe as structural — deliberately not comparing a
+strategy's _name_ to `"cursor"`/`"since"`, so a third-party strategy under
+another name is still classified correctly by what it returns. `"none"`
+cannot get the same treatment: it produces a plain `OffsetPagination`
+(`{ limit, offset }`), structurally identical to `offset`/`page`, because the
+envelope has no field for "unbounded" to live in. `normalizeInput`'s offset
+branch already computes `limit`/`offset` directly
+(`Math.min(input.limit ?? defaultLimit, maxLimit)`) rather than calling the
+registered strategy — true for `offset`/`page` today, for the same
+architectural reason `PagePaginationStrategy` cannot be reused there either
+(the programmatic API's `limit`/`offset` fields don't share `page`'s wire
+spelling) — so nothing short of a `strategy === "none"` check would make that
+branch unbounded too. This is a deliberate, narrow, and comment-flagged
+exception to the "structural, not name-based" rule, not a reversal of it: the
+rule still holds for every strategy whose _shape_ can carry the information
+(`cursor`, `since`, and any future keyset strategy).
+
+**5. `defaultLimit`/`maxLimit` go unused under `"none"`.** No new
+`validateSettings` rule was added — an unused pair of built-in defaults
+(`20`/`100`) always satisfies the existing positive-integer check, so
+leaving them be costs nothing and avoids a config error that would only fire
+because a value nobody reads happens to be present.
+
+## Consequences
+
+- **A resource opted into `"none"` has no configured ceiling — the adopter's
+  judgment call, not a warning Kavo issues.** Nothing here detects a table
+  that has outgrown one response; that stays an adopter obligation, the same
+  posture ADR-0021 takes toward the missing composite index a cursor strategy
+  needs.
+- **`@kavo/graphql`/`@kavo/mcp` are not restricted the way `cursor`/`since`
+  are.** Both bindings pass through whatever `limit`/`offset` a caller
+  supplies; a caller that never asks for either gets the whole match set
+  correctly, and one that does gets the same `KAVO_QUERY_UNSUPPORTED_PARAM`
+  a REST caller would. No `requireOffsetPageable`-style bootstrap refusal was
+  added — unlike a keyset strategy, `"none"` does not silently return the
+  wrong page when a binding ignores something; it composes correctly by
+  construction, so there is nothing for a bootstrap check to catch.
+- **The OpenAPI `limit`/`offset` docs for `"none"` are decoration-time-blind
+  to a global-only default.** `pagination` merges through the full
+  precedence chain (global → entity → operation), so `KavoBinder.
+onModuleInit`'s `applyPaginationDocs` (mirroring `applySearchQueryDocs`)
+  is what actually applies the "not supported" description, using the fully
+  resolved `pagination.strategy` — `listQueryParams` no longer declares
+  `limit`/`offset` at decoration time at all, because `@nestjs/swagger`'s own
+  parameter de-duplication (`unionWith` over `{ name, in }`) keeps the
+  _first_ match, so a second `ApiQuery({ name: "limit" })` applied later
+  would have been silently discarded rather than override an
+  earlier-declared one.

--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -217,6 +217,23 @@ LOWER(:v)`), identical on every driver. Both operators apply to string
   not per-request, because the forced sort is entirely config-known before
   any request arrives.
 
+  The fifth built-in, `none`, opts a resource out of pagination altogether
+  (ADR-0030, issue #225): `findMany` always serves the whole match set, and a
+  client-sent `limit`/`offset` is `KAVO_QUERY_UNSUPPORTED_PARAM` rather than
+  silently ignored — both issues collected into one exception when both are
+  sent, the same "every issue in one round trip" contract the rest of this
+  normalizer keeps. Unlike `cursor`/`since`, "none" produces a plain
+  `OffsetPagination` (`{ limit, offset }`, `limit` fixed at `2^31 - 1`, the
+  largest value every consumer in the workspace — SQL `LIMIT`, GraphQL's
+  `Int`, MongoDB's int32 limit — can carry without its own ceiling), so it
+  is structurally indistinguishable from `offset` to `paginationShape`'s
+  probe. That is why it is the one strategy `QueryNormalizer.normalizeInput`
+  has to recognize by name rather than by the shape it produces: the
+  programmatic path computes `limit`/`offset` directly (`Math.min(input.
+limit ?? defaultLimit, maxLimit)`) rather than calling the registered
+  strategy, the same as it already does for `offset`/`page`, so nothing
+  short of a name check would make it unbounded there too.
+
 - **Field selection:** `fields=id,name,email` — sparse fieldset for the
   root resource, validated against the selectable allowlist.
   `fields[<relation path>]=id,title` narrows an included node, validated

--- a/docs/querying/pagination.md
+++ b/docs/querying/pagination.md
@@ -49,6 +49,22 @@ Three things cursor pagination does **not** support:
 
 Finally, the **GraphQL and MCP bindings cannot page a cursor- or since-configured entity.** Both expose `limit`/`offset` only, and a keyset page ignores `offset`, so binding one would answer every paged query with the first page (or, under `since`, everything from the beginning). They refuse at bootstrap with a configuration error instead. Page those entities over REST, or give them an entity-scope `pagination.strategy` of `"offset"`/`"page"`.
 
+## No pagination
+
+```http
+GET /countries
+```
+
+For entities configured with `pagination.strategy: "none"`, `findMany` always serves the whole match set — the escape hatch for a resource that should never be paginated, like a small lookup/reference table. There is no configured ceiling to raise: `defaultLimit`/`maxLimit` go unused entirely under this strategy.
+
+Things to know:
+
+- **`limit`/`offset` are rejected, not ignored.** Sending either is a 400 (`KAVO_QUERY_UNSUPPORTED_PARAM`) naming the param — the same "wrong strategy, told, not silently narrowed" treatment `cursor`/`since` params get under any other strategy. A client that thinks it is getting a page should be told it is not.
+- **The envelope's `limit` is not a real page size.** The response shape is fixed (`items`, `limit`, `offset`, `total`, `meta`), so `limit` still has to report _something_ — it reports `2147483647` (`2^31 - 1`, the largest value every consumer in the workspace — every SQL `LIMIT`, GraphQL's `Int`, MongoDB's int32 limit — can carry without its own ceiling). Read `items.length` for the actual count returned. `offset` is always `0`.
+- **`total` still respects `pagination.count`,** the same as every other strategy — it is not implied by `items.length` being the same number; `count: false` still turns the extra `COUNT` query off.
+- **Kavo never owns your schema.** Nothing here warns you when a table this is configured on has grown past what one response should reasonably carry — that judgment call is yours to make when you opt an entity in.
+- **Everything else composes normally.** Unlike `cursor`/`since`, this is not a keyset strategy — `filter`/`sort`/`include`/`search` all work exactly as they do under `offset`; only `limit`/`offset` are off the table.
+
 ## Since (seek-by-timestamp) pagination
 
 ```http

--- a/examples/nest-typeorm/src/tag/tag.controller.ts
+++ b/examples/nest-typeorm/src/tag/tag.controller.ts
@@ -5,7 +5,10 @@ import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.j
 
 /**
  * Plain CRUD over `Tag`, the many-to-many side pets associate by id
- * (`include=tags` on `/cats`).
+ * (`include=tags` on `/cats`). A small lookup table, and the example's
+ * demonstration of `pagination.strategy: "none"` (issue #225): `GET /tags`
+ * always serves every tag, never a `defaultLimit`-sized page, and an
+ * explicit `?limit=`/`?offset=` is rejected rather than silently narrowed.
  */
 @Kavo(Tag, {
   dto: {
@@ -14,6 +17,7 @@ import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.j
     item: TagItemDto,
     list: TagListDto,
   },
+  pagination: { strategy: "none" },
 })
 @Controller("tags")
 export class TagController {}

--- a/examples/nest-typeorm/tests/crud-e2e.suite.ts
+++ b/examples/nest-typeorm/tests/crud-e2e.suite.ts
@@ -1191,4 +1191,87 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       expect(response.body.code).toBe("KAVO_NOT_FOUND");
     });
   });
+
+  /**
+   * `TagController` sets `pagination: { strategy: "none" }` (issue #225):
+   * `/tags` is a small lookup table that should never be paginated.
+   */
+  describe("Tag: pagination.strategy 'none' (issue #225)", () => {
+    it("serves every tag in one response, unbounded by the default 20-row page", async () => {
+      // More than the built-in `defaultLimit` (20) and `maxLimit` (100) an
+      // ordinary offset-paginated entity would clamp to — proof that
+      // neither applies here.
+      const created: number[] = [];
+      for (let i = 0; i < 25; i++) {
+        const tag = await request(server())
+          .post("/tags")
+          .send({ name: `unbounded-${i}` })
+          .expect(201);
+        created.push(tag.body.id as number);
+      }
+
+      const response = await request(server()).get("/tags").expect(200);
+      // Every tag ever created in this run is still present (no reset
+      // between tests) — `items.length` equals `total`, never a clamped
+      // subset of it, which is what would happen under ordinary pagination.
+      // `total` itself is asserted past `defaultLimit` (20): otherwise this
+      // test would pass just as well against an ordinary offset-paginated
+      // entity whose `total` happens to be small.
+      expect(response.body.total).toBeGreaterThan(20);
+      expect(response.body.items.length).toBe(response.body.total);
+      const ids = response.body.items.map((tag: { id: number }) => tag.id);
+      for (const id of created) expect(ids).toContain(id);
+    });
+
+    it("rejects an explicit limit as unsupported, rather than silently paginating anyway", async () => {
+      const response = await request(server())
+        .get("/tags")
+        .query("limit=5")
+        .expect(400)
+        .expect("Content-Type", /application\/problem\+json/);
+      expect(response.body.errors).toEqual([
+        expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+      ]);
+    });
+
+    it("rejects an explicit offset as unsupported, rather than silently paginating anyway", async () => {
+      const response = await request(server())
+        .get("/tags")
+        .query("offset=5")
+        .expect(400)
+        .expect("Content-Type", /application\/problem\+json/);
+      expect(response.body.errors).toEqual([
+        expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+      ]);
+    });
+
+    it("collects both limit and offset into one 400 when both are sent, not one round trip each", async () => {
+      const response = await request(server())
+        .get("/tags")
+        .query("limit=5&offset=10")
+        .expect(400)
+        .expect("Content-Type", /application\/problem\+json/);
+      expect(response.body.errors).toEqual([
+        expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+        expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+      ]);
+    });
+
+    it("still composes with filter/sort — only limit/offset are off the table", async () => {
+      await request(server()).post("/tags").send({ name: "sortable-zzz" }).expect(201);
+      await request(server()).post("/tags").send({ name: "sortable-aaa" }).expect(201);
+      const filtered = await request(server())
+        .get("/tags")
+        .query("filter[name][like]=sortable-%25&sort=name")
+        .expect(200);
+      expect(filtered.body.items.map((tag: { name: string }) => tag.name)).toEqual(["sortable-aaa", "sortable-zzz"]);
+    });
+
+    it("documents limit/offset as unsupported in the OpenAPI schema", () => {
+      const document = SwaggerModule.createDocument(getApp(), new DocumentBuilder().build());
+      const params = (document.paths["/tags"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+      expect(params.find((param) => param.name === "limit")?.description).toContain("pagination.strategy' is 'none'");
+      expect(params.find((param) => param.name === "offset")?.description).toContain("pagination.strategy' is 'none'");
+    });
+  });
 }

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -15,11 +15,19 @@ import type { RealtimeTransport } from "../realtime/realtime-transport.js";
  */
 
 /** Built-in pagination strategy names; open for custom strategies. */
-export type PaginationStrategyName = "offset" | "page" | "cursor" | "since" | (string & {});
+export type PaginationStrategyName = "offset" | "page" | "cursor" | "since" | "none" | (string & {});
 
 export interface PaginationSettings {
   readonly defaultLimit: number;
   readonly maxLimit: number;
+  /**
+   * `"none"` (ADR-0030) opts the entity out of pagination altogether —
+   * `findMany` serves the whole match set every time, `defaultLimit`/
+   * `maxLimit` are unused, and a client-sent `limit`/`offset` is rejected
+   * outright rather than silently ignored (`NonePaginationStrategy`,
+   * `pagination-strategies.ts`). It composes with no other strategy: this
+   * key picks exactly one.
+   */
   readonly strategy: PaginationStrategyName;
   /** Whether list responses compute `total` (the count query). */
   readonly count: boolean;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,6 +243,8 @@ export {
   PagePaginationStrategy,
   CursorPaginationStrategy,
   SincePaginationStrategy,
+  NonePaginationStrategy,
+  NONE_PAGINATION_LIMIT,
   builtInPaginationStrategies,
 } from "./query/pagination-strategies.js";
 export { QueryNormalizer } from "./query/query-normalizer.js";

--- a/packages/core/src/query/pagination-strategies.ts
+++ b/packages/core/src/query/pagination-strategies.ts
@@ -5,6 +5,7 @@ import type {
   PaginationStrategy,
   SincePagination,
 } from "./pagination.js";
+import type { QueryIssueDto } from "../errors/problem-details.js";
 import { QueryValidationException } from "../errors/exceptions.js";
 
 /**
@@ -100,6 +101,65 @@ export class SincePaginationStrategy implements PaginationStrategy {
   }
 }
 
+/**
+ * The `limit` this strategy reports for an unbounded page, and every
+ * adapter's numeric limit call (`.take()`, `.limit()`, …) then receives
+ * unchanged. `Number.MAX_SAFE_INTEGER` would overflow a signed 32-bit
+ * integer — which is what `@kavo/graphql`'s `GraphQLInt` envelope field is,
+ * and what MongoDB's wire protocol uses for a query's `limit` — so this is
+ * `2^31 - 1` instead: the largest value every consumer in the workspace
+ * (every SQL `LIMIT`, `GraphQLInt`, MongoDB's int32 limit) can carry without
+ * a second, adapter-specific ceiling. It is not a real limit for any table
+ * this strategy is a reasonable fit for.
+ */
+export const NONE_PAGINATION_LIMIT = 2147483647;
+
+/**
+ * "none" (ADR-0030): opts a resource out of pagination altogether — every
+ * `findMany` call serves the whole match set, for a resource that genuinely never
+ * wants a page boundary (a small lookup/reference table, say). `limit`/
+ * `offset` are rejected outright if the client sends either, the same
+ * "wrong strategy, told, not silently ignored" treatment `cursor`/`since`
+ * params get under any other strategy (`QueryNormalizer`'s
+ * `keysetParamUnsupportedIssue`) — accepting a client-sent `limit` and then
+ * ignoring it would leave the client believing paging took effect when it
+ * didn't. Both are collected into one exception when both are sent, the
+ * same "every issue in one round trip" contract `QueryNormalizer` documents
+ * for itself — a strategy raising its own exception is not exempt from it.
+ *
+ * The response envelope still reports `limit`/`offset` — its shape is
+ * fixed, the same reason a keyset page's envelope always reports
+ * `offset: 0` — so this strategy reports {@link NONE_PAGINATION_LIMIT}
+ * rather than inventing a sentinel the envelope has no field for.
+ */
+export class NonePaginationStrategy implements PaginationStrategy {
+  readonly name = "none";
+
+  // `_limits` (`defaultLimit`/`maxLimit`) is part of the interface but goes
+  // unused here — the whole point of "none" is that neither applies.
+  normalize(rawParams: Readonly<Record<string, unknown>>, _limits: PaginationLimits): OffsetPagination {
+    const issues: QueryIssueDto[] = [];
+    if (hasValue(rawParams["limit"])) issues.push(noneParamUnsupportedIssue("limit"));
+    if (hasValue(rawParams["offset"])) issues.push(noneParamUnsupportedIssue("offset"));
+    if (issues.length > 0) throw new QueryValidationException(issues);
+    return { limit: NONE_PAGINATION_LIMIT, offset: 0 };
+  }
+}
+
+function hasValue(raw: unknown): boolean {
+  return raw !== undefined && raw !== null && raw !== "";
+}
+
+function noneParamUnsupportedIssue(param: "limit" | "offset"): QueryIssueDto {
+  return {
+    field: param,
+    code: "KAVO_QUERY_UNSUPPORTED_PARAM",
+    detail:
+      `Query parameter '${param}' is not supported: this entity does not paginate ` +
+      `('pagination.strategy' is 'none'), so every request serves the whole match set.`,
+  };
+}
+
 /** Built-in strategies, keyed by the `pagination.strategy` config value. */
 export function builtInPaginationStrategies(): ReadonlyMap<string, PaginationStrategy> {
   const strategies = [
@@ -107,6 +167,7 @@ export function builtInPaginationStrategies(): ReadonlyMap<string, PaginationStr
     new PagePaginationStrategy(),
     new CursorPaginationStrategy(),
     new SincePaginationStrategy(),
+    new NonePaginationStrategy(),
   ];
   return new Map(strategies.map((strategy) => [strategy.name, strategy]));
 }

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -538,10 +538,14 @@ function keysetParamUnsupportedIssue<Entity>(
 }
 
 /**
- * One wording for "this entity does not paginate", shared by the wire path
- * (via `NonePaginationStrategy`, which throws the equivalent
- * `QueryValidationException` itself rather than pushing through here — it
- * has no `issues` array to push onto) and the programmatic path above.
+ * The programmatic-path counterpart of `NonePaginationStrategy`'s own
+ * rejection (`pagination-strategies.ts`) — same field, same code, same
+ * meaning, but genuinely **not** the identical string: `PaginationStrategy.
+ * normalize(rawParams, limits)` carries no entity name for a strategy to
+ * phrase its own message with (widening that signature to add one would be
+ * a breaking change to every third-party strategy for one sentence's sake),
+ * so the wire path's wording stays entity-agnostic ("this entity") while
+ * this one, which already has `config` in scope, names the entity.
  */
 function noneParamUnsupportedIssue<Entity>(
   config: ResolvedEntityConfig<Entity>,

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -13,7 +13,7 @@ import type { AllowlistUsage } from "../errors/message-hints.js";
 import { ConfigurationException, QueryValidationException } from "../errors/exceptions.js";
 import { pushAllowlistIssue } from "../errors/message-hints.js";
 import { DefaultFilterParser } from "./default-filter-parser.js";
-import { builtInPaginationStrategies } from "./pagination-strategies.js";
+import { NONE_PAGINATION_LIMIT, builtInPaginationStrategies } from "./pagination-strategies.js";
 import { isCursorPagination, isSincePagination } from "./pagination.js";
 import { decodeCursor, keysetExpression } from "./cursor.js";
 import { coerceScalar, isIssue } from "./value-coercion.js";
@@ -172,9 +172,22 @@ export class QueryNormalizer<Entity = unknown> {
     };
     const include = this.resolveIncludes(input.include ?? [], fields, config, issues);
 
-    const { defaultLimit, maxLimit } = config.settings.pagination;
-    const limit = Math.min(input.limit ?? defaultLimit, maxLimit);
-    const offset = input.offset ?? 0;
+    const { defaultLimit, maxLimit, strategy } = config.settings.pagination;
+    // `NonePaginationStrategy` (`pagination-strategies.ts`) is never invoked
+    // here: unlike cursor/since, "none" has no wire shape of its own to
+    // decode, and the programmatic path already knows its own `limit`/
+    // `offset` field names, so there is nothing a strategy call would add.
+    // This is the one place that has to know the strategy by name rather
+    // than by the shape it produces — `paginationShape`'s probe cannot tell
+    // "none" apart from "offset" structurally, since both produce a plain
+    // `{ limit, offset }`. A deliberate, narrow exception to §4's
+    // structural-not-name-based rule, not a reversal of it (ADR-0030).
+    if (strategy === "none") {
+      if (input.limit !== undefined) issues.push(noneParamUnsupportedIssue(config, "limit"));
+      if (input.offset !== undefined) issues.push(noneParamUnsupportedIssue(config, "offset"));
+    }
+    const limit = strategy === "none" ? NONE_PAGINATION_LIMIT : Math.min(input.limit ?? defaultLimit, maxLimit);
+    const offset = strategy === "none" ? 0 : (input.offset ?? 0);
     if (limit < 1 || offset < 0 || !Number.isInteger(limit) || !Number.isInteger(offset)) {
       issues.push({
         field: limit < 1 || !Number.isInteger(limit) ? "limit" : "offset",
@@ -521,6 +534,25 @@ function keysetParamUnsupportedIssue<Entity>(
       `strategy '${config.settings.pagination.strategy}'. Set 'pagination.strategy' to '${param}' to page by ${
         param === "cursor" ? "keyset" : "seeking since a value"
       }.`,
+  };
+}
+
+/**
+ * One wording for "this entity does not paginate", shared by the wire path
+ * (via `NonePaginationStrategy`, which throws the equivalent
+ * `QueryValidationException` itself rather than pushing through here — it
+ * has no `issues` array to push onto) and the programmatic path above.
+ */
+function noneParamUnsupportedIssue<Entity>(
+  config: ResolvedEntityConfig<Entity>,
+  param: "limit" | "offset",
+): QueryIssueDto {
+  return {
+    field: param,
+    code: "KAVO_QUERY_UNSUPPORTED_PARAM",
+    detail:
+      `Query parameter '${param}' is not supported: ${config.entityName} does not paginate ` +
+      `('pagination.strategy' is 'none'), so every request serves the whole match set.`,
   };
 }
 

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -144,6 +144,8 @@ const PUBLIC_SURFACE: readonly string[] = [
   "ListResultDto",
   "LogicalOperator",
   "MetadataSource",
+  "NONE_PAGINATION_LIMIT",
+  "NonePaginationStrategy",
   "NormalizedQueryContext",
   "NotDeletedException",
   "NotFoundException",

--- a/packages/core/tests/pagination-strategies.spec.ts
+++ b/packages/core/tests/pagination-strategies.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { PaginationLimits } from "@kavo/core";
 import {
   CursorPaginationStrategy,
+  NONE_PAGINATION_LIMIT,
+  NonePaginationStrategy,
   OffsetPaginationStrategy,
   PagePaginationStrategy,
   builtInPaginationStrategies,
@@ -11,6 +13,7 @@ import { issuesOf } from "./support/query-issues.js";
 const limits: PaginationLimits = { defaultLimit: 20, maxLimit: 100 };
 const offset = new OffsetPaginationStrategy();
 const page = new PagePaginationStrategy();
+const none = new NonePaginationStrategy();
 
 describe("OffsetPaginationStrategy — flat limit/offset", () => {
   it("falls back to defaultLimit and offset 0 when nothing is sent", () => {
@@ -125,10 +128,50 @@ describe("PagePaginationStrategy — page[number]/page[size]", () => {
   });
 });
 
+describe("NonePaginationStrategy — no pagination at all", () => {
+  it("serves the whole match set when neither limit nor offset is sent", () => {
+    expect(none.normalize({}, limits)).toEqual({ limit: NONE_PAGINATION_LIMIT, offset: 0 });
+  });
+
+  it("ignores the limits it is handed — defaultLimit/maxLimit play no role", () => {
+    expect(none.normalize({}, { defaultLimit: 1, maxLimit: 1 })).toEqual({
+      limit: NONE_PAGINATION_LIMIT,
+      offset: 0,
+    });
+  });
+
+  it("rejects an explicit limit rather than silently ignoring it", () => {
+    const issues = issuesOf(() => none.normalize({ limit: "5" }, limits));
+    expect(issues).toEqual([expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" })]);
+  });
+
+  it("rejects an explicit offset rather than silently ignoring it", () => {
+    const issues = issuesOf(() => none.normalize({ offset: "10" }, limits));
+    expect(issues).toEqual([expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" })]);
+  });
+
+  it("collects both limit and offset into one exception when both are sent, not one round trip each", () => {
+    const issues = issuesOf(() => none.normalize({ limit: "5", offset: "10" }, limits));
+    expect(issues).toEqual([
+      expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+      expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+    ]);
+  });
+
+  it("treats empty string, null, and undefined as absent, not a rejection", () => {
+    for (const absent of ["", null, undefined]) {
+      expect(none.normalize({ limit: absent, offset: absent }, limits)).toEqual({
+        limit: NONE_PAGINATION_LIMIT,
+        offset: 0,
+      });
+    }
+  });
+});
+
 describe("builtInPaginationStrategies", () => {
-  it("ships exactly the four built-ins, keyed by strategy name", () => {
+  it("ships exactly the five built-ins, keyed by strategy name", () => {
     const strategies = builtInPaginationStrategies();
-    expect([...strategies.keys()].sort()).toEqual(["cursor", "offset", "page", "since"]);
+    expect([...strategies.keys()].sort()).toEqual(["cursor", "none", "offset", "page", "since"]);
   });
 
   it("keys each strategy by its own name property", () => {
@@ -137,10 +180,11 @@ describe("builtInPaginationStrategies", () => {
     }
   });
 
-  it("maps the names to the three exported classes", () => {
+  it("maps the names to the exported classes", () => {
     const strategies = builtInPaginationStrategies();
     expect(strategies.get("offset")).toBeInstanceOf(OffsetPaginationStrategy);
     expect(strategies.get("page")).toBeInstanceOf(PagePaginationStrategy);
     expect(strategies.get("cursor")).toBeInstanceOf(CursorPaginationStrategy);
+    expect(strategies.get("none")).toBeInstanceOf(NonePaginationStrategy);
   });
 });

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -4,6 +4,7 @@ import {
   ConfigurationException,
   DefaultEntityCatalog,
   DefaultIncludeResolver,
+  NONE_PAGINATION_LIMIT,
   QueryNormalizer,
   QueryValidationException,
   resolveEntityConfig,
@@ -122,6 +123,29 @@ describe("QueryNormalizer — wire params", () => {
   it("honors pagination.count=false", () => {
     const uncounted = resolveEntityConfig(userMetadata, { pagination: { count: false } }, undefined);
     expect(normalizer.normalizeWire({}, uncounted).count).toBe(false);
+  });
+
+  it("serves the whole match set under strategy 'none', ignoring configured defaultLimit/maxLimit", () => {
+    const unpaginated = resolveEntityConfig(userMetadata, { pagination: { strategy: "none" } }, undefined);
+    const query = normalizer.normalizeWire({}, unpaginated);
+    expect(query.pagination).toEqual({ limit: NONE_PAGINATION_LIMIT, offset: 0 });
+  });
+
+  it("rejects an explicit limit/offset under strategy 'none' instead of silently narrowing", () => {
+    const unpaginated = resolveEntityConfig(userMetadata, { pagination: { strategy: "none" } }, undefined);
+    const limitIssues = issuesOf(() => normalizer.normalizeWire({ limit: "5" }, unpaginated));
+    expect(limitIssues).toEqual([expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" })]);
+    const offsetIssues = issuesOf(() => normalizer.normalizeWire({ offset: "5" }, unpaginated));
+    expect(offsetIssues).toEqual([expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" })]);
+  });
+
+  it("collects both limit and offset into one exception under strategy 'none', not one round trip each", () => {
+    const unpaginated = resolveEntityConfig(userMetadata, { pagination: { strategy: "none" } }, undefined);
+    const issues = issuesOf(() => normalizer.normalizeWire({ limit: "5", offset: "10" }, unpaginated));
+    expect(issues).toEqual([
+      expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+      expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+    ]);
   });
 
   it("falls back to the configured defaultSort when the client supplies no sort", () => {
@@ -585,6 +609,29 @@ describe("QueryNormalizer — programmatic input", () => {
     );
     const query = normalizer.normalizeInput({ sort: [{ field: "name", direction: "asc" }] }, defaulted);
     expect(query.sort).toEqual([{ field: "name", direction: "asc" }]);
+  });
+
+  it("serves the whole match set under strategy 'none', the same as the wire path", () => {
+    const unpaginated = resolveEntityConfig(userMetadata, { pagination: { strategy: "none" } }, undefined);
+    const query = normalizer.normalizeInput({}, unpaginated);
+    expect(query.pagination).toEqual({ limit: NONE_PAGINATION_LIMIT, offset: 0 });
+  });
+
+  it("rejects an explicit limit/offset under strategy 'none' rather than silently clamping it", () => {
+    const unpaginated = resolveEntityConfig(userMetadata, { pagination: { strategy: "none" } }, undefined);
+    const limitIssues = issuesOf(() => normalizer.normalizeInput({ limit: 5 }, unpaginated));
+    expect(limitIssues).toEqual([expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" })]);
+    const offsetIssues = issuesOf(() => normalizer.normalizeInput({ offset: 5 }, unpaginated));
+    expect(offsetIssues).toEqual([expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" })]);
+  });
+
+  it("collects both limit and offset into one exception under strategy 'none', not one round trip each", () => {
+    const unpaginated = resolveEntityConfig(userMetadata, { pagination: { strategy: "none" } }, undefined);
+    const issues = issuesOf(() => normalizer.normalizeInput({ limit: 5, offset: 10 }, unpaginated));
+    expect(issues).toEqual([
+      expect.objectContaining({ field: "limit", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+      expect.objectContaining({ field: "offset", code: "KAVO_QUERY_UNSUPPORTED_PARAM" }),
+    ]);
   });
 });
 

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -14,7 +14,7 @@ import { KavoExceptionFilter } from "./kavo-exception.filter.js";
 import { createDefaultGraphQLController, DEFAULT_GRAPHQL_PATH } from "./graphql/default-graphql.controller.js";
 import { createDefaultMcpController, DEFAULT_MCP_PATH } from "./mcp/default-mcp.controller.js";
 import { resolvePrincipalExtractor } from "./principal.js";
-import { applyConditionalRequestDocs, applySearchQueryDocs } from "./swagger.js";
+import { applyConditionalRequestDocs, applyPaginationDocs, applySearchQueryDocs } from "./swagger.js";
 import {
   KAVO_INSTANCE,
   KAVO_MODULE_OPTIONS,
@@ -403,6 +403,10 @@ class KavoBinder implements OnModuleInit {
             settings.query.search.enabled,
             service.engine.config.allowlists.searchable as readonly string[],
           );
+          // `limit`/`offset` docs (issue #225) — deferred for the same
+          // reason as the two above (`applyPaginationDocs`'s doc comment):
+          // `pagination.strategy` needs the full precedence chain too.
+          applyPaginationDocs(prototype, methodName, descriptor, settings.pagination.strategy);
         }
       }
     }

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -95,8 +95,8 @@ export const KAVO_API_GUIDE = `### List query parameters
 
 - \`filter\`: filter[field][operator]=value (operators: eq, ne, gt, gte, lt, lte, in, notIn, like, ilike, between, isNull, isNotNull; or/and/not groups; JSON escape hatch via filter={...}).
 - \`sort\`: comma-separated fields; '-' prefix = descending.
-- \`limit\`: page size (clamped to the configured maximum).
-- \`offset\`: zero-based index of the first returned row.
+- \`limit\`: page size (clamped to the configured maximum). Rejected outright on an entity configured with \`pagination.strategy: "none"\`, which always returns the whole match set instead.
+- \`offset\`: zero-based index of the first returned row. Same rejection as \`limit\` under \`pagination.strategy: "none"\`.
 - \`fields\`: sparse fieldset — comma-separated field names.
 - \`search[query]\`: free-text search across the entity's searchable fields, composed (AND) with any \`filter\`. \`search[mode]\` (\`substring\`, the default, or \`words\`) and \`search[fields]\` (narrows to a subset of the entity's searchable fields) are optional modifiers, and require \`search[query]\` to be present. Only present on entities that have search enabled — see this route's own \`search[fields]\` description.
 
@@ -115,11 +115,10 @@ Each read route's own \`include\` parameter description names which relations ar
 - \`If-Match\`: apply this write only if the row's current ETag is one of these entity-tags. Take the tag from an unnarrowed read — a \`fields=\`/\`include=\`-narrowed one identifies a different representation and will not match.`;
 
 /**
- * The `filter`/`sort`/`limit`/`offset`/`fields` params on a list route.
- * `limit`/`offset` carry no per-route description at all — their syntax is
- * always generic, so it lives only in `KAVO_API_GUIDE`.
- * `filter`/`sort`/`fields` carry a description exactly when decoration
- * time can name the entity's actual allowlisted fields (issue #171):
+ * The `filter`/`sort`/`fields` params on a list route — `limit`/`offset`
+ * are deliberately not here, see {@link applyPaginationDocs}. A description
+ * exactly when decoration time can name the entity's actual allowlisted
+ * fields (issue #171):
  *
  * `allowlists` sits outside `resolveEntityConfig`'s `SETTINGS_KEYS`
  * (`packages/core/src/config/resolve-entity-config.ts`): it merges from
@@ -142,8 +141,6 @@ function listQueryParams(config: EntityConfig<object> | undefined): readonly { n
   return [
     { name: "filter", description: allowedFieldsDescription(allowlists?.filterable) },
     { name: "sort", description: allowedFieldsDescription(allowlists?.sortable) },
-    { name: "limit" },
-    { name: "offset" },
     { name: "fields", description: allowedFieldsDescription(allowlists?.selectable) },
   ];
 }
@@ -464,6 +461,74 @@ export function applySearchQueryDocs(
       required: false,
       type: String,
       description: searchable.length === 0 ? "No field is searchable." : `Allowed fields: ${searchable.join(", ")}.`,
+    }),
+  );
+}
+
+const UNPAGINATED_DESCRIPTION =
+  "Not supported: this entity does not paginate ('pagination.strategy' is 'none') — every request serves the whole match set.";
+
+/**
+ * The `limit`/`offset` params on a list route (`pagination.strategy: "none"`,
+ * ADR-0030) — deferred to bind time, the same reason `applySearchQueryDocs`
+ * is: whether either is actually
+ * supported depends on `pagination.strategy` resolved through the *full*
+ * precedence chain (built-in default → global → entity → operation), which
+ * only exists once `KavoBinder.onModuleInit` runs, long after `@Kavo`
+ * decoration (ADR-0012). Unlike `search[...]`, this can't be "declared at
+ * decoration time, refined here" (`applySwaggerMetadata`'s doc comment for
+ * `caching.etag` describes that shape) — `@nestjs/swagger`'s own parameter
+ * de-duplication (`unionWith` over `{ name, in }`, `api-parameters.
+ * explorer.js`) keeps the *first* match for a given `{ name, in }` pair, so
+ * a second, later `ApiQuery({ name: "limit" })` here would be silently
+ * discarded rather than override one `listQueryParams` already applied.
+ * `limit`/`offset` are therefore declared *only* here, never at decoration
+ * time — the one param pair on a list route this file applies just once.
+ *
+ * Consequence, same as `applyConditionalRequestDocs`'s own: an app with no
+ * `KavoModule.forRoot`/`forRootAsync` in its module graph never reaches
+ * `KavoBinder.onModuleInit`, so its list routes now document neither
+ * `limit` nor `offset` at all — a regression from decoration time's
+ * always-present, undescribed pair. Deliberate, not missed: the same graph
+ * shape leaves that app with no working `@Kavo` service either, so nothing
+ * about it actually works yet.
+ */
+const alreadyPaginationDocumented = new WeakSet<object>();
+
+export function applyPaginationDocs(
+  prototype: Record<string, unknown>,
+  methodName: string,
+  descriptor: OperationDescriptor<object>,
+  strategy: string,
+): void {
+  const isList = descriptor.kind === "read" && descriptor.cardinality === "many";
+  if (!isList) return;
+  const swagger = loadSwagger();
+  if (swagger === null) return;
+
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, methodName) as PropertyDescriptor;
+  const method = propertyDescriptor.value as object;
+  if (alreadyPaginationDocumented.has(method)) return;
+  alreadyPaginationDocumented.add(method);
+  const apply = (decorator: MethodDecorator): void => {
+    decorator(prototype, methodName, propertyDescriptor);
+  };
+
+  const description = strategy === "none" ? UNPAGINATED_DESCRIPTION : undefined;
+  apply(
+    swagger.ApiQuery({
+      name: "limit",
+      required: false,
+      type: String,
+      ...(description !== undefined && { description }),
+    }),
+  );
+  apply(
+    swagger.ApiQuery({
+      name: "offset",
+      required: false,
+      type: String,
+      ...(description !== undefined && { description }),
     }),
   );
 }

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1619,6 +1619,21 @@ describe("@Kavo Swagger allowlist-aware query docs", () => {
     expect(params.find((param) => param.name === "limit")?.description).toBeUndefined();
     expect(params.find((param) => param.name === "offset")?.description).toBeUndefined();
   });
+
+  it("documents limit/offset as unsupported when the entity's own config declares pagination.strategy: 'none'", async () => {
+    @Kavo(Todo, { pagination: { strategy: "none" } })
+    @Controller("todos")
+    class UnpaginatedController {}
+
+    await app.close();
+    await bootstrap(UnpaginatedController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const expected =
+      "Not supported: this entity does not paginate ('pagination.strategy' is 'none') — every request serves the whole match set.";
+    expect(params.find((param) => param.name === "limit")?.description).toBe(expected);
+    expect(params.find((param) => param.name === "offset")?.description).toBe(expected);
+  });
 });
 
 /**

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1616,8 +1616,16 @@ describe("@Kavo Swagger allowlist-aware query docs", () => {
   it("carries no description at all on limit/offset — their syntax is always generic", async () => {
     const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
     const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
-    expect(params.find((param) => param.name === "limit")?.description).toBeUndefined();
-    expect(params.find((param) => param.name === "offset")?.description).toBeUndefined();
+    // `applyPaginationDocs` (bind time) is what declares `limit`/`offset` at
+    // all now (issue #225) — `?.description` alone would pass identically
+    // whether the param exists undescribed or is missing outright, so the
+    // param's presence is asserted first.
+    const limit = params.find((param) => param.name === "limit");
+    const offset = params.find((param) => param.name === "offset");
+    expect(limit).toBeDefined();
+    expect(offset).toBeDefined();
+    expect(limit?.description).toBeUndefined();
+    expect(offset?.description).toBeUndefined();
   });
 
   it("documents limit/offset as unsupported when the entity's own config declares pagination.strategy: 'none'", async () => {
@@ -1627,6 +1635,25 @@ describe("@Kavo Swagger allowlist-aware query docs", () => {
 
     await app.close();
     await bootstrap(UnpaginatedController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const expected =
+      "Not supported: this entity does not paginate ('pagination.strategy' is 'none') — every request serves the whole match set.";
+    expect(params.find((param) => param.name === "limit")?.description).toBe(expected);
+    expect(params.find((param) => param.name === "offset")?.description).toBe(expected);
+  });
+
+  it("documents limit/offset as unsupported when only a global default declares pagination.strategy: 'none'", async () => {
+    // The actual reason `applyPaginationDocs` is deferred to bind time
+    // (`swagger.ts`'s doc comment): `pagination.strategy` resolves through
+    // global → entity → operation, and a plain `@Kavo(Todo)` with no
+    // pagination config of its own has nothing for decoration time to see.
+    @Kavo(Todo)
+    @Controller("todos")
+    class GloballyUnpaginatedController {}
+
+    await app.close();
+    await bootstrap(GloballyUnpaginatedController, { defaults: { pagination: { strategy: "none" } } });
     const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
     const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
     const expected =

--- a/packages/orms/mongoose/tests/adapter.spec.ts
+++ b/packages/orms/mongoose/tests/adapter.spec.ts
@@ -423,6 +423,33 @@ describe("MongooseRepositoryAdapter — query translation", () => {
   });
 });
 
+/**
+ * `pagination.strategy: "none"` (ADR-0030, issue #225) reports
+ * `NONE_PAGINATION_LIMIT` (`2147483647`, `2^31 - 1`) as the envelope's
+ * `limit`, and `MongooseRepositoryAdapter.findMany` passes that value
+ * straight to the query builder's `.limit(...)` — the ADR's reasoning for
+ * choosing that exact value over `Number.MAX_SAFE_INTEGER` is that it
+ * survives MongoDB's int32 wire `limit`. Proven here against a real
+ * `mongod` (`mongodb-memory-server`, not a Docker container — this suite
+ * already runs without one) rather than inferred from the driver's
+ * documented range.
+ */
+describe("MongooseRepositoryAdapter — pagination.strategy: 'none'", () => {
+  it("returns the whole match set with limit 2147483647, not truncated or errored", async () => {
+    await seed();
+    const unpaginated = kavo.createCrud(models.Author, {
+      pagination: { strategy: "none" },
+    } as never) as unknown as DefaultKavoService<Author>;
+
+    const list = await unpaginated.findMany({});
+
+    expect(list.items).toHaveLength(4);
+    expect(list.total).toBe(4);
+    expect(list.limit).toBe(2147483647);
+    expect(list.offset).toBe(0);
+  });
+});
+
 describe("MongooseRepositoryAdapter — schema constraints hold on every write", () => {
   it("enforces schema validators on update and patch, not only on create", async () => {
     // Mongoose runs validators on `create` but *not* on any update unless

--- a/packages/protocols/graphql/tests/graphql-schema.spec.ts
+++ b/packages/protocols/graphql/tests/graphql-schema.spec.ts
@@ -321,3 +321,87 @@ describe("cursor-paginated entities are refused at bootstrap", () => {
     expect(() => createKavoGraphQLSchema({ name: "Todo", service, itemType: cursorTodoType() })).not.toThrow();
   });
 });
+
+/**
+ * `pagination.strategy: "none"` (ADR-0030) is not `"cursor"`/`"since"`, so
+ * `requireOffsetPageable` lets it through at bootstrap — the ADR's
+ * Consequences section claims this composes correctly by construction
+ * rather than needing a bootstrap refusal of its own. That claim rests on
+ * `NONE_PAGINATION_LIMIT` (`2^31 - 1`) surviving `GraphQLInt.serialize`,
+ * which throws on anything outside `[-2^31, 2^31 - 1]` — one off from the
+ * boundary this envelope field actually carries. Proven here rather than
+ * inferred, and the regression guard if the sentinel ever changes.
+ */
+describe("pagination.strategy: 'none' entities (ADR-0030, issue #225)", () => {
+  function unpaginatedTodoType() {
+    return new GraphQLObjectType({
+      name: "Todo",
+      fields: {
+        id: { type: new GraphQLNonNull(GraphQLInt) },
+        title: { type: new GraphQLNonNull(GraphQLString) },
+      },
+    });
+  }
+
+  function unpaginatedTodoService(adapter: InMemoryTodoAdapter) {
+    return createKavo({ defaults: { pagination: { strategy: "none" } } } as never).createCrud(Todo, undefined, {
+      adapter,
+      metadata: todoMetadata,
+    });
+  }
+
+  it("binds without a bootstrap refusal, unlike cursor/since", () => {
+    expect(() =>
+      createKavoGraphQLSchema({
+        name: "Todo",
+        service: unpaginatedTodoService(new InMemoryTodoAdapter()),
+        itemType: unpaginatedTodoType(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("serves the whole match set when the query sends no limit/offset, and limit serializes as GraphQLInt", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    adapter.rows.push(
+      { id: 1, title: "a", done: false },
+      { id: 2, title: "b", done: false },
+      { id: 3, title: "c", done: false },
+      { id: 4, title: "d", done: false },
+      { id: 5, title: "e", done: false },
+    );
+    const schema = createKavoGraphQLSchema({
+      name: "Todo",
+      service: unpaginatedTodoService(adapter),
+      itemType: unpaginatedTodoType(),
+    });
+
+    const result = await graphql({ schema, source: `query { todos { items { id } total limit offset } }` });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.todos).toEqual({
+      items: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+      total: 5,
+      limit: 2147483647,
+      offset: 0,
+    });
+  });
+
+  it("rejects an explicit limit/offset the same way REST does, rather than truncating silently", async () => {
+    const schema = createKavoGraphQLSchema({
+      name: "Todo",
+      service: unpaginatedTodoService(new InMemoryTodoAdapter()),
+      itemType: unpaginatedTodoType(),
+    });
+
+    const result = await graphql({ schema, source: `query { todos(limit: 5) { total } }` });
+
+    // The binding surfaces `QueryValidationException` as-is; its `.message`
+    // is the catalog's generic `KAVO_QUERY_INVALID` summary (the field-level
+    // "pagination.strategy is 'none'" detail lives on `.issues`, which this
+    // binding does not expose through `GraphQLError`) — so what's provable
+    // here is that the field errors at all, rather than silently truncating
+    // to a page.
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.message).toBe("The request query is invalid.");
+  });
+});

--- a/packages/protocols/mcp/tests/mcp-tools.spec.ts
+++ b/packages/protocols/mcp/tests/mcp-tools.spec.ts
@@ -224,3 +224,64 @@ describe("cursor-paginated entities are refused at bootstrap", () => {
     expect(() => crudTools({ name: "Todo", service })).not.toThrow();
   });
 });
+
+/**
+ * `pagination.strategy: "none"` (ADR-0030) is not `"cursor"`/`"since"`, so
+ * `requireOffsetPageable` lets it through at bootstrap here too — same
+ * treatment `@kavo/graphql` gets (`graphql-schema.spec.ts`'s equivalent
+ * describe block). `<entity>.findMany`'s tool schema declares `limit`/
+ * `offset` as plain optional integers (`tools.ts`), so a model that never
+ * names either in its arguments gets `args["limit"]`/`args["offset"]` as
+ * `undefined` — the same "caller didn't ask" signal `normalizeInput`
+ * already treats as absent — proven here rather than inferred.
+ */
+describe("pagination.strategy: 'none' entities (ADR-0030, issue #225)", () => {
+  function unpaginatedTodoService(adapter: InMemoryTodoAdapter) {
+    return createKavo({ defaults: { pagination: { strategy: "none" } } } as never).createCrud(Todo, undefined, {
+      adapter,
+      metadata: todoMetadata,
+    });
+  }
+
+  it("binds without a bootstrap refusal, unlike cursor/since", () => {
+    expect(() => crudTools({ name: "Todo", service: unpaginatedTodoService(new InMemoryTodoAdapter()) })).not.toThrow();
+  });
+
+  it("serves the whole match set when the call omits limit/offset entirely", async () => {
+    const adapter = new InMemoryTodoAdapter();
+    adapter.rows.push(
+      { id: 1, title: "a", done: false },
+      { id: 2, title: "b", done: false },
+      { id: 3, title: "c", done: false },
+      { id: 4, title: "d", done: false },
+      { id: 5, title: "e", done: false },
+    );
+    const bindings = crudTools({ name: "Todo", service: unpaginatedTodoService(adapter) });
+    const binding = bindings.find((candidate) => candidate.tool.name === "todo.findMany");
+    if (binding === undefined) throw new Error("no tool named todo.findMany");
+
+    const result = await binding.handler({});
+
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.items).toHaveLength(5);
+    expect(payload.total).toBe(5);
+    expect(payload.limit).toBe(2147483647);
+    expect(payload.offset).toBe(0);
+  });
+
+  it("rejects an explicit limit/offset the same way REST does, rather than truncating silently", async () => {
+    const bindings = crudTools({ name: "Todo", service: unpaginatedTodoService(new InMemoryTodoAdapter()) });
+    const binding = bindings.find((candidate) => candidate.tool.name === "todo.findMany");
+    if (binding === undefined) throw new Error("no tool named todo.findMany");
+
+    const result = await binding.handler({ limit: 5 });
+
+    // Same limitation the GraphQL binding has: `KavoException.detail` is the
+    // catalog's generic `KAVO_QUERY_INVALID` summary, not the field-level
+    // "pagination.strategy is 'none'" detail on `.issues` — provable here is
+    // that the call errors at all, not that it silently paginates anyway.
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toBe("KAVO_QUERY_INVALID: The request query is invalid.");
+  });
+});


### PR DESCRIPTION
## What & why

`pagination.maxLimit` always clamped `findMany`, with no way to opt a resource out — a small lookup/reference table could only raise `defaultLimit`/`maxLimit` to some large number, still a clamp and still an arbitrary ceiling advertised in the OpenAPI docs.

`pagination.strategy: "none"` is a fifth built-in pagination strategy that makes `findMany` always serve the whole match set for an entity configured this way. A client-sent `limit`/`offset` is rejected outright (`KAVO_QUERY_UNSUPPORTED_PARAM`, both collected into one exception when both are sent) rather than silently ignored — the same "wrong strategy, told" treatment `cursor`/`since` params already get. The envelope's `limit` reports `2147483647` (`2^31-1`), chosen so it survives GraphQL's `Int` scalar and MongoDB's int32 limit unchanged without a second, adapter-specific ceiling.

`@kavo/nest`'s OpenAPI docs for `limit`/`offset` moved from decoration-time to `KavoBinder`'s bind-time pass (mirroring the existing `search[...]` docs) — a second decoration-time `ApiQuery` would have been silently discarded by `@nestjs/swagger`'s own parameter de-duplication, so bind time (where the fully resolved `pagination.strategy` is available) is the only place this can be accurate.

`ADR-0030` records the design decision, including why the issue's other candidate shape (`pagination.maxLimit: false`) was rejected in favor of a dedicated strategy name.

## Public API impact

- `@kavo/core`: new export `NonePaginationStrategy`, new export `NONE_PAGINATION_LIMIT`, `PaginationStrategyName` gains `"none"`. Additive, not breaking.
- `@kavo/nest`: no new exports; the OpenAPI doc-generation timing change for `limit`/`offset` is an internal implementation detail (documented in `swagger.ts`'s `applyPaginationDocs` comment), not a public API change.

## Testing

- `packages/core/tests/pagination-strategies.spec.ts`, `packages/core/tests/query-normalizer.spec.ts`: wire and programmatic path coverage for `strategy: "none"`, including the both-limit-and-offset-rejected-in-one-round-trip case.
- `packages/frameworks/nest/tests/binding.e2e.spec.ts`: the OpenAPI doc for `limit`/`offset` under `strategy: "none"`.
- `packages/protocols/graphql/tests/graphql-schema.spec.ts`: binds and executes a `"none"`-strategy list query end to end — proves the `2147483647` sentinel actually serializes through `GraphQLInt` without throwing, not just that it should in theory.
- `examples/nest-typeorm`: `Tag` now uses `pagination: { strategy: "none" }`; e2e coverage in `crud-e2e.suite.ts` (unbounded response, rejected `limit`/`offset`, composes with `filter`/`sort`, OpenAPI doc).
- `pnpm check`: build/typecheck/depcruise/lint clean, 2357 tests pass. The only failures are 5 pre-existing Testcontainers/Docker-dependent e2e suites (Postgres/MariaDB/CockroachDB/Mongo variants) that fail in the sandbox this was implemented in for lack of a Docker runtime — unrelated to this change, and true of `main` as well. Those suites include the new Tag tests, so **CI is the first real execution of `LIMIT 2147483647` against Postgres, MariaDB, and CockroachDB** — worth watching.
- `pnpm docs:links`: clean.

## Review notes

- The Tag e2e "still composes with filter/sort" test and the GraphQL binding test were both added after an internal review pass caught gaps (issue-collection ordering, an unverified GraphQL serialization claim, a stale test name) — see `ADR-0030` for the full reasoning trail.
- `@kavo/graphql`/`@kavo/mcp` get no bootstrap refusal for `"none"` (unlike `cursor`/`since`) — deliberate, reasoning in ADR-0030's Consequences.

Closes #225