### PR TITLE
ci: let release-please own the GitHub Release, drop it from publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  # Read-only checkout is all this job needs: it publishes to npm and nothing
+  # else. The GitHub Release is release-please's to create (ADR-0041), so no
+  # `contents: write` here. `id-token: write` is for npm OIDC trusted
+  # publishing (and the provenance attestation that comes with it).
+  contents: read
   id-token: write
 
 jobs:
@@ -177,14 +181,12 @@ jobs:
             fi
           done
 
-      # Only runs once every publish above succeeded. Attaches the exact
-      # published tarballs as release assets and lets GitHub generate the
-      # notes from merged PRs since the previous tag.
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "$GITHUB_REF_NAME" \
-            $TARBALL_DIR/*.tgz \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
+      # No GitHub Release step here on purpose. release-please owns the
+      # Release: it creates it, with notes from CHANGELOG.md, as part of
+      # cutting the tag (ADR-0041). This job's one job is to get the packages
+      # onto npm — the distribution channel — and `npm publish` runs with
+      # `id-token: write`, so each package carries an npm provenance
+      # attestation pointing back at this workflow and commit. Attaching the
+      # .tgz files to the Release as well would duplicate that for artifacts
+      # nobody installs from GitHub, and force this job to coordinate on a
+      # Release object another workflow made.

--- a/tests/release-workflow.spec.ts
+++ b/tests/release-workflow.spec.ts
@@ -499,6 +499,16 @@ describe("publish.yml wiring", () => {
     expect([...packageDirs].sort()).toEqual(publishable.sort());
   });
 
+  it("never touches the GitHub Release — release-please owns it", () => {
+    // release-please creates the Release (notes from CHANGELOG.md) as part of
+    // cutting the tag (ADR-0041). publish.yml only pushes to npm. A
+    // `gh release create` here collided with release-please's Release ("a
+    // release with the same tag name already exists") and failed the job
+    // after every package had already published; `gh release upload` would
+    // just re-couple the two workflows. Keep the responsibility split.
+    expect(workflow).not.toMatch(/gh release (create|upload|edit|delete)/);
+  });
+
   it("verifies the packed tarballs after packing them and before publishing", () => {
     const steps = readStepNames(workflow);
     const pack = steps.indexOf("Pack packages");


### PR DESCRIPTION
## Problem

`publish.yml`'s final step ran `gh release create "$GITHUB_REF_NAME"`, but for a routine release-please release the Release **already exists** — release-please creates it (with notes from `CHANGELOG.md`) as part of cutting the tag (ADR-0041):

```
a release with the same tag name already exists: v0.15.2
Error: Process completed with exit code 1
```

...after every package had already published to npm, so the job failed on a red herring.

## Change — split the responsibility, don't re-couple it

- **release-please owns the GitHub Release** (creation + changelog notes). `publish.yml` no longer touches it — the Release step is deleted, not rewritten to `upload`.
- **`publish.yml` owns npm only.** `npm publish` runs with `id-token: write` via OIDC trusted publishing, so every package already carries an npm provenance attestation pointing at this workflow + commit. Attaching the 9 `.tgz` files to the Release would duplicate that for artifacts nobody installs from GitHub.
- **Least privilege:** `contents: write` → `contents: read`. With no Release step the job only needs a read-only checkout plus `id-token: write`.
- `tests/release-workflow.spec.ts`: asserts `publish.yml` never runs `gh release create/upload/edit/delete`.

The `release: types: [published]` trigger on `publish.yml` stays — it's still the path for a Release created by a real identity (manual, or a future PAT/App-token release-please).

## Verification

`pnpm vitest run tests/release-workflow.spec.ts` → 52 passed. `pnpm format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)