### PR TITLE
fix(nest): document relation properties in the synthesized fallback body schema

### DIFF
--- a/docs/internals/adr/0014-associate-by-id-not-deep-writes.md
+++ b/docs/internals/adr/0014-associate-by-id-not-deep-writes.md
@@ -42,7 +42,10 @@ cascade; the framework does not partially honor a deep write.
 Relations join the derived write shape by default, so association works
 with zero config. An entity with a registered `create`/`update` DTO opts
 in by declaring the property (`owner: number | null = null`), which also
-documents it in Swagger.
+documents it in Swagger. Without a write DTO, the synthesized fallback body
+schema documents the relation too — as a `{ id }` reference object, an
+array of them for a to-many — from `metadata.relations` (see
+`docs/internals/architecture/10-nestjs-integration.md`, issue #339).
 
 Deep nested writes are **out of scope**, not merely unimplemented.
 

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -476,6 +476,20 @@ update never requires a field, so its `<Entity>Patch` carries no
 `required` regardless of nullability. An empty `required` is omitted
 rather than emitted as `[]`.
 
+A `creatable`/`updatable` name that is a **relation** rather than a scalar
+column has no `metadata.fields` entry, so it is picked up from
+`metadata.relations` and documented as the association-by-id shape the
+deserializer accepts (ADR-0014): a `{ id }` reference object for a to-one,
+a nullable array of them for a to-many, `id` left untyped because the
+target entity's primary-key kind isn't reachable from the binding. A
+relation never joins the body's `required` (`RelationDescriptor` carries no
+nullability). Without this, an entity whose entire writable projection is
+relations — a pure join row associated by id — would synthesize an empty
+`properties: {}` a client generator reads as "this route takes no body"
+(issue #339). The description fallback ("No field is writable.") is
+therefore gated on the synthesized schema ending up with zero properties,
+not on the allowlist being empty.
+
 Two known over-statements, both narrowing documentation only — the schema
 stays open (no `additionalProperties: false`, matching `allowlists.md`'s
 "narrows silently"), so neither lies about what the route accepts or

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -8,6 +8,7 @@ import type {
   OperationDescriptor,
   OperationDtoMap,
   QueryFieldSelector,
+  RelationCardinality,
   RelationFieldSelector,
 } from "@kavo/core";
 import { DefaultDtoResolver } from "@kavo/core";
@@ -984,17 +985,23 @@ const alreadyBodySchemaDocumented = new WeakSet<object>();
  * *silently* (`docs/features/allowlists.md`'s opening line), the same way an
  * unknown body key already does, so declaring the schema closed would tell a
  * validating client/gateway that a body Kavo actually accepts is invalid.
- * An empty allowlist still has to read as "no field is allowed" rather than
- * fall through to no documentation at all, so that case gets a `description`
- * saying so instead of a schema constraint — the same distinction
- * `allowedFieldsDescription` draws for an explicit empty selector.
+ * A schema that ends up with no properties at all still has to read as "no
+ * field is allowed" rather than fall through to no documentation — an empty
+ * `properties: {}` with no `description` reads to a client generator as
+ * "this route takes no body", which is a lie (issue #339). That case gets a
+ * `description` saying so instead of a schema constraint — the same
+ * distinction `allowedFieldsDescription` draws for an explicit empty
+ * selector.
  *
- * Relation names in `creatable`/`updatable` (associable by id, ADR-0014) are
- * not documented here: `metadata.fields` lists scalar columns only, so an
- * entity whose default allowlist includes a relation gets that one write
- * path silently left off the synthesized schema — the same "known gap, not
- * a lie" tradeoff `includableRelations`'s own doc comment accepts elsewhere
- * in this file.
+ * Relation names on `creatable`/`updatable` (associable by id, ADR-0014)
+ * have no `metadata.fields` entry — `metadata.fields` is scalar columns
+ * only — so they are picked up from `metadata.relations` instead and
+ * documented as the reference-object shape the deserializer accepts:
+ * `{ "id": ... }` for a to-one, an array of them for a to-many, either
+ * nullable so `null` can disassociate. The related row's id *type* needs
+ * the target entity's own metadata, which this function does not receive,
+ * so `id` is left untyped rather than guessed, and a relation never joins
+ * the outer `required` list (`RelationDescriptor` carries no nullability).
  */
 export function applyBodySchemaDocs(
   prototype: Record<string, unknown>,
@@ -1030,6 +1037,18 @@ export function applyBodySchemaDocs(
       required.push(field.name);
     }
   }
+  // A relation on the allowlist is associable by id (ADR-0014): it is
+  // written as a `{ "id": ... }` reference object — an array of them for a
+  // to-many — or `null` to disassociate. It has no `metadata.fields` entry,
+  // so it is emitted from `metadata.relations` here; without this, an entity
+  // whose entire writable projection is relations synthesizes an empty
+  // `properties: {}` that reads as "no body" (issue #339).
+  for (const relation of metadata.relations) {
+    if (!allowed.includes(relation.name)) {
+      continue;
+    }
+    properties[relation.name] = associationBodySchema(relation.cardinality);
+  }
   // `patchOne` is a partial update — every field is optional regardless of
   // column nullability — so it never carries `required`. `createOne` and
   // `updateOne` replace the row, so a non-nullable column the caller is
@@ -1045,7 +1064,7 @@ export function applyBodySchemaDocs(
         type: "object",
         properties,
         ...(emitRequired ? { required } : {}),
-        ...(allowed.length === 0 ? { description: "No field is writable." } : {}),
+        ...(Object.keys(properties).length === 0 ? { description: "No field is writable." } : {}),
       },
       metadata.name,
     ),
@@ -1100,6 +1119,24 @@ function fieldKindSchema(field: FieldMetadata): object {
 function fieldSchema(field: FieldMetadata): object {
   const base = fieldKindSchema(field);
   return field.nullable ? { ...base, nullable: true } : base;
+}
+
+/**
+ * The request-body fragment for a write-side relation property (ADR-0014):
+ * a `{ id }` reference object for a to-one, an array of them for a to-many,
+ * either one nullable so `null` disassociates. `id` is left untyped — the
+ * related entity's primary-key kind isn't reachable from here.
+ */
+function associationBodySchema(cardinality: RelationCardinality): object {
+  const reference = {
+    type: "object",
+    properties: { id: {} },
+    required: ["id"],
+    description: "Associate by id (ADR-0014); pass `null` to disassociate.",
+  };
+  return cardinality === "many"
+    ? { type: "array", nullable: true, items: reference }
+    : { ...reference, nullable: true };
 }
 
 /**

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -2316,14 +2316,18 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
   // all-nullable case, so `required` derivation can be pinned without
   // touching the shared `Todo` fixture every other test asserts exact keys
   // against.
-  const withMetadata = async (fields: EntityMetadata<object>["fields"]) => {
+  const withMetadata = async (
+    fields: EntityMetadata<object>["fields"],
+    relations: EntityMetadata<object>["relations"] = [],
+    config?: unknown,
+  ) => {
     class Note {}
     const metadata: EntityMetadata<object> = {
       entity: Note,
       name: "Note",
       idField: "id",
       fields,
-      relations: [],
+      relations,
     };
     const adapter = {
       findOneById: async () => null,
@@ -2344,9 +2348,9 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
       adapterFor: () => adapter as never,
     };
 
-    @Kavo(Note)
     @Controller("notes")
     class NoteController {}
+    Kavo(Note, config as Parameters<typeof Kavo>[1])(NoteController);
 
     const moduleRef = await Test.createTestingModule({
       imports: [KavoModule.forRoot({ infrastructure }), KavoModule.forFeature([NoteController])],
@@ -2407,10 +2411,24 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
       ["patch", "/todos/{id}"],
     ] as const) {
       const schema = bodySchema(path, verb);
-      expect(Object.keys(schema?.properties ?? {})).toEqual(["title", "done", "priority"]);
+      // `list` is a to-one relation on `Todo` — it has no `metadata.fields`
+      // entry but is on the default `creatable`/`updatable` allowlist
+      // (associable by id, ADR-0014), so it must be documented, not dropped
+      // (issue #339).
+      expect(Object.keys(schema?.properties ?? {})).toEqual(["title", "done", "priority", "list"]);
       expect(schema?.properties?.title).toEqual({ type: "string" });
       expect(schema?.properties?.done).toEqual({ type: "boolean" });
       expect(schema?.properties?.priority).toEqual({ type: "number" });
+      expect(schema?.properties?.list).toEqual({
+        type: "object",
+        nullable: true,
+        properties: { id: {} },
+        required: ["id"],
+        description: "Associate by id (ADR-0014); pass `null` to disassociate.",
+      });
+      // A relation never joins the outer `required` list — no nullability
+      // is derivable for it.
+      expect(schema?.required ?? []).not.toContain("list");
       // `creatable`/`updatable` narrow silently (an unknown body key is
       // dropped, not rejected), so the synthesized schema must not declare
       // itself closed — that would tell a validating client a body Kavo
@@ -2429,6 +2447,65 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
     document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
 
     const schema = bodySchema("/todos", "post");
+    expect(schema?.properties).toEqual({});
+    expect(schema?.description).toBe("No field is writable.");
+  });
+
+  it("documents a relation-only writable projection instead of an empty, bodyless-looking schema (issue #339)", async () => {
+    await withMetadata(
+      // The whole entity is a generated id plus two relations — nothing the
+      // scalar-column loop can match.
+      [{ name: "id", kind: "string", nullable: false, generated: true }],
+      [
+        { name: "word", target: () => class {}, cardinality: "one", includable: false, strategy: "auto" },
+        { name: "tags", target: () => class {}, cardinality: "many", includable: false, strategy: "auto" },
+      ],
+    );
+
+    const schema = bodySchema("/notes", "post");
+    // Before #339 this was `{}` with no `description` — read by a client
+    // generator as "POST /notes takes no body", which is false.
+    expect(Object.keys(schema?.properties ?? {})).toEqual(["word", "tags"]);
+    expect(schema?.description).toBeUndefined();
+    expect(schema?.properties?.word).toEqual({
+      type: "object",
+      nullable: true,
+      properties: { id: {} },
+      required: ["id"],
+      description: "Associate by id (ADR-0014); pass `null` to disassociate.",
+    });
+    // A to-many relation takes an array of reference objects (ADR-0014).
+    expect(schema?.properties?.tags).toEqual({
+      type: "array",
+      nullable: true,
+      items: {
+        type: "object",
+        properties: { id: {} },
+        required: ["id"],
+        description: "Associate by id (ADR-0014); pass `null` to disassociate.",
+      },
+    });
+    // No nullability is derivable for a relation, so none joins `required`.
+    expect(schema?.required).toBeUndefined();
+    // Still not declared closed — an unknown body key is dropped, not rejected.
+    expect(schema?.additionalProperties).toBeUndefined();
+  });
+
+  it("still reads as closed when a non-empty allowlist resolves to zero documentable properties", async () => {
+    // `creatable` explicitly names a `generated` column — a real, non-empty
+    // allowlist — but the synthesized-schema loop skips generated columns,
+    // so it produces zero properties. The "no body" description must still
+    // appear: it is gated on the property count, not the allowlist length.
+    await withMetadata([{ name: "id", kind: "string", nullable: false, generated: true }], [], {
+      allowlists: { creatable: ["id"], updatable: ["id"] },
+    });
+
+    const schema = (
+      document.paths["/notes"] as Record<
+        string,
+        { requestBody?: { content?: Record<string, { schema?: { properties?: object; description?: string } }> } }
+      >
+    )?.post?.requestBody?.content?.["application/json"]?.schema;
     expect(schema?.properties).toEqual({});
     expect(schema?.description).toBe("No field is writable.");
   });
@@ -2459,7 +2536,12 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
     // run and, say, widen it back out to every writable column.
     expect(Object.keys(bodySchema("/todos", "post")?.properties ?? {})).toEqual(["title"]);
     // No DTO is registered for update/patch, so those still fall back.
-    expect(Object.keys(bodySchema("/todos/{id}", "put")?.properties ?? {})).toEqual(["title", "done", "priority"]);
+    expect(Object.keys(bodySchema("/todos/{id}", "put")?.properties ?? {})).toEqual([
+      "title",
+      "done",
+      "priority",
+      "list",
+    ]);
   });
 
   it("stays idempotent across repeated bootstraps of the same controller", async () => {
@@ -2474,7 +2556,7 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
     // A second `ApiBody` application would overwrite rather than duplicate
     // properties here, so this mainly documents that no crash/duplicate
     // registration happens across repeated `onModuleInit` runs.
-    expect(Object.keys(bodySchema("/todos", "post")?.properties ?? {})).toEqual(["title", "done", "priority"]);
+    expect(Object.keys(bodySchema("/todos", "post")?.properties ?? {})).toEqual(["title", "done", "priority", "list"]);
   });
 });
 


### PR DESCRIPTION
## What & why

The `#264` fallback request-body schema (`applyBodySchemaDocs`) only iterated `metadata.fields` — scalar columns. A `creatable`/`updatable` name that is a **relation** (relations join the writable base by default, ADR-0014) matched nothing, so an entity whose entire writable projection is relations synthesized `"properties": {}` — which a client generator reads as "this route takes no body", when `POST /bookmarks` genuinely accepts `{"word": {"id": "..."}}`.

Now any allowlisted relation is emitted from `metadata.relations` as the association-by-id shape the deserializer actually accepts: a `{ id }` reference object for a to-one, a nullable array of them for a to-many (`null` clears it), `id` left untyped since the target entity's PK kind isn't reachable from the binding. Relations never join the outer `required` list — `RelationDescriptor` carries no nullability. The "No field is writable." description now keys off the synthesized property count rather than the allowlist length, so a non-empty allowlist that resolves to zero documentable properties still reads as closed.

Note: the issue suggested a bare `{ "type": "string" }`; that's stale — #291 made a bare scalar id a 400 (`KAVO_ASSOCIATION_INVALID_SHAPE`), so the reference-object shape from ADR-0014 is what's implemented.

Closes #339

## Public API impact

None. No barrel changes — `RelationCardinality` is already exported from `@kavo/core`.

## Testing

- New: relation-only writable projection documents `word` (to-one) and `tags` (to-many) instead of an empty bodyless-looking schema; asserts no `additionalProperties`, no `description`, no `required`.
- New: a non-empty allowlist resolving to zero properties still emits "No field is writable." (pins the description-gate change).
- Updated 3 existing assertions that had encoded the dropped-relation behavior (`Todo.list` now correctly appears in synthesized create/update/patch bodies).
- `pnpm check` green (build, typecheck, depcruise, lint, 3466 tests). `pnpm docs:links` green.

## Review notes

- Scope was deliberately kept to the reported bug. `applyResponseSchemaDocs` and `applyQuerySchemaDocs` (filter/sort) are named in the issue but have **no bug**: `selectable` defaults to `ownColumns + computed` and `filterable`/`sortable` to `ownColumns`, so no relation name reaches those loops; relation *paths* there are a pre-existing documented non-enumeration.
- Out of scope (separate, lesser defect): a registered write DTO with a relation property yields an untyped `{}` fragment via `jsonSchemaForValue(null)` — a loosely-typed property, not the "no body" lie. The #339 repro has no DTO.
- `format` on the relation's `id` (from the target PK kind) is skipped — it needs target-entity metadata the function doesn't receive; the issue marks it optional.
- Docs updated: `docs/internals/architecture/10-nestjs-integration.md` and a one-clause amendment to ADR-0014.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Swagger request-body documentation now includes writable relationships as ID-based references.
  - Supports both single and multiple relationships, including nullable relationship arrays.
  - Relationship-only request schemas are documented correctly.

- **Bug Fixes**
  - Relationship fields are no longer incorrectly marked as required.
  - Empty or non-writable request schemas now display accurate fallback descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->