### PR TITLE
fix(docs): stop white-screening pnpm docs:dev on the mermaid dep-optimize workaround

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -368,23 +368,4 @@ const config = defineConfig({
   },
 });
 
-const mermaidConfig = withMermaid(config);
-
-// vitepress-plugin-mermaid asks Vite to pre-bundle these five transitive
-// dependencies of mermaid by bare name. pnpm does not hoist them to the
-// workspace root, so `vitepress dev` cannot resolve them and serves a blank
-// page. Dropping them from the list lets Vite discover them on demand from
-// inside mermaid's own package, where they do resolve. The production build
-// resolves through the real dependency graph and never needed the hint.
-const PRE_BUNDLED_BY_PLUGIN = ["@braintree/sanitize-url", "dayjs", "debug", "cytoscape-cose-bilkent", "cytoscape"];
-
-export default {
-  ...mermaidConfig,
-  vite: {
-    ...mermaidConfig.vite,
-    optimizeDeps: {
-      ...mermaidConfig.vite?.optimizeDeps,
-      include: (mermaidConfig.vite?.optimizeDeps?.include ?? []).filter((dep) => !PRE_BUNDLED_BY_PLUGIN.includes(dep)),
-    },
-  },
-};
+export default withMermaid(config);

--- a/package.json
+++ b/package.json
@@ -27,9 +27,14 @@
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
+    "@braintree/sanitize-url": "^7.1.2",
     "@swc/core": "^1.16.0",
     "@types/node": "^22.20.1",
     "@vitest/coverage-v8": "^4.1.10",
+    "cytoscape": "^3.33.3",
+    "cytoscape-cose-bilkent": "^4.1.0",
+    "dayjs": "^1.11.20",
+    "debug": "^4.4.3",
     "dependency-cruiser": "^18.2.0",
     "mermaid": "^11.16.1",
     "oxlint": "^1.78.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@braintree/sanitize-url':
+        specifier: ^7.1.2
+        version: 7.1.2
       '@swc/core':
         specifier: ^1.16.0
         version: 1.16.0
@@ -17,6 +20,18 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      cytoscape:
+        specifier: ^3.33.3
+        version: 3.34.1
+      cytoscape-cose-bilkent:
+        specifier: ^4.1.0
+        version: 4.1.0(cytoscape@3.34.1)
+      dayjs:
+        specifier: ^1.11.20
+        version: 1.11.21
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3
       dependency-cruiser:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
## What & why

`pnpm docs:dev` white-screened on load: the Vue app never mounted, and the browser console showed `Uncaught SyntaxError: The requested module '.../dayjs/dayjs.min.js' does not provide an export named 'default'`, thrown from inside mermaid's `mermaid.core` dev chunk.

`docs/.vitepress/config.mts` had a `PRE_BUNDLED_BY_PLUGIN` filter that stripped `dayjs` and four siblings back out of `vitepress-plugin-mermaid`'s own `optimizeDeps.include` list, with a comment claiming pnpm's non-hoisted install made Vite unable to resolve them there. That premise no longer holds: without pre-bundling, Vite serves `dayjs`'s CJS build as native ESM with no CJS→ESM interop — the exact crash above, just reintroduced by the workaround meant to prevent it.

Fix: removed the filter, letting `withMermaid()`'s own `optimizeDeps.include` list through unmodified. Since pnpm still doesn't hoist `dayjs`/`debug`/`cytoscape`/`cytoscape-cose-bilkent`/`@braintree/sanitize-url` to the workspace root (they're only nested inside mermaid's own `node_modules`), also added them as explicit root `devDependencies` so Vite's forced pre-bundle resolution can find them from the project root.

Closes #176

## Public API impact

None — docs tooling config only (`docs/.vitepress/config.mts`, root `devDependencies`).

## Testing

- `pnpm docs:dev` verified in a real browser (by the reporter) to render the homepage without a white screen or console error, both before and after confirming the hoisted `devDependencies` are required alongside the config fix (a config-only version was tested and still white-screened).
- `pnpm check`: build, typecheck, depcruise, lint all pass; 2386/2386 runnable unit/integration tests pass. 5 e2e suites (Postgres/Mongo/MariaDB/CockroachDB via testcontainers) fail in this sandbox only because no Docker daemon is available here — pre-existing environment limitation, unrelated to this change, and CI has Docker.
- `pnpm docs:build` and `pnpm docs:links` pass.

## Review notes

The `PRE_BUNDLED_BY_PLUGIN` filter's own comment turned out to be actively wrong (its claimed fix reintroduced the exact bug it was written to avoid) — worth double-checking the reasoning on any future Vite/mermaid dep-optimization tweak here rather than trusting the existing comment.