### PR TITLE
fix(nest): validate dto.create/update/patch on generated routes, not just @Override()'d ones

### DIFF
--- a/examples/nest-typeorm/README.md
+++ b/examples/nest-typeorm/README.md
@@ -15,10 +15,14 @@ databases below unchanged.
 Every entity but `Dog` also validates its write bodies with `class-validator`
 — Kavo's own DTOs are shapes only, with no validation subsystem of their
 own (see `docs/internals/architecture/04-dto-system.md`), so this app's own
-`ValidationPipe` (`app.module.ts`) plus each `createOne`/`updateOne`/
-`patchOne` override (see `owner.controller.ts`) is what a validation layer
-looks like bolted onto Kavo from application code, with no framework
-changes. `Dog` is left unvalidated on purpose, as the contrast.
+`ValidationPipe` (`app.module.ts`) plus each entity's registered
+`dto.create`/`update`/`patch` class is what a validation layer looks like
+bolted onto Kavo from application code, with no framework changes. `Owner`
+and `Cat` additionally `@Override()` their `createOne`/`updateOne`/`patchOne`
+(see `owner.controller.ts`) to give the body a concrete compile-time type
+inside the method — since issue #281, that override is no longer required
+for the validation itself, which now also runs on a generated route.
+`Dog` is left unvalidated on purpose, as the contrast.
 
 ## SQLite (default)
 

--- a/examples/nest-typeorm/src/address/address.controller.ts
+++ b/examples/nest-typeorm/src/address/address.controller.ts
@@ -37,10 +37,12 @@ import { assertValidPostalCode, clearOwnerAddress, normalizePostalCode } from ".
  *
  * `createOne`/`updateOne`/`patchOne` below are typed with the concrete,
  * `class-validator`-decorated DTO classes (`address.dtos.ts`) rather than
- * `Partial<Address>` — the app's global `ValidationPipe` (`app.module.ts`)
- * only validates a body param whose declared type it can resolve via
- * `emitDecoratorMetadata`, which only exists for a type written directly in
- * this class's own source (see `owner.controller.ts`'s validation note).
+ * `Partial<Address>` purely for a concrete compile-time type inside each
+ * method body — since issue #281, the app's global `ValidationPipe`
+ * (`app.module.ts`) validates a registered `dto.create`/`update`/`patch`
+ * class on a generated route as well (see `owner.controller.ts`'s
+ * validation note), so these overrides exist here for the cross-entity
+ * write and the other custom behavior above, not for validation.
  * `postalCode`'s exact-5-digit format stays a procedural check
  * (`assertValidPostalCode`) run after that generic shape validation passes
  * — a business rule with its own normalization step, not a `class-validator`

--- a/examples/nest-typeorm/src/owner/owner.controller.ts
+++ b/examples/nest-typeorm/src/owner/owner.controller.ts
@@ -34,15 +34,16 @@ import { hasPermission } from "./owner.policy.js";
  * left unconfigured here (contrast Cat's explicit array): the zero-config
  * default. `search[fields]=name` narrows a given request to just one.
  *
- * Validation: `createOne`/`updateOne`/`patchOne` are `@Override()`'d purely
- * to give their body parameter a concrete, `class-validator`-decorated
- * type (`CreateOwnerDto`/`UpdateOwnerDto`/`PatchOwnerDto`) rather than the
- * generated route's untyped one — Kavo's own DTOs are shapes only (doc 04),
- * so nothing validates a generated route's body. Nest's global
- * `ValidationPipe` (`app.module.ts`) reads a body param's declared type off
- * `emitDecoratorMetadata`, which only exists for a param written directly
- * in this class's own source — a generated method has no such metadata,
- * `@Override()` recovers it. Each override otherwise just delegates.
+ * Validation: `createOne`/`updateOne`/`patchOne` are `@Override()`'d to give
+ * their body parameter a concrete, `class-validator`-decorated type
+ * (`CreateOwnerDto`/`UpdateOwnerDto`/`PatchOwnerDto`) — Kavo's own DTOs are
+ * shapes only (doc 04); teams wire NestJS's own `ValidationPipe`
+ * (`app.module.ts`) for actual validation. As of issue #281, a registered
+ * `dto.create`/`update`/`patch` class validates on a *generated* route too
+ * (`@Kavo` writes the `design:paramtypes` metadata `ValidationPipe` needs),
+ * so these overrides are no longer required for validation to run; each
+ * override still exists here purely to give the body a concrete compile-time
+ * type inside the method body, and otherwise just delegates.
  *
  * Authorization: `DELETE /owners/:id` additionally requires the
  * `owner:delete` permission (ADR-0037) — `hasPermission('owner:delete')`

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -16,11 +16,13 @@ import { isObservable } from "rxjs";
 import type {
   ClassRef,
   DefaultKavoService,
+  DtoResolver,
   EntityConfig,
   EntityInput,
   KavoCallOptions,
   KavoResponse,
   OperationDescriptor,
+  OperationDtoMap,
   OperationId,
   OperationsConfig,
   QueryContext,
@@ -32,6 +34,7 @@ import {
   ConfigurationException,
   computeEtag,
   createOperationRegistry,
+  DefaultDtoResolver,
   isEtagEnabled,
   registerArrayMutationOperations,
 } from "@kavo/core";
@@ -49,7 +52,7 @@ import {
   KAVO_SERVICE_PROPERTY,
 } from "./tokens.js";
 import { WireQueryPipe } from "./wire-query.pipe.js";
-import { applySwaggerMetadata } from "./swagger.js";
+import { applySwaggerMetadata, bodyDtoFor } from "./swagger.js";
 
 /**
  * One route whose conditional-request Swagger docs (ADR-0020) `@Kavo`
@@ -362,7 +365,7 @@ export function Kavo<
         if (Object.prototype.hasOwnProperty.call(controller.prototype, methodName)) {
           continue; // manual-method-wins
         }
-        defineRoute(controller.prototype, methodName, descriptor, route);
+        defineRoute(controller.prototype, methodName, descriptor, route, erasedConfig);
         applySwaggerMetadata(controller.prototype, methodName, descriptor, route, entity, erasedConfig);
         conditionalDocs.push({ methodName, descriptor, route });
       } else {
@@ -590,6 +593,7 @@ function defineRoute(
   methodName: string,
   descriptor: OperationDescriptor<object>,
   route: ResolvedRoute,
+  config: EntityConfig<object> | undefined,
 ): void {
   const handler = makeHandler(descriptor, route);
   Object.defineProperty(handler, "name", { value: methodName });
@@ -598,7 +602,8 @@ function defineRoute(
     writable: true,
     configurable: true,
   });
-  applyRouteDecorators(prototype, methodName, descriptor, route);
+  const dtoResolver = new DefaultDtoResolver(config?.dto as OperationDtoMap<object> | undefined);
+  applyRouteDecorators(prototype, methodName, descriptor, route, dtoResolver);
 }
 
 /**
@@ -613,9 +618,10 @@ function applyRouteDecorators(
   methodName: string,
   descriptor: OperationDescriptor<object>,
   route: ResolvedRoute,
+  dtoResolver?: DtoResolver<object>,
 ): void {
   const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, methodName) as PropertyDescriptor;
-  applyParamDecorators(prototype, methodName, descriptor, route);
+  applyParamDecorators(prototype, methodName, descriptor, route, dtoResolver);
   // Route identity for `getResource`/`getOperation` (issue #238), written
   // on the handler function itself — the same target Nest's method
   // decorators write to — so Nest's `Reflector` can read it off
@@ -660,14 +666,30 @@ function applyRouteDecorators(
  * cannot be baked into the generated method — the handler resolves it per
  * request from the controller instance instead, and needs the request to
  * run it against.
+ *
+ * `dtoResolver`, when given, is issue #281's fix: a generated method has no
+ * source-level parameter declaration, so TypeScript's `emitDecoratorMetadata`
+ * never writes `design:paramtypes` for it, and Nest's global `ValidationPipe`
+ * resolves its `metatype` off exactly that metadata — so a registered
+ * `dto.create`/`dto.update`/`dto.patch` class was silently never validated on
+ * a generated route, however it's decorated (`class-validator`, `zod`, or
+ * anything else hooking Nest's pipe system; the gap is generic, not tied to
+ * one validation library). Writing the same metadata by hand here, at the
+ * body parameter's position, is enough to make the existing global pipe
+ * validate it, with no change to how the pipe itself resolves a metatype.
+ * `undefined` (the override path, which already carries real
+ * `design:paramtypes` from its own compiled source) leaves that metadata
+ * untouched rather than clobbering it.
  */
 function applyParamDecorators(
   prototype: Record<string, unknown>,
   methodName: string,
   descriptor: OperationDescriptor<object>,
   route: ResolvedRoute,
+  dtoResolver?: DtoResolver<object>,
 ): void {
   let index = 0;
+  let bodyIndex = -1;
   if (route.hasIdParam) {
     Param("id")(prototype, methodName, index++);
   }
@@ -675,9 +697,17 @@ function applyParamDecorators(
     Query(new WireQueryPipe())(prototype, methodName, index++);
   } else if (takesBody(descriptor, route)) {
     Body()(prototype, methodName, index++);
+    bodyIndex = index - 1;
   }
   ConditionalRequest()(prototype, methodName, index++);
   Req()(prototype, methodName, index++);
+
+  if (bodyIndex === -1 || dtoResolver === undefined) return;
+  const bodyDto = bodyDtoFor(descriptor, dtoResolver);
+  if (bodyDto === null) return;
+  const paramTypes: unknown[] = Array.from({ length: index });
+  paramTypes[bodyIndex] = bodyDto;
+  Reflect.defineMetadata("design:paramtypes", paramTypes, prototype, methodName);
 }
 
 /**

--- a/packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts
@@ -1,0 +1,129 @@
+import "reflect-metadata";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import {
+  Controller,
+  Injectable,
+  type ArgumentMetadata,
+  type INestApplication,
+  type PipeTransform,
+} from "@nestjs/common";
+import { APP_PIPE } from "@nestjs/core";
+import { Test } from "@nestjs/testing";
+import { Kavo, KavoModule, Override, boundKavoService } from "@kavo/nest";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
+
+/**
+ * Issue #281: a generated (non-`@Override()`'d) route's `@Body()` parameter
+ * carries no source-level type declaration, so TypeScript's
+ * `emitDecoratorMetadata` never writes `design:paramtypes` for it — and
+ * Nest's own pipe system resolves a `PipeTransform`'s `ArgumentMetadata.metatype`
+ * off exactly that reflection metadata. Before the fix, a registered
+ * `dto.create`/`dto.update`/`dto.patch` class was invisible to any global
+ * pipe on a generated route: `metatype` always came back `Object`, whatever
+ * class was configured. `RecordingPipe` below stands in for any real
+ * validator hooked through Nest's pipe system (`class-validator`'s
+ * `ValidationPipe`, `nestjs-zod`, or a hand-written one) — the fix is
+ * pinned at the mechanism Nest itself uses, not at one validation library.
+ */
+class RecordingPipe implements PipeTransform {
+  static metatypes: unknown[] = [];
+
+  transform(value: unknown, metadata: ArgumentMetadata): unknown {
+    if (metadata.type === "body") RecordingPipe.metatypes.push(metadata.metatype);
+    return value;
+  }
+}
+
+@Injectable()
+class GlobalRecordingPipe extends RecordingPipe {}
+
+class CreateTodoDto {
+  title = "";
+}
+
+class UpdateTodoDto {
+  title = "";
+}
+
+let app: INestApplication;
+let httpServer: SupertestTarget | undefined;
+
+async function bootstrap(controllers: readonly unknown[]): Promise<void> {
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      KavoModule.forRoot({ infrastructure: fakeInfrastructure(new InMemoryTodoAdapter()) }),
+      KavoModule.forFeature(controllers as never),
+    ],
+    providers: [{ provide: APP_PIPE, useClass: GlobalRecordingPipe }],
+  }).compile();
+  app = moduleRef.createNestApplication();
+  httpServer = await listen(app);
+}
+
+beforeEach(() => {
+  RecordingPipe.metatypes.length = 0;
+});
+
+afterEach(async () => {
+  httpServer = undefined;
+  await app.close();
+});
+
+function server(): SupertestTarget {
+  return boundServer(httpServer);
+}
+
+describe("generated route body metatype (issue #281)", () => {
+  it("exposes the registered dto.create class to a global pipe, not Object", async () => {
+    @Kavo(Todo, { dto: { create: CreateTodoDto } })
+    @Controller("todos")
+    class TodosController {}
+
+    await bootstrap([TodosController]);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    expect(RecordingPipe.metatypes).toEqual([CreateTodoDto]);
+  });
+
+  it("exposes the registered dto.update class on a generated PUT route", async () => {
+    @Kavo(Todo, { dto: { create: CreateTodoDto, update: UpdateTodoDto } })
+    @Controller("todos")
+    class TodosController {}
+
+    await bootstrap([TodosController]);
+    const created = await request(server()).post("/todos").send({ title: "x" }).expect(201);
+    RecordingPipe.metatypes.length = 0;
+    await request(server()).put(`/todos/${created.body.id}`).send({ title: "y" }).expect(200);
+
+    expect(RecordingPipe.metatypes).toEqual([UpdateTodoDto]);
+  });
+
+  it("leaves the metatype unresolved when no dto.create is registered", async () => {
+    @Kavo(Todo)
+    @Controller("todos")
+    class TodosController {}
+
+    await bootstrap([TodosController]);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    expect(RecordingPipe.metatypes).toEqual([undefined]);
+  });
+
+  it("does not disturb an @Override()'d route's own real design:paramtypes", async () => {
+    @Kavo(Todo, { dto: { create: CreateTodoDto } })
+    @Controller("todos")
+    class TodosController {
+      @Override()
+      async createOne(dto: CreateTodoDto) {
+        return boundKavoService<Todo>(this).createOne(dto as never);
+      }
+    }
+
+    await bootstrap([TodosController]);
+    await request(server()).post("/todos").send({ title: "x" }).expect(201);
+
+    expect(RecordingPipe.metatypes).toEqual([CreateTodoDto]);
+  });
+});


### PR DESCRIPTION
## What & why

A registered `dto.create`/`dto.update`/`dto.patch` class only actually validated a write body when the operation was `@Override()`'d — on a generated route, `@Body()` carries no source-level parameter declaration, so TypeScript's `emitDecoratorMetadata` never wrote `design:paramtypes` for it, and Nest's global `ValidationPipe` (or any other pipe hooked the same way — the gap isn't tied to `class-validator`) resolved the metatype to `Object` and silently skipped validation. Bad input either 500'd against the database or was accepted outright.

`defineRoute` (`packages/frameworks/nest/src/kavo.decorator.ts`) now writes real `design:paramtypes` metadata for the body parameter position on a generated route whenever the operation resolves a real DTO class (reusing the same `bodyDtoFor`/`DefaultDtoResolver` `swagger.ts` already uses to document it) — restoring validation without requiring `@Override()`. The `@Override()` path is untouched: it already carries real metadata from its own compiled source, and the fix only writes metadata when a resolver is explicitly passed in from the generated-route path.

Closes #281

## Public API impact

None — internal behavior fix inside `@kavo/nest`'s route generation; no barrel changes.

## Testing

Added `packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts` (4 cases, using a hand-written `PipeTransform` to keep the coverage validator-agnostic): a generated `POST`/`PUT` route now exposes the registered DTO class as `metatype` to a global pipe; no `dto.create` registered leaves the metatype `undefined` (no regression); an `@Override()`'d route's own real metatype is left undisturbed.

`pnpm check` (generate + build + typecheck + depcruise + lint + test): green, 2971/2971 tests. `pnpm docs:links`: green.

## Review notes

Also corrected stale comments in `examples/nest-typeorm` (`owner.controller.ts`, `address.controller.ts`, `README.md`) that claimed `@Override()` is the only way to get body validation on a generated route — no longer true after this fix; those `@Override()`s remain for other reasons (concrete compile-time typing, cross-entity writes) and are called out as such.

Not included, left for a possible follow-up: a full-stack example combining a policy-gated write with `@Override()` + `boundKavoPrincipal` (mentioned as a nice-to-have in the issue, not the core gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
