### PR TITLE
refactor(core): simplify cache.etag to a plain boolean

### DIFF
--- a/docs/reference/config-keys.md
+++ b/docs/reference/config-keys.md
@@ -61,12 +61,11 @@ Whether a relation is includable at all is `allowlists.includable` (entity scope
 
 ## cache
 
-| Key                  | Type                     | Default |
-| -------------------- | ------------------------ | ------- |
-| `cache`              | `{ ttl, etag } \| false` | `false` |
-| `cache.ttl`          | `number` (seconds)       | `0`     |
-| `cache.etag`         | `boolean \| { enabled }` | `true`  |
-| `cache.etag.enabled` | `boolean`                | `true`  |
+| Key          | Type                     | Default |
+| ------------ | ------------------------ | ------- |
+| `cache`      | `{ ttl, etag } \| false` | `false` |
+| `cache.ttl`  | `number` (seconds)       | `0`     |
+| `cache.etag` | `boolean`                | `true`  |
 
 One subtree covers both halves of HTTP response caching. `cache.ttl` is the engine-level result cache that serves a repeated `findOne`/`findMany` read from a store without touching the adapter — a positive `ttl` turns it on, `0` (the default) means off, and there is no separate `enabled` key. `cache.etag` is the conditional-request machinery — the ETag on single-item responses plus `If-None-Match`/`If-Match`. `cache: false` turns both halves off together. The result cache's backing store is a live object registered on `KavoOptions.cacheStore`, not a settings key (ADR-0023, ADR-0031). See [Caching & ETags](/features/caching-and-etags) and [Result cache](/features/result-cache).
 

--- a/packages/core/src/caching/etag.ts
+++ b/packages/core/src/caching/etag.ts
@@ -14,16 +14,14 @@ import type { CacheSettings } from "../config/settings.js";
 /**
  * Whether the conditional-request machinery is on for a resolved `cache`
  * subtree (ADR-0031). `cache: false` turns etags off with the whole
- * subtree; otherwise `etag` answers — boolean shorthand or the object
- * form — independent of `cache.ttl`, so an entity with result caching
- * off still serves ETags. The engine and the framework layer both need
- * this resolved answer, which is why it lives here rather than in either.
+ * subtree; otherwise `etag` answers directly, independent of `cache.ttl`,
+ * so an entity with result caching off still serves ETags. The engine and
+ * the framework layer both need this resolved answer, which is why it
+ * lives here rather than in either.
  */
 export function isEtagEnabled(cache: CacheSettings | false): boolean {
   if (cache === false) return false;
-  if (cache.etag === true) return true;
-  if (cache.etag === false) return false;
-  return cache.etag.enabled;
+  return cache.etag;
 }
 
 /**

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -144,17 +144,16 @@ export interface RelationSettings {
 
 /**
  * The `etag` half of `cache` (ADR-0020) — the conditional-request
- * machinery. The boolean shorthand and the object form agree: `false` (and
- * `{ enabled: false }`) turns both halves of the feature off — no tag is
- * computed, `If-None-Match` is ignored, and an `If-Match` — the one header
- * whose whole purpose is to prevent a write — is **refused** with 412
+ * machinery. `false` turns the feature off — no tag is computed,
+ * `If-None-Match` is ignored, and an `If-Match` — the one header whose
+ * whole purpose is to prevent a write — is **refused** with 412
  * `KAVO_PRECONDITION_UNSUPPORTED` rather than ignored. Ignoring it would
  * answer 2xx for a guard that was never applied, which the per-operation
  * scope makes easy to arrive at by accident: `findOne` serving tags while
  * `updateOne` has `etag` off is a client holding a tag nothing will ever
  * check.
  */
-export type EtagSettings = boolean | { readonly enabled: boolean };
+export type EtagSettings = boolean;
 
 /**
  * Result caching and its ETag half (ADR-0031). `etag` is the
@@ -172,8 +171,7 @@ export type EtagSettings = boolean | { readonly enabled: boolean };
  * default) and an omitted `ttl` both mean "off"; `@Kavo(Entity,
  * { cache: { ttl: 60 } })` means "on, 60 seconds". Touching only `etag` on
  * an otherwise-off entity is then the natural spelling —
- * `cache: { etag: { enabled: false } }` — and never flips the result cache
- * on.
+ * `cache: { etag: false }` — and never flips the result cache on.
  *
  * `etag` defaults **on** (`true`) independent of `ttl`: an entity with
  * result caching off still serves ETags and honors the conditional

--- a/packages/core/src/config/validate-settings.ts
+++ b/packages/core/src/config/validate-settings.ts
@@ -142,7 +142,7 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
       throw new ConfigurationException(
         entityName,
         "cache",
-        `expected { ttl: number, etag: boolean | { enabled: boolean } } or false, got ${JSON.stringify(cache)} — ` +
+        `expected { ttl: number, etag: boolean } or false, got ${JSON.stringify(cache)} — ` +
           `to turn result caching and ETags off together, set 'cache' to false`,
       );
     }
@@ -153,18 +153,7 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
         `expected a non-negative integer (0 disables the result cache), got ${JSON.stringify(cache.ttl)}`,
       );
     }
-    const etag = cache.etag;
-    if (etag === true || etag === false) {
-      // boolean shorthand; nothing more to check
-    } else if (typeof etag === "object" && etag !== null) {
-      bool("cache.etag.enabled", etag.enabled);
-    } else {
-      throw new ConfigurationException(
-        entityName,
-        "cache.etag",
-        `expected true, false, or { enabled: boolean }, got ${JSON.stringify(etag)}`,
-      );
-    }
+    bool("cache.etag", cache.etag);
   }
 
   if (settings.softDelete !== false) {

--- a/packages/core/tests/config-validation.spec.ts
+++ b/packages/core/tests/config-validation.spec.ts
@@ -161,24 +161,15 @@ describe("validateSettings — errors", () => {
 });
 
 describe("validateSettings — cache", () => {
-  it("rejects a cache.etag that is neither a boolean nor an object", () => {
-    for (const value of ["false", 0, null]) {
+  it("rejects a cache.etag that is not a boolean", () => {
+    for (const value of ["false", 0, null, {}, { enabled: true }]) {
       expectRejected({ cache: { etag: value } }, "cache.etag", value);
     }
   });
 
-  it("rejects a cache.etag object without a boolean enabled", () => {
-    for (const value of [{}, { enabled: "yes" }]) {
-      const error = rejectionOf({ cache: { etag: value } });
-      expect(error.messageParams).toMatchObject({ entity: "User", path: "cache.etag.enabled" });
-    }
-  });
-
-  it("accepts the boolean shorthand and the object form", () => {
+  it("accepts the boolean shorthand", () => {
     expect(() => accept({ cache: { etag: true } })).not.toThrow();
     expect(() => accept({ cache: { etag: false } })).not.toThrow();
-    expect(() => accept({ cache: { etag: { enabled: true } } })).not.toThrow();
-    expect(() => accept({ cache: { etag: { enabled: false } } })).not.toThrow();
     expect(() => accept({ cache: false })).not.toThrow();
   });
 


### PR DESCRIPTION
## What

Narrows `EtagSettings` (`packages/core/src/config/settings.ts`) from `boolean | { readonly enabled: boolean }` to plain `boolean`. The object form was exactly equivalent to the shorthand — `isEtagEnabled` just unwrapped it to the same true/false — so it doubled the states callers and docs had to reason about for one bit of information, with no caller composing it with anything else.

`isEtagEnabled` (`packages/core/src/caching/etag.ts`) now reads `cache.etag` directly instead of unwrapping an object. `validateSettings`'s `cache.etag` check reuses the existing `bool()` helper instead of a bespoke object-shape check, with an updated error message. `docs/reference/config-keys.md` drops the now-nonexistent `cache.etag.enabled` row.

`docs/features/caching-and-etags.md`, `docs/guides/configuration/etag-overrides.md`, and ADRs 0020/0027/0031 were checked and already spelled `cache.etag` as boolean-only, so none needed edits.

## Why

Dead flexibility: the two shapes meant four states (`true`, `false`, `{ enabled: true }`, `{ enabled: false }`) to express one bit, and nothing in the codebase composed the object form with anything else.

Closes #248

## Public API impact

Breaking config-schema change: `EtagSettings` no longer accepts `{ enabled: boolean }`. Any caller passing that shape at any config scope (global/entity/operation/per-call) now fails `validateSettings` with `KAVO_CONFIG_INVALID`. No repo `CHANGELOG.md`/migration doc exists to update.

## Testing

`packages/core/tests/config-validation.spec.ts` updated: the old "accepts boolean and object form" test is now boolean-only, and the object-form rejection case (`{}`, `{ enabled: true }`) was added to the existing "rejects a non-boolean cache.etag" test.

`pnpm check`: build, typecheck, depcruise, and lint all green. 2521 tests passed, 341 skipped. 5 testcontainer-backed e2e suites (Postgres/MariaDB/CockroachDB/Mongo examples) failed to start with "Could not find a working container runtime strategy" — this environment has no Docker at all (`docker info` fails), and none of those suites touch cache/etag config; CI has Docker.

`pnpm docs:links`: passed.

## Review notes

None outstanding — the change is a straight type/validation narrowing with no behavior change to etag computation or precondition handling, as scoped by the issue.