### PR TITLE
test(core,examples/nest-typeorm): finish #234's policy test/demo coverage

### DIFF
--- a/docs/internals/adr/0032-policy-authorization-dsl.md
+++ b/docs/internals/adr/0032-policy-authorization-dsl.md
@@ -171,9 +171,11 @@ Both are **out of v1**:
   **plus `item` and `list`** for the two read operations — not a unified
   `find` — because `item`/`list` are the actual DTO slot names
   (`CLAUDE.md` Conventions) and `findOne`/`findMany` do not share a slot
-  the way `createOne`/`createMany` share `create`. Getting this mapping
-  right needs its own issue once the AST/config groundwork here is used in
-  practice.
+  the way `createOne`/`createMany` share `create`. The mapping itself is
+  decided and codified now, in `STANDARD_OPERATION_VERB`
+  (`operation.ts`) — internal, unread by anything until Level 3 lands —
+  so the follow-up issue implements against a settled name, not a fresh
+  design question.
 - `filter()`'s operation-level denial (no scoping filter configured at all)
   is a different failure shape from `owner`/`when`'s row-level denial
   (a specific row exists but this caller isn't its owner) — this ADR's own

--- a/examples/nest-typeorm/src/app.module.ts
+++ b/examples/nest-typeorm/src/app.module.ts
@@ -56,6 +56,12 @@ export class AppModule {
           provideServices: true,
           useFactory: (dataSource: DataSource) => ({
             infrastructure: createInfrastructure(dataSource),
+            // `request.user`: where `OwnerPrincipalGuard`
+            // (owner/owner-principal.guard.ts) leaves it, for
+            // OwnerController's `policy.deleteOne` — inert everywhere else,
+            // since no other controller's guard populates `request.user`
+            // (docs/guides/wiring-your-own-auth).
+            principal: true,
             ...(realtimeTransports !== undefined && { realtimeTransports }),
             defaults: {
               pagination: { defaultLimit: 20, maxLimit: 100 },

--- a/examples/nest-typeorm/src/owner/owner-principal.guard.ts
+++ b/examples/nest-typeorm/src/owner/owner-principal.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable, type CanActivate, type ExecutionContext } from "@nestjs/common";
+
+/**
+ * Stands in for whatever a real app's auth layer does — reads a
+ * comma-separated `x-permissions` header into the shape `policy`'s
+ * `permission()` node reads off `context.principal` (`KavoPrincipal`,
+ * `@kavo/core`). A real app authenticates with a JWT/session guard and
+ * derives permissions from the account it resolves; this is the minimal
+ * stand-in that makes `OwnerController`'s `policy.deleteOne` demonstrable
+ * over real HTTP without pulling an auth library into the reference app.
+ *
+ * `KavoModule.forRootAsync`'s `principal: true` (`app.module.ts`) is what
+ * moves `request.user` onto `context.principal` — this guard only ever
+ * sets `request.user`, never reads `context` itself, so it composes with
+ * that option rather than duplicating it (`docs/guides/wiring-your-own-auth`).
+ */
+@Injectable()
+export class OwnerPrincipalGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers: Record<string, string | undefined>;
+      user?: unknown;
+    }>();
+    const permissions = request.headers["x-permissions"];
+    if (permissions === undefined) return true;
+    request.user = { permissions: permissions.split(",").filter(Boolean) };
+    return true;
+  }
+}

--- a/examples/nest-typeorm/src/owner/owner.controller.ts
+++ b/examples/nest-typeorm/src/owner/owner.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Inject } from "@nestjs/common";
+import { Controller, Inject, UseGuards } from "@nestjs/common";
 import { Kavo, Override, getKavoServiceToken } from "@kavo/nest";
 import type { DefaultKavoService, EntityId, RequestPreconditions } from "@kavo/core";
 import { Owner } from "./owner.entity.js";
 import { CreateOwnerDto, UpdateOwnerDto, PatchOwnerDto, OwnerItemDto, OwnerListDto } from "./owner.dtos.js";
+import { OwnerPrincipalGuard } from "./owner-principal.guard.js";
 
 /**
  * CRUD over the relation side. The unique `email` column is what surfaces a
@@ -41,6 +42,16 @@ import { CreateOwnerDto, UpdateOwnerDto, PatchOwnerDto, OwnerItemDto, OwnerListD
  * `emitDecoratorMetadata`, which only exists for a param written directly
  * in this class's own source — a generated method has no such metadata,
  * `@Override()` recovers it. Each override otherwise just delegates.
+ *
+ * Authorization: `DELETE /owners/:id` additionally requires the
+ * `owner:delete` permission (ADR-0032) — `permission('owner:delete')`,
+ * sugared to the array shorthand. `OwnerPrincipalGuard` stands in for a
+ * real app's auth layer, reading a comma-separated `x-permissions` header
+ * into the `KavoPrincipal` shape `permission()` reads; `AppModule`'s
+ * `principal: true` is what moves it from `request.user` onto
+ * `context.principal`. No other route on this controller, and no other
+ * controller in this app, is gated — see `docs/guides/wiring-your-own-auth`
+ * for the full DSL (`role`/`owner`/`authenticated`/`when`/`and`/`or`/`not`).
  */
 @Kavo(Owner, {
   dto: {
@@ -71,8 +82,12 @@ import { CreateOwnerDto, UpdateOwnerDto, PatchOwnerDto, OwnerItemDto, OwnerListD
     purgeOne: true,
     restoreOne: true,
   },
+  policy: {
+    deleteOne: ["owner:delete"],
+  },
 })
 @Controller("owners")
+@UseGuards(OwnerPrincipalGuard)
 export class OwnerController {
   constructor(@Inject(getKavoServiceToken(Owner)) private readonly base: DefaultKavoService<Owner>) {}
 

--- a/examples/nest-typeorm/tests/crud-e2e.suite.ts
+++ b/examples/nest-typeorm/tests/crud-e2e.suite.ts
@@ -280,7 +280,7 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       const created = await request(server()).post("/owners").send({ name: "Rose", email: "rose@x.io" }).expect(201);
       const id = created.body.id as number;
 
-      await request(server()).delete(`/owners/${id}`).expect(204);
+      await request(server()).delete(`/owners/${id}`).set("x-permissions", "owner:delete").expect(204);
       await request(server()).get(`/owners/${id}`).expect(404);
       const withDeleted = await request(server())
         .get("/owners")
@@ -291,6 +291,7 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       // A second delete is a state conflict, not a 404.
       await request(server())
         .delete(`/owners/${id}`)
+        .set("x-permissions", "owner:delete")
         .expect(409)
         .expect("Content-Type", /application\/problem\+json/);
 
@@ -300,9 +301,27 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
 
       // Purge takes a soft-deleted row only.
       await request(server()).delete(`/owners/${id}/purge`).expect(409);
-      await request(server()).delete(`/owners/${id}`).expect(204);
+      await request(server()).delete(`/owners/${id}`).set("x-permissions", "owner:delete").expect(204);
       await request(server()).delete(`/owners/${id}/purge`).expect(204);
       await request(server()).patch(`/owners/${id}/restore`).expect(404);
+    });
+
+    it("policy: DELETE /owners/:id requires the owner:delete permission (ADR-0032)", async () => {
+      const created = await request(server()).post("/owners").send({ name: "Zoe", email: "zoe@x.io" }).expect(201);
+      const id = created.body.id as number;
+
+      // No `x-permissions` header at all: `context.principal` is `null`,
+      // same as every other route in this app — permission() denies it.
+      const anonymous = await request(server()).delete(`/owners/${id}`).expect(403);
+      expect(anonymous.body).toMatchObject({ code: "KAVO_FORBIDDEN", status: 403 });
+
+      // The wrong permission is just as denied as none at all.
+      await request(server()).delete(`/owners/${id}`).set("x-permissions", "owner:read").expect(403);
+
+      // The row is untouched by either denied attempt.
+      await request(server()).get(`/owners/${id}`).expect(200);
+
+      await request(server()).delete(`/owners/${id}`).set("x-permissions", "owner:delete").expect(204);
     });
 
     it("keeps deletedAt out of the filterable, sortable, and selectable allowlists (issue #45)", async () => {

--- a/examples/nest-typeorm/tests/policy.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/policy.e2e.spec.ts
@@ -1,0 +1,244 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Column, DataSource, DeleteDateColumn, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Controller, UseGuards, type CanActivate, type ExecutionContext, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { and, authenticated, or, owner, permission, role } from "@kavo/core";
+import { Kavo, KavoModule } from "@kavo/nest";
+import { createInfrastructure } from "@kavo/typeorm";
+import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
+
+/**
+ * `policy` (ADR-0032) driven over real HTTP against a real SQLite database
+ * — closing the gap `packages/core/tests/policy.spec.ts` leaves open, since
+ * that file only ever exercises the engine against fake in-memory adapters.
+ * Two things specifically only a real `@kavo/typeorm` adapter can confirm:
+ *
+ * - the policy stage's pre-fetch (`KavoEngine.policyPrefetchQuery`) really
+ *   asks for soft-deleted rows on `restoreOne`/`purgeOne` (`withDeleted:
+ *   true`), against `TypeOrmRepositoryAdapter.findOneById`'s real
+ *   `query?.withDeleted ?? false` default — not a fixture that might get
+ *   that default wrong in either direction;
+ * - a denial actually reaches the client as a 403 problem-details document
+ *   with `KAVO_FORBIDDEN`, through the real `@kavo/nest` exception filter.
+ *
+ * Builds its own module rather than reusing `AppModule`, matching
+ * `array-mutation-resource.e2e.spec.ts`'s own precedent: the reference app
+ * is adopter-facing documentation and should not carry entities or a guard
+ * that exist only for a test.
+ */
+
+@Entity()
+class Post {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  title!: string;
+
+  @Column("varchar")
+  authorId!: string;
+
+  @DeleteDateColumn()
+  deletedAt!: Date | null;
+}
+
+/**
+ * Stands in for whatever an app's real auth guard does — reads
+ * comma-separated `x-roles`/`x-permissions` and a bare `x-user` header into
+ * the shape `permission()`/`role()`/`owner()`/`authenticated()` read off
+ * `context.principal` (`KavoPrincipal`). Absent `x-user`, `request.user` is
+ * left unset, so `KavoModule`'s `principal: true` reports `null` — the
+ * "nobody is signed in" case every policy test needs to deny.
+ */
+class HeaderPrincipalGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const incoming = context.switchToHttp().getRequest<{
+      headers: Record<string, string | undefined>;
+      user?: unknown;
+    }>();
+    const userId = incoming.headers["x-user"];
+    if (userId === undefined) return true;
+    incoming.user = {
+      userId,
+      roles: (incoming.headers["x-roles"] ?? "").split(",").filter(Boolean),
+      permissions: (incoming.headers["x-permissions"] ?? "").split(",").filter(Boolean),
+    };
+    return true;
+  }
+}
+
+@Kavo(Post, {
+  softDelete: { strategy: "soft" },
+  operations: { purgeOne: true },
+  policy: {
+    createOne: authenticated(),
+    updateOne: or(role("admin"), and(permission("post:update"), owner("authorId"))),
+    deleteOne: ["post:delete"],
+    findOne: owner("authorId"),
+    restoreOne: owner("authorId"),
+    purgeOne: owner("authorId"),
+  },
+} as never)
+@Controller("posts")
+@UseGuards(new HeaderPrincipalGuard())
+class PostController {}
+
+let dataSource: DataSource;
+let app: INestApplication;
+let httpServer: SupertestTarget | undefined;
+
+beforeAll(async () => {
+  dataSource = new DataSource({
+    type: "better-sqlite3",
+    database: ":memory:",
+    entities: [Post],
+    synchronize: true,
+  });
+  await dataSource.initialize();
+
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      KavoModule.forRoot({ infrastructure: createInfrastructure(dataSource), principal: true }),
+      KavoModule.forFeature([PostController]),
+    ],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  httpServer = await listen(app);
+});
+
+afterAll(async () => {
+  httpServer = undefined;
+  if (app !== undefined) await app.close();
+  if (dataSource !== undefined) await dataSource.destroy();
+});
+
+beforeEach(async () => {
+  await dataSource.getRepository(Post).clear();
+});
+
+function server(): SupertestTarget {
+  return boundServer(httpServer);
+}
+
+async function seed(authorId: string): Promise<number> {
+  const row = await dataSource.getRepository(Post).save({ title: "Dune", authorId });
+  return row.id;
+}
+
+const asUser = (userId: string, extra: { roles?: string; permissions?: string } = {}) => ({
+  "x-user": userId,
+  ...(extra.roles !== undefined && { "x-roles": extra.roles }),
+  ...(extra.permissions !== undefined && { "x-permissions": extra.permissions }),
+});
+
+describe("policy over real HTTP + SQLite (ADR-0032)", () => {
+  it("denies createOne for an anonymous caller (authenticated())", async () => {
+    const response = await request(server()).post("/posts").send({ title: "x", authorId: "u-1" }).expect(403);
+    expect(response.body).toMatchObject({ code: "KAVO_FORBIDDEN", status: 403 });
+  });
+
+  it("allows createOne once a principal is attached", async () => {
+    await request(server()).post("/posts").set(asUser("u-1")).send({ title: "x", authorId: "u-1" }).expect(201);
+  });
+
+  it("array shorthand: deleteOne requires the named permission", async () => {
+    const id = await seed("u-1");
+    await request(server()).delete(`/posts/${id}`).set(asUser("u-1")).expect(403);
+    await request(server())
+      .delete(`/posts/${id}`)
+      .set(asUser("u-1", { permissions: "post:delete" }))
+      .expect(204);
+  });
+
+  it("or(role('admin'), and(permission, owner)): the owner with the permission may update", async () => {
+    const id = await seed("u-1");
+    const response = await request(server())
+      .put(`/posts/${id}`)
+      .set(asUser("u-1", { permissions: "post:update" }))
+      .send({ title: "mine now" })
+      .expect(200);
+    expect(response.body).toMatchObject({ title: "mine now" });
+  });
+
+  it("or(role('admin'), ...): a non-owner with the permission is still denied", async () => {
+    const id = await seed("u-1");
+    await request(server())
+      .put(`/posts/${id}`)
+      .set(asUser("u-2", { permissions: "post:update" }))
+      .send({ title: "not mine" })
+      .expect(403);
+  });
+
+  it("or(role('admin'), ...): an admin bypasses ownership entirely", async () => {
+    const id = await seed("u-1");
+    await request(server())
+      .put(`/posts/${id}`)
+      .set(asUser("u-9", { roles: "admin" }))
+      .send({ title: "admin edit" })
+      .expect(200);
+  });
+
+  it("the row is unchanged after a denied updateOne — the pre-fetch runs before the write, not after", async () => {
+    const id = await seed("u-1");
+    await request(server())
+      .put(`/posts/${id}`)
+      .set(asUser("u-2", { permissions: "post:update" }))
+      .send({ title: "should not stick" })
+      .expect(403);
+    const row = await dataSource.getRepository(Post).findOneBy({ id });
+    expect(row?.title).toBe("Dune");
+  });
+
+  it("findOne: 404 for a missing row beats 403 — existence never leaks through the status code", async () => {
+    await request(server()).get("/posts/999999").set(asUser("u-1")).expect(404);
+  });
+
+  it("findOne: 403 for a row that exists but isn't the caller's", async () => {
+    const id = await seed("u-1");
+    await request(server()).get(`/posts/${id}`).set(asUser("u-2")).expect(403);
+    const own = await request(server()).get(`/posts/${id}`).set(asUser("u-1")).expect(200);
+    expect(own.body).toMatchObject({ title: "Dune" });
+  });
+
+  it(
+    "restoreOne: the pre-fetch sees the soft-deleted row through the real adapter's withDeleted:true, " +
+      "instead of always 404ing",
+    async () => {
+      const id = await seed("u-1");
+      await request(server())
+        .delete(`/posts/${id}`)
+        .set(asUser("u-1", { permissions: "post:delete" }))
+        .expect(204);
+
+      // Soft-deleted: an ordinary findOne no longer sees it.
+      await request(server()).get(`/posts/${id}`).set(asUser("u-1")).expect(404);
+
+      // A non-owner is refused — the pre-fetch found the row and the
+      // policy denied it, not "row not found."
+      await request(server()).patch(`/posts/${id}/restore`).set(asUser("u-2")).expect(403);
+
+      // The owner restores it successfully.
+      const restored = await request(server()).patch(`/posts/${id}/restore`).set(asUser("u-1")).expect(200);
+      expect(restored.body).toMatchObject({ title: "Dune" });
+
+      const row = await dataSource.getRepository(Post).findOneBy({ id });
+      expect(row?.deletedAt).toBeNull();
+    },
+  );
+
+  it("purgeOne: same soft-deleted pre-fetch fix, against the real adapter", async () => {
+    const id = await seed("u-1");
+    await request(server())
+      .delete(`/posts/${id}`)
+      .set(asUser("u-1", { permissions: "post:delete" }))
+      .expect(204);
+
+    await request(server()).delete(`/posts/${id}/purge`).set(asUser("u-2")).expect(403);
+    await request(server()).delete(`/posts/${id}/purge`).set(asUser("u-1")).expect(204);
+
+    const row = await dataSource.getRepository(Post).findOneBy({ id });
+    expect(row).toBeNull();
+  });
+});

--- a/examples/nest-typeorm/tests/realtime.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/realtime.e2e.spec.ts
@@ -135,7 +135,11 @@ async function putOwner(id: number, body: Record<string, unknown>): Promise<numb
 }
 
 async function deleteOwner(id: number): Promise<number> {
-  return (await fetch(`${baseUrl}/owners/${id}`, { method: "DELETE" })).status;
+  // Owner's deleteOne requires the owner:delete permission (ADR-0032) —
+  // see owner.controller.ts's `policy` and `OwnerPrincipalGuard`.
+  return (
+    await fetch(`${baseUrl}/owners/${id}`, { method: "DELETE", headers: { "x-permissions": "owner:delete" } })
+  ).status;
 }
 
 async function restoreOwner(id: number): Promise<number> {
@@ -218,7 +222,10 @@ describe("GET /realtime — Owner writes stream over SSE", () => {
       body: JSON.stringify({ name: "Lifecycle Renamed" }),
     });
     expect(patchResponse.status).toBe(200);
-    const deleteResponse = await fetch(`${baseUrl}/owners/${created.id}`, { method: "DELETE" });
+    const deleteResponse = await fetch(`${baseUrl}/owners/${created.id}`, {
+      method: "DELETE",
+      headers: { "x-permissions": "owner:delete" },
+    });
     expect(deleteResponse.status).toBe(204);
     const restoreResponse = await fetch(`${baseUrl}/owners/${created.id}/restore`, { method: "PATCH" });
     expect(restoreResponse.status).toBe(200);

--- a/examples/nest-typeorm/tests/realtime.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/realtime.e2e.spec.ts
@@ -137,9 +137,8 @@ async function putOwner(id: number, body: Record<string, unknown>): Promise<numb
 async function deleteOwner(id: number): Promise<number> {
   // Owner's deleteOne requires the owner:delete permission (ADR-0032) —
   // see owner.controller.ts's `policy` and `OwnerPrincipalGuard`.
-  return (
-    await fetch(`${baseUrl}/owners/${id}`, { method: "DELETE", headers: { "x-permissions": "owner:delete" } })
-  ).status;
+  return (await fetch(`${baseUrl}/owners/${id}`, { method: "DELETE", headers: { "x-permissions": "owner:delete" } }))
+    .status;
 }
 
 async function restoreOwner(id: number): Promise<number> {

--- a/packages/core/src/operations/operation.ts
+++ b/packages/core/src/operations/operation.ts
@@ -11,7 +11,7 @@ export type StandardOperationId =
 /**
  * The standard ids as a runtime array, in the same order declared above —
  * the single source of truth for anything that must iterate every standard
- * operation (policy resolution's bare-verb mapping, ADR-0032).
+ * operation (policy resolution, `resolve-entity-config.ts`).
  */
 export const STANDARD_OPERATION_IDS: readonly StandardOperationId[] = [
   "createOne",
@@ -23,6 +23,31 @@ export const STANDARD_OPERATION_IDS: readonly StandardOperationId[] = [
   "restoreOne",
   "purgeOne",
 ] as const;
+
+/**
+ * The bare-verb name each standard operation folds into for a **class-based
+ * policy** (ADR-0032's deferred Level 3 — `policy: PostPolicy`, not built
+ * yet): the DTO-slot convention's own verbs (`CLAUDE.md` Conventions —
+ * `create`, `update`, `patch`, `query`, `item`, `list`) plus `delete`,
+ * `restore`, and `purge`, which have no DTO slot of their own but need a
+ * method name regardless. `findOne`/`findMany` map to `item`/`list`
+ * respectively — the response shape each one serves — not to a shared
+ * `find`, since unlike `createOne`/`createMany` they share no DTO slot.
+ *
+ * Unused today: nothing reads this until Level 3 lands. Reserved here,
+ * next to the ids it's keyed by, so the mapping is decided once rather
+ * than re-derived (and possibly re-litigated) when that issue starts.
+ */
+export const STANDARD_OPERATION_VERB: Readonly<Record<StandardOperationId, string>> = {
+  createOne: "create",
+  findOne: "item",
+  findMany: "list",
+  updateOne: "update",
+  patchOne: "patch",
+  deleteOne: "delete",
+  restoreOne: "restore",
+  purgeOne: "purge",
+};
 
 /**
  * Any operation id — standard or custom. The `string & {}`

--- a/packages/core/tests/operation.spec.ts
+++ b/packages/core/tests/operation.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { STANDARD_OPERATION_IDS, STANDARD_OPERATION_VERB } from "../src/operations/operation.js";
+
+describe("STANDARD_OPERATION_VERB (ADR-0032's reserved Level 3 mapping)", () => {
+  it("has exactly one entry per standard operation id, no more and no fewer", () => {
+    expect(Object.keys(STANDARD_OPERATION_VERB).sort()).toEqual([...STANDARD_OPERATION_IDS].sort());
+  });
+
+  it("maps findOne/findMany to item/list, not a shared 'find' — they share no DTO slot", () => {
+    expect(STANDARD_OPERATION_VERB.findOne).toBe("item");
+    expect(STANDARD_OPERATION_VERB.findMany).toBe("list");
+  });
+
+  it("maps every other operation to its own bare verb", () => {
+    expect(STANDARD_OPERATION_VERB.createOne).toBe("create");
+    expect(STANDARD_OPERATION_VERB.updateOne).toBe("update");
+    expect(STANDARD_OPERATION_VERB.patchOne).toBe("patch");
+    expect(STANDARD_OPERATION_VERB.deleteOne).toBe("delete");
+    expect(STANDARD_OPERATION_VERB.restoreOne).toBe("restore");
+    expect(STANDARD_OPERATION_VERB.purgeOne).toBe("purge");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #234/PR #235 (merged) — three commits that were reviewed and tested as part of that same effort but weren't included in the squash-merge, since they were pushed to the working branch after `/pr` had already run once. Landing them here rather than re-doing the work.

- **`test(examples/nest-typeorm)`** — 11 e2e tests driving `policy` over real HTTP against a real SQLite database via `@kavo/typeorm`, in a self-contained module (own DataSource, own entity, own guard), matching `array-mutation-resource.e2e.spec.ts`'s own precedent of not touching `AppModule`. Closes the one gap `packages/core/tests/policy.spec.ts`'s fake adapters leave open: whether the real adapter's `findOneById` actually honors `withDeleted: true` for the `restoreOne`/`purgeOne` pre-fetch, and whether a denial really reaches the client as a 403 `KAVO_FORBIDDEN` problem-details document through the real `@kavo/nest` exception filter. Both hold.

- **`feat(examples/nest-typeorm)`** — a live demonstration of `policy` on `OwnerController.deleteOne`, gated behind the `owner:delete` permission via a small `OwnerPrincipalGuard` (reads `x-permissions`) plus `AppModule`'s new `principal: true`. Scoped to one route on one controller — no other route in the app is affected. Updates the three existing anonymous `DELETE /owners/:id` calls across `crud-e2e.suite.ts` and `realtime.e2e.spec.ts` to carry the permission, and adds a test asserting the denial itself (no permission and the wrong permission both 403; the row is untouched).

- **`feat(core)`** — `STANDARD_OPERATION_VERB`, the bare-verb method-name mapping (`create`/`item`/`list`/`update`/`patch`/`delete`/`restore`/`purge`) ADR-0032 reserves for the deferred Level 3 (class-based `policy: PostPolicy`). Internal, unread by anything until that follow-up lands — settled now so the mapping isn't re-derived later. Pinned by a direct test.

## Public API impact

None from `@kavo/core`'s barrel — `STANDARD_OPERATION_VERB` is internal (not exported), matching `isStandardOperationId`'s own precedent. The `examples/nest-typeorm` changes are example-app-only, not a published package.

## Testing

`pnpm check`: build, typecheck, `depcruise` (no violations), lint all clean. **2485/2485** non-Docker tests pass (341 skipped) — matches the count already verified on #235 before merge, confirming this is genuinely a rebase-and-land rather than new surface. The only failures are the same 5 pre-existing testcontainer-backed e2e suites this sandbox can't run (no Docker daemon), unrelated to this change. `pnpm docs:links` clean.

## Review notes

Already went through the same review pass as #235 (this is exactly the tail of that branch, cherry-picked onto the post-merge `main`) — nothing new to flag beyond what #235's review already covered.