### PR TITLE
feat(core): add creatable/updatable allowlists to constrain writable fields

### DIFF
--- a/.claude/skills/add-config-key/SKILL.md
+++ b/.claude/skills/add-config-key/SKILL.md
@@ -77,3 +77,57 @@ it's the single source of truth for what's configurable, and a key missing
 from it is invisible to the next reader. If the key represents a new
 load-bearing precedent (not just a parameter on an existing mechanism),
 see the `add-adr` skill.
+
+## Allowlist-style keys are a different mechanism — don't force them in here
+
+`EntityConfig.allowlists` (`filterable`/`sortable`/`selectable`/`includable`/
+`searchable`/`creatable`/`updatable`) is declared on `EntityConfig` directly,
+**not** on `KavoSettings` — there is no global default, no per-operation
+override, and none of the merge machinery above applies. A key belongs here
+instead of in `KavoSettings` when its job is to name a **subset of the
+entity's own fields or relations that a request may touch**, rather than to
+tune a behavior. Issue #259 (`creatable`/`updatable`, narrowing the writable
+projection for `createOne`/`updateOne`/`patchOne`) is a worked example of
+adding one:
+
+1. **The raw selector type** (`packages/core/src/config/entity-config.ts`) —
+   an array-or-`{ exclude }` shape typed against the right path depth.
+   `QueryFieldSelector<Entity>` (`FieldPath<Entity>`, depth 3) for a key that
+   can name a dotted relation path; a depth-1 `FieldPath<Entity, 1>` selector
+   (see `WritableFieldSelector`) for a key that only ever grants one field or
+   relation segment, the way a write body does. Add the key to
+   `QueryAllowlists`, documented with its default posture (does it default to
+   "every own column", like `filterable`, or opt-in like `includable`?) and
+   its narrowing/precedence relationship to any nearby DTO-based override.
+2. **The resolved type** (`resolved-entity-config.ts`) — add the frozen,
+   always-array field to `ResolvedQueryAllowlists`.
+3. **`resolveAllowlists`** (`resolve-entity-config.ts`) — compute the key's
+   **base set** (what it means unconfigured) from `EntityMetadata`, and
+   resolve the configured selector against that base with
+   `resolveFieldSelector` (generic over the path type, so it serves both
+   depth-3 and depth-1 selectors already). If the key can never legally name
+   a computed field (as `creatable`/`updatable` can't — a computed field has
+   no column to write, ADR-0019), reject one at bootstrap with a
+   `ConfigurationException`, the same way `filterable`/`sortable`/`searchable`
+   already reject one.
+4. **Where the resolved list actually gates something** — an allowlist key is
+   inert until some consumer reads it. `creatable`/`updatable` are read in
+   `DefaultDeserializer.deserialize` (per call, off `context.config.allowlists`,
+   keyed by `context.operation`) — find or add the analogous read site for a
+   new key, and decide its **DTO precedence**: does a registered DTO with a
+   runtime shape still win outright (the `selectable`-vs-`dto.item` precedent,
+   ADR-0026), or does the new key gate something no DTO already governs?
+5. **The core barrel** (`index.ts`) — a new selector type is a new public
+   type; add it to the explicit list (ADR-0010), and to
+   `tests/barrel.spec.ts`'s manifest.
+6. **Docs** — `docs/features/allowlists.md` (the adopter-facing guide) and
+   `docs/reference/config-keys.md`'s `## allowlists` table, not
+   `08-configuration.md` — that document is `KavoSettings` only.
+
+Tests follow the same shape as `write-tests` describes for a `KavoSettings`
+key, minus the per-call/operation-override cases that don't apply here: the
+default derivation, an explicit array used verbatim, the `{ exclude }` form
+resolved against the base (not "every column"), the computed-field rejection
+if applicable, and — for a key with a consumer — that the consumer actually
+narrows behavior and that any unconditional exclusion it must respect (an id,
+a soft-delete marker) survives even when the list names it explicitly.

--- a/docs/features/allowlists.md
+++ b/docs/features/allowlists.md
@@ -1,6 +1,6 @@
 # Allowlists
 
-What a request may filter, sort, select, and include, including relation paths. Anything outside an allowlist is rejected with a 400, never silently dropped:
+What a request may filter, sort, select, include, and write, including relation paths. Anything outside a query-side allowlist is rejected with a 400, never silently dropped; a write-side allowlist (`creatable`/`updatable`) narrows silently, the same way an unknown body key already does:
 
 ```ts
 @Kavo(Book, {
@@ -10,6 +10,8 @@ What a request may filter, sort, select, and include, including relation paths. 
     selectable: ["id", "title", "author"],
     includable: ["author"],
     searchable: ["title", "author"],
+    creatable: ["title", "author"],
+    updatable: ["title"],
   },
 })
 ```
@@ -19,8 +21,12 @@ What a request may filter, sort, select, and include, including relation paths. 
 - `selectable` (same shape): fields usable in `fields=`, and what a response carries.
 - `includable` (`readonly IncludePath<Entity, 1>[]` \| `{ exclude: readonly IncludePath<Entity, 1>[] }`): relation names usable in `include=`, one segment at a time from the root ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)).
 - `searchable` (`readonly FieldPath[]` \| `{ exclude: readonly FieldPath[] }`): fields `search[query]`/`search[fields]` may search. Relation paths are permitted here, unlike `filterable`/`sortable`. Default: every own string-kind column, not every own column. Also gated by `query.search.enabled` (off by default); see [Search](/querying/search).
+- `creatable` (`readonly FieldPath<Entity, 1>[]` \| `{ exclude: readonly FieldPath<Entity, 1>[] }`): fields `createOne` may write. Default: every non-generated own column except the primary key, plus every relation (associable by id). Capped to one path segment — a write body addresses the entity's own fields and relations, never a dotted path into a relation's own fields.
+- `updatable` (same shape as `creatable`): fields `updateOne`/`patchOne` may write. `update` (PUT) and `patch` (PATCH) share this one list, since both mutate an existing row.
 
-`{ exclude: [...] }` means "every own column except these" (plus, for `selectable`, every selectable computed field; for `includable`, every own relation; for `searchable`, every own string-kind column). It resolves at bootstrap against exactly the base set that key's plain default uses.
+`{ exclude: [...] }` means "every own column except these" (plus, for `selectable`, every selectable computed field; for `includable`, every own relation; for `searchable`, every own string-kind column; for `creatable`/`updatable`, every relation too). It resolves at bootstrap against exactly the base set that key's plain default uses.
+
+**`creatable`/`updatable` only narrow — they never widen.** They intersect with the writable projection [`DefaultDeserializer` already derives](/internals/architecture/04-dto-system#_3-runtime-derivation-rules): naming the primary key or the soft-delete marker there has no effect, since neither is in that base set to begin with. A registered `create`/`update`/`patch` DTO with a runtime shape replaces the projection outright rather than intersecting with it — exactly as a registered `item`/`list` DTO outranks `selectable` below — so register the DTO as the narrowing statement where you use one.
 
 **`includable` is the one key here that does not default to "everything".** Omit `filterable`/`sortable`/`selectable` and it derives from the `query` DTO or entity metadata, every own column. Omit `includable` and it resolves to `[]`, no relation is includable, the same opt-in posture `relations.edges` had before this key existed. Write `{ exclude: [] }` to opt every own relation in at once; that is the one spelling that crosses the fail-closed default rather than narrowing a fail-open one.
 
@@ -39,12 +45,12 @@ When `@nestjs/swagger` is installed, an explicit array here also names the gener
 ::: danger `selectable` alone is not a credential control
 It closes the **response body**. Three other doors stay open, and a column you actually need to protect has to close all four.
 
-| Door                      | Still open after `selectable`                                                                                                        | Close it with                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| `filter[apiKey][like]=a%` | Yes. `filterable` defaults to every column, and `LIKE`/`GT`/`LT` binary-search the value in `O(log n)` requests                      | Name `filterable` explicitly, without the column                    |
-| `sort=apiKey`             | Yes. `sortable` defaults to every column, and ordering leaks the column across pages                                                 | Name `sortable` explicitly, without the column                      |
-| `PATCH {"apiKey":"…"}`    | Yes. Writable columns are derived separately, and after this change the write is invisible, because the response no longer echoes it | Register `dto.update` (`patch` falls back to it) without the column |
-| response body             | No                                                                                                                                   | `selectable`                                                        |
+| Door                      | Still open after `selectable`                                                                                                        | Close it with                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `filter[apiKey][like]=a%` | Yes. `filterable` defaults to every column, and `LIKE`/`GT`/`LT` binary-search the value in `O(log n)` requests                      | Name `filterable` explicitly, without the column                                                      |
+| `sort=apiKey`             | Yes. `sortable` defaults to every column, and ordering leaks the column across pages                                                 | Name `sortable` explicitly, without the column                                                        |
+| `PATCH {"apiKey":"…"}`    | Yes. Writable columns are derived separately, and after this change the write is invisible, because the response no longer echoes it | Narrow `updatable` without the column, or register `dto.update` (`patch` falls back to it) without it |
+| response body             | No                                                                                                                                   | `selectable`                                                                                          |
 
 The filter and sort doors are the same oracle [ADR-0021](/internals/adr/0021-cursor-pagination-is-an-opaque-keyset-union) refuses for cursor sort keys. Narrow all three allowlists together, and add the write DTO.
 :::

--- a/docs/internals/architecture/04-dto-system.md
+++ b/docs/internals/architecture/04-dto-system.md
@@ -54,25 +54,40 @@ the defaults derive from:
   A registered DTO wins outright over the allowlist rather than
   intersecting with it: it is the narrower, more specific statement.
 - **Writable projection** (`create`/`update`/`patch` default): every
-  scalar column with `generated: false`, minus the primary key and the
-  soft-delete marker field, which are excluded **regardless of**
-  `generated` — an app-assigned id or a marker column that isn't the ORM's
-  own delete-date column would otherwise be an ordinary writable field with
-  no other guard. The id is fixed metadata, so its exclusion is resolved
-  once; the marker is an ordinary settings key (entity → operation →
-  per-call, like any other), so `DefaultDeserializer` reads it off
-  `context.config.softDelete.field` **at deserialize time**, per call —
-  the same scope the request's own soft-delete strategy resolves at — not
-  a value baked in once at bootstrap, so a per-operation or per-call
-  override that renames the marker stays covered. Generated columns (auto
-  ids, `@CreateDateColumn`, versions) can never be written from a request
-  body either — the default deserializer silently strips all of these,
-  which is the safe posture in a system with no validation stage. An
-  explicit write DTO can still name the id or the marker field (a
+  scalar column with `generated: false`, plus every relation (associable
+  by id, [ADR-0014](/internals/adr/0014-associate-by-id-not-deep-writes)),
+  minus the primary key and the soft-delete marker field, which are
+  excluded **regardless of** `generated` — an app-assigned id or a marker
+  column that isn't the ORM's own delete-date column would otherwise be an
+  ordinary writable field with no other guard. The id is fixed metadata,
+  so its exclusion is resolved once; the marker is an ordinary settings key
+  (entity → operation → per-call, like any other), so `DefaultDeserializer`
+  reads it off `context.config.softDelete.field` **at deserialize time**,
+  per call — the same scope the request's own soft-delete strategy
+  resolves at — not a value baked in once at bootstrap, so a per-operation
+  or per-call override that renames the marker stays covered. Generated
+  columns (auto ids, `@CreateDateColumn`, versions) can never be written
+  from a request body either — the default deserializer silently strips
+  all of these, which is the safe posture in a system with no validation
+  stage. An explicit write DTO can still name the id or the marker field (a
   legitimate opt-in for a caller-assigned key); `update`/`patch` write
   paths additionally strip both from the payload before persisting, as
   defence in depth against reassigning an _existing_ row's identity or
   soft-delete state that way.
+
+  This default projection can be narrowed further, without registering a
+  DTO at all, by `allowlists.creatable` (for `createOne`) and
+  `allowlists.updatable` (for `updateOne`/`patchOne` — the two share one
+  list, since both mutate an existing row) — the write-side counterpart to
+  `allowlists.selectable` above, and subject to the same rules: it can only
+  narrow the derived projection, never widen it, so naming the id or the
+  soft-delete marker there has no effect; and a registered write DTO with a
+  runtime shape wins outright, exactly as a registered `item`/`list` DTO
+  wins over `selectable` — where you register one, it, not the allowlist,
+  is the narrowing statement. Unconfigured, both default to the same base
+  described above, so an entity that never sets either sees no change
+  (issue #259).
+
 - **Embedded objects** map to a `json`-kind column and travel as one
   opaque value; they are not flattened into sub-fields.
 

--- a/docs/reference/config-keys.md
+++ b/docs/reference/config-keys.md
@@ -102,13 +102,15 @@ Coarser than the per-entity `EntityConfig.operations`, which also carries `handl
 
 Not part of `KavoSettings`. Declared on `EntityConfig` directly, so there's no global default and no per-operation override.
 
-| Key                     | Type                                          | Default                            |
-| ----------------------- | --------------------------------------------- | ---------------------------------- |
-| `allowlists.filterable` | `FieldPath[] \| { exclude: FieldPath[] }`     | every own column                   |
-| `allowlists.sortable`   | same shape                                    | every own column                   |
-| `allowlists.selectable` | same shape                                    | every own column + computed fields |
-| `allowlists.includable` | `IncludePath[] \| { exclude: IncludePath[] }` | `[]`, no relation includable       |
-| `allowlists.searchable` | `FieldPath[] \| { exclude: FieldPath[] }`     | every own string-kind column       |
+| Key                     | Type                                                          | Default                                                           |
+| ----------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `allowlists.filterable` | `FieldPath[] \| { exclude: FieldPath[] }`                     | every own column                                                  |
+| `allowlists.sortable`   | same shape                                                    | every own column                                                  |
+| `allowlists.selectable` | same shape                                                    | every own column + computed fields                                |
+| `allowlists.includable` | `IncludePath[] \| { exclude: IncludePath[] }`                 | `[]`, no relation includable                                      |
+| `allowlists.searchable` | `FieldPath[] \| { exclude: FieldPath[] }`                     | every own string-kind column                                      |
+| `allowlists.creatable`  | `FieldPath<Entity,1>[] \| { exclude: FieldPath<Entity,1>[] }` | every non-generated own column except the id, plus every relation |
+| `allowlists.updatable`  | same shape                                                    | same default as `creatable`                                       |
 
 See [Allowlists](/features/allowlists).
 

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -26,6 +26,17 @@ export type QueryFieldSelector<Entity, Extra extends string = never> =
   readonly (FieldPath<Entity> | Extra)[] | { readonly exclude: readonly (FieldPath<Entity> | Extra)[] };
 
 /**
+ * One writable-field allowlist key's raw configuration — the same array-or-
+ * `{ exclude }` shape as {@link QueryFieldSelector}, but capped to depth 1
+ * ({@link FieldPath} with `MaxDepth` 1): a write body addresses the
+ * entity's own scalar columns and its relations by association (ADR-0014),
+ * never a dotted path into a relation's own fields, so `creatable`/
+ * `updatable` have nothing to grant past one segment.
+ */
+export type WritableFieldSelector<Entity> =
+  readonly FieldPath<Entity, 1>[] | { readonly exclude: readonly FieldPath<Entity, 1>[] };
+
+/**
  * One relation allowlist key's raw configuration — the same array-or-
  * `{ exclude }` shape as {@link QueryFieldSelector}, but typed against the
  * entity's own top-level relation names ({@link IncludePath} capped to
@@ -118,6 +129,31 @@ export interface QueryAllowlists<Entity = unknown, Computed extends string = nev
    * (`KavoSettings`), off by default — see doc 05 §4.
    */
   readonly searchable?: QueryFieldSelector<Entity>;
+  /**
+   * What `createOne` (and `createMany`, once #137 lands) may write. Same
+   * default posture as `filterable`/`sortable`: unconfigured, every own
+   * writable field — every non-generated scalar column except the primary
+   * key, plus every relation, by association (ADR-0014) — the same base
+   * `DefaultDeserializer`'s derived writable projection already uses.
+   *
+   * Narrows that derived projection; it never widens it; the primary key
+   * and the resolved soft-delete marker stay excluded even if named here
+   * (commit 8aa8d65's exclusion is unconditional). A registered `create`
+   * DTO with a runtime shape **replaces** the projection rather than
+   * intersecting with it, exactly as a registered `dto.item`/`dto.list`
+   * outranks `selectable` (ADR-0026) — where you register one, it, not
+   * this key, is the narrowing statement.
+   */
+  readonly creatable?: WritableFieldSelector<Entity>;
+  /**
+   * What `updateOne`/`patchOne` (and their `*Many` forms, once #137 lands)
+   * may write. `update` (PUT) and `patch` (PATCH) share this one list
+   * rather than each getting its own — both mutate an existing row, so the
+   * set of fields open to being overwritten is the same question either
+   * way. Same default posture, narrowing behaviour, and DTO precedence as
+   * {@link QueryAllowlists.creatable} — see its note.
+   */
+  readonly updatable?: WritableFieldSelector<Entity>;
 }
 
 /**

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -1,7 +1,7 @@
 import type { KavoSettings } from "./settings.js";
 import type { DeepPartial } from "../types/utility.js";
 import type { ComputedFieldDescriptor, ComputedFieldMap } from "./computed-field.js";
-import type { EntityConfig, OperationConfig, QueryFieldSelector, RelationFieldSelector } from "./entity-config.js";
+import type { EntityConfig, OperationConfig, RelationFieldSelector } from "./entity-config.js";
 import type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./resolved-entity-config.js";
 import type { DtoClass } from "../dto/dto.js";
 import type { EntityMetadata } from "../metadata/entity-metadata.js";
@@ -362,6 +362,18 @@ function resolveAllowlists<Entity extends object>(
     Entity,
     1
   >[];
+  // The same base `DefaultDeserializer`'s derived writable projection uses:
+  // every non-generated scalar column except the primary key, plus every
+  // relation (associable by id, ADR-0014). Kept in lockstep with that
+  // constructor deliberately — `creatable`/`updatable` narrow the same set
+  // the deserializer falls back to when no DTO is registered.
+  const writableColumns = metadata.fields
+    .filter((field) => !field.generated && field.name !== metadata.idField)
+    .map((field) => field.name);
+  const writableBase = [...writableColumns, ...(relationNames as readonly string[])] as unknown as readonly FieldPath<
+    Entity,
+    1
+  >[];
   const configured = entityConfig?.allowlists;
   const allowlists = {
     filterable: resolveFieldSelector(ownColumns, configured?.filterable),
@@ -372,6 +384,8 @@ function resolveAllowlists<Entity extends object>(
     // than "every own column" — a non-string column has nothing an `ILIKE`
     // fragment can usefully match (doc 05 §4).
     searchable: resolveFieldSelector(stringColumns, configured?.searchable),
+    creatable: resolveFieldSelector(writableBase, configured?.creatable),
+    updatable: resolveFieldSelector(writableBase, configured?.updatable),
   };
   const COMPUTED_REJECTION = {
     filterable: { verb: "filtered on", clause: "WHERE" },
@@ -387,6 +401,21 @@ function resolveAllowlists<Entity extends object>(
         `allowlists.${key}`,
         `'${field}' is a computed field on '${metadata.name}', which can never be ${verb} — ` +
           `it has no column to translate to ${clause}`,
+      );
+    }
+  }
+  // Computed fields have no column behind them, so they can never be
+  // written (ADR-0019) — `creatable`/`updatable` reject one by name at
+  // bootstrap for the same reason `rejectComputedWriteDtoKeys` rejects one
+  // named in a write DTO, rather than letting it fall out silently later.
+  for (const key of ["creatable", "updatable"] as const) {
+    for (const field of allowlists[key] as readonly string[]) {
+      if (!Object.prototype.hasOwnProperty.call(computed, field)) continue;
+      throw new ConfigurationException(
+        metadata.name,
+        `allowlists.${key}`,
+        `'${field}' is a computed field on '${metadata.name}', which is never writable (ADR-0019) — ` +
+          `it has no column behind it`,
       );
     }
   }
@@ -572,10 +601,15 @@ function resolveProjection<Entity extends object>(
   return readable.filter((name) => !excluded.has(name)) as unknown as readonly FieldPath<Entity>[];
 }
 
-function resolveFieldSelector<Entity>(
-  base: readonly FieldPath<Entity>[],
-  selector: QueryFieldSelector<Entity> | undefined,
-): readonly FieldPath<Entity>[] {
+/**
+ * Generic over the path type so it serves both `QueryFieldSelector`
+ * (depth-capped-3 `FieldPath`) and `WritableFieldSelector` (depth-1) — the
+ * array-or-`{ exclude }` resolution logic is identical either way.
+ */
+function resolveFieldSelector<Path extends string>(
+  base: readonly Path[],
+  selector: readonly Path[] | { readonly exclude: readonly Path[] } | undefined,
+): readonly Path[] {
   if (selector === undefined) return base;
   if (!("exclude" in selector)) return selector;
   const excluded = new Set(selector.exclude);

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -23,6 +23,8 @@ export interface ResolvedQueryAllowlists<Entity = unknown> {
   readonly selectable: readonly FieldPath<Entity>[];
   readonly includable: readonly IncludePath<Entity, 1>[];
   readonly searchable: readonly FieldPath<Entity>[];
+  readonly creatable: readonly FieldPath<Entity, 1>[];
+  readonly updatable: readonly FieldPath<Entity, 1>[];
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,6 +99,7 @@ export type {
   QueryAllowlists,
   QueryFieldSelector,
   RelationFieldSelector,
+  WritableFieldSelector,
 } from "./config/entity-config.js";
 export type { ComputedFieldDescriptor, ComputedFieldMap } from "./config/computed-field.js";
 export type { ResolvedEntityConfig, ResolvedQueryAllowlists } from "./config/resolved-entity-config.js";

--- a/packages/core/src/serialization/default-serializer.ts
+++ b/packages/core/src/serialization/default-serializer.ts
@@ -307,7 +307,12 @@ export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entit
       return {} as Shape;
     }
     const explicit = dtoShapeKeys(dto);
-    const allowed = explicit ?? this.writableProjection;
+    // Only the derived default is narrowed by `creatable`/`updatable` — an
+    // explicit DTO's own key set is deliberately left alone, exactly as it
+    // already is for the id and the soft-delete marker below: a registered
+    // DTO *replaces* the projection rather than intersecting with it
+    // (ADR-0026's `selectable`-vs-`dto.item` precedent).
+    const allowed = explicit ?? this.narrowToWritableAllowlist(context);
     // Only the derived default excludes the marker — an explicit DTO's own
     // key set is deliberately left alone, same as the id (see class doc).
     // Optional chaining: this class is exported and constructible directly
@@ -333,6 +338,33 @@ export class DefaultDeserializer<Entity = unknown> implements Deserializer<Entit
       result[key] = idField === undefined ? source[key] : associate(source[key], idField);
     }
     return result as Shape;
+  }
+
+  /**
+   * Narrows {@link writableProjection} by `allowlists.creatable`/
+   * `updatable` (issue #259) for the operation the call is actually
+   * making — `createOne` reads `creatable`, `updateOne`/`patchOne` read
+   * `updatable`, and every other operation (a custom write) is left
+   * unnarrowed, since neither key names it. Both lists already default to
+   * the same base this class derives on its own, so an entity that never
+   * configured either sees no change: the filter is a no-op intersection.
+   *
+   * Optional chaining on `context.config`, same reason as the soft-delete
+   * lookup above: this class is constructible directly against a context
+   * that never went through the engine.
+   */
+  private narrowToWritableAllowlist(context: KavoContext<Entity>): readonly string[] {
+    const allowlists = context.config?.allowlists;
+    if (allowlists === undefined) return this.writableProjection;
+    let allowlist: readonly string[] | undefined;
+    if (context.operation === "createOne") {
+      allowlist = allowlists.creatable as readonly string[];
+    } else if (context.operation === "updateOne" || context.operation === "patchOne") {
+      allowlist = allowlists.updatable as readonly string[];
+    }
+    if (allowlist === undefined) return this.writableProjection;
+    const allowed = new Set(allowlist);
+    return this.writableProjection.filter((key) => allowed.has(key));
   }
 }
 

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -229,6 +229,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "TransactionPropagation",
   "WhenParams",
   "WireQuery",
+  "WritableFieldSelector",
   "assertNever",
   "builtInHandlers",
   "builtInPaginationStrategies",

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { BUILT_IN_DEFAULTS, ConfigurationException, createKavo, mergeSettings, resolveEntityConfig } from "@kavo/core";
 import { User, userMetadata } from "./support/user-fixture.js";
-import { authorMetadata } from "./support/blog-fixture.js";
+import { authorMetadata, postMetadata } from "./support/blog-fixture.js";
 
 describe("mergeSettings — merge algebra", () => {
   it("replaces scalars key-by-key, nearer scope wins", () => {
@@ -210,6 +210,62 @@ describe("resolveEntityConfig — bootstrap", () => {
       undefined,
     );
     expect(config.allowlists.searchable).toEqual(["posts.authorId"]);
+  });
+
+  it("defaults creatable/updatable to every non-generated own column except the id, plus every relation", () => {
+    const config = resolveEntityConfig(postMetadata, undefined, undefined);
+    // `id` (generated, and the primary key regardless) and `deletedAt`
+    // (generated) are excluded; `title`/`authorId` and both relations join
+    // the default, the same base `DefaultDeserializer`'s own derived
+    // writable projection uses.
+    expect(config.allowlists.creatable).toEqual(["title", "authorId", "author", "comments"]);
+    expect(config.allowlists.updatable).toEqual(["title", "authorId", "author", "comments"]);
+  });
+
+  it("uses explicit creatable/updatable arrays verbatim, independently of each other", () => {
+    const config = resolveEntityConfig(
+      userMetadata,
+      { allowlists: { creatable: ["name"], updatable: ["name", "email"] } },
+      undefined,
+    );
+    expect(config.allowlists.creatable).toEqual(["name"]);
+    expect(config.allowlists.updatable).toEqual(["name", "email"]);
+    // Unconfigured allowlists still derive.
+    expect(config.allowlists.filterable).toContain("age");
+  });
+
+  it("resolves creatable/updatable { exclude } against the writable base, not every column", () => {
+    const config = resolveEntityConfig(
+      userMetadata,
+      { allowlists: { creatable: { exclude: ["age"] }, updatable: { exclude: ["status"] } } },
+      undefined,
+    );
+    // `id`/`createdAt` are excluded from the base itself (generated/id), so
+    // naming them in `exclude` would be a no-op either way.
+    expect(config.allowlists.creatable).toEqual(["name", "email", "status"]);
+    expect(config.allowlists.updatable).toEqual(["name", "email", "age"]);
+  });
+
+  it("rejects a computed field named in allowlists.creatable or allowlists.updatable", () => {
+    try {
+      resolveEntityConfig(
+        userMetadata,
+        {
+          computed: { fullName: { resolve: () => "" } },
+          allowlists: { creatable: ["fullName" as never] },
+        },
+        undefined,
+      );
+      throw new Error("expected a ConfigurationException");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigurationException);
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as ConfigurationException).messageParams).toMatchObject({
+        entity: "User",
+        path: "allowlists.creatable",
+      });
+      expect((error as ConfigurationException).message).toContain("never writable");
+    }
   });
 
   it("resolves an entity-scope defaultSort", () => {

--- a/packages/core/tests/serializer.spec.ts
+++ b/packages/core/tests/serializer.spec.ts
@@ -323,6 +323,125 @@ describe("DefaultDeserializer — id and soft-delete marker exclusion", () => {
   });
 });
 
+describe("DefaultDeserializer — creatable/updatable narrowing (issue #259)", () => {
+  /** A context carrying a resolved config's allowlists, for one operation. */
+  function writeContext(
+    operation: "createOne" | "updateOne" | "patchOne",
+    config: ResolvedEntityConfig<User>,
+  ): KavoContext<User> {
+    return { operation, config } as KavoContext<User>;
+  }
+
+  it("is a no-op intersection when neither list is configured", () => {
+    const config = resolveEntityConfig(userMetadata, undefined, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const payload = deserializer.deserialize(
+      { name: "Ada", email: "ada@example.com" },
+      null,
+      writeContext("createOne", config),
+    );
+    expect(payload).toEqual({ name: "Ada", email: "ada@example.com" });
+  });
+
+  it("narrows createOne's derived projection to the creatable allowlist", () => {
+    const config = resolveEntityConfig(userMetadata, { allowlists: { creatable: ["name"] } }, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const payload = deserializer.deserialize(
+      { name: "Ada", email: "ada@example.com" },
+      null,
+      writeContext("createOne", config),
+    );
+    expect(payload).toEqual({ name: "Ada" });
+  });
+
+  it("leaves updateOne/patchOne unaffected by a creatable-only restriction", () => {
+    const config = resolveEntityConfig(userMetadata, { allowlists: { creatable: ["name"] } }, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const updatePayload = deserializer.deserialize(
+      { name: "Ada", email: "ada@example.com" },
+      null,
+      writeContext("updateOne", config),
+    );
+    expect(updatePayload).toEqual({ name: "Ada", email: "ada@example.com" });
+  });
+
+  it("narrows both updateOne and patchOne to the same updatable allowlist", () => {
+    const config = resolveEntityConfig(userMetadata, { allowlists: { updatable: ["name"] } }, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const body = { name: "Ada", email: "ada@example.com" };
+    expect(deserializer.deserialize(body, null, writeContext("updateOne", config))).toEqual({ name: "Ada" });
+    expect(deserializer.deserialize(body, null, writeContext("patchOne", config))).toEqual({ name: "Ada" });
+  });
+
+  it("leaves createOne unaffected by an updatable-only restriction", () => {
+    const config = resolveEntityConfig(userMetadata, { allowlists: { updatable: ["name"] } }, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const payload = deserializer.deserialize(
+      { name: "Ada", email: "ada@example.com" },
+      null,
+      writeContext("createOne", config),
+    );
+    expect(payload).toEqual({ name: "Ada", email: "ada@example.com" });
+  });
+
+  it("keeps the primary key excluded even when explicitly named in creatable", () => {
+    // `creatable: ["id", "name"]` is used verbatim by `resolveEntityConfig`,
+    // but `id` was never in the derived writable projection this class
+    // intersects against — the exclusion holds because a list can only
+    // narrow that base, never add a name back to it (commit 8aa8d65).
+    const config = resolveEntityConfig(userMetadata, { allowlists: { creatable: ["id" as never, "name"] } }, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const payload = deserializer.deserialize({ id: 5, name: "Ada" }, null, writeContext("createOne", config));
+    expect(payload).toEqual({ name: "Ada" });
+  });
+
+  it("keeps the soft-delete marker excluded even when explicitly named in updatable", () => {
+    const withMarker = {
+      ...userMetadata,
+      fields: [...userMetadata.fields, { name: "deletedAt", kind: "date" as const, nullable: true, generated: false }],
+    };
+    const config = resolveEntityConfig(
+      withMarker,
+      { softDelete: { field: "deletedAt" }, allowlists: { updatable: ["deletedAt" as never, "name"] } },
+      undefined,
+    );
+    const deserializer = new DefaultDeserializer<User>(withMarker);
+    const payload = deserializer.deserialize(
+      { deletedAt: new Date(0), name: "Ada" },
+      null,
+      writeContext("updateOne", config),
+    );
+    expect(payload).toEqual({ name: "Ada" });
+  });
+
+  it("leaves an explicitly registered write DTO's key set untouched by creatable/updatable", () => {
+    // ADR-0026's `selectable`-vs-`dto.item` precedent: a registered DTO
+    // replaces the projection outright, so it wins even where the
+    // allowlist would have narrowed it further.
+    class CreateUserDto {
+      email = "";
+    }
+    const config = resolveEntityConfig(userMetadata, { allowlists: { creatable: ["name"] } }, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const payload = deserializer.deserialize(
+      { name: "Ada", email: "ada@example.com" },
+      CreateUserDto,
+      writeContext("createOne", config),
+    );
+    expect(payload).toEqual({ email: "ada@example.com" });
+  });
+
+  it("does not narrow a custom write operation, which neither list names", () => {
+    const config = resolveEntityConfig(userMetadata, { allowlists: { creatable: ["name"] } }, undefined);
+    const deserializer = new DefaultDeserializer<User>(userMetadata);
+    const payload = deserializer.deserialize({ name: "Ada", email: "ada@example.com" }, null, {
+      operation: "archiveUser",
+      config,
+    } as KavoContext<User>);
+    expect(payload).toEqual({ name: "Ada", email: "ada@example.com" });
+  });
+});
+
 describe("DefaultDtoResolver — slot resolution", () => {
   class CreateUserDto {}
   class UpdateUserDto {}


### PR DESCRIPTION
## What & why

Adds two new entity-scope allowlist keys — `creatable` and `updatable` — mirroring the existing `filterable`/`sortable`/`selectable`/`includable`/`searchable` set on `EntityConfig.allowlists`. `creatable` narrows what `createOne` may write; `updatable` narrows what `updateOne`/`patchOne` may write (the two share one list, since both mutate an existing row).

Today the write side has no declarative allowlist — only automatic derivation (every non-generated scalar column except the primary key, plus every relation) or an explicit DTO class that replaces the projection outright. This closes that gap the same way `selectable` already does on the read side: both default to the same base `DefaultDeserializer` already derives, only *narrow* it (the primary key and soft-delete marker stay excluded even if named explicitly), and a registered write DTO with a runtime shape still wins outright over either list — the same precedent ADR-0026 sets for `selectable` vs. a registered `item`/`list` DTO.

Closes #259

## Public API impact

`@kavo/core` barrel gains one new export: `WritableFieldSelector<Entity>` (the depth-1 `FieldPath` selector type backing `creatable`/`updatable`). `QueryAllowlists` and `ResolvedQueryAllowlists` both gain the two new optional/resolved fields respectively — additive, non-breaking.

## Testing

New/updated tests in `packages/core/tests/config.spec.ts` (default derivation, explicit array, `{ exclude }` form, computed-field rejection) and `packages/core/tests/serializer.spec.ts` (per-operation narrowing, DTO-wins-outright precedence, unconditional id/soft-delete exclusion even when named explicitly, custom-op passthrough). `barrel.spec.ts` manifest updated.

`pnpm check`: build/typecheck/depcruise/lint all green; 2558/2558 applicable tests pass. The 5 `examples/*` e2e suites (TypeORM/Mongoose/MikroORM against real Postgres/MariaDB/CockroachDB/Mongo via testcontainers) fail locally with `Could not find a working container runtime strategy` — this sandbox has no Docker daemon; unrelated to this change and expected to run normally in CI. `pnpm docs:links` passes.

## Review notes

Already ran the full `/review` reviewer fan-out (kavo-reviewer, kavo-test-auditor, kavo-security-auditor) locally — zero blocking findings, all confirmed non-blocking:

- A couple of in-code doc comments in `entity-config.ts` (the `QueryAllowlists`/`selectable` doc comments) still describe the pre-existing behavior and weren't updated alongside the markdown docs that were.
- `narrowToWritableAllowlist`'s operation dispatch is an `if`/`else if` chain rather than a lookup table, which would be more consistent with house style (`INPUT_SLOTS`, `STANDARD_OPERATION_VERB`) and make the future `*Many` extension (#137) mechanical.
- No serializer-level test exercises narrowing an actual relation field (only pinned at config-resolution level today) — the security auditor separately confirmed by code trace that relation narrowing and the RFC 6902 JSON Patch relation-mutation path both behave correctly, just unpinned by a test.
- No compile-time (`*.test-d.ts`) test asserting the `FieldPath<Entity, 1>` depth cap rejects a dotted relation path.

None of these are correctness or security issues — happy to fold them in as a follow-up if preferred over blocking this PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EAt98bhLWjpzJB3vxAQ4vp
