### PR TITLE
ci: drop the release-please Co-authored-by footer

### DIFF
--- a/docs/internals/adr/0041-releases-are-cut-by-release-please.md
+++ b/docs/internals/adr/0041-releases-are-cut-by-release-please.md
@@ -39,9 +39,7 @@ GitHub Release. `publish.yml` runs on `release: published` — a tag pushed by
 
 The release PR's title is `chore: release v${version}`
 (`pull-request-title-pattern`), so the squash-merge commit on `main` reads
-`chore: release vX.Y.Z (#NNN)`. `pull-request-footer` ends the PR body with a
-`Co-authored-by: release-please[bot]` trailer, so the squash-merge commit
-attributes the release to the bot.
+`chore: release vX.Y.Z (#NNN)`.
 
 Pre-1.0 bump rules live in config: `bump-minor-pre-major` keeps a breaking
 change on `0.x` at a minor bump rather than `1.0.0`, and

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "include-component-in-tag": false,
   "separate-pull-requests": false,
   "pull-request-title-pattern": "chore: release v${version}",
-  "pull-request-footer": "Co-authored-by: release-please[bot] <55107282+release-please[bot]@users.noreply.github.com>",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "packages": {

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -769,12 +769,6 @@ describe("release-please config", () => {
   it("titles the release PR with the version so the squash commit carries it", () => {
     expect(config["pull-request-title-pattern"]).toBe("chore: release v${version}");
   });
-
-  it("ends the PR body with a Co-authored-by trailer so the squash commit credits the bot", () => {
-    expect(config["pull-request-footer"]).toBe(
-      "Co-authored-by: release-please[bot] <55107282+release-please[bot]@users.noreply.github.com>",
-    );
-  });
 });
 
 describe("release-please workflow", () => {


### PR DESCRIPTION
Reverts the `pull-request-footer` added in #300. Removes the `Co-authored-by: release-please[bot]` trailer from `release-please-config.json`, along with the matching ADR-0041 note and test assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)