### PR TITLE
ci: add Dependabot config for npm and github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to replace Greenkeeper-style automated dependency PRs:
- `npm` ecosystem at the repo root — pnpm resolves the whole workspace (`packages/*`, `examples/*`) from the single root lockfile, so one entry covers all packages. Weekly checks, one PR per outdated dependency (Dependabot's default). Commit messages prefixed `chore` to match this repo's Conventional Commits convention.
- `github-actions` ecosystem at the repo root — keeps actions used in `.github/workflows/*` up to date, weekly. Commit messages prefixed `ci`.

This was originally part of PR #271 (the autoformat bot), but that PR merged before this commit landed on the branch, so it's split out here.

## Public API impact
None — CI/tooling only.

## Testing
No test suite applies to Dependabot config; correctness is YAML schema shape (validated by GitHub once merged). `pnpm check` and `pnpm docs:links` pass on this branch (unrelated to this change).

## Review notes
Dependabot activates automatically once this lands on `main` — no further wiring needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)