### PR TITLE
fix(typeorm,prisma,mongoose,mikroorm): treat undefined-valued patch keys as absent

### DIFF
--- a/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
+++ b/packages/orms/mikroorm/src/mikro-orm-repository-adapter.ts
@@ -298,12 +298,21 @@ export class MikroOrmRepositoryAdapter<Entity extends object> implements Reposit
    * so a body naming only the id and/or the soft-delete marker is treated
    * the same as a genuinely empty one. Raised before the row is even
    * loaded: this is a client-input problem, not a state one.
+   *
+   * Also drops any key whose value is `undefined` — a DTO instance can
+   * carry these as *own* properties (e.g. a class-fields subclass under
+   * `useDefineForClassFields`, issue #289) even though the client never
+   * sent that key, and `undefined` never means "set this to nothing" in
+   * JSON.
    */
   private requirePatchChanges(id: EntityId, rawData: Partial<Entity>, context: KavoContext<Entity>): void {
     const softDeleteField = context.config.softDelete.field;
     const data = { ...(rawData as Record<string, unknown>) };
     delete data[this.idField];
     if (softDeleteField !== null) delete data[softDeleteField];
+    for (const key of Object.keys(data)) {
+      if (data[key] === undefined) delete data[key];
+    }
     if (Object.keys(data).length === 0) {
       throw new PatchNoChangesException({
         messageParams: { entity: context.entityName, id: String(id) },

--- a/packages/orms/mikroorm/tests/adapter.spec.ts
+++ b/packages/orms/mikroorm/tests/adapter.spec.ts
@@ -215,6 +215,18 @@ describe("MikroOrmRepositoryAdapter — CRUD", () => {
     expect(error).toBeInstanceOf(PatchNoChangesException);
   });
 
+  it("rejects a patch with KAVO_PATCH_NO_CHANGES when every field is present but `undefined` (issue #289)", async () => {
+    // Reproduces the entity-subclass DTO fallback under `useDefineForClassFields`:
+    // fields are *own* properties initialized to `undefined`, not absent, so a
+    // naive `Object.keys(...).length === 0` check must not be fooled by them.
+    const created = await authors.createOne({ email: "phantom@x.io", name: "Phantom", age: 5 } as never);
+    const id = (created as Author).id;
+    const phantomBody = { id: undefined, email: undefined, name: undefined, age: undefined };
+    const error = await authors.patchOne(id, phantomBody as never).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(PatchNoChangesException);
+    expect((error as PatchNoChangesException).code).toBe("KAVO_PATCH_NO_CHANGES");
+  });
+
   it("returns plain objects, never live MikroORM entities", async () => {
     // The adapter converts at its boundary: a `Collection` would break core's
     // `Array.isArray` branch in the serializer, and a managed entity would

--- a/packages/orms/mongoose/src/mongoose-repository-adapter.ts
+++ b/packages/orms/mongoose/src/mongoose-repository-adapter.ts
@@ -269,12 +269,21 @@ export class MongooseRepositoryAdapter<Entity extends object> implements Reposit
    * so a body naming only the id and/or the soft-delete marker is treated
    * the same as a genuinely empty one. Raised before the document is even
    * loaded: this is a client-input problem, not a state one.
+   *
+   * Also drops any key whose value is `undefined` — a DTO instance can
+   * carry these as *own* properties (e.g. a class-fields subclass under
+   * `useDefineForClassFields`, issue #289) even though the client never
+   * sent that key, and `undefined` never means "set this to nothing" in
+   * JSON.
    */
   private requirePatchChanges(id: EntityId, rawData: Partial<Entity>, context: KavoContext<Entity>): void {
     const softDeleteField = context.config.softDelete.field;
     const changes = { ...(rawData as Record<string, unknown>) };
     delete changes[this.idField];
     if (softDeleteField !== null) delete changes[softDeleteField];
+    for (const key of Object.keys(changes)) {
+      if (changes[key] === undefined) delete changes[key];
+    }
     if (Object.keys(changes).length === 0) {
       throw new PatchNoChangesException({
         messageParams: { entity: context.entityName, id: String(id) },

--- a/packages/orms/mongoose/tests/adapter.spec.ts
+++ b/packages/orms/mongoose/tests/adapter.spec.ts
@@ -203,6 +203,17 @@ describe("MongooseRepositoryAdapter — CRUD", () => {
     expect(error.code).toBe("KAVO_PATCH_NO_CHANGES");
   });
 
+  it("rejects a patch with KAVO_PATCH_NO_CHANGES when every field is present but `undefined` (issue #289)", async () => {
+    // Reproduces the entity-subclass DTO fallback under `useDefineForClassFields`:
+    // fields are *own* properties initialized to `undefined`, not absent, so a
+    // naive `Object.keys(...).length === 0` check must not be fooled by them.
+    const created = (await authors.createOne({ email: "phantom@x.io", name: "Phantom", age: 5 } as never)) as Author;
+    const phantomBody = { _id: undefined, email: undefined, name: undefined, age: undefined };
+    const error = await rejectionOf(authors.patchOne(created._id, phantomBody as never));
+    expect(error).toBeInstanceOf(PatchNoChangesException);
+    expect(error.code).toBe("KAVO_PATCH_NO_CHANGES");
+  });
+
   it("rejects an empty patch before checking whether the document exists", async () => {
     // The emptiness check is client-input validation, so it fires ahead of
     // any existence check — an absent id gets the same 400 a present one

--- a/packages/orms/prisma/src/prisma-repository-adapter.ts
+++ b/packages/orms/prisma/src/prisma-repository-adapter.ts
@@ -247,12 +247,21 @@ export class PrismaRepositoryAdapter<Entity extends object> implements Repositor
    * so a body naming only the id and/or the soft-delete marker is treated
    * the same as a genuinely empty one. Raised before the row is even
    * loaded: this is a client-input problem, not a state one.
+   *
+   * Also drops any key whose value is `undefined` — a DTO instance can
+   * carry these as *own* properties (e.g. a class-fields subclass under
+   * `useDefineForClassFields`, issue #289) even though the client never
+   * sent that key, and `undefined` never means "set this to nothing" in
+   * JSON.
    */
   private requirePatchChanges(id: EntityId, rawData: Partial<Entity>, context: KavoContext<Entity>): void {
     const softDeleteField = context.config.softDelete.field;
     const data = { ...(rawData as Record<string, unknown>) };
     delete data[this.idField];
     if (softDeleteField !== null) delete data[softDeleteField];
+    for (const key of Object.keys(data)) {
+      if (data[key] === undefined) delete data[key];
+    }
     if (Object.keys(data).length === 0) {
       throw new PatchNoChangesException({
         messageParams: { entity: context.entityName, id: String(id) },

--- a/packages/orms/prisma/tests/adapter.spec.ts
+++ b/packages/orms/prisma/tests/adapter.spec.ts
@@ -156,6 +156,18 @@ describe("PrismaRepositoryAdapter — CRUD", () => {
     const error = await authors.patchOne(id, { id } as never).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(PatchNoChangesException);
   });
+
+  it("rejects a patch with KAVO_PATCH_NO_CHANGES when every field is present but `undefined` (issue #289)", async () => {
+    // Reproduces the entity-subclass DTO fallback under `useDefineForClassFields`:
+    // fields are *own* properties initialized to `undefined`, not absent, so a
+    // naive `Object.keys(...).length === 0` check must not be fooled by them.
+    const created = await authors.createOne({ email: "phantom@x.io", name: "Phantom", age: 5 } as never);
+    const id = (created as Author).id;
+    const phantomBody = { id: undefined, email: undefined, name: undefined, age: undefined };
+    const error = await authors.patchOne(id, phantomBody as never).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(PatchNoChangesException);
+    expect((error as PatchNoChangesException).code).toBe("KAVO_PATCH_NO_CHANGES");
+  });
 });
 
 /**

--- a/packages/orms/typeorm/src/typeorm-repository-adapter.ts
+++ b/packages/orms/typeorm/src/typeorm-repository-adapter.ts
@@ -934,7 +934,12 @@ export class TypeOrmRepositoryAdapter<Entity extends ObjectLiteral> implements R
  * `mergeAndSave`'s defence-in-depth strip: a shallow copy of `data` with
  * the id field and (when soft-deletable) the resolved marker field
  * removed, so neither reaches `merge`/`update` regardless of what a write
- * DTO declared.
+ * DTO declared. Also drops any key whose value is `undefined` — a DTO
+ * instance can carry these as *own* properties (e.g. a class-fields
+ * subclass under `useDefineForClassFields`, issue #289) even though the
+ * client never sent that key, and `undefined` never means "set this to
+ * nothing" in JSON. Leaving them in would make an effectively-empty patch
+ * look non-empty to both this function's caller and `requirePatchChanges`.
  */
 function stripImmutableKeys<Entity>(
   data: Partial<Entity>,
@@ -944,6 +949,9 @@ function stripImmutableKeys<Entity>(
   const copy = { ...(data as Record<string, unknown>) };
   for (const idField of idFields) delete copy[idField];
   if (softDeleteField !== null) delete copy[softDeleteField];
+  for (const key of Object.keys(copy)) {
+    if (copy[key] === undefined) delete copy[key];
+  }
   return copy as Partial<Entity>;
 }
 

--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -229,6 +229,26 @@ describe("TypeOrmRepositoryAdapter — CRUD", () => {
     const id = (created as Author).id;
     await expect(authors.updateOne(id, { id } as never)).resolves.toMatchObject({ name: "Put" });
   });
+
+  it("rejects a patch with KAVO_PATCH_NO_CHANGES when every field is present but `undefined` (issue #289)", async () => {
+    // Reproduces the entity-subclass DTO fallback under `useDefineForClassFields`:
+    // fields are *own* properties initialized to `undefined`, not absent, so a
+    // naive `Object.keys(...).length === 0` check must not be fooled by them.
+    const created = await authors.createOne({ email: "phantom@x.io", name: "Phantom", age: 5 } as never);
+    const id = (created as Author).id;
+    const phantomBody = { id: undefined, email: undefined, name: undefined, age: undefined };
+    expect(Object.keys(phantomBody)).not.toHaveLength(0);
+    const error = await authors.patchOne(id, phantomBody as never).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(PatchNoChangesException);
+    expect((error as PatchNoChangesException).code).toBe("KAVO_PATCH_NO_CHANGES");
+  });
+
+  it("still applies a real field change carried alongside phantom `undefined` fields", async () => {
+    const created = await authors.createOne({ email: "mixed@x.io", name: "Mixed", age: 5 } as never);
+    const id = (created as Author).id;
+    const mixedBody = { id: undefined, email: undefined, name: "Renamed", age: undefined };
+    await expect(authors.patchOne(id, mixedBody as never)).resolves.toMatchObject({ name: "Renamed" });
+  });
 });
 
 describe("TypeOrmRepositoryAdapter — query translation", () => {


### PR DESCRIPTION
## What & why

`patchOne`'s entity-subclass DTO fallback (#285/f11f4fa) builds a body instance by subclassing the entity class itself. Under `useDefineForClassFields` (any ES2022+ `tsconfig` target — an unremarkable, increasingly common config), every bare-declared field on the entity becomes an *own*, `undefined`-valued property on that instance at construction time, regardless of whether the client's JSON body named it.

For an empty `PATCH {}`, this means the object handed to each ORM adapter is not actually empty — it carries every one of the entity's fields as own keys, just all `undefined`. Each adapter's `requirePatchChanges` no-op check (`Object.keys(data).length === 0`, added for #287) never trips, so execution falls through to the real write, where the driver blows up on an empty change set (e.g. TypeORM's `UpdateValuesMissingError`) — surfacing as an unrelated `500` instead of the intended `PatchNoChangesException` (`400`).

Fix: `requirePatchChanges` in all four adapters (`typeorm`, `prisma`, `mongoose`, `mikroorm`) now strips `undefined`-valued keys before deciding whether a patch is a no-op — `undefined` never means "the client set this to nothing" in JSON, it means "the client didn't send this key." `typeorm`'s shared `stripImmutableKeys` helper picked up the fix directly, which also closes the same hole in `mergeAndSave`'s own empty-check used by real writes.

Not included: the issue's other suggested angle — building `entityPartialValidationClass`'s fallback DTO without subclassing the entity's runtime class at all, copying `class-validator` metadata onto a bare class instead. `class-validator`'s inherited-decorator resolution genuinely depends on the real JS prototype chain, so reimplementing that without real inheritance risks silently breaking metadata inheritance from a base class above the entity. This PR's fix fully closes the reported bug on its own; happy to take the other angle as a follow-up if wanted.

Closes #289

## Public API impact

None — no barrel changes, no new exports, no signature changes.

## Testing

Added one regression test per adapter (`typeorm`, `mikroorm`, `mongoose`, `prisma`): a `PATCH` body where every key is present but `undefined` now throws `KAVO_PATCH_NO_CHANGES`. `typeorm` also gets a test confirming a real field change still applies when phantom `undefined` keys ride alongside it.

`pnpm check`: 3041/3041 tests passing, build/typecheck/depcruise/lint all green.
`pnpm docs:links`: OK.

## Review notes

No docs changes — `docs/internals/architecture/06-error-handling.md`'s existing description of `KAVO_PATCH_NO_CHANGES` already matches the restored behavior; this is a bugfix, not new documented behavior.