### PR TITLE
ci: version the release-please PR title

### DIFF
--- a/docs/internals/adr/0041-releases-are-cut-by-release-please.md
+++ b/docs/internals/adr/0041-releases-are-cut-by-release-please.md
@@ -37,6 +37,10 @@ GitHub Release. `publish.yml` runs on `release: published` — a tag pushed by
 `GITHUB_TOKEN` does not fire `on: push: tags`, but the Release does. The
 `push: tags: v*.*.*` trigger is kept as a manual escape hatch.
 
+The release PR's title is `chore: release v${version}`
+(`pull-request-title-pattern`), so the squash-merge commit on `main` reads
+`chore: release vX.Y.Z (#NNN)`.
+
 Pre-1.0 bump rules live in config: `bump-minor-pre-major` keeps a breaking
 change on `0.x` at a minor bump rather than `1.0.0`, and
 `bump-patch-for-minor-pre-major` makes a plain `feat:` a **patch** bump. The

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "include-component-in-tag": false,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore: release v${version}",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "packages": {

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -765,6 +765,10 @@ describe("release-please config", () => {
       expect(KNOWN.has(section.type), `unknown changelog type: ${section.type}`).toBe(true);
     }
   });
+
+  it("titles the release PR with the version so the squash commit carries it", () => {
+    expect(config["pull-request-title-pattern"]).toBe("chore: release v${version}");
+  });
 });
 
 describe("release-please workflow", () => {


### PR DESCRIPTION
Follow-up to #296.

The org setting "Allow GitHub Actions to create and approve pull requests" is now enabled, so `GITHUB_TOKEN` works — no PAT needed.

## Change

- **`release-please-config.json`** — `pull-request-title-pattern: "chore: release v${version}"`. The release PR (and, on GitHub squash merge, the commit on `main`) reads `chore: release v0.14.7` instead of the default `chore: release main`.
- **ADR-0041** — note the title pattern.
- **`tests/release-workflow.spec.ts`** — assert the pattern.

## After merge

Re-run the latest `release-please.yml` run (or push any commit to `main`); it opens `chore: release v0.14.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)