### PR TITLE
feat(core): add entity- and global-scope policy defaults

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -377,6 +377,10 @@ const config = defineConfig({
                 text: "0035 — authorization.required denies standard operations with no configured policy",
                 link: "/internals/adr/0035-authorization-required-default-deny-switch",
               },
+              {
+                text: "0036 — policy gains entity- and global-scope defaults",
+                link: "/internals/adr/0036-policy-gains-entity-and-global-defaults",
+              },
             ],
           },
         ],

--- a/docs/features/policy.md
+++ b/docs/features/policy.md
@@ -15,7 +15,7 @@ import { and, authenticated, filtered, or, owner, permission, role } from "@kavo
 })
 ```
 
-That config makes `POST /posts` require a signed-in caller, `GET /posts` pass for an `admin` or a signed-in caller whose query filters `userId`, `GET /posts/:id` pass for an `admin` or the row's author, and `PUT /posts/:id` require both the `post:update` permission and authorship. `patchOne` and `deleteOne` have no entry, so they run for any caller: an operation with no `policy.<id>` is unrestricted by default, the same opt-in posture every other Kavo default takes, and adding an entry is how an entity opts in — there is still no global switch that populates `policy` itself. [`authorization.required`](#default-deny-authorization-required) is a separate, genuinely global switch for the opposite question: what happens when nothing was configured at all.
+That config makes `POST /posts` require a signed-in caller, `GET /posts` pass for an `admin` or a signed-in caller whose query filters `userId`, `GET /posts/:id` pass for an `admin` or the row's author, and `PUT /posts/:id` require both the `post:update` permission and authorship. `patchOne` and `deleteOne` have no entry, so they fall back to whatever `EntityConfig.policy`/`GlobalConfig.policy` default is in force (below), or run for any caller if neither is set: an operation with no policy at any scope is unrestricted by default, the same opt-in posture every other Kavo default takes. [`authorization.required`](#default-deny-authorization-required) is a separate switch for the opposite question: what happens when nothing was configured at _any_ scope.
 
 ## Node types
 
@@ -61,7 +61,19 @@ The `permission`, `role`, `owner`, and `authenticated` nodes cast `context.princ
 
 ## Config placement
 
-`policy` is set per operation, at `operations.<id>.policy` (ADR-0032, amended by ADR-0033) — there is no entity-scope `policy` map to fall back to; an entity that still passes a root-level `policy` map gets a bootstrap error naming the new location. There is no global `policy` and no per-call override either: like `computed`, a `when()` predicate carries a closure, so the key lives outside the settings precedence chain, and a per-call parameter that could loosen a rule would let a caller weaken its own authorization. [Entity config](/guides/configuration/entity-config) covers where the field sits among `@Kavo`'s own keys.
+`policy` resolves nearest-scope-wins across three places (ADR-0032, amended by ADR-0033 and ADR-0036): `operations.<id>.policy`, then the entity's own `policy` (`EntityConfig.policy` — one node, applied as the default for every operation that configures none of its own), then a root-level default set once at `createKavo({ policy })` (`GlobalConfig.policy`). Whichever scope defines a node wins outright — scopes are never merged field-by-field, only replaced wholesale — and `operations.<id>.policy: false` opts one operation back out of an inherited entity- or global-scope default:
+
+```ts
+@Kavo(Post, {
+  policy: authenticated(), // default for every operation on this entity
+  operations: {
+    updateOne: { policy: and(permission("post:update"), owner("authorId")) }, // overrides the default
+    findMany: { policy: false }, // explicitly public, opts out of the default
+  },
+})
+```
+
+Like `computed`, `policy` lives outside the settings precedence chain at every scope — a `when()` predicate carries a closure, and `PolicyNode` is a discriminated union a field-by-field settings merge would corrupt — so `GlobalConfig.policy` is its own field rather than a `KavoSettings` key inside `defaults`. There is still no per-call override at any scope: a per-call parameter that could loosen a rule would let a caller weaken its own authorization. [Entity config](/guides/configuration/entity-config) covers where the field sits among `@Kavo`'s own keys.
 
 ## Default deny (`authorization.required`)
 
@@ -82,7 +94,7 @@ KavoModule.forRoot({
 })
 ```
 
-Unlike `policy` itself, `authorization` is an ordinary `KavoSettings` key: it merges through the usual `built-in defaults → global → entity → operation` chain, so a global default (`KavoModule.forRoot`'s `defaults`), an entity default, and a per-operation override all compose the way `cache`/`realtime`/every other settings key does. It is a genuinely different mechanism from `policy` — a settings subtree that governs _what happens when `policy` has nothing configured_, not a way to populate `policy` from outside an entity's own config; `policy`'s own "no global, no per-call" rule (above) is unchanged.
+Unlike `policy` itself, `authorization` is an ordinary `KavoSettings` key: it merges through the usual `built-in defaults → global → entity → operation` chain, so a global default (`KavoModule.forRoot`'s `defaults`), an entity default, and a per-operation override all compose the way `cache`/`realtime`/every other settings key does — `policy`'s three scopes (above) are resolved by their own nearest-wins walk instead, not `mergeSettings`. `authorization.required` remains a genuinely different mechanism from `policy`, even though both now have a global default: it governs _what happens when `policy`'s own fallback chain resolved to nothing at all_ (operation, entity, and global all silent), never overriding a `policy` node that scope chain did resolve — including one an operation opted out of with `policy: false`, which counts as "resolved to nothing" the same as never having configured one. `policy`'s "no per-call override" rule (above) is unchanged.
 
 **Per-call is the one scope excluded.** A per-call `{ settings: { authorization: { required: false } } }` cannot loosen an entity that requires it, and — symmetrically, since the whole subtree is pinned rather than merged — a per-call override cannot tighten an entity that doesn't either. The reasoning is the same ADR-0032 gives for `policy` itself: a per-call parameter able to loosen enforcement would let a caller weaken its own authorization.
 

--- a/docs/guides/configuration/entity-config.md
+++ b/docs/guides/configuration/entity-config.md
@@ -1,6 +1,6 @@
 # Entity config
 
-`@Kavo(Entity, config)` accepts every settings field from [Settings](/guides/configuration/settings) one level above global, plus four fields that only make sense per entity: `dto`, `allowlists` (see [Allowlists](/features/allowlists)), `computed` (see [Computed fields](/features/computed-fields)), and `operations` (its own page, see [Operations](/guides/configuration/operations#operations-1)) — which is also where `policy` (below) is configured, per operation.
+`@Kavo(Entity, config)` accepts every settings field from [Settings](/guides/configuration/settings) one level above global, plus fields that only make sense per entity: `dto`, `allowlists` (see [Allowlists](/features/allowlists)), `computed` (see [Computed fields](/features/computed-fields)), `policy` (below, an entity-wide default), and `operations` (its own page, see [Operations](/guides/configuration/operations#operations-1)) — which is also where `policy` may be overridden per operation.
 
 ## dto
 
@@ -34,17 +34,19 @@ Moved to [Allowlists](/features/allowlists) and [Computed fields](/features/comp
 
 ## policy
 
-Authorization, set per operation at `operations.<id>.policy` (ADR-0032, ADR-0033). An operation with no `policy` runs unrestricted:
+Authorization (ADR-0032, amended by ADR-0033 and ADR-0036), resolved nearest-scope-wins across `operations.<id>.policy`, the entity's own `policy` (one default node, applied to every operation that configures none of its own), and a root-level `createKavo({ policy })` default. An operation with no policy at any of the three scopes runs unrestricted:
 
 ```ts
-import { and, owner, permission } from "@kavo/core";
+import { and, authenticated, owner, permission } from "@kavo/core";
 
 @Kavo(Post, {
+  policy: authenticated(), // default for every operation on this entity
   operations: {
-    updateOne: { policy: and(permission("post:update"), owner("authorId")) },
+    updateOne: { policy: and(permission("post:update"), owner("authorId")) }, // overrides the default
     deleteOne: { policy: and(permission("post:delete"), permission("admin")) }, // every name required
+    findMany: { policy: false }, // explicitly public, opts out of the entity-level default
   },
 })
 ```
 
-`owner`/`when` need the loaded row, so they're only legal on the single-row operations (`findOne`/`updateOne`/`patchOne`/`deleteOne`/`restoreOne`/`purgeOne`) — configuring either on `createOne`/`findMany` is a bootstrap error. There is no entity-scope `policy` map to fall back to — `operations.<id>.policy` is the only place a policy is declared. See [Policy](/features/policy) for the node reference and how the stage behaves, and [Wiring your own auth](/guides/wiring-your-own-auth) for getting the caller onto `context.principal`.
+`owner`/`when` need the loaded row, so they're only legal on the single-row operations (`findOne`/`updateOne`/`patchOne`/`deleteOne`/`restoreOne`/`purgeOne`) — configuring either on `createOne`/`findMany` is a bootstrap error, whether declared on the operation directly or inherited from an entity/global default. See [Policy](/features/policy) for the node reference, the full scope-resolution rules, and how the stage behaves, and [Wiring your own auth](/guides/wiring-your-own-auth) for getting the caller onto `context.principal`.

--- a/docs/guides/configuration/index.md
+++ b/docs/guides/configuration/index.md
@@ -6,7 +6,7 @@
 built-in defaults → global (KavoModule) → entity (@Kavo config) → operation (operations.<id>) → per-call
 ```
 
-If you don't set a field at a given scope, it falls through to the next one down. The full merge rules (deep-merge behavior, what "unset" means per field) are in [Configuration](/internals/architecture/08-configuration). `policy` is the one field that doesn't follow this chain: operation scope only — no entity-scope map, no global default, and no per-call override (ADR-0032, ADR-0033) — a per-call parameter that could loosen a policy would let a caller weaken its own authorization. These pages document what each field means and where to set it:
+If you don't set a field at a given scope, it falls through to the next one down. The full merge rules (deep-merge behavior, what "unset" means per field) are in [Configuration](/internals/architecture/08-configuration). `policy` doesn't follow this chain's merge algebra: it resolves nearest-scope-wins across global (`createKavo({ policy })`), entity (`@Kavo` config), and operation (`operations.<id>.policy`) — the nearest scope that defines a node replaces every farther one wholesale rather than merging field-by-field — and has no per-call override at any scope (ADR-0032, amended by ADR-0033 and ADR-0036): a per-call parameter that could loosen a policy would let a caller weaken its own authorization. These pages document what each field means and where to set it:
 
 - **[Module setup](/guides/configuration/module-setup)**: `KavoModule.forRoot`/`forRootAsync`, and the `principal` extractor.
 - **[Settings](/guides/configuration/settings)**: the app-wide `KavoSettings` fields: pagination, query, errors, relations, arrayMutation, cache, softDelete, realtime.

--- a/docs/internals/adr/0032-policy-authorization-dsl.md
+++ b/docs/internals/adr/0032-policy-authorization-dsl.md
@@ -2,14 +2,19 @@
 
 **Status:** accepted (the "Config surface" section's entity-scope `policy`
 map is amended by [ADR-0033](/internals/adr/0033-policy-moves-to-operation-scope-only) —
-`operations.<id>.policy` is now the only place `policy` is configured; the
+`operations.<id>.policy` became the only place `policy` was configured; the
 array shorthand the "The node types" and "Config surface" sections describe
 below was removed — issue #242 — since the `PolicyNode` DSL already covers
 everything it could express. `policy` now takes a `PolicyNode<Entity>` only.
 "The node types" section's `when(predicate)` signature is further amended by
 [ADR-0034](/internals/adr/0034-when-predicate-takes-a-single-object-argument) —
 the predicate now takes one object argument, `{ context, entity, resource,
-operation, params }`, not `(context, entity?)`.)
+operation, params }`, not `(context, entity?)`. The "Config surface"
+section's "no global `policy`, no entity-scope fallback" posture is further
+amended by [ADR-0036](/internals/adr/0036-policy-gains-entity-and-global-defaults) —
+`policy` gains an entity-scope default (a single node, not the per-operation
+map ADR-0033 removed) and a global-scope default; the "no per-call override"
+half is unchanged.)
 
 ## Context
 

--- a/docs/internals/adr/0033-policy-moves-to-operation-scope-only.md
+++ b/docs/internals/adr/0033-policy-moves-to-operation-scope-only.md
@@ -1,6 +1,6 @@
 # ADR-0033 — `policy` moves to operation scope only
 
-**Status:** accepted — amends [ADR-0032](/internals/adr/0032-policy-authorization-dsl)'s "Config surface" section
+**Status:** superseded by [ADR-0036](/internals/adr/0036-policy-gains-entity-and-global-defaults), which reintroduces an entity-scope `policy` (a single default node, not the per-operation map this ADR removed) and adds a global scope — amends [ADR-0032](/internals/adr/0032-policy-authorization-dsl)'s "Config surface" section
 
 ## Context
 

--- a/docs/internals/adr/0035-authorization-required-default-deny-switch.md
+++ b/docs/internals/adr/0035-authorization-required-default-deny-switch.md
@@ -1,6 +1,10 @@
 # ADR-0035 — `authorization.required` denies standard operations with no configured policy
 
-**Status:** accepted
+**Status:** accepted (the closing Consequence's "does not reopen ADR-0032's
+'no global `policy`' decision" is superseded by
+[ADR-0036](/internals/adr/0036-policy-gains-entity-and-global-defaults),
+which gives `policy` a global scope — the two mechanisms stay orthogonal;
+see that ADR's "Interaction with `authorization.required`" section)
 
 ## Context
 

--- a/docs/internals/adr/0036-policy-gains-entity-and-global-defaults.md
+++ b/docs/internals/adr/0036-policy-gains-entity-and-global-defaults.md
@@ -1,0 +1,149 @@
+# ADR-0036 — `policy` gains entity- and global-scope defaults
+
+**Status:** accepted — supersedes [ADR-0033](/internals/adr/0033-policy-moves-to-operation-scope-only), amends [ADR-0032](/internals/adr/0032-policy-authorization-dsl)'s "Config surface" section and [ADR-0035](/internals/adr/0035-authorization-required-default-deny-switch)'s closing Consequence
+
+## Context
+
+ADR-0032 shipped `policy` at two surfaces — an entity-scope map
+(`EntityConfig.policy: Partial<Record<StandardOperationId, PolicyNode>>`)
+and a per-operation override, the latter winning when both were set.
+ADR-0033 removed the entity-scope surface: the map never had content of its
+own the way `dto`'s entity-derived default does, so it was only ever a
+second place to type the same per-operation rule, and a config that set both
+read as a trap rather than a feature. Since then, `operations.<id>.policy`
+has been the only surface, and `policy` has had no global scope at all —
+ADR-0035 said so explicitly when it declined to nest `authorization.required`
+under `policy` for exactly that reason.
+
+In practice, the common case an entity's authors reach for is not "a
+different rule per operation" but "the same rule on every write" —
+`authenticated()` on `createOne`/`updateOne`/`patchOne`/`deleteOne`, say.
+Under operation-scope-only, that means repeating the identical `PolicyNode`
+on every operation id, and a new operation added later silently runs
+unrestricted unless someone remembers to copy the line again. Issue #250
+asks for an entity-level and a global-level default that every operation
+inherits unless it says otherwise, plus a way for one operation to opt out
+of an inherited default explicitly.
+
+This is a different shape from the one ADR-0033 removed, not a plain
+revert: the pre-ADR-0033 entity map was **per-operation**, so it was a
+second complete spelling of the same rule set. What this ADR adds is a
+single **default node**, applied uniformly and only overridden where an
+operation names its own — the two surfaces can never disagree about the
+same operation, because the default only ever fills a gap the operation
+scope left open.
+
+## Decision
+
+**`policy` gets two more scopes, resolved nearest-defined-wins:**
+`operations.<id>.policy` → `EntityConfig.policy` → `GlobalConfig.policy` →
+unrestricted.
+
+- `EntityConfig.policy?: PolicyNode<Entity>` — one node, the default for
+  every operation on this entity that configures no `policy` of its own.
+  Structural entity-scope config, like `dto`/`computed` — resolved by its
+  own precedence walk in `resolveEntityConfig`, not `mergeSettings`, for the
+  same reason ADR-0032 gave: `when()` carries a closure, and the settings
+  tree is deep-frozen and merged field-by-field, which would corrupt a
+  discriminated union's shape rather than replace it wholesale.
+- `GlobalConfig.policy?: PolicyNode` — the root-level default, set at
+  `createKavo({ policy })`. **Deliberately not a `KavoSettings` field**,
+  unlike `authorization.required`: `GlobalConfig.defaults` is typed
+  `DeepPartial<KavoSettings>`, and `DeepPartialValue`'s conditional
+  distributes over a union, so `DeepPartial<PolicyNode>` would partialize
+  every branch of the discriminated union independently — `{ type?:
+"permission"; name?: string } | { type?: "owner"; field?: string } | …`
+  — erasing the discriminant and admitting a malformed node the type system
+  can no longer catch. `GlobalConfig` gets its own `policy` field, sibling
+  to `defaults`, the same way `EntityConfig.policy` sits beside (not inside)
+  `DeepPartial<KavoSettings>`.
+- `OperationConfig.policy` widens to `PolicyNode<Entity> | false`. `false`
+  opts that one operation out of an inherited entity- or global-scope
+  default, back to unrestricted — the only way to spell "no policy here" once
+  a default exists to inherit from, since omitting the key means "inherit,"
+  not "none." `EntityConfig.policy`/`GlobalConfig.policy` do **not** accept
+  `false` — there is nothing above global scope to opt out of, and an entity
+  wanting every operation unrestricted despite a global default can still
+  reach that with `operations.<id>.policy: false` per operation, or simply
+  by not inheriting a global default it does not want (an entity's own
+  `policy`, once set, already replaces the global one wholesale for any
+  operation that does not itself override it).
+- **Resolution is wholesale, not deep-merged.** The nearest scope that
+  defines a value wins outright — an `authenticated()` at global scope and
+  an `owner('authorId')` at entity scope never combine into some third node;
+  entity scope simply replaces global scope for every operation it reaches.
+  This is `PolicyNode`'s only sound merge algebra: two node variants have
+  different fields, so a field-by-field merge (`mergeSettings`'s algebra)
+  would leave a stale field from one variant attached to the other's `type`.
+- **Bootstrap validation runs against the effective (resolved) node for
+  every operation, not only a node declared directly on that operation.**
+  An entity- or global-scope `owner`/`when` that inherits onto
+  `createOne`/`findMany` is exactly as unrunnable as one declared there
+  directly (ADR-0032's "Where entity-aware nodes are and aren't legal"), and
+  an inherited `owner(field)` crossing a relation boundary is exactly as
+  broken as one declared per-operation (the pre-fetch still loads no
+  relations). Both fail loudly at bootstrap, naming the operation the
+  inherited node reaches, the same bar every other check in
+  `resolveEntityConfig` holds to.
+- **Shape validation widens accordingly.** A `policy` value at any of the
+  three scopes must have a recognized `PolicyNode` `type` discriminant (the
+  new `isPolicyNode` guard, `packages/core/src/policy/kavo-policy.ts`) or be
+  the array shorthand ADR-0032 already rejects by name (issue #242) — this
+  is what catches the pre-ADR-0033 entity-scope map shape if a caller still
+  passes one: it has no `type` field, so it now fails as "not a PolicyNode"
+  rather than the ADR-0033-era "entity-scope map no longer supported"
+  message, since the field it is landing on has a different, real meaning
+  now.
+- **Still no per-call override.** `KavoEngine.configViewFor` continues to
+  pin `policy` to whatever bootstrap resolved, unaffected by this ADR — the
+  reasoning is ADR-0032's, unchanged: a per-call parameter able to loosen a
+  policy would let a caller weaken its own authorization.
+
+### Interaction with `authorization.required` (ADR-0035)
+
+ADR-0035's `authorization.required` is unaffected in mechanism: it fires
+only when the policy stage's per-operation lookup finds nothing, i.e. `node
+=== undefined` — after this ADR, that still means "operation scope said
+nothing, entity scope said nothing, global scope said nothing." An entity or
+global default now closes that gap more often than before, but the switch
+itself does not change: an operation with an _explicit_ `policy` (its own,
+or an inherited default) is still unaffected by `required` either way, and
+an operation `false`'d back to unrestricted is, correctly,
+**still exempt from `authorization.required`** — `false` resolves to `node
+=== undefined` for `checkPolicy`'s purposes (there is no rule, by the
+caller's own explicit choice), the same as an operation that never had a
+`policy` entry at all. This is intentional, not an oversight: `required`
+denies a _gap_ (nothing considered), while `false` is a considered decision
+to leave the operation open despite an inherited default; conflating the two
+would remove the one way this ADR gives an author to say "this one really is
+public."
+
+ADR-0035's Consequences bullet ("This does not reopen ADR-0032's 'no global
+`policy`' decision … `authorization.required` is a sibling switch over what
+happens when that map has nothing to say") is superseded by this ADR:
+`policy` **does** now have a global scope. The two mechanisms remain
+orthogonal, though, and that half of ADR-0035's reasoning still holds:
+`authorization.required` is not how a global default is populated — it
+still only governs the _absence_ of any policy at all, resolved _after_
+this ADR's fallback chain has already run and found nothing.
+
+## Consequences
+
+- `EntityConfig.policy` returns as a public field, with a different shape
+  and meaning than the one ADR-0033 removed (a single default, not a
+  per-operation map) — an application migrating from the pre-ADR-0033 shape
+  still needs to move a per-operation map into `operations.<id>.policy`
+  entries; only a single, entity-wide rule now has a shorter spelling.
+- `GlobalConfig`/`KavoOptions` gains `policy?: PolicyNode`, read once at
+  `createKavo`, threaded into every entity's `resolveEntityConfig` call.
+- `resolvePolicy` (`packages/core/src/config/resolve-entity-config.ts`) walks
+  three scopes instead of one and validates the _effective_ node per
+  operation, not only a directly-configured one.
+- `docs/features/policy.md`, `docs/guides/configuration/entity-config.md`,
+  `docs/guides/configuration/index.md`, and
+  `docs/internals/architecture/08-configuration.md` are updated to show the
+  three-scope form.
+- Nothing about the engine's enforcement point, pre-fetch behavior, 404-vs-403
+  handling, or `authorization.required`'s own mechanism changes — this ADR
+  is entirely about where a `PolicyNode` may be _declared_, not how one is
+  _evaluated_.

--- a/docs/internals/architecture/08-configuration.md
+++ b/docs/internals/architecture/08-configuration.md
@@ -60,13 +60,21 @@ participates in the merge. `computed` carries functions, so like `dto` it
 is entity-scope-only and never merges through the chain — see
 [ADR-0019](/internals/adr/0019-computed-fields-are-serializer-evaluated).
 `policy` is the same shape of exception, for the same reason (a `when()`
-node carries a closure), but it has no entity-scope map at all
-([ADR-0033](/internals/adr/0033-policy-moves-to-operation-scope-only)):
-`operations.<id>.policy` is the only place it is configured, and — unlike
-every ordinary settings key — it takes **no** per-call override either,
-since a per-call parameter that could loosen a policy would let a caller
-weaken its own authorization. See
-[ADR-0032](/internals/adr/0032-policy-authorization-dsl).
+node carries a closure, and `PolicyNode` is a discriminated union a
+field-by-field merge would corrupt): it resolves through its own
+nearest-scope-wins walk in `resolveEntityConfig` — `operations.<id>.policy`,
+then `EntityConfig.policy` (one default node for the whole entity), then a
+`GlobalConfig.policy` set once at `createKavo`
+([ADR-0032](/internals/adr/0032-policy-authorization-dsl), amended by
+[ADR-0033](/internals/adr/0033-policy-moves-to-operation-scope-only) and
+[ADR-0036](/internals/adr/0036-policy-gains-entity-and-global-defaults)) —
+never `mergeSettings`, and, unlike every ordinary settings key, it takes
+**no** per-call override at any of its three scopes, since a per-call
+parameter that could loosen a policy would let a caller weaken its own
+authorization. `GlobalConfig.policy` is deliberately not a `KavoSettings`
+field even though it is `policy`'s global-scope home — `DeepPartial`
+(what `GlobalConfig.defaults` is typed as) would partialize each branch of
+the `PolicyNode` union independently, erasing its discriminant.
 
 `authorization` (governing `authorization.required`, the `policy`
 default-deny switch) is, by contrast, an **ordinary** `KavoSettings` key —
@@ -165,16 +173,24 @@ bootstrap rather than as a surprising response later
 An `owner`/`when` node — the two whose result depends on the loaded row,
 not only on `context` — configured on `createOne` or `findMany` fails at
 bootstrap ([ADR-0032](/internals/adr/0032-policy-authorization-dsl)): the
-former has no row yet, the latter resolves a set rather than one. The
-error names the entity and the `operations.<id>.policy` path, the same bar
-every other entry in this section holds to. `permission`/`role`/
+former has no row yet, the latter resolves a set rather than one. This is
+checked against the **effective** (resolved) node for every operation, not
+only one declared directly on it — an entity- or global-scope default that
+inherits onto `createOne`/`findMany` fails exactly the same way
+([ADR-0036](/internals/adr/0036-policy-gains-entity-and-global-defaults)).
+The error names the entity and the `operations.<id>.policy` path, the same
+bar every other entry in this section holds to. `permission`/`role`/
 `authenticated` are context-only and legal everywhere.
 
-One more `policy` shape fails the same way rather than silently misbehaving
+Two more `policy` shapes fail the same way rather than silently misbehaving
 at request time: an `owner(field)` whose first dotted segment names a
-relation (the pre-fetch loads no relations, so it could never pass). A
-root-level `policy` map — the pre-ADR-0033 entity-scope shape — is rejected
-outright, naming `operations.<id>.policy` as the replacement.
+relation (the pre-fetch loads no relations, so it could never pass), checked
+the same way whether declared or inherited; and a value with no recognized
+`PolicyNode` `type` discriminant, which catches the pre-ADR-0033
+per-operation entity-scope map shape (`{ updateOne: permission(...) }`) if a
+caller still passes one — it has no `type` field, so it fails as "not a
+PolicyNode" rather than being silently ignored, at whichever of the three
+scopes it landed on.
 
 ### `query.defaultSort`
 

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -154,16 +154,21 @@ export interface OperationConfig<Entity = unknown, DtoOverride = OperationDtoOve
    */
   readonly dto?: DtoOverride;
   /**
-   * Authorization for this operation (ADR-0032, amended by ADR-0033) — the
-   * only surface `policy` is configured on; there is no entity-scope
-   * `policy` map to fall back to. Absent, the operation runs unrestricted:
-   * the same opt-in posture every other Kavo default takes. `owner`/`when`
-   * nodes are only meaningful on a single-row operation
+   * Authorization for this operation (ADR-0032, amended by ADR-0033 and
+   * ADR-0036). Nearest scope wins, wholesale: this overrides the entity's
+   * own `EntityConfig.policy`, which overrides the root `GlobalConfig.policy`
+   * (`createKavo({ policy })`). `false` opts this operation back out of an
+   * inherited entity- or global-scope default, back to unrestricted — the
+   * only way to spell that, since omitting the key here instead means
+   * "inherit," not "no policy." Absent every scope, the operation runs
+   * unrestricted: the same opt-in posture every other Kavo default takes.
+   * `owner`/`when` nodes are only meaningful on a single-row operation
    * (`findOne`/`updateOne`/`patchOne`/`deleteOne`/`restoreOne`/`purgeOne`);
    * on `createOne`/`findMany` they are a bootstrap `ConfigurationException`
-   * (`resolveEntityConfig`), since no single entity exists yet to check.
+   * (`resolveEntityConfig`), since no single entity exists yet to check —
+   * this applies to an inherited node too, not just one declared here.
    */
-  readonly policy?: PolicyNode<Entity>;
+  readonly policy?: PolicyNode<Entity> | false;
 }
 
 /**
@@ -364,6 +369,23 @@ export interface EntityConfig<
   >,
 > extends Omit<DeepPartial<KavoSettings>, "operations"> {
   readonly dto?: OperationDtoMap<Entity, CreateDto, UpdateDto, PatchDto, QueryDto, ItemDto, ListDto>;
+  /**
+   * Default authorization for every operation on this entity (ADR-0036,
+   * reintroducing entity scope after ADR-0033 removed it — see that ADR for
+   * why this is a single default-for-all-operations node rather than the
+   * pre-ADR-0033 per-operation map: a map invited "which of the two spots
+   * governs `updateOne`?"; a plain default that `operations.<id>.policy`
+   * overrides (or opts out of with `false`) does not.
+   *
+   * Structural entity-scope config like `dto`/`computed` — outside the
+   * settings precedence chain (`policy` still carries `when()`'s closure) —
+   * resolved by its own "nearest scope wins" walk, not `mergeSettings`.
+   * Falls back to `GlobalConfig.policy` (`createKavo({ policy })`) when
+   * unset here; overridden per operation by `operations.<id>.policy`,
+   * including `operations.<id>.policy: false` to opt one operation out.
+   * There is still no per-call override (ADR-0032).
+   */
+  readonly policy?: PolicyNode<Entity>;
   /**
    * Computed (virtual) response fields, keyed by the name each serializes
    * as — structural entity-scope config like `dto`, deliberately outside

--- a/packages/core/src/config/global-config.ts
+++ b/packages/core/src/config/global-config.ts
@@ -1,5 +1,6 @@
 import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
+import type { PolicyNode } from "../policy/kavo-policy.js";
 
 /**
  * Raw global (framework-scope) configuration — the argument to
@@ -10,4 +11,26 @@ import type { DeepPartial } from "../types/utility.js";
 export interface GlobalConfig {
   /** Framework-wide defaults, merged below entity/operation scope. */
   readonly defaults?: DeepPartial<KavoSettings>;
+  /**
+   * Framework-wide default policy (ADR-0036, amending ADR-0032/ADR-0033):
+   * applied to every operation on every entity that configures no `policy`
+   * of its own, at either entity scope (`EntityConfig.policy`) or operation
+   * scope (`OperationConfig.policy`) — nearest scope wins, wholesale, not a
+   * field-by-field merge.
+   *
+   * Deliberately **not** a `KavoSettings` field, even though this is the
+   * settings tree's global-scope home: `PolicyNode` is a discriminated
+   * union, and `DeepPartial` (what `defaults` is typed as) partializes every
+   * branch independently, which would erase the discriminant and admit a
+   * malformed node the type system can no longer catch. `policy` stays a
+   * structural field at every scope it is configured on, `defaults` included
+   * — the same reason `EntityConfig.policy`/`OperationConfig.policy` sit
+   * beside `DeepPartial<KavoSettings>` rather than inside it.
+   *
+   * `operations.<id>.policy: false` still overrides this (or an entity's
+   * own `policy`) back to unrestricted for that one operation. There is
+   * still no per-call override — a per-call parameter that could loosen a
+   * policy would let a caller weaken its own authorization (ADR-0032).
+   */
+  readonly policy?: PolicyNode;
 }

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -13,7 +13,7 @@ import type { CacheStore } from "../caching/cache-store.js";
 import type { PolicyNode } from "../policy/kavo-policy.js";
 import { createMemoryCacheStore } from "../caching/cache-store.js";
 import { STANDARD_OPERATION_IDS } from "../operations/operation.js";
-import { collectOwnerFields, policyNeedsEntity } from "../policy/kavo-policy.js";
+import { collectOwnerFields, isPolicyNode, policyNeedsEntity } from "../policy/kavo-policy.js";
 import { BUILT_IN_DEFAULTS } from "./defaults.js";
 import { deepFreeze, mergeSettings } from "./merge-settings.js";
 import { validateSettings } from "./validate-settings.js";
@@ -74,11 +74,12 @@ export function resolveEntityConfig<Entity extends object>(
   globalDefaults: DeepPartial<KavoSettings> | undefined,
   realtimeTransports: readonly RealtimeTransport[] = [],
   cacheStore: CacheStore = createMemoryCacheStore(),
+  globalPolicy?: PolicyNode,
 ): ResolvedEntityConfig<Entity> {
   const entityName = metadata.name;
   const computed = resolveComputedFields(metadata, entityConfig);
   rejectComputedWriteDtoKeys(entityName, entityConfig, computed);
-  const policy = resolvePolicy(entityName, entityConfig, metadata);
+  const policy = resolvePolicy(entityName, entityConfig, metadata, globalPolicy);
   const allowlists = resolveAllowlists(metadata, entityConfig, computed);
   const projection = resolveProjection(metadata, entityConfig, computed, allowlists);
   const entitySettings = mergeSettings(
@@ -155,58 +156,78 @@ export function resolveEntityConfig<Entity extends object>(
 const ENTITY_AWARE_POLICY_FORBIDDEN: ReadonlySet<StandardOperationId> = new Set(["createOne", "findMany"]);
 
 /**
- * Reject a root-level `policy` map (pre-ADR-0033 shape): `policy` now
- * configures only per-operation, at `operations.<id>.policy`, so a caller
- * still passing the old entity-scope map gets a bootstrap error naming the
- * new location instead of the map being silently ignored.
+ * Reject a shape that cannot be a `PolicyNode`: the array shorthand issue
+ * #242 removed (TypeScript callers get a compile error instead, but this
+ * catches a JS or dynamically-built config the type system can't see), and
+ * — since ADR-0036 gave `policy` real content at every scope — anything else
+ * without a recognized `type` discriminant, including the pre-ADR-0033
+ * entity-scope `Partial<Record<StandardOperationId, PolicyNode>>` map, which
+ * would otherwise reach `evaluatePolicy`'s exhaustive switch, fall through
+ * to `undefined`, and silently deny every caller rather than failing loud
+ * here.
  */
-function rejectLegacyEntityLevelPolicy(entityName: string, entityConfig: EntityConfig<never> | undefined): void {
-  if (entityConfig === undefined || !("policy" in entityConfig) || entityConfig.policy === undefined) return;
-  throw new ConfigurationException(
-    entityName,
-    "policy",
-    `an entity-scope 'policy' map is no longer supported (ADR-0033) — configure each operation's policy at ` +
-      `'operations.<id>.policy' instead`,
-  );
+function assertPolicyShape(entityName: string, scope: string, node: unknown): asserts node is PolicyNode {
+  if (Array.isArray(node)) {
+    throw new ConfigurationException(
+      entityName,
+      scope,
+      `the array shorthand was removed (issue #242) — 'policy' now takes a PolicyNode only. ` +
+        `Use 'permission(name)', or 'and(permission(a), permission(b))' for what a multi-name array expressed.`,
+    );
+  }
+  if (!isPolicyNode(node)) {
+    throw new ConfigurationException(
+      entityName,
+      scope,
+      `'${scope}' must be a PolicyNode built with 'permission'/'role'/'owner'/'authenticated'/'filtered'/'when'/` +
+        `'and'/'or'/'not' — got ${JSON.stringify(node)}. A per-operation entry may also be 'false', to opt out of ` +
+        `an inherited entity- or global-scope default.`,
+    );
+  }
 }
 
 /**
- * Resolve `policy`: `operations.<id>.policy` alone (ADR-0033 — there is no
- * entity-scope 'policy' map to fall back to), validated against
- * {@link ENTITY_AWARE_POLICY_FORBIDDEN} (ADR-0032). Also rejects, at
- * bootstrap: a bare array (the shorthand issue #242 removed — TypeScript
- * callers get a compile error instead, but this catches a JS or
- * dynamically-built config the type system can't see, which would
- * otherwise reach `evaluatePolicy`'s exhaustive switch, fall through to
- * `undefined`, and silently deny every caller rather than failing loud
- * here); and an `owner(field)` whose first dotted segment names a relation
- * (the pre-fetch loads no relations, so it would silently deny every caller
- * instead of ever passing).
+ * Resolve `policy` (ADR-0032, amended by ADR-0033 and ADR-0036): nearest
+ * scope wins, wholesale — `operations.<id>.policy`, else `EntityConfig.policy`,
+ * else `GlobalConfig.policy`, else unrestricted. `operations.<id>.policy:
+ * false` opts one operation out of an inherited entity/global default.
+ *
+ * The effective node for every standard operation id is validated against
+ * {@link ENTITY_AWARE_POLICY_FORBIDDEN} (ADR-0032) and against a relation-
+ * crossing `owner(field)` — including one inherited from entity or global
+ * scope, not only one declared on the operation itself, since an inherited
+ * `owner`/`when` on `createOne`/`findMany` is exactly as unrunnable as one
+ * declared there directly.
  */
 function resolvePolicy<Entity extends object>(
   entityName: string,
   entityConfig: EntityConfig<Entity> | undefined,
   metadata: EntityMetadata<Entity>,
+  globalPolicy: PolicyNode | undefined,
 ): Readonly<Partial<Record<StandardOperationId, PolicyNode<Entity>>>> {
-  rejectLegacyEntityLevelPolicy(entityName, entityConfig as EntityConfig<never> | undefined);
   const relationNames = new Set(metadata.relations.map((relation) => relation.name));
+
+  const entityPolicy = entityConfig?.policy;
+  if (entityPolicy !== undefined) assertPolicyShape(entityName, "policy", entityPolicy);
+  if (globalPolicy !== undefined) assertPolicyShape(entityName, "policy (global default)", globalPolicy);
 
   const resolved: Partial<Record<StandardOperationId, PolicyNode<Entity>>> = {};
   for (const id of STANDARD_OPERATION_IDS) {
     const operationConfig = entityConfig?.operations?.[id];
-    const node =
+    const operationPolicy =
       typeof operationConfig === "object" && operationConfig !== null
         ? (operationConfig as OperationConfig<Entity>).policy
         : undefined;
-    if (node === undefined) continue;
-    if (Array.isArray(node)) {
-      throw new ConfigurationException(
-        entityName,
-        `operations.${id}.policy`,
-        `the array shorthand was removed (issue #242) — 'policy' now takes a PolicyNode only. ` +
-          `Use 'permission(name)', or 'and(permission(a), permission(b))' for what a multi-name array expressed.`,
-      );
+    if (operationPolicy !== undefined && operationPolicy !== false) {
+      assertPolicyShape(entityName, `operations.${id}.policy`, operationPolicy);
     }
+
+    const node: PolicyNode<Entity> | false | undefined =
+      operationPolicy !== undefined
+        ? operationPolicy
+        : ((entityPolicy ?? globalPolicy) as PolicyNode<Entity> | undefined);
+    if (node === undefined || node === false) continue;
+
     if (ENTITY_AWARE_POLICY_FORBIDDEN.has(id) && policyNeedsEntity(node)) {
       throw new ConfigurationException(
         entityName,

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -298,11 +298,16 @@ export interface ArrayMutationSettings {
 }
 
 /**
- * The default-deny switch for the `policy` stage (ADR-0033). `policy`
- * itself (`EntityConfig.policy`/`OperationConfig.policy`) is a structural
- * field, not a `KavoSettings` one, and has no global scope — this is a
- * deliberately separate, ordinary settings subtree so it gets one. `false`
- * is not accepted here (unlike `cache`/`realtime`/`softDelete`): there is
+ * The default-deny switch for the `policy` stage (ADR-0035). `policy`
+ * itself (`GlobalConfig.policy`/`EntityConfig.policy`/`OperationConfig.policy`,
+ * ADR-0036) is a structural field at every scope it is configured on, never
+ * a `KavoSettings` one — `PolicyNode` is a discriminated union `DeepPartial`
+ * would corrupt — so this stays a deliberately separate, ordinary settings
+ * subtree even though `policy` gained a global default of its own. The two
+ * remain distinct mechanisms: `authorization.required` only fills the gap
+ * where `policy`'s own fallback chain (operation → entity → global) resolved
+ * to nothing at all, it never overrides a resolved `policy` node. `false` is
+ * not accepted here (unlike `cache`/`realtime`/`softDelete`): there is
  * nothing else in this subtree to disable wholesale, so the plain object is
  * always the shape.
  */
@@ -335,7 +340,7 @@ export interface KavoSettings {
    * relation anything by itself.
    */
   readonly arrayMutation: ArrayMutationSettings | false;
-  /** The `policy` default-deny switch (ADR-0033). Excluded from per-call override — see `KavoEngine.configViewFor`. */
+  /** The `policy` default-deny switch (ADR-0035). Excluded from per-call override — see `KavoEngine.configViewFor`. */
   readonly authorization: AuthorizationSettings;
   /**
    * Global operation enablement, keyed by standard operation id — booleans

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -147,6 +147,7 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
         options.defaults,
         options.realtimeTransports,
         cacheStore,
+        options.policy,
       );
       // `builtInHandlers()` takes no adapter: the built-ins read the
       // request's `context.repository`, which the engine below fills from

--- a/packages/core/src/policy/kavo-policy.ts
+++ b/packages/core/src/policy/kavo-policy.ts
@@ -141,6 +141,34 @@ export function not<Entity = unknown>(child: PolicyNode<Entity>): PolicyNode<Ent
   return { type: "not", child };
 }
 
+const POLICY_NODE_TYPES: ReadonlySet<PolicyNode["type"]> = new Set([
+  "permission",
+  "role",
+  "owner",
+  "authenticated",
+  "filtered",
+  "when",
+  "and",
+  "or",
+  "not",
+]);
+
+/**
+ * `true` when `value` has the shape of a `PolicyNode` — a recognized `type`
+ * discriminant, nothing more. Not a proof it evaluates correctly (a `when`
+ * predicate's function is not otherwise checkable), but enough for
+ * `resolveEntityConfig` to catch a stray shorthand (the pre-ADR-0033
+ * entity-scope map, an array) reaching a `policy` field at bootstrap rather
+ * than silently falling through `evaluatePolicy`'s switch to `undefined`.
+ */
+export function isPolicyNode<Entity>(value: unknown): value is PolicyNode<Entity> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    POLICY_NODE_TYPES.has((value as { type?: unknown }).type as PolicyNode["type"])
+  );
+}
+
 function principalOf<Entity>(context: KavoContext<Entity>): KavoPrincipal {
   return (context.principal as KavoPrincipal | null | undefined) ?? {};
 }

--- a/packages/core/tests/policy.spec.ts
+++ b/packages/core/tests/policy.spec.ts
@@ -266,7 +266,7 @@ describe("policy — entity-aware nodes need the loaded row", () => {
 });
 
 describe("policy — bootstrap validation", () => {
-  it("rejects an entity-level 'policy' map, pointing at operations.<id>.policy instead", () => {
+  it("rejects a malformed entity-level 'policy' value — including the pre-ADR-0033 per-operation map shape, which has no PolicyNode 'type'", () => {
     expect(() => makeCrud({ policy: { updateOne: permission("post:update") } } as never)).toThrowError(
       ConfigurationException,
     );
@@ -275,13 +275,19 @@ describe("policy — bootstrap validation", () => {
       expect.unreachable();
     } catch (error) {
       expect(error).toMatchObject({ code: "KAVO_CONFIG_INVALID" });
-      expect((error as ConfigurationException).detail).toContain("at 'policy'");
-      expect((error as ConfigurationException).detail).toContain("operations.<id>.policy");
+      expect((error as ConfigurationException).detail).toContain("'policy'");
+      expect((error as ConfigurationException).detail).toContain("PolicyNode");
     }
   });
 
-  it("rejects an entity-level 'policy' map even when empty — presence, not content, is what's rejected", () => {
+  it("rejects an entity-level 'policy' value that is an empty object", () => {
     expect(() => makeCrud({ policy: {} } as never)).toThrowError(ConfigurationException);
+  });
+
+  it("rejects a malformed global (createKavo) 'policy' value the same way", () => {
+    expect(() => makeCrud(undefined, { policy: { updateOne: permission("post:update") } } as never)).toThrowError(
+      ConfigurationException,
+    );
   });
 
   it("rejects a bare array reaching 'policy' at runtime, since TypeScript can't catch a JS or dynamically-built config", () => {
@@ -320,6 +326,105 @@ describe("policy — bootstrap validation", () => {
   it("rejects an owner() field that crosses a relation, since the pre-fetch loads no relations", () => {
     expect(() => makeCrud({ operations: { updateOne: { policy: owner("author.id") } } } as never)).toThrowError(
       ConfigurationException,
+    );
+  });
+
+  it("rejects an entity-aware entity-level default that inherits onto createOne, not just one declared there directly", () => {
+    expect(() => makeCrud({ policy: owner("authorId") } as never)).toThrowError(ConfigurationException);
+  });
+
+  it("rejects an entity-aware global default that inherits onto findMany", () => {
+    expect(() => makeCrud(undefined, { policy: when<Post>(() => true) } as never)).toThrowError(ConfigurationException);
+  });
+
+  it("rejects an inherited entity-level owner() field that crosses a relation", () => {
+    expect(() => makeCrud({ policy: owner("author.id") } as never)).toThrowError(ConfigurationException);
+  });
+});
+
+describe("policy — entity-level and global default (ADR-0036)", () => {
+  it("an entity-level default policy applies to every operation that configures none of its own", async () => {
+    const { crud, adapter } = makeCrud({ policy: authenticated() } as never);
+    adapter.rows.push({ id: 1, title: "a", authorId: 0, author: null, comments: [], deletedAt: null } as Post);
+
+    await expect(crud.updateOne(1, { title: "b" } as never)).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(crud.updateOne(1, { title: "b" } as never, { principal: OWNER })).resolves.toMatchObject({
+      title: "b",
+    });
+    await expect(crud.findMany(undefined)).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(crud.findMany(undefined, { principal: OWNER })).resolves.toMatchObject({
+      items: [{ title: "b" }],
+    });
+  });
+
+  it("operations.<id>.policy overrides an inherited entity-level default with a different rule", async () => {
+    const { crud, adapter } = makeCrud({
+      policy: authenticated(),
+      operations: { updateOne: { policy: permission("post:update") } },
+    } as never);
+    adapter.rows.push({ id: 1, title: "a", authorId: 0, author: null, comments: [], deletedAt: null } as Post);
+
+    // Merely authenticated is not enough for updateOne: its own rule wins.
+    await expect(crud.updateOne(1, { title: "b" } as never, { principal: OWNER })).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    await expect(
+      crud.updateOne(1, { title: "b" } as never, { principal: { permissions: ["post:update"] } }),
+    ).resolves.toMatchObject({ title: "b" });
+    // findMany still falls back to the entity-level default.
+    await expect(crud.findMany(undefined)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("operations.<id>.policy: false opts one operation out of an inherited entity-level default", async () => {
+    const { crud } = makeCrud({
+      policy: authenticated(),
+      operations: { findMany: { policy: false } },
+    } as never);
+    await expect(crud.findMany(undefined)).resolves.toMatchObject({ items: [] });
+    await expect(crud.createOne({ title: "x", authorId: "u-1" } as never)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("a global (createKavo) default policy applies when neither entity nor operation configures one", async () => {
+    const { crud, adapter } = makeCrud(undefined, { policy: authenticated() });
+    adapter.rows.push({ id: 1, title: "a", authorId: 0, author: null, comments: [], deletedAt: null } as Post);
+    await expect(crud.updateOne(1, { title: "b" } as never)).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(crud.updateOne(1, { title: "b" } as never, { principal: OWNER })).resolves.toMatchObject({
+      title: "b",
+    });
+  });
+
+  it("operations.<id>.policy: false opts an operation out of an inherited global default", async () => {
+    const { crud } = makeCrud({ operations: { findMany: { policy: false } } } as never, {
+      policy: authenticated(),
+    });
+    await expect(crud.findMany(undefined)).resolves.toMatchObject({ items: [] });
+    await expect(crud.createOne({ title: "x", authorId: "u-1" } as never)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("precedence is nearest-defined-wins: operation over entity over global", async () => {
+    const { crud, adapter } = makeCrud(
+      {
+        policy: permission("entity:default"),
+        operations: { updateOne: { policy: permission("operation:override") } },
+      } as never,
+      { policy: permission("global:default") },
+    );
+    adapter.rows.push({ id: 1, title: "a", authorId: 0, author: null, comments: [], deletedAt: null } as Post);
+
+    // updateOne: operation-level wins over both entity and global.
+    await expect(
+      crud.updateOne(1, { title: "b" } as never, { principal: { permissions: ["operation:override"] } }),
+    ).resolves.toMatchObject({ title: "b" });
+    await expect(
+      crud.updateOne(1, { title: "b" } as never, { principal: { permissions: ["entity:default"] } }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    // findMany has no operation-level entry: entity-level wins over global.
+    await expect(crud.findMany(undefined, { principal: { permissions: ["entity:default"] } })).resolves.toMatchObject({
+      items: [{ title: "b" }],
+    });
+    await expect(crud.findMany(undefined, { principal: { permissions: ["global:default"] } })).rejects.toBeInstanceOf(
+      ForbiddenException,
     );
   });
 });

--- a/packages/frameworks/nest/tests/policy-legacy-config-rejection.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/policy-legacy-config-rejection.e2e.spec.ts
@@ -7,7 +7,7 @@ import { Kavo, KavoModule } from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 
 /**
- * `resolveEntityConfig`'s rejection of a root-level `policy` map
+ * `resolveEntityConfig`'s rejection of a malformed `policy` value
  * (`packages/core/tests/policy.spec.ts` pins the core-level behavior
  * directly) only actually runs once `createCrud` is called — for a
  * `@Kavo`-decorated class that happens in `KavoBinder.onModuleInit`
@@ -17,9 +17,15 @@ import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-in
  * `KavoModule`'s bootstrap sequence, the same integration-check shape
  * `array-mutation-route-reachable.e2e.spec.ts` uses for its own
  * `createCrud`-time bootstrap error.
+ *
+ * The entity-scope `policy` field is real again since ADR-0036, but the
+ * pre-ADR-0033 shape — a `Partial<Record<StandardOperationId,
+ * PolicyShorthand>>` map — is still not a `PolicyNode` (it has no `type`
+ * discriminant), so it still fails, just with a different message: "not a
+ * PolicyNode" rather than "entity-scope map no longer supported."
  */
-describe("KavoModule — legacy entity-level 'policy' map (ADR-0033)", () => {
-  it("rejects at bootstrap, naming operations.<id>.policy as the replacement", async () => {
+describe("KavoModule — malformed entity-level 'policy' value (the pre-ADR-0033 per-operation map shape)", () => {
+  it("rejects at bootstrap, naming 'policy' and requiring a PolicyNode", async () => {
     @Kavo(Todo, { policy: { updateOne: ["todo:update"] } } as never)
     @Controller("todos")
     class TodoController {}
@@ -38,6 +44,6 @@ describe("KavoModule — legacy entity-level 'policy' map (ADR-0033)", () => {
     expect(error.code).toBe("KAVO_CONFIG_INVALID");
     expect(error.context.entityName).toBe("Todo");
     expect(error.messageParams).toMatchObject({ path: "policy" });
-    expect(error.detail).toContain("operations.<id>.policy");
+    expect(error.detail).toContain("PolicyNode");
   });
 });


### PR DESCRIPTION
## What & why

`policy` currently resolves only at `operations.<id>.policy` (ADR-0033), so an entity wanting the same authorization rule on every operation had to repeat it per operation id, and a new operation added later silently ran unrestricted unless someone remembered to copy the rule again.

`policy` now resolves nearest-scope-wins across three places: `operations.<id>.policy`, then `EntityConfig.policy` (one default node for the whole entity), then `GlobalConfig.policy` (`createKavo({ policy })`). `operations.<id>.policy: false` opts one operation out of an inherited entity- or global-scope default, back to unrestricted.

`GlobalConfig.policy` is a field of its own rather than a `KavoSettings` key inside `defaults`: `DeepPartial` (what `defaults` is typed as) would partialize each branch of `PolicyNode`'s discriminated union independently, erasing the discriminant `defaults` relies on to stay sound — this is a deliberate deviation from the issue's literal wording, documented in the new ADR.

Bootstrap validation (an entity-aware node on `createOne`/`findMany`, an `owner()` field crossing a relation) now runs against the *effective* resolved node for every operation, not only one declared directly on it, since an inherited node is exactly as unrunnable. Shape validation widens to reject any value without a recognized `PolicyNode` `type` discriminant, which is what catches the pre-ADR-0033 per-operation entity-scope map shape if a caller still passes one.

Adds ADR-0036, superseding ADR-0033 and amending ADR-0032/ADR-0035; `authorization.required` (ADR-0035) is unaffected in mechanism and stays orthogonal — it still only fires when `policy`'s own three-scope chain resolves to nothing at all.

Closes #250

## Public API impact

`@kavo/core` barrel: no new exports. `EntityConfig.policy` (single `PolicyNode<Entity>` default) and `GlobalConfig.policy`/`KavoOptions.policy` are new optional fields on existing exported interfaces; `OperationConfig.policy` widens from `PolicyNode<Entity>` to `PolicyNode<Entity> | false`. All additive — nothing existing narrows or is removed.

## Testing

Added to `packages/core/tests/policy.spec.ts`: entity-level default applied across operations, operation-level override and `false` opt-out, global default applied, full operation > entity > global precedence, malformed entity/global policy value rejection (including the pre-ADR-0033 map shape), and inherited entity-aware/relation-crossing node rejection on `createOne`/`findMany`. Updated `packages/frameworks/nest/tests/policy-legacy-config-rejection.e2e.spec.ts` for the new rejection message.

`pnpm check`: build, typecheck, depcruise, and lint all pass; 2765/2765 real tests pass. The only failing suite is `examples/nest-typeorm/tests/app-cockroach.e2e.spec.ts` (a CockroachDB testcontainer health-check timeout) — pre-existing and unrelated: the spec has zero references to `policy`, and it fails identically against a clean `main` checkout with no changes applied, in this sandboxed environment. `pnpm docs:links` and `pnpm format:check` both pass.

## Review notes

Please double-check the choice to put `policy` on `GlobalConfig` rather than literally inside `KavoSettings` as the issue's example wording suggested — ADR-0036's Decision section explains why (`DeepPartial` would corrupt the discriminated union). Also worth a look: whether `EntityConfig.policy`/`GlobalConfig.policy` should also accept `false` for symmetry with the operation-level override — I scoped that out since the issue only asked for it at operation level, but an entity wanting to fully opt out of an inherited *global* default currently has to do it per-operation.