### PR TITLE
fix(nest): fall back an unregistered write DTO to a validated entity class

### DIFF
--- a/examples/nest-typeorm/README.md
+++ b/examples/nest-typeorm/README.md
@@ -22,7 +22,11 @@ and `Cat` additionally `@Override()` their `createOne`/`updateOne`/`patchOne`
 (see `owner.controller.ts`) to give the body a concrete compile-time type
 inside the method — since issue #281, that override is no longer required
 for the validation itself, which now also runs on a generated route.
-`Dog` is left unvalidated on purpose, as the contrast.
+`Dog` is left unvalidated on purpose, as the contrast: it registers no
+`dto.create`/`update`/`patch` _and_ carries no `class-validator` decorators
+of its own, so issue #283's entity-class fallback (`@kavo/nest` falls an
+unregistered write slot back to the entity class, but only when the entity
+itself is `class-validator`-decorated) has nothing to fall back to either.
 
 ## SQLite (default)
 

--- a/packages/frameworks/nest/package.json
+++ b/packages/frameworks/nest/package.json
@@ -39,6 +39,7 @@
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "@nestjs/swagger": "^8.0.0 || ^11.0.0",
+    "class-validator": "^0.14.0 || ^0.15.0",
     "graphql": "^17.0.0",
     "reflect-metadata": "^0.1.13 || ^0.2.0",
     "rxjs": "^7.8.0"
@@ -48,6 +49,9 @@
       "optional": true
     },
     "@nestjs/swagger": {
+      "optional": true
+    },
+    "class-validator": {
       "optional": true
     },
     "graphql": {
@@ -62,6 +66,7 @@
     "@nestjs/swagger": "^11.4.6",
     "@nestjs/testing": "^11.2.1",
     "@types/supertest": "^7.2.1",
+    "class-validator": "^0.15.1",
     "graphql": "^17.0.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",

--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -53,6 +53,7 @@ import {
 } from "./tokens.js";
 import { WireQueryPipe } from "./wire-query.pipe.js";
 import { applySwaggerMetadata, bodyDtoFor } from "./swagger.js";
+import { entityHasValidationMetadata } from "./load-class-validator.js";
 
 /**
  * One route whose conditional-request Swagger docs (ADR-0020) `@Kavo`
@@ -365,7 +366,7 @@ export function Kavo<
         if (Object.prototype.hasOwnProperty.call(controller.prototype, methodName)) {
           continue; // manual-method-wins
         }
-        defineRoute(controller.prototype, methodName, descriptor, route, erasedConfig);
+        defineRoute(controller.prototype, methodName, descriptor, route, erasedConfig, entity);
         applySwaggerMetadata(controller.prototype, methodName, descriptor, route, entity, erasedConfig);
         conditionalDocs.push({ methodName, descriptor, route });
       } else {
@@ -594,6 +595,7 @@ function defineRoute(
   descriptor: OperationDescriptor<object>,
   route: ResolvedRoute,
   config: EntityConfig<object> | undefined,
+  entity: ClassRef<object>,
 ): void {
   const handler = makeHandler(descriptor, route);
   Object.defineProperty(handler, "name", { value: methodName });
@@ -603,7 +605,7 @@ function defineRoute(
     configurable: true,
   });
   const dtoResolver = new DefaultDtoResolver(config?.dto as OperationDtoMap<object> | undefined);
-  applyRouteDecorators(prototype, methodName, descriptor, route, dtoResolver);
+  applyRouteDecorators(prototype, methodName, descriptor, route, dtoResolver, entity);
 }
 
 /**
@@ -619,9 +621,10 @@ function applyRouteDecorators(
   descriptor: OperationDescriptor<object>,
   route: ResolvedRoute,
   dtoResolver?: DtoResolver<object>,
+  entity?: ClassRef<object>,
 ): void {
   const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, methodName) as PropertyDescriptor;
-  applyParamDecorators(prototype, methodName, descriptor, route, dtoResolver);
+  applyParamDecorators(prototype, methodName, descriptor, route, dtoResolver, entity);
   // Route identity for `getResource`/`getOperation` (issue #238), written
   // on the handler function itself — the same target Nest's method
   // decorators write to — so Nest's `Reflector` can read it off
@@ -687,6 +690,7 @@ function applyParamDecorators(
   descriptor: OperationDescriptor<object>,
   route: ResolvedRoute,
   dtoResolver?: DtoResolver<object>,
+  entity?: ClassRef<object>,
 ): void {
   let index = 0;
   let bodyIndex = -1;
@@ -703,11 +707,26 @@ function applyParamDecorators(
   Req()(prototype, methodName, index++);
 
   if (bodyIndex === -1 || dtoResolver === undefined) return;
-  const bodyDto = bodyDtoFor(descriptor, dtoResolver);
+  const bodyDto = bodyDtoFor(descriptor, dtoResolver) ?? entityFallbackDto(descriptor, entity);
   if (bodyDto === null) return;
   const paramTypes: unknown[] = Array.from({ length: index });
   paramTypes[bodyIndex] = bodyDto;
   Reflect.defineMetadata("design:paramtypes", paramTypes, prototype, methodName);
+}
+
+/**
+ * Issue #283: when no `dto.create`/`dto.update`/`dto.patch` is registered,
+ * fall back to the entity class itself — but only when it actually carries
+ * `class-validator` decorators. An undecorated entity has no validation
+ * rules to gain, and under `ValidationPipe({ whitelist: true })` (this
+ * repo's own example config) naming an undecorated class as the body's
+ * metatype would strip every property instead of validating them, trading
+ * the silent-no-validation gap #283 closes for a silent data-loss one.
+ */
+function entityFallbackDto(descriptor: OperationDescriptor<object>, entity?: ClassRef<object>): ClassRef | null {
+  if (entity === undefined) return null;
+  if (descriptor.id !== "createOne" && descriptor.id !== "updateOne" && descriptor.id !== "patchOne") return null;
+  return entityHasValidationMetadata(entity) ? entity : null;
 }
 
 /**

--- a/packages/frameworks/nest/src/load-class-validator.ts
+++ b/packages/frameworks/nest/src/load-class-validator.ts
@@ -1,0 +1,52 @@
+import { createRequire } from "node:module";
+import type { ClassRef } from "@kavo/core";
+
+type ClassValidatorModule = {
+  getMetadataStorage(): {
+    getTargetValidationMetadatas(
+      targetConstructor: Function,
+      targetSchema: string,
+      always: boolean,
+      strictGroups: boolean,
+    ): readonly unknown[];
+  };
+};
+
+let cached: ClassValidatorModule | null | undefined;
+
+/**
+ * `class-validator` is an *optional* peer, loaded synchronously (like
+ * `@nestjs/swagger` in `swagger.ts`) because `@Kavo`'s route generation runs
+ * at class-decoration time (ADR-0012), which cannot await a dynamic import.
+ */
+function loadClassValidator(): ClassValidatorModule | null {
+  if (cached !== undefined) return cached;
+  try {
+    const require = createRequire(import.meta.url);
+    cached = require("class-validator") as ClassValidatorModule;
+  } catch {
+    cached = null;
+  }
+  return cached;
+}
+
+/**
+ * Whether `entity` itself carries any `class-validator` decorator — the
+ * gate for issue #283's entity-class DTO fallback. `@kavo/nest` writes
+ * `design:paramtypes` generically for *any* validation library hooked
+ * through Nest's pipe system (issue #281's fix is not tied to one), but the
+ * fallback itself must be library-aware: an undecorated entity has no
+ * validation rules to gain, and under `ValidationPipe({ whitelist: true })`
+ * — this repo's own example config — naming an undecorated class as the
+ * body's metatype would strip every property instead of validating them,
+ * a silent-data-loss regression worse than the silent-no-validation gap
+ * #283 exists to close. Returns `false`, not an error, when `class-validator`
+ * itself isn't installed — the fallback then behaves exactly like today,
+ * for a library-agnostic app that hooks a different validator.
+ */
+export function entityHasValidationMetadata(entity: ClassRef): boolean {
+  const classValidator = loadClassValidator();
+  if (classValidator === null) return false;
+  const target = entity as unknown as Function;
+  return classValidator.getMetadataStorage().getTargetValidationMetadatas(target, "", true, false).length > 0;
+}

--- a/packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts
@@ -10,6 +10,8 @@ import {
 } from "@nestjs/common";
 import { APP_PIPE } from "@nestjs/core";
 import { Test } from "@nestjs/testing";
+import { IsString } from "class-validator";
+import type { EntityMetadata, KavoInfrastructure } from "@kavo/core";
 import { Kavo, KavoModule, Override, boundKavoService } from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
@@ -100,7 +102,7 @@ describe("generated route body metatype (issue #281)", () => {
     expect(RecordingPipe.metatypes).toEqual([UpdateTodoDto]);
   });
 
-  it("leaves the metatype unresolved when no dto.create is registered", async () => {
+  it("leaves the metatype unresolved when no dto.create is registered and the entity carries no validation decorators", async () => {
     @Kavo(Todo)
     @Controller("todos")
     class TodosController {}
@@ -125,5 +127,93 @@ describe("generated route body metatype (issue #281)", () => {
     await request(server()).post("/todos").send({ title: "x" }).expect(201);
 
     expect(RecordingPipe.metatypes).toEqual([CreateTodoDto]);
+  });
+});
+
+/**
+ * Issue #283: an unregistered `dto.create`/`dto.update`/`dto.patch` slot
+ * falls back to the entity class itself, but only when it actually carries
+ * `class-validator` decorators — gated in `entityFallbackDto`
+ * (`kavo.decorator.ts`) via `entityHasValidationMetadata`
+ * (`load-class-validator.ts`). The gate matters: under
+ * `ValidationPipe({ whitelist: true })` (this repo's own example config),
+ * naming an *undecorated* class as the body metatype would strip every
+ * property instead of validating them — the case the previous describe
+ * block's "leaves the metatype unresolved" test guards.
+ */
+class ValidatedTodo {
+  id = 0;
+  @IsString()
+  title = "";
+}
+
+function validatedTodoInfrastructure(adapter: InMemoryTodoAdapter): KavoInfrastructure {
+  const metadata: EntityMetadata<ValidatedTodo> = {
+    entity: ValidatedTodo,
+    name: "ValidatedTodo",
+    idField: "id",
+    fields: [
+      { name: "id", kind: "number", nullable: false, generated: true },
+      { name: "title", kind: "string", nullable: false, generated: false },
+    ],
+    relations: [],
+  };
+  return {
+    metadataFor: <Entity extends object>() => metadata as unknown as EntityMetadata<Entity>,
+    adapterFor: <Entity extends object>() => ({
+      findOneById: () => Promise.reject(new Error("unused")),
+      findOne: () => Promise.reject(new Error("unused")),
+      findMany: () => Promise.resolve([]),
+      count: () => Promise.resolve(0),
+      create: (data: Partial<Entity>) =>
+        Promise.resolve({ ...new ValidatedTodo(), ...data, id: adapter.rows.length + 1 } as unknown as Entity),
+      update: () => Promise.reject(new Error("unused")),
+      patch: () => Promise.reject(new Error("unused")),
+      delete: () => Promise.reject(new Error("unused")),
+      restore: () => Promise.reject(new Error("unused")),
+      purge: () => Promise.reject(new Error("unused")),
+    }),
+  };
+}
+
+describe("entity-class DTO fallback (issue #283)", () => {
+  it("exposes the entity class as the body metatype when it carries validation decorators", async () => {
+    @Kavo(ValidatedTodo)
+    @Controller("validated-todos")
+    class ValidatedTodosController {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        KavoModule.forRoot({ infrastructure: validatedTodoInfrastructure(new InMemoryTodoAdapter()) }),
+        KavoModule.forFeature([ValidatedTodosController] as never),
+      ],
+      providers: [{ provide: APP_PIPE, useClass: GlobalRecordingPipe }],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    httpServer = await listen(app);
+
+    await request(server()).post("/validated-todos").send({ title: "x" }).expect(201);
+
+    expect(RecordingPipe.metatypes).toEqual([ValidatedTodo]);
+  });
+
+  it("rejects a body that fails the entity's own validation decorators, through a real ValidationPipe", async () => {
+    @Kavo(ValidatedTodo)
+    @Controller("validated-todos")
+    class ValidatedTodosController {}
+
+    const { ValidationPipe } = await import("@nestjs/common");
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        KavoModule.forRoot({ infrastructure: validatedTodoInfrastructure(new InMemoryTodoAdapter()) }),
+        KavoModule.forFeature([ValidatedTodosController] as never),
+      ],
+      providers: [{ provide: APP_PIPE, useValue: new ValidationPipe({ whitelist: true, transform: true }) }],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    httpServer = await listen(app);
+
+    // `title` must be a string — a number fails `@IsString()`.
+    await request(server()).post("/validated-todos").send({ title: 42 }).expect(400);
   });
 });

--- a/packages/frameworks/nest/tests/load-class-validator.spec.ts
+++ b/packages/frameworks/nest/tests/load-class-validator.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { IsString } from "class-validator";
+import { entityHasValidationMetadata } from "../src/load-class-validator.js";
+
+class Decorated {
+  @IsString()
+  title = "";
+}
+
+class Undecorated {
+  title = "";
+}
+
+class DecoratedSubclass extends Decorated {
+  extra = "";
+}
+
+describe("entityHasValidationMetadata (issue #283)", () => {
+  it("is true for a class carrying its own class-validator decorator", () => {
+    expect(entityHasValidationMetadata(Decorated)).toBe(true);
+  });
+
+  it("is false for a plain class with no class-validator decorators", () => {
+    expect(entityHasValidationMetadata(Undecorated)).toBe(false);
+  });
+
+  it("is true for a subclass inheriting a decorated property", () => {
+    expect(entityHasValidationMetadata(DecoratedSubclass)).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@types/supertest':
         specifier: ^7.2.1
         version: 7.2.1
+      class-validator:
+        specifier: ^0.15.1
+        version: 0.15.1
       graphql:
         specifier: ^17.0.2
         version: 17.0.2


### PR DESCRIPTION
## What & why

When no `dto.create`/`update`/`patch` is registered for an entity, a generated route now falls back to the entity class itself as the write body's validation metatype — but only when the entity actually carries its own `class-validator` decorators (checked synchronously via `class-validator`'s `MetadataStorage` at route-decoration time; `class-validator` is a new optional peer of `@kavo/nest`). Decorating the entity is now enough to get validation on `createOne`/`updateOne`/`patchOne`, without also spelling out `dto.create: Entity` — closing the footgun issue #281 left open. An undecorated entity keeps today's behavior untouched.

The fallback was first attempted where the issue suggested — core's `DefaultDtoResolver` (`map.create ?? entity`) — but that broke two things during implementation: Mongoose's "entity" is a live Model constructor, not a plain class, so treating it as a DTO class corrupted the writable-projection derivation (fixed, then reconsidered); and more decisively, under `ValidationPipe({ whitelist: true })` (this repo's own example config), naming an *undecorated* entity as the body metatype makes `class-validator` strip every property instead of validating them — a silent data-loss regression, worse than the gap being closed. Core has zero runtime dependencies (ADR-0005) and cannot check for `class-validator` metadata, so the fallback moved into `@kavo/nest`, gated on real decorators. Core is untouched by this PR.

## Public API impact

`@kavo/nest`'s `package.json` gains `class-validator` as a new **optional** peer dependency (`peerDependenciesMeta.optional: true`), mirroring `@nestjs/swagger`/`@modelcontextprotocol/sdk`. No breaking change: an app that never installs `class-validator`, or whose entities carry no `class-validator` decorators, sees no behavior change. No `@kavo/core` changes, no barrel changes.

## Testing

- `packages/frameworks/nest/tests/load-class-validator.spec.ts` (new): unit coverage for `entityHasValidationMetadata` — decorated class, undecorated class, and inherited decorators on a subclass.
- `packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts` (extended): a positive case (decorated entity's class becomes the body metatype) and a full round-trip through a real `ValidationPipe({ whitelist: true })` proving an invalid body is rejected 400, not silently stripped.
- `pnpm check` (build, typecheck, depcruise, lint, full test suite — 3022 tests) and `pnpm docs:links`: both green.

## Review notes

Worth a close look: `entityHasValidationMetadata` in `load-class-validator.ts` calls `class-validator`'s `getTargetValidationMetadatas(target, "", true, false)` with `always: true` to get an unfiltered "does this class have any decorator at all" signal — this also correctly picks up decorators inherited from a base class (e.g. a `Dog extends Pet` single-table-inheritance subtype), verified by the "inherited decorators on a subclass" test.

Closes #283