### PR TITLE
fix(typeorm): map invalid-uuid driver errors to a 400, not KAVO_PERSISTENCE_FAILED

### DIFF
--- a/docs/internals/architecture/09-typeorm-adapter.md
+++ b/docs/internals/architecture/09-typeorm-adapter.md
@@ -87,6 +87,7 @@ is true, so `total: null` costs zero extra queries.
 | ---------------------------------------------------------------------------- | ------------------------------------------ |
 | unique violation (`23505` / 1062 / `SQLITE_CONSTRAINT_UNIQUE`·`_PRIMARYKEY`) | `ConflictException`                        |
 | FK violation (`23503` / 1451·1452 / `SQLITE_CONSTRAINT_FOREIGNKEY`)          | `ConflictException`                        |
+| invalid input syntax (PG `22P02`, e.g. a non-UUID id)                        | `QueryValidationException` (400)           |
 | serialization/deadlock (`40001`·`40P01` / 1213 / `SQLITE_BUSY`)              | `TransactionException` (`retryable: true`) |
 | anything else                                                                | `PersistenceException` with `cause`        |
 

--- a/packages/orms/typeorm/src/error-mapping.ts
+++ b/packages/orms/typeorm/src/error-mapping.ts
@@ -1,5 +1,11 @@
 import type { ErrorContext } from "@kavo/core";
-import { ConflictException, KavoException, PersistenceException, TransactionException } from "@kavo/core";
+import {
+  ConflictException,
+  KavoException,
+  PersistenceException,
+  QueryValidationException,
+  TransactionException,
+} from "@kavo/core";
 import { QueryFailedError } from "typeorm";
 
 /**
@@ -9,12 +15,24 @@ import { QueryFailedError } from "typeorm";
  * | --------------------------------- | ---------------------------------- |
  * | unique violation                  | ConflictException                  |
  * | foreign-key violation             | ConflictException                  |
+ * | invalid input syntax (bad value)  | QueryValidationException           |
  * | serialization failure / deadlock  | TransactionException (retryable)   |
  * | anything else                     | PersistenceException with `cause`  |
  *
  * Codes covered: Postgres SQLSTATE, MySQL errno, SQLite extended codes.
  * Unknown drivers fall through to `PersistenceException` — the original
  * error always travels as `cause`, never swallowed.
+ *
+ * **Invalid input syntax.** A malformed id/filter value that a driver
+ * itself rejects for not matching a column's storage format (e.g. a
+ * non-UUID string against a `uuid` column) is a 400, not a 500: the
+ * request was bad, not the connection to the database (issue #279). This
+ * covers only what a driver actually errors on — `coerceId`
+ * (`kavo-engine.ts`) already gives a clean 400 for a numeric-column id
+ * pre-query; core has no generic "string ids must match a format" concept,
+ * so this is the adapter's own catch for the formats it knows about.
+ * Scoped to Postgres's `22P02` for now (issue #279); MySQL/SQLite
+ * equivalents are a follow-up if reported.
  *
  * **Soft delete and unique indexes.** A soft-deleted row still
  * occupies its unique indexes, so re-creating "the same" row after a soft
@@ -62,6 +80,18 @@ export function mapDriverError(error: unknown, context: ErrorContext): KavoExcep
       code === "SQLITE_BUSY";
     if (retryable) {
       return new TransactionException({ retryable: true, context, cause: error });
+    }
+
+    const invalidInput = code === "22P02"; // Postgres invalid_text_representation
+    if (invalidInput) {
+      return QueryValidationException.single(
+        {
+          field: "id",
+          code: "KAVO_QUERY_INVALID_VALUE",
+          detail: message,
+        },
+        { context, cause: error },
+      );
     }
   }
 

--- a/packages/orms/typeorm/tests/error-mapping.spec.ts
+++ b/packages/orms/typeorm/tests/error-mapping.spec.ts
@@ -119,6 +119,29 @@ describe("mapDriverError — serialization failures and deadlocks", () => {
   });
 });
 
+describe("mapDriverError — invalid input syntax", () => {
+  it("maps Postgres invalid_text_representation (22P02) to a query-validation 400", () => {
+    const mapped = mapDriverError(
+      queryFailed({ code: "22P02", message: 'invalid input syntax for type uuid: "not-a-uuid"' }),
+      context,
+    );
+    expect(mapped).toBeInstanceOf(QueryValidationException);
+    expect(mapped).toMatchObject({ code: "KAVO_QUERY_INVALID", status: 400 });
+    expect((mapped as QueryValidationException).issues).toEqual([
+      {
+        field: "id",
+        code: "KAVO_QUERY_INVALID_VALUE",
+        detail: 'invalid input syntax for type uuid: "not-a-uuid"',
+      },
+    ]);
+  });
+
+  it("keeps the original driver error as cause", () => {
+    const error = queryFailed({ code: "22P02" });
+    expect(mapDriverError(error, context).cause).toBe(error);
+  });
+});
+
 describe("mapDriverError — the fallback row", () => {
   it("maps an unrecognized driver code to a persistence failure", () => {
     const mapped = mapDriverError(queryFailed({ code: "42P01" }), context);
@@ -168,6 +191,7 @@ describe("mapDriverError — cause and context propagation", () => {
     ...uniqueViolations,
     ...foreignKeyViolations,
     ...retryableFailures,
+    ["Postgres invalid_text_representation", { code: "22P02" }],
     ["unknown", { code: "42P01" }],
   ] as const;
 


### PR DESCRIPTION
## What / why

`GET /ads/not-a-uuid` against a uuid-kind primary key returned 500 `KAVO_PERSISTENCE_FAILED` instead of 400. The malformed id reached Postgres unchecked, which raised `22P02 invalid_input_syntax`, and `mapDriverError` had no branch for it — it fell through to the generic `PersistenceException` row. `mapDriverError` now maps `22P02` to `QueryValidationException` (400, `KAVO_QUERY_INVALID_VALUE`), matching the existing clean-400 behavior `coerceId` already gives a non-numeric id on a numeric-kind column.

Scoped to Postgres per the issue — core has no `"uuid"` `FieldKind`, so this lives entirely in `@kavo/typeorm`'s driver-error mapping, not in `coerceId`.

## Public API impact

None. No barrel export changes.

## Testing

- Unit tests added in `packages/orms/typeorm/tests/error-mapping.spec.ts`: `22P02` → `QueryValidationException` with the right issue shape, `cause` preserved, included in cross-cutting cause/context propagation checks.
- `docs/internals/architecture/09-typeorm-adapter.md` §5 error-mapping table updated with the new row.
- `pnpm check`: build + typecheck + depcruise + lint + test all green (119 files, 2967 tests passed).
- `pnpm docs:links`: OK.

## Review notes

The issue also asked for an integration test in `adapter.spec.ts` exercising a real malformed id against a UUID-PK entity. That suite runs on `better-sqlite3`, which has no `uuid` column type and never raises Postgres's `22P02`, so a true end-to-end repro isn't reachable with this package's current test DB — the unit test against `mapDriverError` directly is the coverage added instead. Flagging for reviewer awareness rather than silently dropping the criterion.

Closes #279