### PR TITLE
fix(nest): relax patchOne's entity-fallback DTO to optional fields

### DIFF
--- a/packages/frameworks/nest/src/kavo.decorator.ts
+++ b/packages/frameworks/nest/src/kavo.decorator.ts
@@ -53,7 +53,7 @@ import {
 } from "./tokens.js";
 import { WireQueryPipe } from "./wire-query.pipe.js";
 import { applySwaggerMetadata, bodyDtoFor } from "./swagger.js";
-import { entityHasValidationMetadata } from "./load-class-validator.js";
+import { entityHasValidationMetadata, entityPartialValidationClass } from "./load-class-validator.js";
 
 /**
  * One route whose conditional-request Swagger docs (ADR-0020) `@Kavo`
@@ -722,10 +722,17 @@ function applyParamDecorators(
  * repo's own example config) naming an undecorated class as the body's
  * metatype would strip every property instead of validating them, trading
  * the silent-no-validation gap #283 closes for a silent data-loss one.
+ *
+ * Issue #285: `patchOne` cannot reuse the entity class as-is — the entity's
+ * own decorators require every field, so the same fallback would reject any
+ * partial `PATCH` body. It gets `entityPartialValidationClass`'s subclass
+ * instead, which inherits those decorators but relaxes every one of them to
+ * optional, matching a `PATCH`'s actual semantics.
  */
 function entityFallbackDto(descriptor: OperationDescriptor<object>, entity?: ClassRef<object>): ClassRef | null {
   if (entity === undefined) return null;
-  if (descriptor.id !== "createOne" && descriptor.id !== "updateOne" && descriptor.id !== "patchOne") return null;
+  if (descriptor.id === "patchOne") return entityPartialValidationClass(entity);
+  if (descriptor.id !== "createOne" && descriptor.id !== "updateOne") return null;
   return entityHasValidationMetadata(entity) ? entity : null;
 }
 

--- a/packages/frameworks/nest/src/load-class-validator.ts
+++ b/packages/frameworks/nest/src/load-class-validator.ts
@@ -8,8 +8,9 @@ type ClassValidatorModule = {
       targetSchema: string,
       always: boolean,
       strictGroups: boolean,
-    ): readonly unknown[];
+    ): readonly { propertyName: string }[];
   };
+  IsOptional(validationOptions?: object): PropertyDecorator;
 };
 
 let cached: ClassValidatorModule | null | undefined;
@@ -49,4 +50,38 @@ export function entityHasValidationMetadata(entity: ClassRef): boolean {
   if (classValidator === null) return false;
   const target = entity as unknown as Function;
   return classValidator.getMetadataStorage().getTargetValidationMetadatas(target, "", true, false).length > 0;
+}
+
+const partialClasses = new WeakMap<ClassRef, ClassRef>();
+
+/**
+ * Issue #285: `patchOne`'s entity-class fallback (#283) named the entity
+ * class itself as the body metatype, so every field the entity's own
+ * `class-validator` decorators require became required on a partial `PATCH`
+ * body too — rejecting any body that omits one. Builds (and caches, per
+ * entity) a subclass that inherits the entity's decorators — `class-validator`
+ * resolves inherited metadata through the prototype chain — plus an
+ * `@IsOptional()` on every one of its decorated properties, which
+ * `class-validator` runs first and short-circuits: a property that's
+ * `undefined`/`null` skips its other validators instead of failing them.
+ * Returns `null` under the same gate as `entityHasValidationMetadata` — an
+ * entity with no validation decorators has nothing to make optional.
+ */
+export function entityPartialValidationClass(entity: ClassRef): ClassRef | null {
+  const classValidator = loadClassValidator();
+  if (classValidator === null) return null;
+  const cached = partialClasses.get(entity);
+  if (cached !== undefined) return cached;
+  const target = entity as unknown as Function;
+  const metadatas = classValidator.getMetadataStorage().getTargetValidationMetadatas(target, "", true, false);
+  if (metadatas.length === 0) return null;
+  class PartialEntityDto extends (entity as unknown as new (...args: never[]) => object) {}
+  Object.defineProperty(PartialEntityDto, "name", { value: `Partial${target.name}` });
+  const propertyNames = new Set(metadatas.map((metadata) => metadata.propertyName));
+  for (const propertyName of propertyNames) {
+    classValidator.IsOptional()(PartialEntityDto.prototype, propertyName);
+  }
+  const partialClass = PartialEntityDto as unknown as ClassRef;
+  partialClasses.set(entity, partialClass);
+  return partialClass;
 }

--- a/packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/generated-route-body-validation.e2e.spec.ts
@@ -11,7 +11,7 @@ import {
 import { APP_PIPE } from "@nestjs/core";
 import { Test } from "@nestjs/testing";
 import { IsString } from "class-validator";
-import type { EntityMetadata, KavoInfrastructure } from "@kavo/core";
+import type { EntityId, EntityMetadata, KavoInfrastructure } from "@kavo/core";
 import { Kavo, KavoModule, Override, boundKavoService } from "@kavo/nest";
 import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
 import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
@@ -158,17 +158,26 @@ function validatedTodoInfrastructure(adapter: InMemoryTodoAdapter): KavoInfrastr
     ],
     relations: [],
   };
+  const rows = new Map<number, ValidatedTodo>();
   return {
     metadataFor: <Entity extends object>() => metadata as unknown as EntityMetadata<Entity>,
     adapterFor: <Entity extends object>() => ({
-      findOneById: () => Promise.reject(new Error("unused")),
+      findOneById: (id: EntityId) => Promise.resolve((rows.get(Number(id)) ?? null) as unknown as Entity | null),
       findOne: () => Promise.reject(new Error("unused")),
       findMany: () => Promise.resolve([]),
       count: () => Promise.resolve(0),
-      create: (data: Partial<Entity>) =>
-        Promise.resolve({ ...new ValidatedTodo(), ...data, id: adapter.rows.length + 1 } as unknown as Entity),
+      create: (data: Partial<Entity>) => {
+        const row = { ...new ValidatedTodo(), ...data, id: adapter.rows.length + rows.size + 1 } as ValidatedTodo;
+        rows.set(row.id, row);
+        return Promise.resolve(row as unknown as Entity);
+      },
       update: () => Promise.reject(new Error("unused")),
-      patch: () => Promise.reject(new Error("unused")),
+      patch: (id: EntityId, data: Partial<Entity>) => {
+        const row = rows.get(Number(id));
+        if (row === undefined) return Promise.reject(new Error("not found"));
+        Object.assign(row, data);
+        return Promise.resolve(row as unknown as Entity);
+      },
       delete: () => Promise.reject(new Error("unused")),
       restore: () => Promise.reject(new Error("unused")),
       purge: () => Promise.reject(new Error("unused")),
@@ -215,5 +224,53 @@ describe("entity-class DTO fallback (issue #283)", () => {
 
     // `title` must be a string — a number fails `@IsString()`.
     await request(server()).post("/validated-todos").send({ title: 42 }).expect(400);
+  });
+
+  /**
+   * Issue #285: `patchOne`'s fallback used to name `ValidatedTodo` itself as
+   * the body metatype, so `@IsString() title` — required on the entity —
+   * rejected any `PATCH` body that omitted `title`. It must accept a partial
+   * body, and still reject a `title` that's present but the wrong type.
+   */
+  it("accepts a PATCH body omitting a field the entity itself requires", async () => {
+    @Kavo(ValidatedTodo)
+    @Controller("validated-todos")
+    class ValidatedTodosController {}
+
+    const { ValidationPipe } = await import("@nestjs/common");
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        KavoModule.forRoot({ infrastructure: validatedTodoInfrastructure(new InMemoryTodoAdapter()) }),
+        KavoModule.forFeature([ValidatedTodosController] as never),
+      ],
+      providers: [{ provide: APP_PIPE, useValue: new ValidationPipe({ whitelist: true, transform: true }) }],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    httpServer = await listen(app);
+
+    const created = await request(server()).post("/validated-todos").send({ title: "x" }).expect(201);
+
+    await request(server()).patch(`/validated-todos/${created.body.id}`).send({}).expect(200);
+  });
+
+  it("still rejects a PATCH body whose present field fails the entity's own validator", async () => {
+    @Kavo(ValidatedTodo)
+    @Controller("validated-todos")
+    class ValidatedTodosController {}
+
+    const { ValidationPipe } = await import("@nestjs/common");
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        KavoModule.forRoot({ infrastructure: validatedTodoInfrastructure(new InMemoryTodoAdapter()) }),
+        KavoModule.forFeature([ValidatedTodosController] as never),
+      ],
+      providers: [{ provide: APP_PIPE, useValue: new ValidationPipe({ whitelist: true, transform: true }) }],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    httpServer = await listen(app);
+
+    const created = await request(server()).post("/validated-todos").send({ title: "x" }).expect(201);
+
+    await request(server()).patch(`/validated-todos/${created.body.id}`).send({ title: 42 }).expect(400);
   });
 });

--- a/packages/frameworks/nest/tests/load-class-validator.spec.ts
+++ b/packages/frameworks/nest/tests/load-class-validator.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { IsString } from "class-validator";
-import { entityHasValidationMetadata } from "../src/load-class-validator.js";
+import { IsString, validate } from "class-validator";
+import { entityHasValidationMetadata, entityPartialValidationClass } from "../src/load-class-validator.js";
 
 class Decorated {
   @IsString()
@@ -26,5 +26,36 @@ describe("entityHasValidationMetadata (issue #283)", () => {
 
   it("is true for a subclass inheriting a decorated property", () => {
     expect(entityHasValidationMetadata(DecoratedSubclass)).toBe(true);
+  });
+});
+
+describe("entityPartialValidationClass (issue #285)", () => {
+  it("returns null for a class with no class-validator decorators", () => {
+    expect(entityPartialValidationClass(Undecorated)).toBeNull();
+  });
+
+  it("accepts a body omitting a required field of the entity", async () => {
+    const PartialDecorated = entityPartialValidationClass(Decorated);
+    expect(PartialDecorated).not.toBeNull();
+    const instance = Object.assign(new (PartialDecorated as unknown as new () => Decorated)(), {});
+    delete (instance as { title?: string }).title;
+
+    const errors = await validate(instance);
+
+    expect(errors).toEqual([]);
+  });
+
+  it("still rejects a present field that fails the entity's own validator", async () => {
+    const PartialDecorated = entityPartialValidationClass(Decorated);
+    const instance = Object.assign(new (PartialDecorated as unknown as new () => Decorated)(), { title: 42 });
+
+    const errors = await validate(instance);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.property).toBe("title");
+  });
+
+  it("caches the same subclass for repeated calls on the same entity", () => {
+    expect(entityPartialValidationClass(Decorated)).toBe(entityPartialValidationClass(Decorated));
   });
 });


### PR DESCRIPTION
## What & why

`entityFallbackDto` (#283, `900f41d`) falls back to the entity class itself as the body metatype for `createOne`/`updateOne`/`patchOne` when no `dto.create`/`update`/`patch` is registered. For `patchOne` this was wrong: any `class-validator`-decorated required field on the entity made every partial `PATCH` body fail validation, since the entity class itself requires those fields.

`patchOne` now resolves through `entityPartialValidationClass` (`load-class-validator.ts`) instead of the entity class directly: it builds (and caches per entity) a subclass that inherits the entity's decorators through the prototype chain, then applies `@IsOptional()` to each decorated property — `class-validator` runs `IsOptional` first and short-circuits validation when the property is `undefined`/`null`. `createOne`/`updateOne` keep using the entity class as before, since those bodies should require those fields.

Closes #285

## Public API impact

None — no barrel exports changed. `entityPartialValidationClass` is an internal helper in `packages/frameworks/nest/src/load-class-validator.ts`, not exported from the package.

## Testing

- `load-class-validator.spec.ts`: `entityPartialValidationClass` returns `null` for an undecorated entity, accepts an object missing a required field, still rejects a present-but-invalid field, and caches the same subclass per entity.
- `generated-route-body-validation.e2e.spec.ts`: real `PATCH` requests through a `ValidationPipe({ whitelist: true, transform: true })` — accepts a body omitting the entity's required field, still rejects a present field that fails the entity's own validator.
- `pnpm check`: build, typecheck, depcruise, and lint all pass; 2570 tests pass. The only failures are 12 pre-existing container/network-dependent e2e suites (Postgres/MariaDB/CockroachDB via testcontainers, Mongo via `mongodb-memory-server`) that can't run in this sandbox (no Docker, no network to fetch the Mongo binary) — unrelated to this change.
- `pnpm docs:links`: passes.

## Review notes

No docs changes — this fallback's behavior was never documented outside code comments/tests, so nothing needed updating.


---
_Generated by [Claude Code](https://claude.ai/code/session_011PBDE6NRNMPPenqi3Zan3L)_