### PR TITLE
Exclude id and soft-delete marker from default writable projection

### DIFF
--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -54,10 +54,18 @@ the defaults derive from:
   A registered DTO wins outright over the allowlist rather than
   intersecting with it: it is the narrower, more specific statement.
 - **Writable projection** (`create`/`update`/`patch` default): every
-  scalar column with `generated: false`. Generated columns (auto ids,
-  `@CreateDateColumn`, versions) can never be written from a request
-  body — the default deserializer silently strips them, which is the safe
-  posture in a system with no validation stage.
+  scalar column with `generated: false`, minus the primary key and the
+  resolved soft-delete marker field, which are excluded **regardless of**
+  `generated` — an app-assigned id or a marker column that isn't the ORM's
+  own delete-date column would otherwise be an ordinary writable field with
+  no other guard. Generated columns (auto ids, `@CreateDateColumn`,
+  versions) can never be written from a request body either — the default
+  deserializer silently strips all of these, which is the safe posture in a
+  system with no validation stage. An explicit write DTO can still name the
+  id or the marker field (a legitimate opt-in for a caller-assigned key);
+  `update`/`patch` write paths additionally strip both from the payload
+  before persisting, as defence in depth against reassigning an _existing_
+  row's identity or soft-delete state that way.
 - **Embedded objects** map to a `json`-kind column and travel as one
   opaque value; they are not flattened into sub-fields.
 

--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -55,17 +55,24 @@ the defaults derive from:
   intersecting with it: it is the narrower, more specific statement.
 - **Writable projection** (`create`/`update`/`patch` default): every
   scalar column with `generated: false`, minus the primary key and the
-  resolved soft-delete marker field, which are excluded **regardless of**
+  soft-delete marker field, which are excluded **regardless of**
   `generated` — an app-assigned id or a marker column that isn't the ORM's
   own delete-date column would otherwise be an ordinary writable field with
-  no other guard. Generated columns (auto ids, `@CreateDateColumn`,
-  versions) can never be written from a request body either — the default
-  deserializer silently strips all of these, which is the safe posture in a
-  system with no validation stage. An explicit write DTO can still name the
-  id or the marker field (a legitimate opt-in for a caller-assigned key);
-  `update`/`patch` write paths additionally strip both from the payload
-  before persisting, as defence in depth against reassigning an _existing_
-  row's identity or soft-delete state that way.
+  no other guard. The id is fixed metadata, so its exclusion is resolved
+  once; the marker is an ordinary settings key (entity → operation →
+  per-call, like any other), so `DefaultDeserializer` reads it off
+  `context.config.softDelete.field` **at deserialize time**, per call —
+  the same scope the request's own soft-delete strategy resolves at — not
+  a value baked in once at bootstrap, so a per-operation or per-call
+  override that renames the marker stays covered. Generated columns (auto
+  ids, `@CreateDateColumn`, versions) can never be written from a request
+  body either — the default deserializer silently strips all of these,
+  which is the safe posture in a system with no validation stage. An
+  explicit write DTO can still name the id or the marker field (a
+  legitimate opt-in for a caller-assigned key); `update`/`patch` write
+  paths additionally strip both from the payload before persisting, as
+  defence in depth against reassigning an _existing_ row's identity or
+  soft-delete state that way.
 - **Embedded objects** map to a `json`-kind column and travel as one
   opaque value; they are not flattened into sub-fields.
 

--- a/docs/internals/architecture/11-soft-delete.md
+++ b/docs/internals/architecture/11-soft-delete.md
@@ -39,10 +39,14 @@ is _always_ explicit `softDelete.field` configuration (ADR-0017,
 ADR-0018, doc 17 §5). MikroORM comes closest — it has a soft-delete
 pattern — but it is a user-defined `@Filter`, a query concern rather than
 a column declaration, and nothing in it is detectable as "this column is
-the marker". One consequence is worth naming: because those adapters
-cannot mark the marker column generated the way `@kavo/typeorm` does, it
-stays writable through an ordinary update unless a DTO excludes it — see
-doc 15 §7.
+the marker". This is not a TypeORM-exclusive concern, though: any adapter's
+`softDelete.field` — including `@kavo/typeorm`'s, when it names an ordinary
+column rather than a `@DeleteDateColumn` — is excluded from the derived
+`create`/`update`/`patch` writable projection by name, not by `generated`,
+precisely because the marker column cannot always be marked generated
+(`DefaultDeserializer`, doc 04 §3). Adapter write paths additionally strip
+the resolved marker (and the id field) from an `update`/`patch` payload as
+defence in depth, so it survives even a write DTO that names it explicitly.
 
 Resolution runs at every settings scope, so an operation or a single call
 may narrow it (`operations: { deleteOne: { softDelete: { strategy: "hard" } } }`),

--- a/docs/internals/architecture/15-mongoose-adapter.md
+++ b/docs/internals/architecture/15-mongoose-adapter.md
@@ -295,16 +295,6 @@ null }`).
   adding it later is a capability gain, not a bug fix.
 - **Virtual populate:** see §3 — needs a metadata source beyond
   `schema.paths`.
-- **The soft-delete marker is writable.** Nothing in a Mongoose schema
-  declares "this is the delete column", so `EntityMetadata.softDeleteField`
-  is `null` and the marker path is an ordinary field — which means a client
-  can soft-delete or revive a document with a plain `PATCH` of `deletedAt`,
-  bypassing `deleteOne`'s already-deleted check. `@kavo/prisma` is in
-  exactly the same position for the same reason (`@kavo/typeorm` escapes it
-  only because `@DeleteDateColumn` is detectable). The fix belongs in core —
-  excluding the _resolved_ `softDelete.field` from the writable projection,
-  which would close it for both adapters at once — and is deliberately not
-  worked around here.
 - **Un-included reference ids:** see §1 — also a core-side change.
 - **Projections:** `query.fields` is applied by core's serializer, not
   pushed down as a MongoDB projection. Correct today, and a clear

--- a/docs/internals/architecture/17-mikroorm-adapter.md
+++ b/docs/internals/architecture/17-mikroorm-adapter.md
@@ -256,8 +256,9 @@ whose `@DeleteDateColumn` the seam reports.
 `resolveSoftDelete` matches the configured _name_ against the entity's own
 columns before falling back to `softDeleteField`. So an entity carrying a
 plain `deletedAt` property is soft-deletable with no config whatsoever. What
-reporting `null` actually costs is narrower and sharper: the adapter cannot
-mark the marker column generated, so it stays **client-writable** — see §7.
+reporting `null` used to cost is narrower and sharper: the adapter cannot
+mark the marker column generated, so `DefaultDeserializer` excludes it from
+the derived writable projection by name instead — see §7.
 
 There is consequently one marker shape to handle rather than TypeORM's two:
 the marker is always an ordinary property, so the `IS NULL` /
@@ -307,34 +308,28 @@ character, so `filter[name][like]=100\%` matches the literal text `100\`
 followed by anything rather than the string `100%`. `@kavo/typeorm` emits
 `ESCAPE '\'` explicitly and does not have this gap.
 
-**The soft-delete marker is writable, and it is enabled by default.**
-Because nothing declares it, the marker is an ordinary non-generated
-property, so it joins the derived writable projection: a plain `PATCH` of it
-soft-deletes a row, bypassing `deleteOne`'s already-deleted check, any
-per-operation override on `deleteOne`, and even
-`operations: { deleteOne: false }`. With `purgeOne` enabled that is a
-two-request permanent delete through the update route. It cannot _revive_ a
-row — writes are scoped to the live set, so a soft-deleted row 404s on
-`PUT`/`PATCH`.
+**The soft-delete marker and the primary key are excluded from the derived
+writable projection by name, not just by `generated`.** Because nothing
+declares the marker column, it is an ordinary non-generated property, and
+`@PrimaryKey() id: string = v4()` — the idiomatic UUID spelling — carries
+none of MikroORM's generated flags either. `DefaultDeserializer` excludes
+`metadata.idField` and the resolved `softDelete.field` from its derived
+default regardless of `generated`, so a client cannot rewrite a row's
+identity or soft-delete/revive it through a plain `PATCH`/`PUT` when the
+entity has no explicit write DTO. `mergeAndFlush` additionally strips both
+keys from the payload before `assign`, as defence in depth against an
+explicit write DTO that names either field: `create` may still assign a
+caller-chosen id (a legitimate use for a non-auto-increment key), but an
+`update`/`patch` against an _existing_ row never reassigns its id or its
+soft-delete state, whatever the registered DTO declares. The one thing this
+does not do is let a `PATCH` revive a soft-deleted row even if a DTO wanted
+to — writes stay scoped to the live set, so a soft-deleted row 404s on
+`PUT`/`PATCH` regardless.
 
-Read that together with §5: because `strategy: "auto"` matches the column
-_name_, this surface is live on any entity with a `deletedAt` property and
-no `dto` block — nobody has to opt in. This is the shared hole
-`@kavo/prisma` and `@kavo/mongoose` have (only `@kavo/typeorm` escapes it,
-because `@DeleteDateColumn` is detectable and therefore markable), and the
-real fix — subtracting the resolved `softDelete.field` from
-`DefaultDeserializer`'s writable projection — belongs in core. Until then,
-register an explicit `update`/`patch` DTO that omits the marker, as
-`examples/nest-mikroorm`'s `OwnerController` does.
-
-**A primary key that is not auto-increment is client-writable.**
-`isGenerated` reads MikroORM's own flags, and `@PrimaryKey() id: string =
-v4()` — the idiomatic UUID spelling — carries none of them, so the key lands
-in the writable projection and a `PATCH` can rewrite a row's identity. A
-numeric `@PrimaryKey()` gets `autoincrement: true` and is safe.
-`@kavo/typeorm` has the same gap for `@PrimaryColumn`, so this is parity
-rather than a regression, but the risky spelling is the common one here.
-Name the write DTOs explicitly for any entity with a caller-assigned key.
+`@kavo/prisma` and `@kavo/mongoose` are in the same position for the same
+reason (`@kavo/typeorm` escapes the marker half only because
+`@DeleteDateColumn` is detectable and therefore markable) and get the same
+fix, since the derivation lives once in `@kavo/core`.
 
 **A `hidden` or `lazy` property is dropped from the seam entirely.** Not
 just from responses: excluding it from `fields` is what keeps it off the

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -247,7 +247,12 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
           resolved.computed,
           resolved.projection as readonly string[] | null,
         ),
-        deserializer: new DefaultDeserializer(metadata as EntityMetadata<Entity>, catalog, resolved.computed),
+        deserializer: new DefaultDeserializer(
+          metadata as EntityMetadata<Entity>,
+          catalog,
+          resolved.computed,
+          resolved.softDelete.field,
+        ),
         normalizer: new QueryNormalizer(
           metadata as EntityMetadata<Entity>,
           options.paginationStrategies ?? [],

--- a/packages/core/src/kavo.ts
+++ b/packages/core/src/kavo.ts
@@ -247,12 +247,7 @@ export function createKavo(options: KavoOptions = {}): KavoInstance {
           resolved.computed,
           resolved.projection as readonly string[] | null,
         ),
-        deserializer: new DefaultDeserializer(
-          metadata as EntityMetadata<Entity>,
-          catalog,
-          resolved.computed,
-          resolved.softDelete.field,
-        ),
+        deserializer: new DefaultDeserializer(metadata as EntityMetadata<Entity>, catalog, resolved.computed),
         normalizer: new QueryNormalizer(
           metadata as EntityMetadata<Entity>,
           options.paginationStrategies ?? [],

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -254,15 +254,36 @@ function narrowToDto(projection: Projection, dto: DtoClass | null): Projection {
  * strip below is what keeps that true for a `DefaultDeserializer`
  * constructed directly — it is exported, and its contract is "computed
  * names never reach the adapter", not "the config resolver checked first".
+ *
+ * The primary key and the soft-delete marker field are excluded from the
+ * derived default **regardless of `generated`**: an app-assigned id (a
+ * natural key, a `@BeforeInsert`-populated UUID) is not driver-generated
+ * but must not be reassignable by an ordinary write, and a soft-delete
+ * marker that isn't the ORM's own delete-date column is an ordinary
+ * writable column with no special exclusion otherwise — either would let a
+ * client rewrite a row's identity or its deleted state through the generic
+ * write route instead of `create`'s intentional choice of id or
+ * `deleteOne`/`restoreOne`'s state machine. Unlike computed
+ * fields, this is a deliberately narrower guarantee: an explicit write DTO
+ * naming the id or marker field still reaches it, because both are real
+ * columns with legitimate opt-in uses (assigning a natural key on
+ * `create`) that a computed field never has.
  */
 export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entity> {
   private readonly writableProjection: readonly string[];
   private readonly relationIdFields: ReadonlyMap<string, () => string | undefined>;
   private readonly computedNames: ReadonlySet<string>;
 
-  constructor(metadata: EntityMetadata<Entity>, catalog?: EntityCatalog, computed: ComputedFieldMap<Entity> = {}) {
+  constructor(
+    metadata: EntityMetadata<Entity>,
+    catalog?: EntityCatalog,
+    computed: ComputedFieldMap<Entity> = {},
+    softDeleteField: string | null = null,
+  ) {
     this.computedNames = new Set(Object.keys(computed));
-    const columns = metadata.fields.filter((field) => !field.generated).map((field) => field.name);
+    const columns = metadata.fields
+      .filter((field) => !field.generated && field.name !== metadata.idField && field.name !== softDeleteField)
+      .map((field) => field.name);
     const relations = new Map<string, () => string | undefined>();
     for (const relation of metadata.relations) {
       // Lazily: the target may enter the catalog after this entity does.

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -255,34 +255,41 @@ function narrowToDto(projection: Projection, dto: DtoClass | null): Projection {
  * constructed directly — it is exported, and its contract is "computed
  * names never reach the adapter", not "the config resolver checked first".
  *
- * The primary key and the soft-delete marker field are excluded from the
- * derived default **regardless of `generated`**: an app-assigned id (a
- * natural key, a `@BeforeInsert`-populated UUID) is not driver-generated
- * but must not be reassignable by an ordinary write, and a soft-delete
- * marker that isn't the ORM's own delete-date column is an ordinary
- * writable column with no special exclusion otherwise — either would let a
- * client rewrite a row's identity or its deleted state through the generic
- * write route instead of `create`'s intentional choice of id or
- * `deleteOne`/`restoreOne`'s state machine. Unlike computed
- * fields, this is a deliberately narrower guarantee: an explicit write DTO
- * naming the id or marker field still reaches it, because both are real
- * columns with legitimate opt-in uses (assigning a natural key on
- * `create`) that a computed field never has.
+ * The primary key is excluded from the derived default **regardless of
+ * `generated`**: an app-assigned id (a natural key, a
+ * `@BeforeInsert`-populated UUID) is not driver-generated but must not be
+ * reassignable by an ordinary write. It has no per-call scope — an entity's
+ * identifier is fixed metadata — so it is excluded once, at construction.
+ *
+ * The soft-delete marker gets the same exclusion, but resolved **per call**
+ * from `context.config.softDelete.field` rather than baked in at
+ * construction: `softDelete` is an ordinary settings key (entity → operation
+ * → per-call, ADR-0013), so the field an operation actually writes through
+ * can differ from the entity's own default — an `update`/`patch` this class
+ * cannot see through `context` is exactly what the per-adapter strip in each
+ * `RepositoryAdapter.update`/`patch` already covers as defence in depth, but
+ * `create` has no such backstop (an explicit DTO may legitimately assign a
+ * natural key there), so the marker exclusion has to track the same scope
+ * `context.config` resolves it at, not the scope this class was built in.
+ * A marker that isn't the ORM's own delete-date column is an ordinary
+ * writable column with no special exclusion otherwise — either gap would
+ * let a client rewrite a row's identity or its deleted state through the
+ * generic write route instead of `create`'s intentional choice of id or
+ * `deleteOne`/`restoreOne`'s state machine. Unlike computed fields, both are
+ * a deliberately narrower guarantee: an explicit write DTO naming the id or
+ * marker field still reaches it, because both are real columns with
+ * legitimate opt-in uses (assigning a natural key on `create`) that a
+ * computed field never has.
  */
 export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entity> {
   private readonly writableProjection: readonly string[];
   private readonly relationIdFields: ReadonlyMap<string, () => string | undefined>;
   private readonly computedNames: ReadonlySet<string>;
 
-  constructor(
-    metadata: EntityMetadata<Entity>,
-    catalog?: EntityCatalog,
-    computed: ComputedFieldMap<Entity> = {},
-    softDeleteField: string | null = null,
-  ) {
+  constructor(metadata: EntityMetadata<Entity>, catalog?: EntityCatalog, computed: ComputedFieldMap<Entity> = {}) {
     this.computedNames = new Set(Object.keys(computed));
     const columns = metadata.fields
-      .filter((field) => !field.generated && field.name !== metadata.idField && field.name !== softDeleteField)
+      .filter((field) => !field.generated && field.name !== metadata.idField)
       .map((field) => field.name);
     const relations = new Map<string, () => string | undefined>();
     for (const relation of metadata.relations) {
@@ -295,17 +302,26 @@ export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entit
     this.writableProjection = [...columns, ...relations.keys()];
   }
 
-  deserialize<Shape>(raw: unknown, dto: DtoClass<Shape & object> | null, _context: KavoContext<Entity>): Shape {
+  deserialize<Shape>(raw: unknown, dto: DtoClass<Shape & object> | null, context: KavoContext<Entity>): Shape {
     if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
       return {} as Shape;
     }
-    const allowed = dtoShapeKeys(dto) ?? this.writableProjection;
+    const explicit = dtoShapeKeys(dto);
+    const allowed = explicit ?? this.writableProjection;
+    // Only the derived default excludes the marker — an explicit DTO's own
+    // key set is deliberately left alone, same as the id (see class doc).
+    // Optional chaining: this class is exported and constructible directly
+    // against a context that never went through the engine (a test stub,
+    // say), and the exclusion degrading to "none" there is the same
+    // graceful fallback the id/computed-field guards already make.
+    const softDeleteField = explicit === null ? (context.config?.softDelete?.field ?? null) : null;
     const source = raw as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const key of allowed) {
       // A computed field has no column behind it, so a value for it could
       // only ever reach the adapter as an unknown write (ADR-0019).
       if (this.computedNames.has(key)) continue;
+      if (key === softDeleteField) continue;
       // Own properties only. `raw` is a wire body, so an inherited key is
       // never something the client sent — but it *is* something a polluted
       // `Object.prototype` would supply, silently adding a writable field to

--- a/packages/core/tests/serializer.spec.ts
+++ b/packages/core/tests/serializer.spec.ts
@@ -214,6 +214,61 @@ describe("DefaultDeserializer — write projection", () => {
   });
 });
 
+describe("DefaultDeserializer — id and soft-delete marker exclusion", () => {
+  // `User.id` is `generated: true`, which already excludes it — these cases
+  // need a primary key an ORM does *not* mark generated (an app-assigned
+  // natural key), the case a `generated`-only check misses entirely.
+  const naturalKeyMetadata = {
+    ...userMetadata,
+    fields: userMetadata.fields.map((field) => (field.name === "id" ? { ...field, generated: false } : field)),
+  };
+
+  it("drops a non-generated primary key from the derived default regardless of `generated`", () => {
+    const deserializer = new DefaultDeserializer(naturalKeyMetadata);
+    const payload = deserializer.deserialize({ id: "chosen-id", name: "Ada" }, null, contextStub());
+    expect(payload).toEqual({ name: "Ada" });
+  });
+
+  it("still lets an explicit write DTO name the primary key", () => {
+    // Unlike a computed field, the id is a real column with a legitimate
+    // opt-in use (assigning a natural key on create), so an explicit DTO
+    // still reaches it.
+    class CreateUserDto {
+      id = "";
+      name = "";
+    }
+    const deserializer = new DefaultDeserializer(naturalKeyMetadata);
+    const payload = deserializer.deserialize({ id: "chosen-id", name: "Ada" }, CreateUserDto, contextStub());
+    expect(payload).toEqual({ id: "chosen-id", name: "Ada" });
+  });
+
+  it("drops the resolved soft-delete marker field from the derived default", () => {
+    // The marker is an ordinary, non-generated column whenever the ORM
+    // cannot declare a delete-date column (Prisma/Mongoose/MikroORM, and
+    // `@kavo/typeorm` too when `softDelete.field` names a plain column) —
+    // exactly the shape a `generated`-only check cannot see.
+    const withMarker = {
+      ...userMetadata,
+      fields: [...userMetadata.fields, { name: "deletedAt", kind: "date" as const, nullable: true, generated: false }],
+    };
+    const deserializer = new DefaultDeserializer(withMarker, undefined, {}, "deletedAt");
+    const payload = deserializer.deserialize({ deletedAt: new Date(0), name: "Ada" }, null, contextStub());
+    expect(payload).toEqual({ name: "Ada" });
+  });
+
+  it("leaves an ordinary column named 'deletedAt' writable when the entity has no soft-delete marker", () => {
+    // `softDeleteField` argument is `null` by default — no marker resolved,
+    // no exclusion.
+    const withMarker = {
+      ...userMetadata,
+      fields: [...userMetadata.fields, { name: "deletedAt", kind: "date" as const, nullable: true, generated: false }],
+    };
+    const deserializer = new DefaultDeserializer(withMarker);
+    const payload = deserializer.deserialize({ deletedAt: new Date(0), name: "Ada" }, null, contextStub());
+    expect(payload).toEqual({ deletedAt: new Date(0), name: "Ada" });
+  });
+});
+
 describe("DefaultDtoResolver — slot resolution", () => {
   class CreateUserDto {}
   class UpdateUserDto {}

--- a/packages/core/tests/serializer.spec.ts
+++ b/packages/core/tests/serializer.spec.ts
@@ -242,29 +242,83 @@ describe("DefaultDeserializer — id and soft-delete marker exclusion", () => {
     expect(payload).toEqual({ id: "chosen-id", name: "Ada" });
   });
 
-  it("drops the resolved soft-delete marker field from the derived default", () => {
+  const withMarker = {
+    ...userMetadata,
+    fields: [...userMetadata.fields, { name: "deletedAt", kind: "date" as const, nullable: true, generated: false }],
+  };
+
+  /**
+   * A context carrying only what `deserialize` reads off it: the resolved
+   * soft-delete field for *this call*. Deliberately not a full
+   * `resolveEntityConfig` output — the field this class must track is
+   * `context.config.softDelete.field` specifically, resolved fresh per
+   * request/operation/call (ADR-0013's precedence chain), never a value
+   * baked into the deserializer at construction.
+   */
+  function contextWithMarker(field: string | null): KavoContext<User> {
+    return {
+      config: { softDelete: field === null ? { strategy: "hard", field: null } : { strategy: "soft", field } },
+    } as KavoContext<User>;
+  }
+
+  it("drops the soft-delete marker field the call context resolves, from the derived default", () => {
     // The marker is an ordinary, non-generated column whenever the ORM
     // cannot declare a delete-date column (Prisma/Mongoose/MikroORM, and
     // `@kavo/typeorm` too when `softDelete.field` names a plain column) —
     // exactly the shape a `generated`-only check cannot see.
-    const withMarker = {
-      ...userMetadata,
-      fields: [...userMetadata.fields, { name: "deletedAt", kind: "date" as const, nullable: true, generated: false }],
-    };
-    const deserializer = new DefaultDeserializer(withMarker, undefined, {}, "deletedAt");
-    const payload = deserializer.deserialize({ deletedAt: new Date(0), name: "Ada" }, null, contextStub());
+    const deserializer = new DefaultDeserializer(withMarker);
+    const payload = deserializer.deserialize(
+      { deletedAt: new Date(0), name: "Ada" },
+      null,
+      contextWithMarker("deletedAt"),
+    );
     expect(payload).toEqual({ name: "Ada" });
   });
 
-  it("leaves an ordinary column named 'deletedAt' writable when the entity has no soft-delete marker", () => {
-    // `softDeleteField` argument is `null` by default — no marker resolved,
-    // no exclusion.
-    const withMarker = {
-      ...userMetadata,
-      fields: [...userMetadata.fields, { name: "deletedAt", kind: "date" as const, nullable: true, generated: false }],
-    };
+  it("leaves an ordinary column named 'deletedAt' writable when the call resolves no soft-delete marker", () => {
     const deserializer = new DefaultDeserializer(withMarker);
-    const payload = deserializer.deserialize({ deletedAt: new Date(0), name: "Ada" }, null, contextStub());
+    const payload = deserializer.deserialize({ deletedAt: new Date(0), name: "Ada" }, null, contextWithMarker(null));
+    expect(payload).toEqual({ deletedAt: new Date(0), name: "Ada" });
+  });
+
+  it("tracks a per-call marker override, not a value fixed at construction — the same deserializer excludes a different field for a different call", () => {
+    // The regression this pins: an entity-scope-only exclusion (baked in
+    // once, at bootstrap) would miss an operation or per-call
+    // `softDelete.field` override that renames the marker — reopening the
+    // exact mass-assignment gap this class exists to close, for that one
+    // config shape. One `DefaultDeserializer` instance is shared across
+    // every call for an entity, so tracking the override has to happen at
+    // `deserialize` time, against that call's own resolved context.
+    const renamed = {
+      ...userMetadata,
+      fields: [...userMetadata.fields, { name: "archivedAt", kind: "date" as const, nullable: true, generated: false }],
+    };
+    const deserializer = new DefaultDeserializer(renamed);
+    const defaultScope = deserializer.deserialize(
+      { archivedAt: new Date(0), name: "Ada" },
+      null,
+      contextWithMarker(null),
+    );
+    expect(defaultScope).toEqual({ archivedAt: new Date(0), name: "Ada" });
+    const overriddenScope = deserializer.deserialize(
+      { archivedAt: new Date(0), name: "Ada" },
+      null,
+      contextWithMarker("archivedAt"),
+    );
+    expect(overriddenScope).toEqual({ name: "Ada" });
+  });
+
+  it("still lets an explicit write DTO name the soft-delete marker, even when the call resolves one", () => {
+    class UpdateUserDto {
+      deletedAt: Date | null = null;
+      name = "";
+    }
+    const deserializer = new DefaultDeserializer(withMarker);
+    const payload = deserializer.deserialize(
+      { deletedAt: new Date(0), name: "Ada" },
+      UpdateUserDto,
+      contextWithMarker("deletedAt"),
+    );
     expect(payload).toEqual({ deletedAt: new Date(0), name: "Ada" });
   });
 });

--- a/packages/core/tests/soft-delete.spec.ts
+++ b/packages/core/tests/soft-delete.spec.ts
@@ -18,6 +18,7 @@ import {
   accountMetadata,
   accountMetadataWithNaturalKey,
   accountMetadataWithoutMarker,
+  accountMetadataWithTwoMarkerCandidates,
   accountMetadataWithWritableMarker,
 } from "./support/account-fixture.js";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
@@ -249,5 +250,31 @@ describe("the soft-delete marker and primary key are not mass-assignable", () =>
     await crud.patchOne(1, { id: 999, name: "acme corp" } as never);
 
     expect(adapter.rows).toMatchObject([{ id: 1, name: "acme corp" }]);
+  });
+
+  it("excludes the marker a per-operation override actually resolves, not the entity-scope default", async () => {
+    // The regression this pins: the entity declares `deletedAt` as its
+    // soft-delete field, but `createOne` is configured to resolve a
+    // *different* marker (`archivedAt`) — an ordinary, legal per-operation
+    // override (ADR-0013's precedence chain). A `DefaultDeserializer` that
+    // excluded only the entity-scope name would let `archivedAt` straight
+    // through on `createOne`, reopening exactly the bug this file otherwise
+    // covers — for the one config shape where "the marker" isn't fixed at
+    // bootstrap.
+    const adapter = new InMemoryAccountAdapter();
+    const crud = createKavo().createCrud(
+      Account,
+      {
+        softDelete: { field: "deletedAt" },
+        operations: { createOne: { softDelete: { field: "archivedAt" } } },
+      } as never,
+      { adapter, metadata: accountMetadataWithTwoMarkerCandidates },
+    );
+
+    const created = (await crud.createOne({ name: "acme", archivedAt: new Date(0) } as never)) as Account & {
+      archivedAt?: unknown;
+    };
+
+    expect(created.archivedAt).toBeUndefined();
   });
 });

--- a/packages/core/tests/soft-delete.spec.ts
+++ b/packages/core/tests/soft-delete.spec.ts
@@ -16,7 +16,9 @@ import {
   Account,
   InMemoryAccountAdapter,
   accountMetadata,
+  accountMetadataWithNaturalKey,
   accountMetadataWithoutMarker,
+  accountMetadataWithWritableMarker,
 } from "./support/account-fixture.js";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
 
@@ -218,5 +220,34 @@ describe("soft-delete operation enablement (ADR-0013)", () => {
   it("rejects a non-boolean withDeleted value", async () => {
     const { crud } = makeAccountCrud();
     await expect(crud.findMany({ withDeleted: "yes" } as never)).rejects.toBeInstanceOf(QueryValidationException);
+  });
+});
+
+describe("the soft-delete marker and primary key are not mass-assignable", () => {
+  it("cannot be soft-deleted or revived through a plain PATCH, even when the marker is an ordinary column", async () => {
+    // `accountMetadataWithWritableMarker` reports `softDeleteField: null`
+    // and `generated: false` on `deletedAt` — exactly what
+    // Prisma/Mongoose/MikroORM (and `@kavo/typeorm` with a plain-column
+    // `softDelete.field`) report, the shape a `generated`-only exclusion
+    // cannot see.
+    const { crud, adapter } = makeAccountCrud(undefined, accountMetadataWithWritableMarker);
+    await crud.createOne({ name: "acme" } as never);
+
+    await crud.updateOne(1, { name: "acme", deletedAt: new Date(0) } as never);
+
+    expect(adapter.rows[0]!.deletedAt).toBeNull();
+    // The dedicated operation still works — this isn't a broken feature,
+    // just a route the generic write can no longer bypass it through.
+    await crud.deleteOne(1);
+    expect(adapter.rows[0]!.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it("cannot reassign an existing row's id through a plain PATCH", async () => {
+    const { crud, adapter } = makeAccountCrud(undefined, accountMetadataWithNaturalKey);
+    await crud.createOne({ name: "acme" } as never);
+
+    await crud.patchOne(1, { id: 999, name: "acme corp" } as never);
+
+    expect(adapter.rows).toMatchObject([{ id: 1, name: "acme corp" }]);
   });
 });

--- a/packages/core/tests/support/account-fixture.ts
+++ b/packages/core/tests/support/account-fixture.ts
@@ -33,6 +33,24 @@ export const accountMetadataWithoutMarker: EntityMetadata<Account> = {
 };
 
 /**
+ * The same metadata, but as `@kavo/prisma`/`@kavo/mongoose`/`@kavo/mikroorm`
+ * always report it: no `@DeleteDateColumn` equivalent exists, so the marker
+ * is an ordinary `generated: false` column and `softDeleteField` is `null` —
+ * only the entity-scope `softDelete.field` name resolves it.
+ */
+export const accountMetadataWithWritableMarker: EntityMetadata<Account> = {
+  ...accountMetadata,
+  fields: accountMetadata.fields.map((field) => (field.name === "deletedAt" ? { ...field, generated: false } : field)),
+  softDeleteField: null,
+};
+
+/** The same metadata, but with an app-assigned (non-generated) primary key. */
+export const accountMetadataWithNaturalKey: EntityMetadata<Account> = {
+  ...accountMetadata,
+  fields: accountMetadata.fields.map((field) => (field.name === "id" ? { ...field, generated: false } : field)),
+};
+
+/**
  * In-memory adapter that honors the resolved strategy the same way a real
  * one does: it reads `context.config.softDelete` rather than deciding for
  * itself, so these tests exercise the engine's resolution, not a mock's

--- a/packages/core/tests/support/account-fixture.ts
+++ b/packages/core/tests/support/account-fixture.ts
@@ -51,6 +51,24 @@ export const accountMetadataWithNaturalKey: EntityMetadata<Account> = {
 };
 
 /**
+ * A second candidate marker column (`archivedAt`), alongside the usual
+ * `deletedAt` — both ordinary `generated: false` columns, `softDeleteField`
+ * unset. Exists to prove `softDelete.field` is excluded at the scope it is
+ * actually *resolved* at (entity, operation, or per-call — ADR-0013), not a
+ * value fixed once when the deserializer was built: an entity-scope default
+ * of `deletedAt` with a per-operation override renaming the marker to
+ * `archivedAt` must still exclude `archivedAt`, not the stale entity-scope
+ * name.
+ */
+export const accountMetadataWithTwoMarkerCandidates: EntityMetadata<Account> = {
+  ...accountMetadataWithWritableMarker,
+  fields: [
+    ...accountMetadataWithWritableMarker.fields,
+    { name: "archivedAt", kind: "date", nullable: true, generated: false },
+  ],
+};
+
+/**
  * In-memory adapter that honors the resolved strategy the same way a real
  * one does: it reads `context.config.softDelete` rather than deciding for
  * itself, so these tests exercise the engine's resolution, not a mock's

--- a/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
+++ b/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
@@ -302,7 +302,7 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
    * turn a missing id into `NotFoundException`, so this costs no extra
    * query.
    */
-  private async mergeAndFlush(id: EntityId, data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+  private async mergeAndFlush(id: EntityId, rawData: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
     try {
       const em = this.fork();
       // Scoped to live rows: a soft-deleted row is invisible to updates,
@@ -310,7 +310,17 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
       const where = this.scopeToLive({ [this.idField]: id }, context, false);
       const existing = await em.findOne(this.entity, where as never);
       if (existing === null) throw this.notFound(id, context);
-      wrap(existing).assign(this.toWriteData(data) as never, { em });
+      // Defence in depth, mirroring the deserializer's own exclusion: even
+      // an explicit write DTO that legitimately names the id (to assign a
+      // natural key on `create`) must not be allowed to reassign an
+      // *existing* row's identity, and the soft-delete marker is
+      // `deleteOne`/`restoreOne`'s state machine to change, not an
+      // ordinary property an update/patch body happens to include.
+      const softDeleteField = context.config.softDelete.field;
+      const data = { ...(rawData as Record<string, unknown>) };
+      delete data[this.idField];
+      if (softDeleteField !== null) delete data[softDeleteField];
+      wrap(existing).assign(this.toWriteData(data as Partial<Entity>) as never, { em });
       await em.flush();
       return toPlain(existing);
     } catch (error) {

--- a/packages/orms/mikroorm/tests/soft-delete.spec.ts
+++ b/packages/orms/mikroorm/tests/soft-delete.spec.ts
@@ -46,12 +46,35 @@ class Invoice {
   archivedAt: Date | null = null;
 }
 
+/** An app-assigned (non-auto-increment) primary key — `isGenerated` reads
+ * none of MikroORM's generated flags for this shape. */
+@Entity()
+class Coupon {
+  @PrimaryKey({ type: "string" })
+  code!: string;
+
+  @Property({ type: "string" })
+  label!: string;
+
+  @Property({ type: "Date", nullable: true })
+  retiredAt: Date | null = null;
+}
+
+/** Names the id and the configured marker explicitly — the opt-in an
+ * explicit write DTO is still allowed to make. */
+class UpdateCouponDto {
+  code = "";
+  label = "";
+  retiredAt: Date | null = null;
+}
+
 let orm: MikroORM;
 let tickets: DefaultKavoService<Ticket>;
 let invoices: DefaultKavoService<Invoice>;
+let coupons: DefaultKavoService<Coupon>;
 
 beforeAll(async () => {
-  orm = await newTestOrm([Ticket, Invoice]);
+  orm = await newTestOrm([Ticket, Invoice, Coupon]);
   const kavo = createMikroOrmKavo(orm);
   tickets = kavo.createCrud(Ticket, {
     softDelete: { strategy: "soft", field: "deletedAt" },
@@ -60,6 +83,10 @@ beforeAll(async () => {
   invoices = kavo.createCrud(Invoice, {
     softDelete: { strategy: "soft", field: "archivedAt" },
   }) as DefaultKavoService<Invoice>;
+  coupons = kavo.createCrud(Coupon, {
+    softDelete: { strategy: "soft", field: "retiredAt" },
+    dto: { create: UpdateCouponDto, update: UpdateCouponDto, patch: UpdateCouponDto },
+  }) as DefaultKavoService<Coupon>;
 });
 
 afterAll(async () => {
@@ -91,9 +118,7 @@ describe("zero-config soft delete", () => {
     // `resolveSoftDelete` matches that name against the entity's own columns.
     // So an adapter reporting `softDeleteField: null` does NOT mean "soft
     // delete is off until configured" — the conventional column name turns it
-    // on by itself. That matters because the marker stays *writable* (nothing
-    // declares it, so it cannot be marked generated), which is what makes the
-    // DTO hardening in the note below load-bearing rather than optional.
+    // on by itself.
     const zeroConfig = createMikroOrmKavo(orm).createCrud(Ticket) as DefaultKavoService<Ticket>;
     const created = (await zeroConfig.createOne({ reference: "T-zero", title: "x" } as never)) as Ticket;
 
@@ -105,18 +130,16 @@ describe("zero-config soft delete", () => {
     expect((await zeroConfig.findMany()).total).toBe(0);
   });
 
-  it("leaves the marker client-writable under derived DTOs", async () => {
-    // The consequence of the above, stated as a test so it cannot regress
-    // silently: with no `dto` block, `deletedAt` is an ordinary non-generated
-    // column and therefore in the writable projection. A plain patch stamps
-    // it, bypassing `deleteOne`'s already-deleted check. The mitigation is an
-    // explicit write DTO (see `examples/nest-mikroorm`'s OwnerController);
-    // the real fix belongs in core — see doc 17 §7.
+  it("keeps the marker out of the derived writable projection with no config at all", async () => {
+    // With no `dto` block, `deletedAt` is an ordinary non-generated column —
+    // `DefaultDeserializer` excludes it by name (the resolved
+    // `softDelete.field`), not just by `generated`, so a plain patch cannot
+    // stamp it and bypass `deleteOne`'s already-deleted check.
     const zeroConfig = createMikroOrmKavo(orm).createCrud(Ticket) as DefaultKavoService<Ticket>;
     const created = (await zeroConfig.createOne({ reference: "T-writable", title: "x" } as never)) as Ticket;
 
     await zeroConfig.patchOne(created.id, { deletedAt: new Date() } as never);
-    expect((await zeroConfig.findMany()).total).toBe(0);
+    expect((await zeroConfig.findMany()).total).toBe(1);
   });
 });
 
@@ -335,5 +358,28 @@ describe("MikroOrmRepositoryAdapter — hard delete", () => {
     await adapter.purge(created.id, hardContext as never);
     expect(await orm.em.fork().count(Invoice, {})).toBe(0);
     await expect(adapter.purge(created.id, hardContext as never)).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+describe("MikroOrmRepositoryAdapter — id and soft-delete marker mass assignment", () => {
+  it("never reassigns an existing row's id through update/patch, even when a write DTO names it", async () => {
+    await coupons.createOne({ code: "SAVE10", label: "10% off", retiredAt: null } as never);
+
+    const patched = await coupons.patchOne("SAVE10", { code: "STOLEN", label: "hijacked" } as never);
+    expect(patched).toMatchObject({ code: "SAVE10", label: "hijacked" });
+
+    await expect(coupons.findOne("STOLEN")).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("never soft-deletes or revives through update/patch, even when a write DTO names the marker", async () => {
+    const created = await coupons.createOne({ code: "WELCOME", label: "welcome", retiredAt: null } as never);
+    expect(created).toMatchObject({ retiredAt: null });
+
+    const patched = await coupons.patchOne("WELCOME", { retiredAt: new Date(0) } as never);
+    expect(patched).toMatchObject({ retiredAt: null });
+    expect((await coupons.findMany()).items).toHaveLength(1);
+
+    await coupons.deleteOne("WELCOME");
+    expect((await coupons.findMany()).items).toHaveLength(0);
   });
 });

--- a/packages/orms/mongoose/src/mongoose-repository-adapter.ts
+++ b/packages/orms/mongoose/src/mongoose-repository-adapter.ts
@@ -272,10 +272,19 @@ export class MongooseRepositoryAdapter<Entity extends object> implements Reposit
    * reported without a separate existence check — no read-then-write gap
    * for a concurrent delete to slip through.
    */
-  private async writeExisting(id: EntityId, data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+  private async writeExisting(id: EntityId, rawData: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
     try {
       const where = this.scopeToLive({ [this.idField]: { $eq: id } }, context, false);
-      const changes = data as Record<string, unknown>;
+      // Defence in depth, mirroring the deserializer's own exclusion: even
+      // an explicit write DTO that legitimately names the id (to assign a
+      // natural key on `create`) must not be allowed to reassign an
+      // *existing* document's identity, and the soft-delete marker is
+      // `deleteOne`/`restoreOne`'s state machine to change, not an
+      // ordinary path an update/patch body happens to include.
+      const softDeleteField = context.config.softDelete.field;
+      const changes = { ...(rawData as Record<string, unknown>) };
+      delete changes[this.idField];
+      if (softDeleteField !== null) delete changes[softDeleteField];
       if (Object.keys(changes).length === 0) {
         // MongoDB rejects an empty `$set`. Nothing to write is not an
         // error — it is the current document, unchanged.

--- a/packages/orms/mongoose/tests/soft-delete.spec.ts
+++ b/packages/orms/mongoose/tests/soft-delete.spec.ts
@@ -31,6 +31,20 @@ interface Invoice {
   archivedAt: Date | null;
 }
 
+interface Coupon {
+  _id: string;
+  label: string;
+  retiredAt: Date | null;
+}
+
+/** Names `_id` and the configured marker explicitly — the opt-in an
+ * explicit write DTO is still allowed to make. */
+class UpdateCouponDto {
+  _id = "";
+  label = "";
+  retiredAt: Date | null = null;
+}
+
 /**
  * Declared through a factory so the models keep their *inferred* Mongoose
  * types — annotating them with `ReturnType<connection["model"]>` would
@@ -47,6 +61,7 @@ function defineModels(connection: TestDatabase["connection"]) {
       }),
     ),
     Invoice: connection.model("Invoice", new Schema({ number: String, archivedAt: { type: Date, default: null } })),
+    Coupon: connection.model("Coupon", new Schema({ label: String, retiredAt: { type: Date, default: null } })),
   };
 }
 
@@ -54,6 +69,7 @@ let database: TestDatabase;
 let models: ReturnType<typeof defineModels>;
 let tickets: DefaultKavoService<Ticket>;
 let invoices: DefaultKavoService<Invoice>;
+let coupons: DefaultKavoService<Coupon>;
 
 beforeAll(async () => {
   database = await startTestDatabase();
@@ -72,6 +88,10 @@ beforeAll(async () => {
   invoices = kavo.createCrud(models.Invoice, {
     softDelete: { field: "archivedAt" },
   }) as unknown as DefaultKavoService<Invoice>;
+  coupons = kavo.createCrud(models.Coupon, {
+    softDelete: { field: "retiredAt" },
+    dto: { create: UpdateCouponDto, update: UpdateCouponDto, patch: UpdateCouponDto },
+  }) as unknown as DefaultKavoService<Coupon>;
 });
 
 afterAll(async () => {
@@ -236,6 +256,28 @@ describe("MongooseRepositoryAdapter — configured marker field", () => {
 
     const list = await invoices.findMany({ onlyDeleted: true });
     expect(list.items).toMatchObject([{ _id: deleted._id }]);
+  });
+});
+
+describe("MongooseRepositoryAdapter — id and soft-delete marker mass assignment", () => {
+  it("never reassigns an existing document's id through update/patch, even when a write DTO names it", async () => {
+    const created = (await coupons.createOne({ label: "10% off", retiredAt: null } as never)) as Coupon;
+
+    const patched = await coupons.patchOne(created._id, { _id: "hijacked", label: "changed" } as never);
+    expect(patched).toMatchObject({ _id: created._id, label: "changed" });
+
+    await expect(coupons.findOne("hijacked")).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("never soft-deletes or revives through update/patch, even when a write DTO names the marker", async () => {
+    const created = (await coupons.createOne({ label: "welcome", retiredAt: null } as never)) as Coupon;
+
+    const patched = await coupons.patchOne(created._id, { retiredAt: new Date(0) } as never);
+    expect(patched).toMatchObject({ retiredAt: null });
+    expect((await coupons.findMany()).items).toHaveLength(1);
+
+    await coupons.deleteOne(created._id);
+    expect((await coupons.findMany()).items).toHaveLength(0);
   });
 });
 

--- a/packages/orms/prisma/prisma/schema.prisma
+++ b/packages/orms/prisma/prisma/schema.prisma
@@ -81,6 +81,12 @@ model Invoice {
   archivedAt DateTime?
 }
 
+model Coupon {
+  code      String    @id
+  label     String
+  retiredAt DateTime?
+}
+
 // ── cursor-pagination.spec.ts ───────────────────────────────────────────
 
 model Post {

--- a/packages/orms/prisma/src/prisma-repository-adapter.ts
+++ b/packages/orms/prisma/src/prisma-repository-adapter.ts
@@ -246,10 +246,20 @@ export class PrismaRepositoryAdapter<Entity extends object> implements Repositor
    * exactly as it is to reads — reviving one is `restore`'s job, so
    * existence is checked against the live scope before the write.
    */
-  private async writeExisting(id: EntityId, data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+  private async writeExisting(id: EntityId, rawData: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
     try {
       const existing = await this.byId(id, context, false);
       if (existing === null) throw this.notFound(id, context);
+      // Defence in depth, mirroring the deserializer's own exclusion: even
+      // an explicit write DTO that legitimately names the id (to assign a
+      // natural key on `create`) must not be allowed to reassign an
+      // *existing* row's identity, and the soft-delete marker is
+      // `deleteOne`/`restoreOne`'s state machine to change, not an
+      // ordinary column an update/patch body happens to include.
+      const softDeleteField = context.config.softDelete.field;
+      const data = { ...(rawData as Record<string, unknown>) };
+      delete data[this.idField];
+      if (softDeleteField !== null) delete data[softDeleteField];
       return (await this.delegate.update({ where: { [this.idField]: id }, data })) as Entity;
     } catch (error) {
       throw mapDriverError(error, errorContext(context));

--- a/packages/orms/prisma/tests/soft-delete.spec.ts
+++ b/packages/orms/prisma/tests/soft-delete.spec.ts
@@ -26,15 +26,32 @@ class Invoice {
   archivedAt!: Date | null;
 }
 
+/** A natural (non-auto) primary key, plus a configured soft-delete marker —
+ * both are ordinary `generated: false` columns Prisma reports the same way. */
+class Coupon {
+  code!: string;
+  label!: string;
+  retiredAt!: Date | null;
+}
+
+/** Names the id and the configured marker explicitly — the opt-in an
+ * explicit write DTO is still allowed to make. */
+class UpdateCouponDto {
+  code = "";
+  label = "";
+  retiredAt: Date | null = null;
+}
+
 let client: PrismaClient;
 let tickets: DefaultKavoService<Ticket>;
 let invoices: DefaultKavoService<Invoice>;
+let coupons: DefaultKavoService<Coupon>;
 
 beforeAll(() => {
   client = newTestPrismaClient();
   const kavo = createPrismaKavo(client as never, {
     datamodel: Prisma.dmmf.datamodel,
-    entities: [Ticket, Invoice],
+    entities: [Ticket, Invoice, Coupon],
     caseInsensitiveFilters: false,
   });
   tickets = kavo.createCrud(Ticket, {
@@ -44,6 +61,10 @@ beforeAll(() => {
   invoices = kavo.createCrud(Invoice, {
     softDelete: { field: "archivedAt" },
   }) as DefaultKavoService<Invoice>;
+  coupons = kavo.createCrud(Coupon, {
+    softDelete: { field: "retiredAt" },
+    dto: { create: UpdateCouponDto, update: UpdateCouponDto, patch: UpdateCouponDto },
+  }) as DefaultKavoService<Coupon>;
 });
 
 afterAll(async () => {
@@ -53,6 +74,7 @@ afterAll(async () => {
 beforeEach(async () => {
   await client.ticket.deleteMany();
   await client.invoice.deleteMany();
+  await client.coupon.deleteMany();
 });
 
 async function newTicket(reference = "T-1"): Promise<number> {
@@ -251,5 +273,29 @@ describe("PrismaRepositoryAdapter — hard-delete strategy guards", () => {
       entity: "Invoice",
       id: String(created.id),
     });
+  });
+});
+
+describe("PrismaRepositoryAdapter — id and soft-delete marker mass assignment", () => {
+  it("never reassigns an existing row's id through update/patch, even when a write DTO names it", async () => {
+    await coupons.createOne({ code: "SAVE10", label: "10% off", retiredAt: null } as never);
+
+    const patched = await coupons.patchOne("SAVE10", { code: "STOLEN", label: "hijacked" } as never);
+    expect(patched).toMatchObject({ code: "SAVE10", label: "hijacked" });
+
+    await expect(coupons.findOne("STOLEN")).rejects.toBeInstanceOf(NotFoundException);
+    expect(await coupons.findOne("SAVE10")).toMatchObject({ code: "SAVE10", label: "hijacked" });
+  });
+
+  it("never soft-deletes or revives through update/patch, even when a write DTO names the marker", async () => {
+    const created = await coupons.createOne({ code: "WELCOME", label: "welcome", retiredAt: null } as never);
+    expect(created).toMatchObject({ retiredAt: null });
+
+    const patched = await coupons.patchOne("WELCOME", { retiredAt: new Date(0) } as never);
+    expect(patched).toMatchObject({ retiredAt: null });
+    expect((await coupons.findMany()).items).toHaveLength(1);
+
+    await coupons.deleteOne("WELCOME");
+    expect((await coupons.findMany()).items).toHaveLength(0);
   });
 });

--- a/packages/orms/typeorm/src/typeorm-repository-adapter.ts
+++ b/packages/orms/typeorm/src/typeorm-repository-adapter.ts
@@ -340,12 +340,24 @@ export class TypeOrmRepositoryAdapter<Entity extends ObjectLiteral> implements R
    * *currently loaded* relation state on `existing`, which is exactly what
    * the extra preload would otherwise fetch.
    */
-  private async mergeAndSave(id: EntityId, data: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
+  private async mergeAndSave(id: EntityId, rawData: Partial<Entity>, context: KavoContext<Entity>): Promise<Entity> {
     try {
       // Scoped to live rows: a soft-deleted row is invisible to updates,
       // exactly as it is to reads. Reviving one is `restore`'s job.
       const existing = await this.byId(id, context, false).getOne();
       if (existing === null) throw this.notFound(id, context);
+      // Defence in depth, mirroring the deserializer's own exclusion: even
+      // an explicit write DTO that legitimately names the id (to assign a
+      // natural key on `create`) must not be allowed to reassign an
+      // *existing* row's identity, and the soft-delete marker is
+      // `deleteOne`/`restoreOne`'s state machine to change, not an
+      // ordinary column an update/patch body happens to include.
+      const data = stripImmutableKeys(rawData, this.idField, context.config.softDelete.field);
+      // Everything the body carried may have been the id and/or the marker
+      // — TypeORM's `update` rejects an empty value set outright, and there
+      // is nothing left to change: the current row, unmodified, is the
+      // correct answer.
+      if (Object.keys(data).length === 0) return existing;
       this.repository.merge(existing, data as never);
       const touchesRelation = Object.keys(data).some((key) => this.relationProperties.has(key));
       if (touchesRelation) {
@@ -771,6 +783,23 @@ export class TypeOrmRepositoryAdapter<Entity extends ObjectLiteral> implements R
       context: errorContext(context),
     });
   }
+}
+
+/**
+ * `mergeAndSave`'s defence-in-depth strip: a shallow copy of `data` with
+ * the id field and (when soft-deletable) the resolved marker field
+ * removed, so neither reaches `merge`/`update` regardless of what a write
+ * DTO declared.
+ */
+function stripImmutableKeys<Entity>(
+  data: Partial<Entity>,
+  idField: string,
+  softDeleteField: string | null,
+): Partial<Entity> {
+  const copy = { ...(data as Record<string, unknown>) };
+  delete copy[idField];
+  if (softDeleteField !== null) delete copy[softDeleteField];
+  return copy as Partial<Entity>;
 }
 
 /** The loaded rows on one relation of a set of parents, flattened. */

--- a/packages/orms/typeorm/tests/soft-delete.spec.ts
+++ b/packages/orms/typeorm/tests/soft-delete.spec.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { Column, DataSource, DeleteDateColumn, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Column, DataSource, DeleteDateColumn, Entity, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
 import {
   AlreadyDeletedException,
   ConfigurationException,
@@ -50,16 +50,41 @@ class Receipt {
   number!: string;
 }
 
+/** An app-assigned (non-generated) primary key, and a soft-delete marker
+ * configured over an ordinary column — the shape that lets a client rewrite
+ * a row's identity or deleted state unless the deserializer and the
+ * adapter's own defence in depth both exclude it. */
+@Entity()
+class Coupon {
+  @PrimaryColumn("varchar")
+  code!: string;
+
+  @Column("varchar")
+  label!: string;
+
+  @Column("datetime", { nullable: true })
+  retiredAt!: Date | null;
+}
+
+/** Names the id and the configured marker explicitly — the opt-in an
+ * explicit write DTO is still allowed to make. */
+class UpdateCouponDto {
+  code = "";
+  label = "";
+  retiredAt: Date | null = null;
+}
+
 let dataSource: DataSource;
 let tickets: DefaultKavoService<Ticket>;
 let invoices: DefaultKavoService<Invoice>;
 let receipts: DefaultKavoService<Receipt>;
+let coupons: DefaultKavoService<Coupon>;
 
 beforeAll(async () => {
   dataSource = new DataSource({
     type: "better-sqlite3",
     database: ":memory:",
-    entities: [Ticket, Invoice, Receipt],
+    entities: [Ticket, Invoice, Receipt, Coupon],
     synchronize: true,
   });
   await dataSource.initialize();
@@ -72,6 +97,10 @@ beforeAll(async () => {
     softDelete: { field: "archivedAt" },
   }) as DefaultKavoService<Invoice>;
   receipts = kavo.createCrud(Receipt) as DefaultKavoService<Receipt>;
+  coupons = kavo.createCrud(Coupon, {
+    softDelete: { field: "retiredAt" },
+    dto: { create: UpdateCouponDto, update: UpdateCouponDto, patch: UpdateCouponDto },
+  }) as DefaultKavoService<Coupon>;
 });
 
 afterAll(async () => {
@@ -82,6 +111,7 @@ beforeEach(async () => {
   await dataSource.getRepository(Ticket).clear();
   await dataSource.getRepository(Invoice).clear();
   await dataSource.getRepository(Receipt).clear();
+  await dataSource.getRepository(Coupon).clear();
 });
 
 /**
@@ -253,5 +283,31 @@ describe("TypeOrmRepositoryAdapter — the adapter's own hard-delete guards", ()
     expect(await dataSource.getRepository(Receipt).countBy({ id: created.id })).toBe(0);
 
     await expect(adapter.purge(created.id, hardContext("purgeOne") as never)).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+describe("TypeOrmRepositoryAdapter — id and soft-delete marker mass assignment", () => {
+  it("never reassigns an existing row's id through update/patch, even when a write DTO names it", async () => {
+    await coupons.createOne({ code: "SAVE10", label: "10% off", retiredAt: null } as never);
+
+    const patched = await coupons.patchOne("SAVE10", { code: "STOLEN", label: "hijacked" } as never);
+    expect(patched).toMatchObject({ code: "SAVE10", label: "hijacked" });
+
+    await expect(coupons.findOne("STOLEN")).rejects.toBeInstanceOf(NotFoundException);
+    expect(await coupons.findOne("SAVE10")).toMatchObject({ code: "SAVE10", label: "hijacked" });
+  });
+
+  it("never soft-deletes or revives through update/patch, even when a write DTO names the marker", async () => {
+    const created = await coupons.createOne({ code: "WELCOME", label: "welcome", retiredAt: null } as never);
+    expect(created).toMatchObject({ retiredAt: null });
+
+    const patched = await coupons.patchOne("WELCOME", { retiredAt: new Date(0) } as never);
+    expect(patched).toMatchObject({ retiredAt: null });
+    expect((await coupons.findMany()).items).toHaveLength(1);
+
+    // The dedicated operation is unaffected — this closes a bypass, not the
+    // feature itself.
+    await coupons.deleteOne("WELCOME");
+    expect((await coupons.findMany()).items).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What & why

`DefaultDeserializer`'s derived writable projection for `create`/`update`/`patch` only excluded columns marked `generated`. That misses two internal-state fields that are ordinary, non-generated columns on every ORM but TypeORM's own `@DeleteDateColumn` case: an app-assigned primary key (a natural key, a `@BeforeInsert`-populated UUID) and a soft-delete marker configured over a plain column. Without an explicit write DTO, a client could `PATCH`/`PUT` `id` to reassign a row's identity, or stamp/clear the soft-delete marker directly, bypassing `deleteOne`/`restoreOne`'s state machine entirely.

This PR excludes both fields from the derived default in `@kavo/core`'s shared `DefaultDeserializer` — fixing all four ORM adapters at once, since they share this class — and adds defence-in-depth stripping in each adapter's own update/patch write path, so even an explicit write DTO that legitimately names the id (a natural-key `create`) or the marker can't reassign an *existing* row's identity or soft-delete state through `update`/`patch`.

**Review update:** `/review` surfaced a real gap — the soft-delete marker exclusion was originally resolved once at bootstrap (entity scope), but `softDelete.field` is an ordinary settings key with the usual entity → operation → per-call precedence, so a per-operation/per-call override renaming the marker would diverge from that baked-in value and reopen mass-assignment on `create` (the one write path with no adapter-level backstop). Fixed by having `DefaultDeserializer.deserialize` read `context.config.softDelete.field` at call time instead of at construction, matching the scope the engine itself resolves `softDelete` at. The primary key exclusion stays bootstrap-resolved, since an entity's id is fixed metadata with no per-call scope.

Closes #255

## Public API impact

None. `DefaultDeserializer`'s constructor signature is unchanged from `main` (the review fix removed a since-added 4th parameter again, moving the marker lookup to `deserialize()` instead).

## Testing

- Core: tests in `serializer.spec.ts` (unit-level `DefaultDeserializer` exclusion, including the explicit-DTO opt-in and a case proving the same deserializer instance excludes a *different* marker field for a different call context) and `soft-delete.spec.ts` (engine-level regression via `createCrud`, including a per-operation-override regression test that would fail against the entity-scope-only version of this fix), plus new fixture variants in `account-fixture.ts`.
- Each ORM package (`typeorm`, `prisma`, `mongoose`, `mikroorm`): tests in `soft-delete.spec.ts` covering that an existing row's id and soft-delete marker survive `update`/`patch` even when an explicit write DTO names them. A MikroORM test that previously asserted the marker was writable by default was flipped to assert the fix.
- `pnpm check`: build, typecheck, `depcruise`, and lint all pass clean. `pnpm test`: 2446 passed, 435 skipped — all skips are pre-existing environment limitations (no network access for the MongoDB test binary, no container runtime for Testcontainers-based Postgres/MariaDB/CockroachDB suites), confirmed identical on unmodified `main`.
- `pnpm docs:links`: passes.

## Review notes

- `/review` (kavo-reviewer + kavo-test-auditor + kavo-security-auditor fan-out) found and this PR now addresses: the entity-scope vs per-operation-scope marker exclusion gap above (blocking, fixed).
- Non-blocking items raised but not yet addressed, left for a follow-up if wanted: (1) TypeORM's `mergeAndSave` relation-touching branch has no test combining a relation-key write with id/marker stripping in the same call; (2) Mongoose's `Coupon` fixture has no positive test of the explicit-DTO-assigns-`_id`-on-create opt-in (the other three adapters have one); (3) a fully-stripped patch body silently no-ops and still fires a realtime update event for a row that wasn't actually changed — safer than pre-fix but a UX/observability nuance worth a note.
- The TypeORM adapter's `mergeAndSave` needed an empty-payload short-circuit: stripping the marker/id can leave the write body empty, and TypeORM's `repository.update` throws on an empty value set. Mirrors a pattern the Mongoose adapter already had.
- Deliberately did **not** add a bootstrap-time rejection (unlike computed fields) for an explicit write DTO naming the id/marker — both are real columns with a legitimate opt-in use (assigning a natural key on `create`), unlike a computed field which never has one.
- Docs updated: `04-dto-system.md`, `11-soft-delete.md`, `15-mongoose-adapter.md`, `17-mikroorm-adapter.md`.