### PR TITLE
Add per-entity Swagger tags and x-kavo-* vendor extensions to generated routes

### DIFF
--- a/docs/core/routes-and-controllers.md
+++ b/docs/core/routes-and-controllers.md
@@ -98,3 +98,9 @@ export class AppModule {}
 ```
 
 `KavoModule`'s discovery binder finds every `@Kavo`-decorated controller in the module graph's `controllers: [...]` array and binds its service. There's no per-entity registration step. See [Module setup](/guides/configuration/module-setup) for the full options surface, and [NestJS integration](/internals/architecture/10-nestjs-integration) for how the binder, route generation, and Swagger metadata fit together underneath.
+
+## OpenAPI documentation
+
+When `@nestjs/swagger` is installed, every generated route — standard, custom, and `@Override`d alike — carries an `operationId` (`Book_findOne`), a `tags: ["Book"]` entry, and `x-kavo-entity`/`x-kavo-operation` vendor extensions on the operation object. Every inline DTO schema Kavo builds for a request or response body carries the same `x-kavo-entity`, so a generated OpenAPI document lets tooling recover which Kavo entity/operation an operation or schema came from without parsing `operationId`.
+
+A client generator that splits output by `tags` — [Orval](https://orval.dev) and `openapi-generator` both do — will produce one module per entity out of the box; point it at the app's `/docs-json` (or wherever `SwaggerModule.setup` serves the document) with no extra configuration.

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -372,12 +372,30 @@ between Kavo's hierarchy and HTTP: catalog status +
 
 Optional and zero-cost when absent (`createRequire` probe, cached).
 When `@nestjs/swagger` is installed, generated routes get: operation ids
-(`User_findMany`), the `:id` param, the query params documented on list
-routes (doc 5), registered DTO classes as body schemas (`ApiBody`),
-problem-details response schemas for 400/404, and the conditional-request
-surface (ADR-0020) — the `ETag` response header, `If-None-Match` + `304`
-on single-item reads, `If-Match` + `412` on single-row writes, gated on
-`cache.etag`.
+(`User_findMany`), a `tags: [entity.name]` entry, `x-kavo-entity`/
+`x-kavo-operation` vendor extensions on the operation object, the `:id`
+param, the query params documented on list routes (doc 5), registered DTO
+classes as body schemas (`ApiBody`), problem-details response schemas for
+400/404, and the conditional-request surface (ADR-0020) — the `ETag`
+response header, `If-None-Match` + `304` on single-item reads, `If-Match` +
+`412` on single-row writes, gated on `cache.etag`.
+
+The tag and both vendor extensions are derived only from `entity.name` and
+`OperationDescriptor` (ADR-0012), so they apply identically to a standard
+route, a custom operation (issue #145), and an `@Override`d route —
+`applySwaggerMetadata` runs the same way for all three. They exist because
+client generators like Orval and `openapi-generator` key file/module
+splitting off `tags` (with none, every operation across every entity lands
+in one flat client module), and because nothing else in the document links
+an operation, or a generated DTO schema, back to the Kavo entity/operation
+it came from. Every inline schema this module builds — `schemaFromDto`
+request/response bodies, a list envelope's element, the `issue #264`
+fallback body/response schemas, and each `oneOf` variant (schema hints,
+below) — carries the same `x-kavo-entity` (`withKavoEntity`). The one
+exception is the `{ type: DtoClass }` fallback path, where
+`@nestjs/swagger`'s own introspection builds the schema instead of this
+module: there is no inline schema object to stamp. `operationId`'s value
+and format are unchanged.
 
 Unlike the rest of this list, that gate can't be applied at decoration
 time (ADR-0012): whether it's on depends on `cache.etag` resolved

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -28,6 +28,7 @@ type SwaggerModule = {
   ApiHeader(options: object): MethodDecorator;
   ApiBody(options: object): MethodDecorator;
   ApiResponse(options: object): MethodDecorator;
+  ApiExtension(extensionKey: string, extensionProperties: unknown): MethodDecorator;
 };
 
 let cached: SwaggerModule | null | undefined;
@@ -167,6 +168,19 @@ function explicitAllowlist(selector: QueryFieldSelector<object> | undefined): re
   return selector;
 }
 
+/**
+ * Stamps `x-kavo-entity` on one inline schema this module built, linking a
+ * generated DTO schema back to the Kavo entity/operation it came from
+ * (issue #294) — additive to whatever OpenAPI keywords the schema already
+ * carries. Only ever applied to a schema this module actually constructed
+ * (`schemaFromDto` and the hand-built fallback/envelope schemas below); the
+ * `{ type: DtoClass }` fallback path, where `@nestjs/swagger`'s own
+ * introspection builds the schema, is a documented gap this can't reach.
+ */
+function withKavoEntity<T extends object>(schema: T, entityName: string): T & { "x-kavo-entity": string } {
+  return { ...schema, "x-kavo-entity": entityName };
+}
+
 export function applySwaggerMetadata(
   prototype: Record<string, unknown>,
   methodName: string,
@@ -189,8 +203,15 @@ export function applySwaggerMetadata(
     swagger.ApiOperation({
       operationId: `${entity.name}_${descriptor.id}`,
       summary: `${descriptor.id} (${entity.name})`,
+      tags: [entity.name],
     }),
   );
+  // Machine-readable link from this operation back to the Kavo
+  // entity/operation it was generated from (issue #294) — additive to the
+  // unchanged `operationId` above, for downstream tooling that would
+  // otherwise have to reverse-engineer it from that string.
+  apply(swagger.ApiExtension("x-kavo-entity", entity.name));
+  apply(swagger.ApiExtension("x-kavo-operation", descriptor.id));
 
   if (route.hasIdParam) {
     apply(swagger.ApiParam({ name: "id", required: true }));
@@ -271,7 +292,7 @@ export function applySwaggerMetadata(
 
   const bodyDto = bodyDtoFor(descriptor, dtoResolver);
   if (bodyDto !== null) {
-    apply(swagger.ApiBody(bodyOptionsFor(bodyDto)));
+    apply(swagger.ApiBody(bodyOptionsFor(bodyDto, entity.name)));
   }
 
   // The success response's ETag header and the conditional-request
@@ -632,12 +653,15 @@ export function applyBodySchemaDocs(
     properties[field.name] = fieldSchema(field);
   }
   swagger.ApiBody({
-    schema: {
-      title: `${metadata.name}${titleForBodyOperation(descriptor.id)}`,
-      type: "object",
-      properties,
-      ...(allowed.length === 0 ? { description: "No field is writable." } : {}),
-    },
+    schema: withKavoEntity(
+      {
+        title: `${metadata.name}${titleForBodyOperation(descriptor.id)}`,
+        type: "object",
+        properties,
+        ...(allowed.length === 0 ? { description: "No field is writable." } : {}),
+      },
+      metadata.name,
+    ),
   })(prototype, methodName, propertyDescriptor);
 }
 
@@ -697,12 +721,12 @@ function fieldSchema(field: FieldMetadata): object {
  * schema from them; when it does not (a `@ApiProperty`-decorated or purely
  * declarative class) we defer to Swagger's own `{ type }` introspection.
  */
-function bodyOptionsFor(bodyDto: ClassRef): object {
-  const schema = schemaFromDto(bodyDto);
+function bodyOptionsFor(bodyDto: ClassRef, entityName: string): object {
+  const schema = schemaFromDto(bodyDto, entityName);
   if (schema === null) {
     return { type: bodyDto };
   }
-  return { schema: { title: bodyDto.name, ...schema } };
+  return { schema: withKavoEntity({ title: bodyDto.name, ...schema }, entityName) };
 }
 
 /**
@@ -738,13 +762,15 @@ function successBodyFor(
   if (descriptor.cardinality === "many") {
     // `list` falls back to `item` inside the resolver.
     const listDto = resolve("list");
-    return { schema: listEnvelopeSchema(schemaFromDto(listDto), listDto.name) };
+    return { schema: listEnvelopeSchema(schemaFromDto(listDto, entity.name), listDto.name, entity.name) };
   }
   // Restore reuses the `item` slot — no dedicated restore shape — and so
   // does every custom single-row operation that registers no `dto.output`.
   const itemDto = resolve("item");
-  const schema = schemaFromDto(itemDto);
-  return schema === null ? { type: itemDto } : { schema: { title: itemDto.name, ...schema } };
+  const schema = schemaFromDto(itemDto, entity.name);
+  return schema === null
+    ? { type: itemDto }
+    : { schema: withKavoEntity({ title: itemDto.name, ...schema }, entity.name) };
 }
 
 /**
@@ -766,6 +792,7 @@ function successBodyFor(
 function listEnvelopeSchema(
   element: { type: "object"; properties: Record<string, object> } | null,
   title: string,
+  entityName: string,
 ): object {
   return {
     title: `${title}List`,
@@ -774,7 +801,7 @@ function listEnvelopeSchema(
     properties: {
       items: {
         type: "array",
-        items: element ?? { type: "object" },
+        items: element === null ? { type: "object" } : withKavoEntity(element, entityName),
       },
       limit: { type: "integer" },
       offset: { type: "integer" },
@@ -868,7 +895,9 @@ export function applyResponseSchemaDocs(
     properties[field.name] = fieldSchema(field);
   }
   const element = { type: "object" as const, properties };
-  const schema = isList ? listEnvelopeSchema(element, metadata.name) : { title: metadata.name, ...element };
+  const schema = isList
+    ? listEnvelopeSchema(element, metadata.name, metadata.name)
+    : withKavoEntity({ title: metadata.name, ...element }, metadata.name);
   // `type: undefined` clears whatever `type` decoration time's `{ type:
   // itemDto }` fallback left on this status's response entry — see this
   // function's doc comment for why a lingering `type` would otherwise win
@@ -876,7 +905,10 @@ export function applyResponseSchemaDocs(
   swagger.ApiResponse({ status: route.status, schema, type: undefined })(prototype, methodName, propertyDescriptor);
 }
 
-function schemaFromDto(bodyDto: ClassRef): { type: "object"; properties: Record<string, object> } | null {
+function schemaFromDto(
+  bodyDto: ClassRef,
+  entityName: string,
+): { type: "object"; properties: Record<string, object> } | null {
   let instance: Record<string, unknown>;
   try {
     instance = new (bodyDto as new () => Record<string, unknown>)();
@@ -889,15 +921,15 @@ function schemaFromDto(bodyDto: ClassRef): { type: "object"; properties: Record<
   }
   const properties: Record<string, object> = {};
   for (const key of keys) {
-    properties[key] = jsonSchemaForValue(instance[key]);
+    properties[key] = jsonSchemaForValue(instance[key], entityName);
   }
   return { type: "object", properties };
 }
 
 /** Infer a JSON-schema fragment from a DTO field's initializer value. */
-function jsonSchemaForValue(value: unknown): object {
+function jsonSchemaForValue(value: unknown, entityName: string): object {
   if (isSchemaHint(value)) {
-    return schemaForHint(readSchemaHint(value));
+    return schemaForHint(readSchemaHint(value), entityName);
   }
   switch (typeof value) {
     case "string":
@@ -925,7 +957,7 @@ function jsonSchemaForValue(value: unknown): object {
 }
 
 /** Expand a schema hint (enum / oneOf array) into its OpenAPI fragment. */
-function schemaForHint(hint: SchemaHint): object {
+function schemaForHint(hint: SchemaHint, entityName: string): object {
   switch (hint.kind) {
     case "enum":
       return {
@@ -938,8 +970,10 @@ function schemaForHint(hint: SchemaHint): object {
         type: "array",
         items: {
           oneOf: hint.variants.map((variant) => {
-            const schema = schemaFromDto(variant);
-            return schema === null ? { type: "object" } : { title: variant.name, ...schema };
+            const schema = schemaFromDto(variant, entityName);
+            return schema === null
+              ? { type: "object" }
+              : withKavoEntity({ title: variant.name, ...schema }, entityName);
           }),
         },
       };

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -771,14 +771,27 @@ describe("@Kavo custom operations (issue #145)", () => {
 
     const operation = (
       document.paths["/todos/{id}/publish"] as {
-        post?: { operationId?: string; responses?: Record<string, { content?: Record<string, { schema?: object }> }> };
+        post?: {
+          operationId?: string;
+          tags?: string[];
+          "x-kavo-entity"?: string;
+          "x-kavo-operation"?: string;
+          responses?: Record<string, { content?: Record<string, { schema?: object }> }>;
+        };
       }
     )?.post;
     expect(operation?.operationId).toBe("Todo_publishOne");
+    // A custom operation carries the same tag/vendor extensions a standard
+    // one does (issue #294) — derived from `entity.name`/`descriptor.id`,
+    // not the operation's own custom route shape.
+    expect(operation?.tags).toEqual(["Todo"]);
+    expect(operation?.["x-kavo-entity"]).toBe("Todo");
+    expect(operation?.["x-kavo-operation"]).toBe("publishOne");
     // The response schema follows `dto.output`, the same class the engine
-    // actually serializes through.
+    // actually serializes through, and carries the same x-kavo-entity link.
     expect(operation?.responses?.["201"]?.content?.["application/json"]?.schema).toMatchObject({
       title: "TodoReceiptDto",
+      "x-kavo-entity": "Todo",
     });
   });
 });
@@ -1072,13 +1085,26 @@ describe("@Kavo @Override — controller-method overrides that keep generated ro
     const getItem = (
       document.paths["/todos/{id}"] as Record<
         string,
-        { operationId?: string; parameters?: { name: string; in: string }[]; responses?: Record<string, unknown> }
+        {
+          operationId?: string;
+          tags?: string[];
+          "x-kavo-entity"?: string;
+          "x-kavo-operation"?: string;
+          parameters?: { name: string; in: string }[];
+          responses?: Record<string, unknown>;
+        }
       >
     )?.get;
     expect(getItem?.operationId).toBe("Todo_findOne");
     expect(getItem?.parameters).toEqual(expect.arrayContaining([expect.objectContaining({ name: "id", in: "path" })]));
     expect(getItem?.responses).toHaveProperty("200");
     expect(getItem?.responses).toHaveProperty("404");
+    // An @Override'd route still carries the same tag/vendor extensions as a
+    // generated one (issue #294) — applySwaggerMetadata runs identically for
+    // both, keyed off entity.name/descriptor.id, not the method it binds to.
+    expect(getItem?.tags).toEqual(["Todo"]);
+    expect(getItem?.["x-kavo-entity"]).toBe("Todo");
+    expect(getItem?.["x-kavo-operation"]).toBe("findOne");
   });
 
   it("leaves plain manual-method-wins (no @Override) exactly as before", async () => {
@@ -2014,6 +2040,7 @@ describe("@Kavo Swagger request-body schemas", () => {
     required?: string[];
     additionalProperties?: boolean;
     description?: string;
+    "x-kavo-entity"?: string;
   };
 
   const responseSchema = (op: string, status: string): Schema | undefined =>
@@ -2044,6 +2071,8 @@ describe("@Kavo Swagger request-body schemas", () => {
     expect(schema?.properties?.title).toEqual({ type: "string" });
     expect(schema?.properties?.priority).toEqual({ type: "integer" });
     expect(schema?.properties?.done).toEqual({ type: "boolean" });
+    // Links the schema back to the entity it belongs to (issue #294).
+    expect(schema?.["x-kavo-entity"]).toBe("Todo");
   });
 
   it("distinguishes the JSON number types a field initializer can imply", async () => {
@@ -2151,6 +2180,8 @@ describe("@Kavo Swagger request-body schemas", () => {
     expect(Object.keys(schema?.properties ?? {})).toEqual(["items", "limit", "offset", "total", "meta"]);
     // Envelope items use the leaner `list` DTO projection.
     expect(Object.keys(schema?.properties?.items?.items?.properties ?? {})).toEqual(["id", "title"]);
+    // The list-envelope element carries the entity link too (issue #294).
+    expect(schema?.properties?.items?.items?.["x-kavo-entity"]).toBe("Todo");
   });
 
   it("marks meta as the one envelope field a client cannot assume is present", () => {
@@ -2265,6 +2296,7 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
     properties?: Record<string, Schema>;
     additionalProperties?: boolean;
     description?: string;
+    "x-kavo-entity"?: string;
   };
 
   const bodySchema = (path: string, verb: string): Schema | undefined =>
@@ -2300,6 +2332,8 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
       // itself closed — that would tell a validating client a body Kavo
       // actually accepts is invalid.
       expect(schema?.additionalProperties).toBeUndefined();
+      // The fallback schema still links back to the entity (issue #294).
+      expect(schema?.["x-kavo-entity"]).toBe("Todo");
     }
   });
 
@@ -2361,7 +2395,7 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
 });
 
 describe("@Kavo Swagger fallback success-response schema when no item/list DTO is configured (issue #264)", () => {
-  type Schema = { type?: string; properties?: Record<string, Schema>; items?: Schema };
+  type Schema = { type?: string; properties?: Record<string, Schema>; items?: Schema; "x-kavo-entity"?: string };
 
   const itemBody = (path: string, verb: string, status: string): Schema | undefined =>
     (
@@ -2386,7 +2420,11 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
       ["patch", "/todos/{id}", "200"],
       ["get", "/todos/{id}", "200"],
     ] as const) {
-      expect(Object.keys(itemBody(path, verb, status)?.properties ?? {})).toEqual(["id", "title"]);
+      const schema = itemBody(path, verb, status);
+      expect(Object.keys(schema?.properties ?? {})).toEqual(["id", "title"]);
+      // The fallback response schema still links back to the entity
+      // (issue #294).
+      expect(schema?.["x-kavo-entity"]).toBe("Todo");
     }
   });
 
@@ -2399,6 +2437,7 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
 
     const items = itemBody("/todos", "get", "200")?.properties?.items;
     expect(Object.keys(items?.items?.properties ?? {})).toEqual(["id", "title"]);
+    expect(items?.items?.["x-kavo-entity"]).toBe("Todo");
   });
 
   it("documents every own column when selectable is left unconfigured, relations excluded", async () => {
@@ -2595,6 +2634,7 @@ describe("@Kavo Swagger schema hints (enum, oneOf)", () => {
     example?: string | number;
     oneOf?: readonly HintSchema[];
     title?: string;
+    "x-kavo-entity"?: string;
   };
 
   let document: ReturnType<typeof SwaggerModule.createDocument>;
@@ -2631,8 +2671,18 @@ describe("@Kavo Swagger schema hints (enum, oneOf)", () => {
     const children = itemSchema()?.properties?.children;
     expect(children?.type).toBe("array");
     expect(children?.items?.oneOf).toEqual([
-      { title: "VariantA", type: "object", properties: { id: { type: "integer" }, a: { type: "string" } } },
-      { title: "VariantB", type: "object", properties: { id: { type: "integer" }, b: { type: "integer" } } },
+      {
+        title: "VariantA",
+        type: "object",
+        properties: { id: { type: "integer" }, a: { type: "string" } },
+        "x-kavo-entity": "Todo",
+      },
+      {
+        title: "VariantB",
+        type: "object",
+        properties: { id: { type: "integer" }, b: { type: "integer" } },
+        "x-kavo-entity": "Todo",
+      },
     ]);
   });
 });


### PR DESCRIPTION
## What & why

Kavo's generated OpenAPI routes carried an `operationId` but no `tags`, so client generators like Orval and `openapi-generator` (which key file/module splitting off `tags`) dumped every operation across every entity into one flat client module. There was also no machine-readable link from an operation, or a generated DTO schema, back to the Kavo entity/operation it came from.

This adds a `tags: [entity.name]` entry and `x-kavo-entity`/`x-kavo-operation` vendor extensions to every generated route (standard, custom, and `@Override`d — `applySwaggerMetadata` runs identically for all three), and stamps `x-kavo-entity` on every inline DTO schema this module builds: request/response bodies (`schemaFromDto`), the list-envelope element, the issue #264 fallback body/response schemas, and each `oneOf` variant. The `{ type: DtoClass }` fallback path (no inline schema — `@nestjs/swagger`'s own introspection builds it) is exempt, per the issue's documented tradeoff. `operationId`'s value and format are unchanged, and the module stays a no-op when `@nestjs/swagger` is not installed.

Closes #294

## Public API impact

None — no changes to `packages/core/src/index.ts`.

## Testing

Extended the existing `binding.e2e.spec.ts` coverage (rather than duplicating suites) with assertions for the tag and both extensions on a custom operation and an `@Override`d route, and `x-kavo-entity` on request bodies, item/list response schemas, list-envelope elements, both #264 fallback schemas, and `oneOf` variants.

Verified `pnpm check` result: generate, build, typecheck, `depcruise`, and `lint` all pass clean. The test stage passes 2758 tests; the only failures are pre-existing sandbox limitations unrelated to this change — no Docker container runtime available for the Postgres/MariaDB/CockroachDB testcontainers suites, and no network access to MongoDB's binary CDN for the mongoose in-memory-server suites. `pnpm docs:links` also passes.

## Review notes

Nothing deliberately left open. Worth a close look: the `entityName` threading through `schemaFromDto`/`jsonSchemaForValue`/`schemaForHint` down to the `oneOf` variant tagging, and that `listEnvelopeSchema` now takes an explicit `entityName` param at both its call sites (`successBodyFor` and `applyResponseSchemaDocs`).

---
_Generated by [Claude Code](https://claude.ai/code/session_015aUGd8iFAQ197R5dqb4Gmi)_