### PR TITLE
feat(examples): add PetTag and OwnerSetting to nest-typeorm example

### DIFF
--- a/docs/features/composite-primary-keys.md
+++ b/docs/features/composite-primary-keys.md
@@ -31,6 +31,8 @@ The key columns are creatable but not updatable by default: `createOne` accepts 
 
 Offset, page, cursor, and since pagination all work. Association by id ([ADR-0014](/internals/adr/0014-associate-by-id-not-deep-writes)) works in both directions: a composite entity can be a relation's source (`include=` from its owner) or its target. A write body names it as either an object keyed by each column (`{ owner: { userId: "u1", topic: "billing" } }`) or the same `~`-delimited scalar a route id uses.
 
+`examples/nest-typeorm`'s `PetTag` (`petId`/`tagId`, no surrogate `id`) is a runnable instance of this shape, served over `GET/PUT/PATCH/DELETE /pet-tags/:petId~:tagId`: [`examples/nest-typeorm/src/pet-tag`](https://github.com/kavo-labs/kavo/tree/main/examples/nest-typeorm/src/pet-tag).
+
 ## Limitations
 
 | Area                                               | Status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |

--- a/examples/nest-typeorm/src/app.module.ts
+++ b/examples/nest-typeorm/src/app.module.ts
@@ -11,6 +11,8 @@ import { DogController } from "./dog/dog.controller.js";
 import { TagController } from "./tag/tag.controller.js";
 import { PhotoController } from "./photo/photo.controller.js";
 import { AddressController } from "./address/address.controller.js";
+import { PetTagController } from "./pet-tag/pet-tag.controller.js";
+import { OwnerSettingController } from "./owner-setting/owner-setting.controller.js";
 
 /**
  * Reference wiring: the app hands `@kavo/nest` its infrastructure (here
@@ -74,7 +76,16 @@ export class AppModule {
           }),
         }),
       ],
-      controllers: [OwnerController, CatController, DogController, TagController, PhotoController, AddressController],
+      controllers: [
+        OwnerController,
+        CatController,
+        DogController,
+        TagController,
+        PhotoController,
+        AddressController,
+        PetTagController,
+        OwnerSettingController,
+      ],
       providers: [
         {
           provide: APP_PIPE,

--- a/examples/nest-typeorm/src/database.module.ts
+++ b/examples/nest-typeorm/src/database.module.ts
@@ -7,10 +7,12 @@ import { Dog } from "./dog/dog.entity.js";
 import { Tag } from "./tag/tag.entity.js";
 import { Photo } from "./photo/photo.entity.js";
 import { Address } from "./address/address.entity.js";
+import { PetTag } from "./pet-tag/pet-tag.entity.js";
+import { OwnerSetting } from "./owner-setting/owner-setting.entity.js";
 
 export const DATA_SOURCE = Symbol("DATA_SOURCE");
 
-const entities = [Owner, Pet, Cat, Dog, Tag, Photo, Address];
+const entities = [Owner, Pet, Cat, Dog, Tag, Photo, Address, PetTag, OwnerSetting];
 
 interface ConnectionOptions {
   host: string;

--- a/examples/nest-typeorm/src/owner-setting/owner-setting.controller.ts
+++ b/examples/nest-typeorm/src/owner-setting/owner-setting.controller.ts
@@ -1,0 +1,60 @@
+import { Controller, Inject } from "@nestjs/common";
+import { Kavo, Override, getKavoServiceToken } from "@kavo/nest";
+import type { DefaultKavoService, EntityId, RequestPreconditions } from "@kavo/core";
+import { OwnerSetting } from "./owner-setting.entity.js";
+import {
+  CreateOwnerSettingDto,
+  UpdateOwnerSettingDto,
+  PatchOwnerSettingDto,
+  OwnerSettingItemDto,
+  OwnerSettingListDto,
+} from "./owner-setting.dtos.js";
+
+/**
+ * Plain CRUD over the shared-primary-key one-to-one (issue #267):
+ * `GET/PUT/PATCH/DELETE /owner-settings/:id` addresses a row by the same
+ * id its owning `Owner` uses, since `owner_id` is both this entity's sole
+ * primary column and the `@JoinColumn` of its `owner` relation. `createOne`
+ * accepts `owner` (association-by-id, ADR-0014), which the adapter writes
+ * through that same join column — there is no separate `owner_id` field on
+ * any DTO here.
+ *
+ * Validation: `createOne`/`updateOne`/`patchOne` are `@Override()`'d purely
+ * to give their body parameter a concrete, `class-validator`-decorated
+ * type — see `owner.controller.ts`'s own validation note for why.
+ */
+@Kavo(OwnerSetting, {
+  dto: {
+    create: CreateOwnerSettingDto,
+    update: UpdateOwnerSettingDto,
+    item: OwnerSettingItemDto,
+    list: OwnerSettingListDto,
+  },
+})
+@Controller("owner-settings")
+export class OwnerSettingController {
+  constructor(@Inject(getKavoServiceToken(OwnerSetting)) private readonly base: DefaultKavoService<OwnerSetting>) {}
+
+  @Override()
+  async createOne(dto: CreateOwnerSettingDto): Promise<unknown> {
+    return this.base.createOne(dto as never);
+  }
+
+  @Override()
+  async updateOne(
+    id: EntityId,
+    dto: UpdateOwnerSettingDto,
+    preconditions: RequestPreconditions | null,
+  ): Promise<unknown> {
+    return this.base.updateOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+
+  @Override()
+  async patchOne(
+    id: EntityId,
+    dto: PatchOwnerSettingDto,
+    preconditions: RequestPreconditions | null,
+  ): Promise<unknown> {
+    return this.base.patchOne(id as never, dto as never, { preconditions: preconditions ?? undefined });
+  }
+}

--- a/examples/nest-typeorm/src/owner-setting/owner-setting.dtos.ts
+++ b/examples/nest-typeorm/src/owner-setting/owner-setting.dtos.ts
@@ -1,0 +1,66 @@
+import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsPositive, IsString } from "class-validator";
+
+/**
+ * DTO slots for the OwnerSetting route. `owner_id` never appears on any of
+ * these: it is the entity's sole primary column, so — like every other
+ * entity's single `idField` — it is excluded from the writable projection
+ * by default. The row's owner is instead set the same way any relation is
+ * (ADR-0014): `owner` on `create` takes the owner's id, and the adapter
+ * writes it through the `@JoinColumn` this entity's `owner` relation
+ * declares, which happens to be `owner_id` itself. `owner` is deliberately
+ * absent from `Update`/`PatchOwnerSettingDto` — which owner a settings row
+ * belongs to isn't something a client repoints after creation.
+ */
+
+/** `create` slot — request body for POST /owner-settings. */
+export class CreateOwnerSettingDto {
+  @IsInt()
+  @IsPositive()
+  owner = 0;
+
+  @IsString()
+  @IsNotEmpty()
+  theme = "";
+
+  @IsBoolean()
+  emailNotifications = true;
+}
+
+/** `update` slot — request body for PUT /owner-settings/:id (patch derives from it). */
+export class UpdateOwnerSettingDto {
+  @IsString()
+  @IsNotEmpty()
+  theme = "";
+
+  @IsBoolean()
+  emailNotifications = true;
+}
+
+/**
+ * `PATCH /owner-settings/:id`'s own validated shape. See `PatchOwnerDto`
+ * (`owner.dtos.ts`) for why this exists as its own class.
+ */
+export class PatchOwnerSettingDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  theme?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  emailNotifications?: boolean;
+}
+
+/** `item` slot — the detail projection. */
+export class OwnerSettingItemDto {
+  owner_id = 0;
+  theme = "";
+  emailNotifications = true;
+}
+
+/** `list` slot — same shape as `item`; an owner-setting has nothing left to trim. */
+export class OwnerSettingListDto {
+  owner_id = 0;
+  theme = "";
+  emailNotifications = true;
+}

--- a/examples/nest-typeorm/src/owner-setting/owner-setting.entity.ts
+++ b/examples/nest-typeorm/src/owner-setting/owner-setting.entity.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from "typeorm";
+import { Owner } from "../owner/owner.entity.js";
+
+/**
+ * A shared-primary-key one-to-one (issue #267): `owner_id` is this entity's
+ * sole `@PrimaryColumn` *and* the `@JoinColumn` of its `@OneToOne` to
+ * `Owner` — there is no separate `id` column. A different shape from the
+ * app's other one-to-one (`Owner`↔`Address`, where `Address` has its own
+ * generated `id`): here the child's identity *is* the parent's id, so a
+ * given `Owner` can have at most one `OwnerSetting` row, addressed by the
+ * same id the owner itself uses. Single-column, not composite — no
+ * `compositeIdFields` involved (ADR-0039), just a natural key that happens
+ * to also be a foreign key.
+ */
+@Entity()
+export class OwnerSetting {
+  @PrimaryColumn()
+  owner_id!: number;
+
+  @OneToOne(() => Owner)
+  @JoinColumn({ name: "owner_id" })
+  owner!: Owner;
+
+  @Column("varchar")
+  theme!: string;
+
+  @Column("boolean", { default: true })
+  emailNotifications!: boolean;
+}

--- a/examples/nest-typeorm/src/pet-tag/pet-tag.controller.ts
+++ b/examples/nest-typeorm/src/pet-tag/pet-tag.controller.ts
@@ -1,0 +1,59 @@
+import { Controller, Inject } from "@nestjs/common";
+import { Kavo, Override, getKavoServiceToken } from "@kavo/nest";
+import type { DefaultKavoService, EntityId, RequestPreconditions } from "@kavo/core";
+import { PetTag } from "./pet-tag.entity.js";
+import { CreatePetTagDto, UpdatePetTagDto, PatchPetTagDto, PetTagItemDto, PetTagListDto } from "./pet-tag.dtos.js";
+import { assertValidNote, normalizeNote } from "./pet-tag.runtime.js";
+
+/**
+ * Plain CRUD over a composite-key entity (ADR-0039, issue #267):
+ * `petId`/`tagId` are the whole primary key, so every route this generates
+ * addresses a row by `GET/PUT/PATCH/DELETE /pet-tags/:petId~:tagId` — one
+ * path segment joining both columns with `~` — instead of a single numeric
+ * `:id`. `createOne` accepts `petId`/`tagId` (a natural key the client
+ * supplies); `updateOne`/`patchOne` don't, since the composite route id
+ * already addresses the row and the key is immutable afterward (ADR-0039's
+ * default — nothing here overrides `creatable`/`updatable` for it).
+ *
+ * Validation: `createOne`/`updateOne`/`patchOne` are `@Override()`'d purely
+ * to give their body parameter a concrete, `class-validator`-decorated
+ * type — see `owner.controller.ts`'s own validation note for why. `note`'s
+ * trim-then-validate step is the same two-step shape `AddressController`
+ * uses for `postalCode`.
+ */
+@Kavo(PetTag, {
+  dto: {
+    create: CreatePetTagDto,
+    update: UpdatePetTagDto,
+    item: PetTagItemDto,
+    list: PetTagListDto,
+  },
+})
+@Controller("pet-tags")
+export class PetTagController {
+  constructor(@Inject(getKavoServiceToken(PetTag)) private readonly base: DefaultKavoService<PetTag>) {}
+
+  @Override()
+  async createOne(dto: CreatePetTagDto): Promise<unknown> {
+    const note = normalizeNote(dto.note);
+    assertValidNote(note);
+    return this.base.createOne({ ...dto, note } as never);
+  }
+
+  @Override()
+  async updateOne(id: EntityId, dto: UpdatePetTagDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    const note = normalizeNote(dto.note);
+    assertValidNote(note);
+    return this.base.updateOne(id as never, { note } as never, { preconditions: preconditions ?? undefined });
+  }
+
+  @Override()
+  async patchOne(id: EntityId, dto: PatchPetTagDto, preconditions: RequestPreconditions | null): Promise<unknown> {
+    const patch = { ...dto };
+    if (patch.note !== undefined) {
+      patch.note = normalizeNote(patch.note);
+      assertValidNote(patch.note);
+    }
+    return this.base.patchOne(id as never, patch as never, { preconditions: preconditions ?? undefined });
+  }
+}

--- a/examples/nest-typeorm/src/pet-tag/pet-tag.dtos.ts
+++ b/examples/nest-typeorm/src/pet-tag/pet-tag.dtos.ts
@@ -1,0 +1,57 @@
+import { IsInt, IsNotEmpty, IsOptional, IsPositive, IsString } from "class-validator";
+
+/**
+ * DTO slots for the PetTag route. `petId`/`tagId` are the composite key
+ * (ADR-0039) — creatable (the client supplies the natural key on
+ * `createOne`) but not part of `Update`/`PatchPetTagDto`, since they are
+ * immutable after creation and the composite route id already addresses
+ * the row. `note`'s trim-then-validate step lives in `pet-tag.runtime.ts`,
+ * the same two-step shape `address.dtos.ts` uses for `postalCode`.
+ */
+
+/** `create` slot — request body for POST /pet-tags. */
+export class CreatePetTagDto {
+  @IsInt()
+  @IsPositive()
+  petId = 0;
+
+  @IsInt()
+  @IsPositive()
+  tagId = 0;
+
+  @IsString()
+  @IsNotEmpty()
+  note = "";
+}
+
+/** `update` slot — request body for PUT /pet-tags/:id (patch derives from it). */
+export class UpdatePetTagDto {
+  @IsString()
+  @IsNotEmpty()
+  note = "";
+}
+
+/**
+ * `PATCH /pet-tags/:id`'s own validated shape. See `PatchOwnerDto`
+ * (`owner.dtos.ts`) for why this exists as its own class.
+ */
+export class PatchPetTagDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  note?: string;
+}
+
+/** `item` slot — the detail projection. */
+export class PetTagItemDto {
+  petId = 0;
+  tagId = 0;
+  note = "";
+}
+
+/** `list` slot — same shape as `item`; a pet-tag has nothing left to trim. */
+export class PetTagListDto {
+  petId = 0;
+  tagId = 0;
+  note = "";
+}

--- a/examples/nest-typeorm/src/pet-tag/pet-tag.entity.ts
+++ b/examples/nest-typeorm/src/pet-tag/pet-tag.entity.ts
@@ -1,0 +1,38 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
+import { Pet } from "../pet/pet.entity.js";
+import { Tag } from "../tag/tag.entity.js";
+
+/**
+ * A composite-key join entity (ADR-0039, issue #267): `petId`/`tagId` are
+ * the whole primary key, declared in this order, and there is no surrogate
+ * `id` column at all. Mirrors the `UserSentence` shape from
+ * `docs/features/composite-primary-keys.md` — each key column doubles as a
+ * `@JoinColumn` for a plain `@ManyToOne` association-by-id relation, kept
+ * deliberately unidirectional (neither `Pet` nor `Tag` references it back),
+ * the same choice `Tag`'s own relation to `Pet` already makes.
+ *
+ * Both relations stay plain `@ManyToOne`s rather than a `@ManyToMany` —
+ * ADR-0039 refuses many-to-many array-mutation writes on a composite-keyed
+ * entity at `createCrud` bootstrap, since TypeORM's `RelationQueryBuilder`
+ * can't address a 2+ column owning side. `Pet.tags` already exercises the
+ * `@ManyToMany` shape; this entity exercises the composite-key one instead.
+ */
+@Entity()
+export class PetTag {
+  @PrimaryColumn()
+  petId!: number;
+
+  @ManyToOne(() => Pet)
+  @JoinColumn({ name: "petId" })
+  pet!: Pet;
+
+  @PrimaryColumn()
+  tagId!: number;
+
+  @ManyToOne(() => Tag)
+  @JoinColumn({ name: "tagId" })
+  tag!: Tag;
+
+  @Column("varchar")
+  note!: string;
+}

--- a/examples/nest-typeorm/src/pet-tag/pet-tag.runtime.ts
+++ b/examples/nest-typeorm/src/pet-tag/pet-tag.runtime.ts
@@ -1,0 +1,16 @@
+import { QueryValidationException } from "@kavo/core";
+
+/** Reused by `PetTagController`'s `createOne`/`updateOne`/`patchOne` overrides. */
+export function normalizeNote(raw: string): string {
+  return raw.trim();
+}
+
+export function assertValidNote(value: string): void {
+  if (value.length === 0) {
+    throw QueryValidationException.single({
+      field: "note",
+      code: "KAVO_QUERY_INVALID_VALUE",
+      detail: "note must not be empty",
+    });
+  }
+}

--- a/examples/nest-typeorm/tests/crud-e2e.suite.ts
+++ b/examples/nest-typeorm/tests/crud-e2e.suite.ts
@@ -1574,5 +1574,79 @@ export function registerCrudE2eSuite(getApp: () => INestApplication): void {
       expect(patched.body.url).toBe("patched.png");
       await request(server()).patch(`/photos/${id}`).send({ url: "" }).expect(400);
     });
+
+    it("addresses a composite-key entity by its ~-joined route id (issue #267, ADR-0039)", async () => {
+      const cat = await request(server())
+        .post("/cats")
+        .send({ name: "Composite", age: 2, size: "small", indoor: true, livesLeft: 9 })
+        .expect(201);
+      const tag = await request(server()).post("/tags").send({ name: "composite-key-demo" }).expect(201);
+      const petId = cat.body.id as number;
+      const tagId = tag.body.id as number;
+
+      const created = await request(server()).post("/pet-tags").send({ petId, tagId, note: "  first!  " }).expect(201);
+      // `note` is trimmed by `PetTagController`'s `createOne` override.
+      expect(created.body).toEqual({ petId, tagId, note: "first!" });
+
+      const routeId = `${petId}~${tagId}`;
+      const fetched = await request(server()).get(`/pet-tags/${routeId}`).expect(200);
+      expect(fetched.body).toEqual({ petId, tagId, note: "first!" });
+
+      // `petId`/`tagId` are creatable but not updatable (ADR-0039's
+      // default) — PUT only carries `note`.
+      const updated = await request(server()).put(`/pet-tags/${routeId}`).send({ note: "renamed" }).expect(200);
+      expect(updated.body).toEqual({ petId, tagId, note: "renamed" });
+
+      const patched = await request(server()).patch(`/pet-tags/${routeId}`).send({ note: "  patched  " }).expect(200);
+      expect(patched.body.note).toBe("patched");
+      await request(server()).patch(`/pet-tags/${routeId}`).send({ note: "" }).expect(400);
+
+      await request(server()).delete(`/pet-tags/${routeId}`).expect(204);
+      await request(server()).get(`/pet-tags/${routeId}`).expect(404);
+    });
+
+    it("rejects an empty note on POST /pet-tags", async () => {
+      const cat = await request(server())
+        .post("/cats")
+        .send({ name: "EmptyNote", age: 1, size: "small", indoor: true, livesLeft: 9 })
+        .expect(201);
+      const tag = await request(server()).post("/tags").send({ name: "empty-note-demo" }).expect(201);
+
+      const response = await request(server())
+        .post("/pet-tags")
+        .send({ petId: cat.body.id, tagId: tag.body.id, note: "   " })
+        .expect(400);
+      expect(response.body.errors).toEqual([
+        expect.objectContaining({ field: "note", code: "KAVO_QUERY_INVALID_VALUE" }),
+      ]);
+    });
+
+    it("addresses a shared-primary-key one-to-one by its owner's own id (issue #267)", async () => {
+      const owner = await request(server())
+        .post("/owners")
+        .send({ name: "Settings Owner", email: "settings@x.io" })
+        .expect(201);
+      const ownerId = owner.body.id as number;
+
+      const created = await request(server())
+        .post("/owner-settings")
+        .send({ owner: ownerId, theme: "dark", emailNotifications: false })
+        .expect(201);
+      // `owner_id` — this entity's sole primary column — comes from the
+      // `owner` relation's join column, never a raw field on the body.
+      expect(created.body).toEqual({ owner_id: ownerId, theme: "dark", emailNotifications: false });
+
+      const fetched = await request(server()).get(`/owner-settings/${ownerId}`).expect(200);
+      expect(fetched.body).toEqual({ owner_id: ownerId, theme: "dark", emailNotifications: false });
+
+      const patched = await request(server())
+        .patch(`/owner-settings/${ownerId}`)
+        .send({ emailNotifications: true })
+        .expect(200);
+      expect(patched.body).toEqual({ owner_id: ownerId, theme: "dark", emailNotifications: true });
+
+      await request(server()).delete(`/owner-settings/${ownerId}`).expect(204);
+      await request(server()).get(`/owner-settings/${ownerId}`).expect(404);
+    });
   });
 }


### PR DESCRIPTION
Exercises two id shapes @kavo/typeorm supports but the example app never
demonstrated: PetTag is a composite-key join entity (petId/tagId, no
surrogate id, ADR-0039) served over /pet-tags/:petId~:tagId; OwnerSetting
is a shared-primary-key one-to-one, where owner_id is both its sole
primary column and the JoinColumn of its OneToOne to Owner. Both are
wired into database.module.ts and app.module.ts and covered by e2e tests
in crud-e2e.suite.ts, which runs against every driver the example
supports.

Closes #267