### PR TITLE
feat(example): add structured-JSON `vitals` column to Dog entity

### DIFF
--- a/examples/nest-typeorm/src/dog/dog.entity.ts
+++ b/examples/nest-typeorm/src/dog/dog.entity.ts
@@ -2,6 +2,19 @@ import { ChildEntity, Column } from "typeorm";
 import { Pet } from "../pet/pet.entity.js";
 
 /**
+ * Structured payload for the `vitals` JSON column. The concrete type is a
+ * compile-time contract only — the TypeORM adapter still maps the column to
+ * core's opaque `json` `FieldKind` (derived from the column type, not this
+ * interface), so the generated DTO / OpenAPI schema stays an open object and
+ * the field remains non-filterable, exactly like `attributes`.
+ */
+export interface DogVitals {
+  weightKg: number;
+  heightCm: number;
+  lastCheckup: string;
+}
+
+/**
  * A concrete Pet subtype. Child columns must be nullable under single-table
  * inheritance (rows of sibling types leave them empty).
  */
@@ -24,4 +37,10 @@ export class Dog extends Pet {
   // cannot be filtered).
   @Column("simple-json", { nullable: true })
   attributes!: Record<string, unknown> | null;
+
+  // Same `simple-json` mechanics as `attributes`, but typed to a concrete
+  // shape (`DogVitals`) rather than an open record — the app-side value is
+  // statically checked, while the wire contract is unchanged.
+  @Column("simple-json", { nullable: true })
+  vitals!: DogVitals | null;
 }


### PR DESCRIPTION
## What

Adds a second `simple-json` column to the `Dog` entity in the `nest-typeorm` example, typed to a concrete `DogVitals` interface (`weightKg` / `heightCm` / `lastCheckup`) rather than an open record.

## Why

`Dog.attributes` already demonstrates the unstructured `json` fallback (`Record<string, unknown>`). `vitals` sits next to it to show the other end: a `json` column whose app-side value is statically checked against a named shape, while the **wire contract is unchanged** — the TypeORM adapter still maps `simple-json` to core's opaque `json` `FieldKind`, so the derived DTO / OpenAPI schema stays an open object and the field is non-filterable.

## Notes

- `simple-json` (not `json`/`jsonb`) so the one column keeps working across all four e2e drivers (sqlite / postgres / mariadb / cockroachdb).
- `pnpm check` green: build, typecheck, depcruise, lint, 3460 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)