### PR TITLE
ci: cut the release without a PAT when the release PR merges

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,19 @@
 name: release-please
 
 on:
+  # Opens / updates the standing release PR as feature commits land on main.
   push:
     branches: [main]
+  # Cuts the tag + GitHub Release once the release PR is merged. A separate
+  # trigger because merging the release PR does NOT fire `on: push` — its
+  # commits are authored by github-actions[bot] via the default GITHUB_TOKEN,
+  # and GitHub suppresses push workflows for those to avoid recursion. The
+  # `pull_request` event fires on the human merge instead, so no PAT is needed.
+  pull_request:
+    types: [closed]
+  # Manual escape hatch: re-run to reconcile a release that never got cut
+  # (manifest ahead of tags).
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,6 +22,10 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'release-please--branches--main')
     steps:
       - uses: googleapis/release-please-action@v4
         with:

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -788,4 +788,17 @@ describe("release-please workflow", () => {
     expect(wf).toContain(".release-please-manifest.json");
     expect(wf).toContain("googleapis/release-please-action@v4");
   });
+
+  it("also cuts the release when the release PR is merged (push is suppressed for GITHUB_TOKEN commits)", () => {
+    // Merging release-please's own PR does not fire `on: push` — its commits
+    // are authored by github-actions[bot] via the default GITHUB_TOKEN. The
+    // `pull_request: closed` event fires on the human merge instead.
+    expect(wf).toMatch(/pull_request:\s*\n\s*types:\s*\[?\s*closed/);
+    expect(wf).toContain("github.event.pull_request.merged == true");
+    expect(wf).toContain("release-please--branches--main");
+  });
+
+  it("has a manual escape hatch to reconcile a release that never got cut", () => {
+    expect(wf).toContain("workflow_dispatch:");
+  });
 });


### PR DESCRIPTION
## What & why

Merging release-please's own release PR does not fire `on: push` — its commits are authored by `github-actions[bot]` via the default `GITHUB_TOKEN`, and GitHub suppresses push-triggered workflows for those to prevent recursion. As a result, when #297 ("chore: release v0.14.7") merged, the second release-please run that creates the tag + GitHub Release never happened: `v0.14.7` was never tagged, no Release was published, and `publish.yml` (which runs on `v*.*.*` tags) never fired. npm is still at `0.14.6` while the manifest and CHANGELOG on `main` are at `0.14.7`.

This adds a `pull_request: closed` trigger, gated by a job `if` to `merged == true` and head ref `release-please--branches--main`, so the release is cut on the human merge click instead of the suppressed push — no PAT required. Also adds `workflow_dispatch` as a manual reconcile hatch for a release that never got cut (manifest ahead of tags). The existing `push: [main]` trigger is unchanged, so the standing release PR still opens and updates from feature merges.

## Recovering v0.14.7

Post-merge, run `gh workflow run release-please.yml --ref main`. release-please sees the manifest at `0.14.7` with no matching tag and cuts it; `publish.yml` then publishes to npm.

## Public API impact

None.

## Testing

Added two assertions to `tests/release-workflow.spec.ts` covering the `pull_request: closed` trigger (event type, `merged` gate, release branch ref) and the `workflow_dispatch` hatch.

`pnpm check`: build, typecheck, depcruise, lint, and 2881 tests pass. The 5 failing specs are the `examples/nest-*` testcontainers e2e suites failing with "Could not find a working container runtime strategy" — no local Docker; unrelated to this change (workflow YAML + its spec only), and green in CI. `pnpm docs:links` passes.

## Review notes

The `if` gate hardcodes the release branch name `release-please--branches--main`; that is release-please-action v4's fixed pattern for a single-package manifest on `main`. Nothing non-blocking left open.