### PR TITLE
ci: cut releases without a PAT and credit release-please[bot]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,19 @@
 name: release-please
 
 on:
+  # Opens / updates the standing release PR as feature commits land on main.
   push:
     branches: [main]
+  # Cuts the tag + GitHub Release once the release PR is merged. A separate
+  # trigger because merging the release PR does NOT fire `on: push` — its
+  # commits are authored by github-actions[bot] via the default GITHUB_TOKEN,
+  # and GitHub suppresses push workflows for those to avoid recursion. The
+  # `pull_request` event fires on the human merge instead, so no PAT is needed.
+  pull_request:
+    types: [closed]
+  # Manual escape hatch: re-run to reconcile a release that never got cut
+  # (manifest ahead of tags).
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,6 +22,10 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'release-please--branches--main')
     steps:
       - uses: googleapis/release-please-action@v4
         with:

--- a/docs/internals/adr/0041-releases-are-cut-by-release-please.md
+++ b/docs/internals/adr/0041-releases-are-cut-by-release-please.md
@@ -39,7 +39,9 @@ GitHub Release. `publish.yml` runs on `release: published` — a tag pushed by
 
 The release PR's title is `chore: release v${version}`
 (`pull-request-title-pattern`), so the squash-merge commit on `main` reads
-`chore: release vX.Y.Z (#NNN)`.
+`chore: release vX.Y.Z (#NNN)`. `pull-request-footer` ends the PR body with a
+`Co-authored-by: release-please[bot]` trailer, so the squash-merge commit
+attributes the release to the bot.
 
 Pre-1.0 bump rules live in config: `bump-minor-pre-major` keeps a breaking
 change on `0.x` at a minor bump rather than `1.0.0`, and

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "include-component-in-tag": false,
   "separate-pull-requests": false,
   "pull-request-title-pattern": "chore: release v${version}",
+  "pull-request-footer": "Co-authored-by: release-please[bot] <55107282+release-please[bot]@users.noreply.github.com>",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "packages": {

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -788,4 +788,17 @@ describe("release-please workflow", () => {
     expect(wf).toContain(".release-please-manifest.json");
     expect(wf).toContain("googleapis/release-please-action@v4");
   });
+
+  it("also cuts the release when the release PR is merged (push is suppressed for GITHUB_TOKEN commits)", () => {
+    // Merging release-please's own PR does not fire `on: push` — its commits
+    // are authored by github-actions[bot] via the default GITHUB_TOKEN. The
+    // `pull_request: closed` event fires on the human merge instead.
+    expect(wf).toMatch(/pull_request:\s*\n\s*types:\s*\[?\s*closed/);
+    expect(wf).toContain("github.event.pull_request.merged == true");
+    expect(wf).toContain("release-please--branches--main");
+  });
+
+  it("has a manual escape hatch to reconcile a release that never got cut", () => {
+    expect(wf).toContain("workflow_dispatch:");
+  });
 });

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -769,6 +769,12 @@ describe("release-please config", () => {
   it("titles the release PR with the version so the squash commit carries it", () => {
     expect(config["pull-request-title-pattern"]).toBe("chore: release v${version}");
   });
+
+  it("ends the PR body with a Co-authored-by trailer so the squash commit credits the bot", () => {
+    expect(config["pull-request-footer"]).toBe(
+      "Co-authored-by: release-please[bot] <55107282+release-please[bot]@users.noreply.github.com>",
+    );
+  });
 });
 
 describe("release-please workflow", () => {


### PR DESCRIPTION
## What

- `release-please.yml` now cuts the tag + GitHub Release via a `pull_request: types: [closed]` trigger when the standing release PR merges, instead of relying on `on: push` (which GitHub suppresses for `github-actions[bot]` commits). No PAT required.
- Add `pull-request-footer` to `release-please-config.json` so the release PR body ends with a `Co-authored-by: release-please[bot]` trailer, which the squash-merge commit on `main` picks up.
- ADR-0041 and `tests/release-workflow.spec.ts` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)