### PR TITLE
feat(examples/nest-typeorm): add a class-validator validation layer

### DIFF
--- a/examples/nest-typeorm/README.md
+++ b/examples/nest-typeorm/README.md
@@ -12,6 +12,14 @@ The entities, DTOs, and controllers are entirely database-agnostic through
 via `.forRoot(...)`) pick a driver, so the same app runs against any of the
 databases below unchanged.
 
+Every entity but `Dog` also validates its write bodies with `class-validator`
+— Kavo's own DTOs are shapes only, with no validation subsystem of their
+own (see `docs/internals/architecture/04-dto-system.md`), so this app's own
+`ValidationPipe` (`app.module.ts`) plus each `createOne`/`updateOne`/
+`patchOne` override (see `owner.controller.ts`) is what a validation layer
+looks like bolted onto Kavo from application code, with no framework
+changes. `Dog` is left unvalidated on purpose, as the contrast.
+
 ## SQLite (default)
 
 No setup required — an in-memory database is created fresh on every run.

--- a/examples/nest-typeorm/package.json
+++ b/examples/nest-typeorm/package.json
@@ -22,6 +22,8 @@
     "@nestjs/platform-express": "^11.2.1",
     "@nestjs/swagger": "^11.4.6",
     "better-sqlite3": "^13.0.3",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
     "mysql2": "^3.23.3",
     "pg": "^8.23.0",
     "reflect-metadata": "^0.2.2",

--- a/examples/nest-typeorm/src/address/address.controller.ts
+++ b/examples/nest-typeorm/src/address/address.controller.ts
@@ -4,7 +4,7 @@ import type { DefaultKavoService, EntityId, KavoContext, RequestPreconditions, W
 import { NotFoundException } from "@kavo/core";
 import type { DataSource } from "typeorm";
 import { Address } from "./address.entity.js";
-import { CreateAddressDto, UpdateAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
+import { CreateAddressDto, UpdateAddressDto, PatchAddressDto, AddressItemDto, AddressListDto } from "./address.dtos.js";
 import { DATA_SOURCE } from "../database.module.js";
 import { assertValidPostalCode, clearOwnerAddress, normalizePostalCode } from "./address.runtime.js";
 
@@ -34,6 +34,17 @@ import { assertValidPostalCode, clearOwnerAddress, normalizePostalCode } from ".
  * app uses is built inside `KavoModule.forRootAsync`'s factory, which has
  * not run yet. There is nothing for the handler to close over, and it needs
  * nothing.
+ *
+ * `createOne`/`updateOne`/`patchOne` below are typed with the concrete,
+ * `class-validator`-decorated DTO classes (`address.dtos.ts`) rather than
+ * `Partial<Address>` — the app's global `ValidationPipe` (`app.module.ts`)
+ * only validates a body param whose declared type it can resolve via
+ * `emitDecoratorMetadata`, which only exists for a type written directly in
+ * this class's own source (see `owner.controller.ts`'s validation note).
+ * `postalCode`'s exact-5-digit format stays a procedural check
+ * (`assertValidPostalCode`) run after that generic shape validation passes
+ * — a business rule with its own normalization step, not a `class-validator`
+ * decorator's job.
  *
  * `validatePostalCode` below is the other shape: a fully custom,
  * registry-independent route (issue #26), a plain native Nest method with
@@ -90,8 +101,8 @@ export class AddressController {
 
   /** Normalizes `postalCode` before persisting. */
   @Override()
-  async createOne(dto: Partial<Address>): Promise<unknown> {
-    const postalCode = normalizePostalCode(dto.postalCode ?? "");
+  async createOne(dto: CreateAddressDto): Promise<unknown> {
+    const postalCode = normalizePostalCode(dto.postalCode);
     assertValidPostalCode(postalCode);
     return this.base.createOne({ ...dto, postalCode } as never);
   }
@@ -106,18 +117,16 @@ export class AddressController {
    * method that drops it accepts an `If-Match` header and writes anyway.
    */
   @Override()
-  async updateOne(id: EntityId, dto: Partial<Address>, preconditions: RequestPreconditions | null): Promise<unknown> {
+  async updateOne(id: EntityId, dto: UpdateAddressDto, preconditions: RequestPreconditions | null): Promise<unknown> {
     const patch = { ...dto };
-    if (patch.postalCode !== undefined) {
-      patch.postalCode = normalizePostalCode(patch.postalCode);
-      assertValidPostalCode(patch.postalCode);
-    }
+    patch.postalCode = normalizePostalCode(patch.postalCode);
+    assertValidPostalCode(patch.postalCode);
     return this.base.updateOne(id as never, patch as never, { preconditions: preconditions ?? undefined });
   }
 
   /** Same validation as `updateOne`, but only when the field is actually present. */
   @Override()
-  async patchOne(id: EntityId, dto: Partial<Address>, preconditions: RequestPreconditions | null): Promise<unknown> {
+  async patchOne(id: EntityId, dto: PatchAddressDto, preconditions: RequestPreconditions | null): Promise<unknown> {
     const patch = { ...dto };
     if (patch.postalCode !== undefined) {
       patch.postalCode = normalizePostalCode(patch.postalCode);

--- a/examples/nest-typeorm/src/address/address.dtos.ts
+++ b/examples/nest-typeorm/src/address/address.dtos.ts
@@ -1,20 +1,67 @@
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+
 /**
  * DTO slots for the Address route. Plain initialized-field classes, same
  * rationale as every other entity's DTOs (see cat.dtos.ts).
+ *
+ * `Create`/`Update`/`PatchAddressDto` carry `class-validator` decorators for
+ * shape (non-empty strings); `postalCode`'s specific 5-digit format is a
+ * business rule with its own normalization step, so it stays in
+ * `address.runtime.ts`'s `assertValidPostalCode`, run from
+ * `AddressController`'s write overrides after the generic shape check here
+ * passes.
  */
 
 /** `create` slot — request body for POST /addresses. */
 export class CreateAddressDto {
+  @IsString()
+  @IsNotEmpty()
   street = "";
+
+  @IsString()
+  @IsNotEmpty()
   city = "";
+
+  @IsString()
+  @IsNotEmpty()
   postalCode = "";
 }
 
 /** `update` slot — request body for PUT /addresses/:id (patch derives from it). */
 export class UpdateAddressDto {
+  @IsString()
+  @IsNotEmpty()
   street = "";
+
+  @IsString()
+  @IsNotEmpty()
   city = "";
+
+  @IsString()
+  @IsNotEmpty()
   postalCode = "";
+}
+
+/**
+ * `PATCH /addresses/:id`'s own validated shape — every field optional. See
+ * `PatchOwnerDto` (`owner.dtos.ts`) for why this exists as its own class
+ * rather than relying on Kavo's `Partial<update>` default.
+ */
+export class PatchAddressDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  street?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  city?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  postalCode?: string;
 }
 
 /** `item` slot — the detail projection. */

--- a/examples/nest-typeorm/src/app.module.ts
+++ b/examples/nest-typeorm/src/app.module.ts
@@ -1,4 +1,5 @@
-import { Module, type DynamicModule } from "@nestjs/common";
+import { Module, ValidationPipe, type DynamicModule } from "@nestjs/common";
+import { APP_PIPE } from "@nestjs/core";
 import { KavoModule } from "@kavo/nest";
 import { createInfrastructure } from "@kavo/typeorm";
 import type { RealtimeTransport } from "@kavo/core";
@@ -24,6 +25,20 @@ import { AddressController } from "./address/address.controller.js";
  * transports (`@kavo/sse`'s, in `main.ts`) — a root-scope option, so it
  * travels alongside `infrastructure` rather than through `defaults`
  * (ADR-0023: a transport is a live object, not settings-tree data).
+ *
+ * The `APP_PIPE` below is the app's validation layer: a global
+ * `class-validator`-backed `ValidationPipe`, registered here (rather than
+ * `main.ts`) so it also covers the e2e test suite, which bootstraps
+ * `AppModule.forRoot()` directly through `@nestjs/testing` and never runs
+ * `main.ts`. `whitelist: true` strips properties a DTO class doesn't
+ * declare instead of rejecting the request — generated Kavo routes already
+ * silently drop unwritable keys (e.g. a client-sent `id`) the same way, so
+ * this keeps that behavior rather than turning it into a 400. It only ever
+ * validates a body whose declared parameter type it can resolve via
+ * `emitDecoratorMetadata` — see e.g. `owner.controller.ts`'s `@Override()`'d
+ * write methods for why every generated route's own body is exempt (Kavo's
+ * DTOs are shapes, not validators — doc 04), and how each entity opts a
+ * write route into validation.
  */
 @Module({})
 export class AppModule {
@@ -54,6 +69,12 @@ export class AppModule {
         }),
       ],
       controllers: [OwnerController, CatController, DogController, TagController, PhotoController, AddressController],
+      providers: [
+        {
+          provide: APP_PIPE,
+          useValue: new ValidationPipe({ whitelist: true, transform: true }),
+        },
+      ],
     };
   }
 }

--- a/examples/nest-typeorm/src/cat/cat.controller.ts
+++ b/examples/nest-typeorm/src/cat/cat.controller.ts
@@ -1,7 +1,15 @@
-import { Controller } from "@nestjs/common";
-import { Kavo } from "@kavo/nest";
+import { Controller, Inject } from "@nestjs/common";
+import { Kavo, Override, getKavoServiceToken } from "@kavo/nest";
+import type { DefaultKavoService, EntityId, RequestPreconditions } from "@kavo/core";
 import { Cat } from "./cat.entity.js";
-import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.js";
+import {
+  CREATE_SIZE_DEFAULT,
+  CreateCatDto,
+  UPDATE_SIZE_DEFAULT,
+  UpdateCatDto,
+  CatItemDto,
+  CatListDto,
+} from "./cat.dtos.js";
 
 /**
  * CRUD over the concrete `Cat` subtype: one decorator, zero methods.
@@ -24,6 +32,16 @@ import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.j
  * `GET /cats?search[query]=whiskers` free-text searches `name` (the one
  * field named in `allowlists.searchable`) — `search[mode]=words` and
  * `search[fields]` are also available, narrowed to that same allowlist.
+ *
+ * Validation: `createOne`/`updateOne` are `@Override()`'d purely to give
+ * their body parameter a concrete, `class-validator`-decorated type — see
+ * `owner.controller.ts`'s own validation note for why. No `patchOne`
+ * override: the operation is disabled below (`operations.patchOne: false`),
+ * so there is no route to give a body type to. Each override also strips
+ * `size` back off the DTO when it's still `cat.dtos.ts`'s own sentinel
+ * default — that marker object only exists for Swagger's benefit
+ * (`cat.dtos.ts`'s own comment) and is never a real `PetSizeEnum` value the
+ * engine should try to persist.
  */
 @Kavo(Cat, {
   dto: {
@@ -74,4 +92,20 @@ import { CreateCatDto, UpdateCatDto, CatItemDto, CatListDto } from "./cat.dtos.j
   },
 })
 @Controller("cats")
-export class CatController {}
+export class CatController {
+  constructor(@Inject(getKavoServiceToken(Cat)) private readonly base: DefaultKavoService<Cat>) {}
+
+  @Override()
+  async createOne(dto: CreateCatDto): Promise<unknown> {
+    const { size, ...rest } = dto;
+    const payload = size === CREATE_SIZE_DEFAULT ? rest : { ...rest, size };
+    return this.base.createOne(payload as never);
+  }
+
+  @Override()
+  async updateOne(id: EntityId, dto: UpdateCatDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    const { size, ...rest } = dto;
+    const payload = size === UPDATE_SIZE_DEFAULT ? rest : { ...rest, size };
+    return this.base.updateOne(id as never, payload as never, { preconditions: preconditions ?? undefined });
+  }
+}

--- a/examples/nest-typeorm/src/cat/cat.dtos.ts
+++ b/examples/nest-typeorm/src/cat/cat.dtos.ts
@@ -1,4 +1,16 @@
 import { enumProp } from "@kavo/nest";
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsPositive,
+  IsString,
+  Min,
+  ValidateIf,
+} from "class-validator";
 import { PetSizeEnum } from "../pet/pet.entity.js";
 import { TagItemDto } from "../tag/tag.dtos.js";
 import { PhotoItemDto } from "../photo/photo.dtos.js";
@@ -9,35 +21,111 @@ import { PhotoItemDto } from "../photo/photo.dtos.js";
  * serializer project responses (and Swagger document them) with no
  * decorator machinery. The `species` discriminator is deliberately absent
  * from every slot: it is never client-writable and never echoed.
+ *
+ * `Create`/`UpdateCatDto` additionally carry `class-validator` decorators —
+ * see `cat.controller.ts`'s `@Override()`'d write methods for how they get
+ * validated. There is no `PatchCatDto`: `patchOne` is disabled on this
+ * entity (`cat.controller.ts`'s `operations.patchOne: false`).
+ *
+ * `size`'s own default is `enumProp(...)`'s schema-hint marker object
+ * (`@kavo/nest`'s `schema-hints.ts`), not a real `PetSizeEnum` value — it
+ * exists only so `@kavo/nest`'s Swagger layer can document the enum's
+ * allowed values off a field's plain initializer. `class-transformer`
+ * carries that same marker onto the instance whenever the client omits
+ * `size` (a missing key falls back to the class's own initializer, not
+ * `undefined`), so a plain `@IsOptional()` — which only skips `undefined`/
+ * `null` — would never see "omitted" and would run `@IsEnum` against the
+ * marker instead. `@ValidateIf` compares by reference against that same
+ * marker object instead, which is what actually detects "the client never
+ * sent this field" — and for the same reason, `cat.controller.ts`'s
+ * `createOne`/`updateOne` overrides strip the field entirely when it's
+ * still this sentinel before delegating, so the marker object itself never
+ * reaches the deserializer as a bogus `size` value.
  */
+export const CREATE_SIZE_DEFAULT = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
+export const UPDATE_SIZE_DEFAULT = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
 
 /** `create` slot — request body for POST /cats. */
 export class CreateCatDto {
+  @IsString()
+  @IsNotEmpty()
   name = "";
+
+  @IsInt()
+  @Min(0)
   age = 0;
-  size = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
+
+  // Optional: several routes rely on the column's own DB default
+  // (`PetSizeEnum.Medium`) rather than sending a size explicitly. See this
+  // file's own top-of-file comment for why `@ValidateIf` rather than
+  // `@IsOptional` is what actually detects "omitted" here.
+  @ValidateIf((dto: CreateCatDto) => dto.size !== CREATE_SIZE_DEFAULT)
+  @IsEnum(PetSizeEnum)
+  size = CREATE_SIZE_DEFAULT;
+
+  @IsBoolean()
   indoor = false;
+
+  @IsInt()
+  @Min(0)
   livesLeft = 9;
+
   // Association by id (ADR-0014): send the owner's id, or an
   // `{ id }` reference. Deep nested writes are deliberately out of scope.
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
   owner: number | null = null;
+
   // Same mechanism, over a to-many edge: an array of tag ids (or `{ id }`
   // refs) replaces the full set of associated tags.
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
   tags: number[] = [];
+
   // Same mechanism again, over `photos` — independently write-opted under
   // the `resource` strategy rather than `tags`'s `replace` (issue #223).
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
   photos: number[] = [];
 }
 
 /** `update` slot — request body for PUT /cats/:id (patch derives from it). */
 export class UpdateCatDto {
+  @IsString()
+  @IsNotEmpty()
   name = "";
+
+  @IsInt()
+  @Min(0)
   age = 0;
-  size = enumProp(Object.values(PetSizeEnum), { example: PetSizeEnum.Medium });
+
+  @ValidateIf((dto: UpdateCatDto) => dto.size !== UPDATE_SIZE_DEFAULT)
+  @IsEnum(PetSizeEnum)
+  size = UPDATE_SIZE_DEFAULT;
+
+  @IsBoolean()
   indoor = false;
+
+  @IsInt()
+  @Min(0)
   livesLeft = 0;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
   owner: number | null = null;
+
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
   tags: number[] = [];
+
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
   photos: number[] = [];
 }
 

--- a/examples/nest-typeorm/src/owner/owner.controller.ts
+++ b/examples/nest-typeorm/src/owner/owner.controller.ts
@@ -1,7 +1,8 @@
-import { Controller } from "@nestjs/common";
-import { Kavo } from "@kavo/nest";
+import { Controller, Inject } from "@nestjs/common";
+import { Kavo, Override, getKavoServiceToken } from "@kavo/nest";
+import type { DefaultKavoService, EntityId, RequestPreconditions } from "@kavo/core";
 import { Owner } from "./owner.entity.js";
-import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./owner.dtos.js";
+import { CreateOwnerDto, UpdateOwnerDto, PatchOwnerDto, OwnerItemDto, OwnerListDto } from "./owner.dtos.js";
 
 /**
  * CRUD over the relation side. The unique `email` column is what surfaces a
@@ -30,6 +31,16 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
  * string column — `name` and `email` — since `allowlists.searchable` is
  * left unconfigured here (contrast Cat's explicit array): the zero-config
  * default. `search[fields]=name` narrows a given request to just one.
+ *
+ * Validation: `createOne`/`updateOne`/`patchOne` are `@Override()`'d purely
+ * to give their body parameter a concrete, `class-validator`-decorated
+ * type (`CreateOwnerDto`/`UpdateOwnerDto`/`PatchOwnerDto`) rather than the
+ * generated route's untyped one — Kavo's own DTOs are shapes only (doc 04),
+ * so nothing validates a generated route's body. Nest's global
+ * `ValidationPipe` (`app.module.ts`) reads a body param's declared type off
+ * `emitDecoratorMetadata`, which only exists for a param written directly
+ * in this class's own source — a generated method has no such metadata,
+ * `@Override()` recovers it. Each override otherwise just delegates.
  */
 @Kavo(Owner, {
   dto: {
@@ -62,4 +73,21 @@ import { CreateOwnerDto, UpdateOwnerDto, OwnerItemDto, OwnerListDto } from "./ow
   },
 })
 @Controller("owners")
-export class OwnerController {}
+export class OwnerController {
+  constructor(@Inject(getKavoServiceToken(Owner)) private readonly base: DefaultKavoService<Owner>) {}
+
+  @Override()
+  async createOne(dto: CreateOwnerDto): Promise<unknown> {
+    return this.base.createOne(dto as never);
+  }
+
+  @Override()
+  async updateOne(id: EntityId, dto: UpdateOwnerDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    return this.base.updateOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+
+  @Override()
+  async patchOne(id: EntityId, dto: PatchOwnerDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    return this.base.patchOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+}

--- a/examples/nest-typeorm/src/owner/owner.dtos.ts
+++ b/examples/nest-typeorm/src/owner/owner.dtos.ts
@@ -1,4 +1,5 @@
 import { enumProp, oneOfArray } from "@kavo/nest";
+import { IsEmail, IsInt, IsISO8601, IsNotEmpty, IsOptional, IsPositive, IsString } from "class-validator";
 import { CatItemDto } from "../cat/cat.dtos.js";
 import { AddressItemDto } from "../address/address.dtos.js";
 import { PetSizeEnum } from "../pet/pet.entity.js";
@@ -6,6 +7,10 @@ import { PetSizeEnum } from "../pet/pet.entity.js";
 /**
  * DTO slots for the Owner route. See `cat.dtos.ts` for the
  * rationale behind plain initialized-field classes.
+ *
+ * `Create`/`Update`/`PatchOwnerDto` additionally carry `class-validator`
+ * decorators — see `owner.controller.ts`'s `@Override()`'d write methods for
+ * why a decorated class here is not enough on its own to get validated.
  */
 
 /**
@@ -27,20 +32,69 @@ export class DogItemDto {
 
 /** `create` slot — request body for POST /owners. */
 export class CreateOwnerDto {
+  @IsString()
+  @IsNotEmpty()
   name = "";
+
+  @IsEmail()
   email = "";
+
+  @IsOptional()
+  @IsISO8601()
   startedAt: Date | null = null;
+
   // Association by id (ADR-0014): send the address's id, or an `{ id }`
   // reference. Deep nested writes are deliberately out of scope.
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
   address: number | null = null;
 }
 
 /** `update` slot — request body for PUT /owners/:id (patch derives from it). */
 export class UpdateOwnerDto {
+  @IsString()
+  @IsNotEmpty()
   name = "";
+
+  @IsEmail()
   email = "";
+
+  @IsOptional()
+  @IsISO8601()
   startedAt: Date | null = null;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
   address: number | null = null;
+}
+
+/**
+ * `PATCH /owners/:id`'s own validated shape — every field optional, unlike
+ * `UpdateOwnerDto`'s full-replace requirement. Not a registered `dto.patch`
+ * slot (Kavo's own default, `Partial<update>`, already types that); this
+ * class exists solely for `OwnerController.patchOne`'s `@Override()` to
+ * declare a concrete, `class-validator`-decorated body type.
+ */
+export class PatchOwnerDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  startedAt?: Date | null;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  address?: number | null;
 }
 
 /** `item` slot — the detail projection. */

--- a/examples/nest-typeorm/src/photo/photo.controller.ts
+++ b/examples/nest-typeorm/src/photo/photo.controller.ts
@@ -1,12 +1,17 @@
-import { Controller } from "@nestjs/common";
-import { Kavo } from "@kavo/nest";
+import { Controller, Inject } from "@nestjs/common";
+import { Kavo, Override, getKavoServiceToken } from "@kavo/nest";
+import type { DefaultKavoService, EntityId, RequestPreconditions } from "@kavo/core";
 import { Photo } from "./photo.entity.js";
-import { CreatePhotoDto, UpdatePhotoDto, PhotoItemDto, PhotoListDto } from "./photo.dtos.js";
+import { CreatePhotoDto, UpdatePhotoDto, PatchPhotoDto, PhotoItemDto, PhotoListDto } from "./photo.dtos.js";
 
 /**
  * Plain CRUD over `Photo`, the many-to-many side pets associate by id
  * (`include=photos` on `/cats`, and `GET/POST/DELETE/PUT /cats/:id/photos`
  * — `arrayMutation`'s `resource` strategy, ADR-0029's resource amendment).
+ *
+ * Validation: `createOne`/`updateOne`/`patchOne` are `@Override()`'d purely
+ * to give their body parameter a concrete, `class-validator`-decorated
+ * type — see `owner.controller.ts`'s own validation note for why.
  */
 @Kavo(Photo, {
   dto: {
@@ -17,4 +22,21 @@ import { CreatePhotoDto, UpdatePhotoDto, PhotoItemDto, PhotoListDto } from "./ph
   },
 })
 @Controller("photos")
-export class PhotoController {}
+export class PhotoController {
+  constructor(@Inject(getKavoServiceToken(Photo)) private readonly base: DefaultKavoService<Photo>) {}
+
+  @Override()
+  async createOne(dto: CreatePhotoDto): Promise<unknown> {
+    return this.base.createOne(dto as never);
+  }
+
+  @Override()
+  async updateOne(id: EntityId, dto: UpdatePhotoDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    return this.base.updateOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+
+  @Override()
+  async patchOne(id: EntityId, dto: PatchPhotoDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    return this.base.patchOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+}

--- a/examples/nest-typeorm/src/photo/photo.dtos.ts
+++ b/examples/nest-typeorm/src/photo/photo.dtos.ts
@@ -1,16 +1,37 @@
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+
 /**
  * DTO slots for the Photo route. See `cat.dtos.ts` for the rationale behind
- * plain initialized-field classes.
+ * plain initialized-field classes. `Create`/`Update`/`PatchPhotoDto` carry
+ * `class-validator` decorators — see `photo.controller.ts`'s `@Override()`'d
+ * write methods for how they get validated. `url` is a non-empty string
+ * rather than `@IsUrl()`: this reference app stores whatever string a
+ * caller sends (e.g. relative paths), not only absolute URLs.
  */
 
 /** `create` slot — request body for POST /photos. */
 export class CreatePhotoDto {
+  @IsString()
+  @IsNotEmpty()
   url = "";
 }
 
 /** `update` slot — request body for PUT /photos/:id (patch derives from it). */
 export class UpdatePhotoDto {
+  @IsString()
+  @IsNotEmpty()
   url = "";
+}
+
+/**
+ * `PATCH /photos/:id`'s own validated shape. See `PatchOwnerDto`
+ * (`owner.dtos.ts`) for why this exists as its own class.
+ */
+export class PatchPhotoDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  url?: string;
 }
 
 /** `item` slot — the detail projection. */

--- a/examples/nest-typeorm/src/tag/tag.controller.ts
+++ b/examples/nest-typeorm/src/tag/tag.controller.ts
@@ -1,7 +1,8 @@
-import { Controller } from "@nestjs/common";
-import { Kavo } from "@kavo/nest";
+import { Controller, Inject } from "@nestjs/common";
+import { Kavo, Override, getKavoServiceToken } from "@kavo/nest";
+import type { DefaultKavoService, EntityId, RequestPreconditions } from "@kavo/core";
 import { Tag } from "./tag.entity.js";
-import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.js";
+import { CreateTagDto, UpdateTagDto, PatchTagDto, TagItemDto, TagListDto } from "./tag.dtos.js";
 
 /**
  * Plain CRUD over `Tag`, the many-to-many side pets associate by id
@@ -9,6 +10,10 @@ import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.j
  * demonstration of `pagination.strategy: "none"` (issue #225): `GET /tags`
  * always serves every tag, never a `defaultLimit`-sized page, and an
  * explicit `?limit=`/`?offset=` is rejected rather than silently narrowed.
+ *
+ * Validation: `createOne`/`updateOne`/`patchOne` are `@Override()`'d purely
+ * to give their body parameter a concrete, `class-validator`-decorated
+ * type — see `owner.controller.ts`'s own validation note for why.
  */
 @Kavo(Tag, {
   dto: {
@@ -20,4 +25,21 @@ import { CreateTagDto, UpdateTagDto, TagItemDto, TagListDto } from "./tag.dtos.j
   pagination: { strategy: "none" },
 })
 @Controller("tags")
-export class TagController {}
+export class TagController {
+  constructor(@Inject(getKavoServiceToken(Tag)) private readonly base: DefaultKavoService<Tag>) {}
+
+  @Override()
+  async createOne(dto: CreateTagDto): Promise<unknown> {
+    return this.base.createOne(dto as never);
+  }
+
+  @Override()
+  async updateOne(id: EntityId, dto: UpdateTagDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    return this.base.updateOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+
+  @Override()
+  async patchOne(id: EntityId, dto: PatchTagDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    return this.base.patchOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+}

--- a/examples/nest-typeorm/src/tag/tag.dtos.ts
+++ b/examples/nest-typeorm/src/tag/tag.dtos.ts
@@ -1,16 +1,35 @@
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+
 /**
  * DTO slots for the Tag route. See `cat.dtos.ts` for the rationale behind
- * plain initialized-field classes.
+ * plain initialized-field classes. `Create`/`Update`/`PatchTagDto` carry
+ * `class-validator` decorators — see `tag.controller.ts`'s `@Override()`'d
+ * write methods for how they get validated.
  */
 
 /** `create` slot — request body for POST /tags. */
 export class CreateTagDto {
+  @IsString()
+  @IsNotEmpty()
   name = "";
 }
 
 /** `update` slot — request body for PUT /tags/:id (patch derives from it). */
 export class UpdateTagDto {
+  @IsString()
+  @IsNotEmpty()
   name = "";
+}
+
+/**
+ * `PATCH /tags/:id`'s own validated shape. See `PatchOwnerDto`
+ * (`owner.dtos.ts`) for why this exists as its own class.
+ */
+export class PatchTagDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
 }
 
 /** `item` slot — the detail projection. */

--- a/examples/nest-typeorm/tests/crud-e2e.suite.ts
+++ b/examples/nest-typeorm/tests/crud-e2e.suite.ts
@@ -1370,4 +1370,106 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       expect(params.find((param) => param.name === "offset")?.description).toContain("pagination.strategy' is 'none'");
     });
   });
+
+  /**
+   * The example's `class-validator` validation layer: `createOne`/
+   * `updateOne`/`patchOne` are `@Override()`'d across every entity but
+   * `Dog` (which deliberately keeps none) purely to give their body
+   * parameter a concrete, decorated DTO type the app's global
+   * `ValidationPipe` (`app.module.ts`) can validate against — see
+   * `owner.controller.ts`'s own comment for the mechanism. Every failure
+   * here reaches the same RFC 9457 problem-details shape the rest of the
+   * app uses, via `@kavo/nest`'s existing `KavoExceptionFilter` (it already
+   * maps any `HttpException` — including a `ValidationPipe`'s
+   * `BadRequestException` — regardless of whether it came from inside the
+   * engine).
+   */
+  describe("class-validator write validation", () => {
+    it("rejects an invalid email on POST /owners as a problem-details 400, not a bare Nest error", async () => {
+      const response = await request(server())
+        .post("/owners")
+        .send({ name: "Bad Email", email: "not-an-email" })
+        .expect(400)
+        .expect("Content-Type", /application\/problem\+json/);
+      expect(response.body).toMatchObject({ status: 400, code: "KAVO_HTTP_ERROR" });
+      expect(response.body.detail).toContain("email");
+    });
+
+    it("rejects a missing required field on POST /owners", async () => {
+      const response = await request(server()).post("/owners").send({ email: "noname@x.io" }).expect(400);
+      expect(response.body.detail).toContain("name");
+    });
+
+    it("accepts a valid PUT /owners/:id and rejects an invalid one", async () => {
+      const created = await request(server()).post("/owners").send({ name: "Val", email: "val@x.io" }).expect(201);
+      const id = created.body.id as number;
+
+      await request(server()).put(`/owners/${id}`).send({ name: "Val Two", email: "val2@x.io" }).expect(200);
+
+      await request(server()).put(`/owners/${id}`).send({ name: "Val", email: "nope" }).expect(400);
+    });
+
+    it("is partial-field aware on PATCH /owners/:id, same as Address's postalCode", async () => {
+      const created = await request(server())
+        .post("/owners")
+        .send({ name: "Patchable", email: "patchable@x.io" })
+        .expect(201);
+      const id = created.body.id as number;
+
+      // Omitting `email` never triggers its validator on patch.
+      const patched = await request(server()).patch(`/owners/${id}`).send({ name: "Patched" }).expect(200);
+      expect(patched.body).toMatchObject({ name: "Patched", email: "patchable@x.io" });
+
+      // Present-but-invalid still rejects.
+      await request(server()).patch(`/owners/${id}`).send({ email: "still-nope" }).expect(400);
+    });
+
+    it("rejects a negative age or non-boolean indoor on POST /cats", async () => {
+      const badAge = await request(server())
+        .post("/cats")
+        .send({ name: "Neg", age: -1, indoor: true, livesLeft: 9 })
+        .expect(400);
+      expect(badAge.body.detail).toContain("age");
+
+      const badIndoor = await request(server())
+        .post("/cats")
+        .send({ name: "NotBool", age: 1, indoor: "yes", livesLeft: 9 })
+        .expect(400);
+      expect(badIndoor.body.detail).toContain("indoor");
+    });
+
+    it("still creates a cat with size omitted, the DB default applying (issue: size's own validator must not misfire on absence)", async () => {
+      const created = await request(server())
+        .post("/cats")
+        .send({ name: "Defaulted", age: 1, indoor: true, livesLeft: 9 })
+        .expect(201);
+      expect(created.body.size).toBe("medium");
+    });
+
+    it("rejects an invalid size enum value on POST /cats", async () => {
+      const response = await request(server())
+        .post("/cats")
+        .send({ name: "BadSize", age: 1, size: "gigantic", indoor: true, livesLeft: 9 })
+        .expect(400);
+      expect(response.body.detail).toContain("size");
+    });
+
+    it("rejects an empty name on POST /tags and POST /photos rejects an empty url", async () => {
+      await request(server()).post("/tags").send({ name: "" }).expect(400);
+      await request(server()).post("/photos").send({ url: "" }).expect(400);
+    });
+
+    it("is partial-field aware on PATCH /tags/:id", async () => {
+      const tag = await request(server()).post("/tags").send({ name: "patch-me" }).expect(201);
+      const id = tag.body.id as number;
+      await request(server()).patch(`/tags/${id}`).send({ name: "patched" }).expect(200);
+      await request(server()).patch(`/tags/${id}`).send({ name: "" }).expect(400);
+    });
+
+    it("strips a client-sent id on POST /photos rather than rejecting the request (whitelist, not forbidNonWhitelisted)", async () => {
+      const created = await request(server()).post("/photos").send({ id: 999999, url: "kept.png" }).expect(201);
+      expect(created.body.id).not.toBe(999999);
+      expect(created.body.url).toBe("kept.png");
+    });
+  });
 }

--- a/examples/nest-typeorm/tests/crud-e2e.suite.ts
+++ b/examples/nest-typeorm/tests/crud-e2e.suite.ts
@@ -1471,5 +1471,89 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       expect(created.body.id).not.toBe(999999);
       expect(created.body.url).toBe("kept.png");
     });
+
+    it("rejects an empty street/city/postalCode on POST /addresses", async () => {
+      const missingStreet = await request(server())
+        .post("/addresses")
+        .send({ street: "", city: "Springfield", postalCode: "10001" })
+        .expect(400);
+      expect(missingStreet.body.detail).toContain("street");
+
+      const missingCity = await request(server())
+        .post("/addresses")
+        .send({ street: "1 Elm St", city: "", postalCode: "10001" })
+        .expect(400);
+      expect(missingCity.body.detail).toContain("city");
+    });
+
+    it("rejects a non-string street on PUT /addresses/:id", async () => {
+      const created = await request(server())
+        .post("/addresses")
+        .send({ street: "1 Elm St", city: "Springfield", postalCode: "10001" })
+        .expect(201);
+      const id = created.body.id as number;
+
+      await request(server())
+        .put(`/addresses/${id}`)
+        .send({ street: 12345, city: "Springfield", postalCode: "10001" })
+        .expect(400);
+    });
+
+    it("rejects a malformed ISO date on POST /owners' startedAt, and accepts a well-formed one", async () => {
+      const bad = await request(server())
+        .post("/owners")
+        .send({ name: "Dated", email: "dated@x.io", startedAt: "not-a-date" })
+        .expect(400);
+      expect(bad.body.detail).toContain("startedAt");
+
+      const good = await request(server())
+        .post("/owners")
+        .send({ name: "Dated Ok", email: "dated-ok@x.io", startedAt: "2021-06-01T00:00:00.000Z" })
+        .expect(201);
+      expect(good.body.startedAt).toBe("2021-06-01T00:00:00.000Z");
+    });
+
+    it("rejects a non-positive owner address id on POST /owners", async () => {
+      const response = await request(server())
+        .post("/owners")
+        .send({ name: "BadAddr", email: "badaddr@x.io", address: -1 })
+        .expect(400);
+      expect(response.body.detail).toContain("address");
+    });
+
+    it("rejects a non-integer element in POST /cats' tags array", async () => {
+      const response = await request(server())
+        .post("/cats")
+        .send({ name: "BadTags", age: 1, indoor: true, livesLeft: 9, tags: [1, "two", 3] })
+        .expect(400);
+      expect(response.body.detail).toContain("tags");
+    });
+
+    it("rejects a negative livesLeft on POST /cats", async () => {
+      const response = await request(server())
+        .post("/cats")
+        .send({ name: "NegLives", age: 1, indoor: true, livesLeft: -1 })
+        .expect(400);
+      expect(response.body.detail).toContain("livesLeft");
+    });
+
+    it("rejects an empty name on PUT /tags/:id", async () => {
+      const tag = await request(server()).post("/tags").send({ name: "renamable" }).expect(201);
+      const id = tag.body.id as number;
+      await request(server()).put(`/tags/${id}`).send({ name: "" }).expect(400);
+      await request(server()).put(`/tags/${id}`).send({ name: "renamed" }).expect(200);
+    });
+
+    it("rejects an empty url on PUT /photos/:id and is partial-field aware on PATCH", async () => {
+      const photo = await request(server()).post("/photos").send({ url: "original.png" }).expect(201);
+      const id = photo.body.id as number;
+
+      await request(server()).put(`/photos/${id}`).send({ url: "" }).expect(400);
+      await request(server()).put(`/photos/${id}`).send({ url: "replaced.png" }).expect(200);
+
+      const patched = await request(server()).patch(`/photos/${id}`).send({ url: "patched.png" }).expect(200);
+      expect(patched.body.url).toBe("patched.png");
+      await request(server()).patch(`/photos/${id}`).send({ url: "" }).expect(400);
+    });
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,16 +73,16 @@ importers:
         version: 7.1.11(@mikro-orm/core@7.1.11(dataloader@2.2.3))
       '@nestjs/common':
         specifier: ^11.2.1
-        version: 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
       '@nestjs/swagger':
         specifier: ^11.4.6
-        version: 11.4.6(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(reflect-metadata@0.2.2)
+        version: 11.4.6(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -98,7 +98,7 @@ importers:
         version: 0.2.8(@electric-sql/pglite-age@0.0.5(@electric-sql/pglite@0.5.5))(@electric-sql/pglite-pg_hashids@0.0.5(@electric-sql/pglite@0.5.5))(@electric-sql/pglite-pg_ivm@0.0.5(@electric-sql/pglite@0.5.5))(@electric-sql/pglite-pg_textsearch@0.0.6(@electric-sql/pglite@0.5.5))(@electric-sql/pglite-pg_uuidv7@0.0.5(@electric-sql/pglite@0.5.5))(@electric-sql/pglite-pgtap@0.0.5(@electric-sql/pglite@0.5.5))(@electric-sql/pglite-pgvector@0.0.5(@electric-sql/pglite@0.5.5))(@electric-sql/pglite@0.5.5)
       '@nestjs/testing':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
       '@testcontainers/postgresql':
         specifier: ^12.1.0
         version: 12.1.0
@@ -122,16 +122,16 @@ importers:
         version: link:../../packages/frameworks/nest
       '@nestjs/common':
         specifier: ^11.2.1
-        version: 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
       '@nestjs/swagger':
         specifier: ^11.4.6
-        version: 11.4.6(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(reflect-metadata@0.2.2)
+        version: 11.4.6(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       mongoose:
         specifier: ^8.24.3
         version: 8.24.3
@@ -144,7 +144,7 @@ importers:
     devDependencies:
       '@nestjs/testing':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
       '@testcontainers/mongodb':
         specifier: ^12.1.0
         version: 12.1.0
@@ -174,19 +174,25 @@ importers:
         version: link:../../packages/orms/typeorm
       '@nestjs/common':
         specifier: ^11.2.1
-        version: 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
       '@nestjs/swagger':
         specifier: ^11.4.6
-        version: 11.4.6(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(reflect-metadata@0.2.2)
+        version: 11.4.6(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       better-sqlite3:
         specifier: ^13.0.3
         version: 13.0.3
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.14.2
+        version: 0.14.4
       mysql2:
         specifier: ^3.23.3
         version: 3.23.3(@types/node@26.2.0)
@@ -205,7 +211,7 @@ importers:
     devDependencies:
       '@nestjs/testing':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
       '@testcontainers/cockroachdb':
         specifier: ^12.1.0
         version: 12.1.0
@@ -241,19 +247,19 @@ importers:
         version: 1.30.0(zod@4.4.3)
       '@nestjs/common':
         specifier: ^11.2.1
-        version: 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
       '@nestjs/swagger':
         specifier: ^11.4.6
-        version: 11.4.6(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(reflect-metadata@0.2.2)
+        version: 11.4.6(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       '@nestjs/testing':
         specifier: ^11.2.1
-        version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
+        version: 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)
       '@types/supertest':
         specifier: ^7.2.1
         version: 7.2.1
@@ -1663,6 +1669,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
@@ -2080,6 +2089,12 @@ packages:
 
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.14.4:
+    resolution: {integrity: sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2919,6 +2934,9 @@ packages:
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
+
+  libphonenumber-js@1.13.11:
+    resolution: {integrity: sha512-ETER2kMaIFTI/Nh1a8Gk03dUF/SL0VZqtI+CcVHZxp5WIHYwNS7S+uiYZDYCvLy3lOR4/DAD5jf0h5WkePPpqg==}
 
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
@@ -4013,6 +4031,10 @@ packages:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -4762,7 +4784,7 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
-  '@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       file-type: 21.3.4
       iterare: 1.2.1
@@ -4771,12 +4793,15 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.4
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/core@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
       path-to-regexp: 8.4.2
@@ -4785,17 +4810,20 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
+      '@nestjs/platform-express': 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
 
-  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)':
     dependencies:
-      '@nestjs/common': 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.4
 
-  '@nestjs/platform-express@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)':
+  '@nestjs/platform-express@11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)':
     dependencies:
-      '@nestjs/common': 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
       multer: 2.2.0
@@ -4804,25 +4832,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/swagger@11.4.6(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@11.4.6(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
-      '@nestjs/common': 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+      '@nestjs/common': 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       js-yaml: 5.2.1
       lodash: 4.18.1
       path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.32.8
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.4
 
-  '@nestjs/testing@11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)':
+  '@nestjs/testing@11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)(@nestjs/platform-express@11.2.1)':
     dependencies:
-      '@nestjs/common': 11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.2.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@nestjs/platform-express': 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
+      '@nestjs/platform-express': 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
 
   '@noble/hashes@1.8.0': {}
 
@@ -5382,6 +5413,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/validator@13.15.10': {}
+
   '@types/web-bluetooth@0.0.21': {}
 
   '@types/webidl-conversions@7.0.3': {}
@@ -5833,6 +5866,14 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.2: {}
+
+  class-transformer@0.5.1: {}
+
+  class-validator@0.14.4:
+    dependencies:
+      '@types/validator': 13.15.10
+      libphonenumber-js: 1.13.11
+      validator: 13.15.35
 
   cliui@8.0.1:
     dependencies:
@@ -6720,6 +6761,8 @@ snapshots:
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+
+  libphonenumber-js@1.13.11: {}
 
   load-esm@1.0.3: {}
 
@@ -7891,6 +7934,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.1: {}
+
+  validator@13.15.35: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## What & why

Adds a request-body validation layer to the `nest-typeorm` example using `class-validator`. Kavo's own DTOs are shapes only, with no validation subsystem of their own (`docs/internals/architecture/04-dto-system.md`), and a generated Kavo route's body parameter carries no type metadata for Nest's `ValidationPipe` to key off (only a real, TS-source-declared method parameter does, via `emitDecoratorMetadata`). So `createOne`/`updateOne`/`patchOne` are `@Override()`'d across every entity but `Dog` (left unvalidated, deliberately, as the contrast with the rest), each typed with a concrete `class-validator`-decorated DTO class instead of the looser type an override would otherwise use. A global `ValidationPipe` is registered via `APP_PIPE` in `AppModule` (rather than `main.ts`) so both real bootstraps and the e2e test suite pick it up. Validation failures ride the existing `KavoExceptionFilter` into the same RFC 9457 problem-details response shape the rest of the app already uses — no new exception type needed.

`AddressController`'s existing postal-code overrides were retyped from `Partial<Address>` to the new concrete DTO classes so they get validated the same way, on top of their existing procedural postal-code check.

## Public API impact

None. Every change is confined to `examples/nest-typeorm`; no `@kavo/*` package source changed.

## Testing

Added a `class-validator write validation` test block to `tests/crud-e2e.suite.ts` (shared by the SQLite/Postgres/MariaDB/CockroachDB e2e specs): invalid email/missing-field/negative-age/invalid-enum/empty-string rejections as problem-details 400s, patch partial-field-awareness, and whitelist-stripping of an unknown field. Also fixed one pre-existing gap: the DTO's own `enumProp(...)` Swagger-hint marker (not a real enum value) needed a `@ValidateIf` (not `@IsOptional`) to correctly detect "field omitted" on `Cat.size`, plus stripping that sentinel before it reaches the deserializer.

`pnpm check` (build, typecheck, depcruise, lint, test) and `pnpm docs:links` both pass. The only test failures observed are pre-existing environment limitations unrelated to this change (no Docker daemon for the Postgres/MariaDB/CockroachDB Testcontainers suites, no network access for the MongoDB memory-server binary download) — the in-process SQLite suite, which exercises the new validation code, passes at 92/92.

## Review notes

Worth a close look: `cat.dtos.ts`'s comment on why `size`'s schema-hint default needed `@ValidateIf` instead of `@IsOptional`, and why `cat.controller.ts`'s overrides strip that sentinel before delegating — a subtle interaction between `class-transformer`'s field-initializer fallback and Kavo's own Swagger-hint mechanism (`enumProp`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rbadk2mvUqTnBEwYxCQgfk)_