### PR TITLE
feat(core): cap an included relation's projection from allowlists.selectable

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -406,6 +406,10 @@ const config = defineConfig({
                 text: "0042 — Filter and Query are documented-only aggregate component schemas",
                 link: "/internals/adr/0042-filter-and-query-component-schemas",
               },
+              {
+                text: "0044 — A relation-dotted allowlists.selectable entry caps an included relation's projection",
+                link: "/internals/adr/0044-relation-projection-ceiling-from-selectable",
+              },
             ],
           },
         ],

--- a/docs/features/allowlists.md
+++ b/docs/features/allowlists.md
@@ -18,7 +18,7 @@ What a request may filter, sort, select, include, and write, including relation 
 
 - `filterable` (`readonly FieldPath[]` \| `{ exclude: readonly FieldPath[] }`): fields usable in `filter[...]`.
 - `sortable` (same shape): fields usable in `sort=`.
-- `selectable` (same shape): fields usable in `fields=`, and what a response carries.
+- `selectable` (same shape): fields usable in `fields=`, and what a response carries. A relation-dotted entry in the **array** form (`selectable: ["id", "title", "dictionary.id"]`) is not a root `fields=` path — it is a projection ceiling for that included relation ([ADR-0044](/internals/adr/0044-relation-projection-ceiling-from-selectable)); see below.
 - `includable` (`readonly IncludePath<Entity, 1>[]` \| `{ exclude: readonly IncludePath<Entity, 1>[] }`): relation names usable in `include=`, one segment at a time from the root ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)).
 - `searchable` (`readonly FieldPath[]` \| `{ exclude: readonly FieldPath[] }`): fields `search[query]`/`search[fields]` may search. Relation paths are permitted here, unlike `filterable`/`sortable`. Default: every own string-kind column, not every own column. Also gated by `query.search` (`false` by default — set it to an object to turn search on); see [Search](/querying/search).
 - `creatable` (`readonly FieldPath<Entity, 1>[]` \| `{ exclude: readonly FieldPath<Entity, 1>[] }`): fields `createOne` may write. Default: every non-generated own column except the primary key, plus every relation (associable by id). Capped to one path segment — a write body addresses the entity's own fields and relations, never a dotted path into a relation's own fields.
@@ -58,3 +58,28 @@ The filter and sort doors are the same oracle [ADR-0021](/internals/adr/0021-cur
 :::
 
 Two more edges. A registered `dto.item`/`dto.list` with a runtime shape replaces the projection rather than intersecting with it, so `selectable` does not fence a column the DTO names, even where the DTO is wider. Register the DTO as the narrowing statement when you use one. And an included relation is projected by its own target's `selectable`, never the root's, so hiding a column on `User` keeps it hidden wherever `user` is included, provided `User` itself went through `@Kavo`/`createCrud`. A relation target that never did gets a derived config, which configures nothing and serves its full column set.
+
+## Capping an included relation's fields
+
+`selectable` also caps what an **included** relation returns, from the config of the entity doing the including. Name the relation and the fields you want, dotted, in the array form:
+
+```ts
+@Kavo(Entry, {
+  allowlists: {
+    includable: ["dictionary"],
+    selectable: ["id", "title", "kind", "published", "dictionary.id"],
+  },
+})
+```
+
+Now `GET /entries?include=dictionary` embeds `{ "id": … }` and nothing else on each `dictionary`, whatever the `Dictionary` entity's own `selectable` or `item` DTO would otherwise expose — an intersection, never a widening ([ADR-0044](/internals/adr/0044-relation-projection-ceiling-from-selectable)). A request may still narrow further (`fields[dictionary]=id`); a field outside the ceiling (`fields[dictionary]=slug`) is a 400, the same as one outside `Dictionary`'s own `selectable`. Each entity's ceiling applies at its own level of a nested `include`.
+
+Rules:
+
+- **Array form only.** A relation path inside `selectable: { exclude: [...] }` is a bootstrap error — use the array form.
+- **One relation segment.** `dictionary.id` is fine; `dictionary.publisher.id` is a bootstrap error (deep projection is out of scope).
+- **Must be includable.** A relation projected here but absent from `allowlists.includable` is a bootstrap error — the ceiling could never apply.
+- A dotted entry whose head is not a real relation is a bootstrap error, not a silently ignored line.
+- The **field** half (`dictionary.id`) is not checked against `Dictionary`'s columns at bootstrap. A request naming a field off `Dictionary`'s own `selectable` is still a 400; a ceiling entry that names no real `Dictionary` column is just omitted from the embed. Name fields that exist.
+- The ceiling applies even when the relation target never went through its own `@Kavo`/`createCrud` — it rides on the owning entity's config, not the target's.
+- `include` resolves for reads only, so this bounds `findOne`/`findMany` (and any custom read); there is no write-echo path in Kavo to bound.

--- a/docs/internals/adr/0044-relation-projection-ceiling-from-selectable.md
+++ b/docs/internals/adr/0044-relation-projection-ceiling-from-selectable.md
@@ -1,0 +1,150 @@
+# ADR-0044 — A relation-dotted `allowlists.selectable` entry caps an included relation's projection
+
+**Status:** accepted
+
+## Context
+
+`allowlists.selectable` narrows the root entity's response projection
+(ADR-0026). An **included** relation was projected by its own target's
+`selectable` or registered `item`/`list` DTO, and never by the config of
+the entity doing the including — ADR-0026 decision 4 states it outright:
+"A relation is projected by its own target's `selectable`, never the
+root's." A caller could trim an include per request with
+`fields[<relation>]=`, but there was no way to say in config "an included
+`dictionary` returns only `id`, always" — an adopter who includes a
+relation to surface one field ships the relation's whole row unless every
+caller remembers the sparse-fieldset param.
+
+Two facts made a config spelling natural rather than novel:
+
+1. `QueryFieldSelector` is typed as `FieldPath<Entity>` at depth 3, so a
+   relation-dotted entry (`"dictionary.id"`) already **type-checks** in
+   `selectable`.
+2. It also already did **nothing**. `resolveProjection` returns the
+   configured list and the serializer intersects it with the entity's
+   derived scalar/computed keys — a dotted entry matches none of them and
+   is silently dropped. ADR-0026's own resolver comment notes the residue:
+   "an explicit `selectable` may legitimately name a relation path, which
+   is not a key this projection ever emits."
+
+So the config surface accepted a plausible-looking line and ignored it.
+The alternative considered — a dedicated per-relation selector, e.g. a
+per-relation object on `allowlists.includable` or a `selectable` key on
+`relations.edges.<name>` — adds a second config mechanism for an outcome
+the first mechanism already half-expresses, and fights ADR-0028's split
+that keeps `relations.edges` loading-tuning-only.
+
+## Decision
+
+**A relation-dotted entry in the _array_ form of `allowlists.selectable`
+is a projection ceiling for that included relation.**
+`selectable: ["id", "title", "dictionary.id"]` resolves to a root
+projection of `["id", "title"]` and a `relationProjection` of
+`{ dictionary: ["id"] }` on `ResolvedEntityConfig`.
+
+- **It is a default and a ceiling.** When a request sends no
+  `fields[<relation>]=` for that node, the ceiling _is_ the node's
+  fieldset. When it does, the requested fields are validated against the
+  target's `selectable` **and** the ceiling; a field allowed by the target
+  but outside the ceiling is a `KAVO_QUERY_INVALID_FIELD` 400, named
+  against the owning entity's config. A request narrows within the
+  ceiling, never past it.
+- **It is an intersection, never a widening.** The ceiling applies on top
+  of whatever the target resolves — its own `selectable` or a registered
+  `item`/`list` DTO — so a DTO that exposes `title` still cannot widen
+  `dictionary` past `["id"]`.
+- **Enforcement is `DefaultIncludeResolver`, against the _owner's_
+  config.** `relationProjection` is keyed by the owning entity's own
+  relation names, and the resolver already walks the tree one level at a
+  time holding the config of the entity that owns each edge — so each
+  owner's ceiling applies at its own level of a nested `include`, with no
+  extra threading.
+- **Reads only.** `KavoEngine.execute` normalizes a query for read
+  operations only; a write never resolves `include`, so there is no
+  write-echo path to bound.
+- **Root residue is removed, not just tolerated.** The relation-dotted
+  entries are stripped from the resolved `allowlists.selectable` (which
+  documents exactly "what a request may name in `fields=`") and from the
+  derived `projection`, so `fields=dictionary.id` no longer passes root
+  field validation as a no-op.
+
+**Rejected shapes fail at bootstrap with a `ConfigurationException`, not
+silently:**
+
+| Shape                                                       | Why it is rejected                                                                                                    |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| a relation path inside `selectable: { exclude: [...] }`     | the `{ exclude }` form cannot express a ceiling — its base set is the readable projection, which has no relation keys |
+| `"a.b.c"` where `a` is a relation                           | deeper than one relation segment; deep projection is out of scope (issue #343)                                        |
+| `"rel.field"` where `rel` is not on `allowlists.includable` | the ceiling could never take effect                                                                                   |
+| `"notARelation.field"`                                      | a dotted entry whose head is not a real relation — a typo, previously inert                                           |
+
+The **field** half of a ceiling entry (`<field>` in `<relation>.<field>`)
+is not checked at bootstrap — the target's metadata is not in scope there,
+the same laxity `resolveAllowlists` already documents for relation paths
+on `searchable`. Its behaviour then splits by path:
+
+- a request that names the field in `fields[<relation>]=` gets a 400 if
+  the field is not on the target's own `selectable`;
+- with no request fieldset, the ceiling is used verbatim and a field that
+  names no real target column is simply **omitted** from the projected
+  relation — a quiet degrade, not an error. An entity that opts into a
+  ceiling is expected to name fields that exist on the target.
+
+## Consequences
+
+**This is a breaking change**, scoped to configs that already carried an
+inert relation path on `selectable`. Every shape in the table above boots
+today (the path type-checks and is silently dropped) and now throws a
+`ConfigurationException` at bootstrap. The one most likely to bite:
+`selectable` built by copying a `filterable`/`sortable` list — which is
+how issue #343's reporter wrote it — where the copied list contains a
+relation path whose relation was never named on `allowlists.includable`.
+Migration: name the relation in `allowlists.includable` (if the ceiling
+is intended), or drop the entry (if it was noise). Pre-1.0, minor bump,
+changelog note.
+
+**The resolved `allowlists.selectable` and `projection` are now narrower**
+for such a config: the relation-dotted entries are removed. Anything that
+reads the resolved list — `fields=` request validation, the
+`<Entity>Query.fields` component-schema enum, `@kavo/nest`'s
+`fallbackListSchema` — no longer sees a relation path it never did
+anything useful with anyway. This is deliberate: the entry means
+"relation ceiling", not "root `fields=` path".
+
+**This amends ADR-0026 decision 4.** The root config _can_ now narrow an
+included relation — but only through `selectable` relation paths, and only
+by intersection. ADR-0026's core rule (an include never _widens_ what its
+target exposes) is unchanged and in fact reinforced.
+
+**The ceiling holds for an unregistered relation target,** unlike
+ADR-0026's projection: that decision notes decision 4 "holds only for
+registered entities" because an unregistered target's derived config
+"configures nothing". This ceiling is enforced through the include tree's
+`node.fields`, set from the **owner's** config, so it applies whether or
+not the target ever went through `createCrud`/`@Kavo` — the strongest
+reason to prefer this spelling over a per-relation selector on the target.
+
+**`ResolvedEntityConfig` gains a member,** `relationProjection`. It is
+barrel-exported; anyone hand-constructing one through a cast (as the
+in-repo tests do) gets an object the compiler no longer checks. This is
+the same break ADR-0026 recorded for `projection` and ADR-0019 for
+`computed`.
+
+**Swagger gains a description.** `fields[<relation>]` carries
+`Restricted to: <fields>.` when the relation has a ceiling — resolvable at
+decoration time (ADR-0012), because the ceiling is literal strings on
+`allowlists.selectable`, unlike an `{ exclude }` selector.
+
+## References
+
+- ADR-0026 (`allowlists.selectable` narrows the response), whose decision
+  4 this amends.
+- ADR-0028 (includable relations live on `allowlists`), for the
+  `relations.edges` vs `allowlists` split this decision stays on the right
+  side of.
+- ADR-0008 (field-path recursion cap), the reason the ceiling is limited
+  to one relation segment.
+- ADR-0012 (decoration-time route generation), for why Swagger can
+  document the ceiling but not an `{ exclude }` selector.
+- `docs/internals/architecture/12-relations-and-includes.md` §2 and §4;
+  `docs/features/allowlists.md`.

--- a/docs/internals/architecture/12-relations-and-includes.md
+++ b/docs/internals/architecture/12-relations-and-includes.md
@@ -51,7 +51,13 @@ first client asks.
    legal until the budget runs out. Visited-type tracking would forbid a
    legitimate self-relation, and depth is the rule a client can predict.
 5. **Fieldsets**: `fields[posts.comments]=id,body` attaches to that node,
-   validated against the _target_ entity's selectable allowlist.
+   validated against the _target_ entity's selectable allowlist — and,
+   when the **owning** entity's `allowlists.selectable` names a relation
+   path (`selectable: [..., "posts.title"]`, ADR-0044), against that
+   ceiling too. With no `fields[<path>]=` in the request the ceiling _is_
+   the node's fieldset; with one, a field outside the ceiling is a 400,
+   the same as one outside the target's `selectable`. A request may narrow
+   within the ceiling, never past it.
 6. **Resolve decisions**: `auto` becomes `join` or `batch`, and the
    target's delete strategy is attached — so the adapter translates
    answers rather than re-deriving them.
@@ -148,6 +154,15 @@ case, and `auto` resolves it to `join` exactly like `Pet.owner`.
   `item` DTO (`list` for a to-many, which falls back to `item`), else the
   target's derived default. A relation key on the _parent's_ DTO is
   documentation, not a load: it stays absent until the node is included.
+- **Relation projection ceiling (ADR-0044):** a relation-dotted entry on
+  the owning entity's `allowlists.selectable` (`"dictionary.id"`) caps
+  what an included `dictionary` returns, whatever its own config or DTO
+  would otherwise expose — an intersection, never a widening. Enforced
+  against the config of the entity that _owns_ the include edge, so each
+  owner's ceiling applies at its own level of a nested path. Array form
+  only; the `{ exclude }` form of `selectable` rejects a relation path at
+  bootstrap. `include` resolution runs for reads only, so there is no
+  write-echo path to bound.
 - **Soft delete:** soft-deleted related rows are excluded from
   includes. Root-level `withDeleted` applies to the **root only** — the
   adapter spells the child predicate out rather than leaving it to the
@@ -156,7 +171,10 @@ case, and `auto` resolves it to `join` exactly like `Pet.owner`.
 - **`findOne` supports `include`** with identical semantics.
 - **Swagger:** `include` and one `fields[<relation>]` per includable
   relation are documented from the entity config's allowlist — the only
-  relation knowledge decoration time has (ADR-0012).
+  relation knowledge decoration time has (ADR-0012). A relation carrying a
+  projection ceiling (ADR-0044) gets a `Restricted to: …` description on
+  its `fields[<relation>]` parameter; the ceiling is literal strings on
+  `allowlists.selectable`, so it resolves at decoration time.
 
 ## 5. Writes
 

--- a/docs/reference/config-keys.md
+++ b/docs/reference/config-keys.md
@@ -102,15 +102,16 @@ Coarser than the per-entity `EntityConfig.operations`, which also carries `handl
 
 Not part of `KavoSettings`. Declared on `EntityConfig` directly, so there's no global default and no per-operation override.
 
-| Key                     | Type                                                          | Default                                                           |
-| ----------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `allowlists.filterable` | `FieldPath[] \| { exclude: FieldPath[] }`                     | every own column                                                  |
-| `allowlists.sortable`   | same shape                                                    | every own column                                                  |
-| `allowlists.selectable` | same shape                                                    | every own column + computed fields                                |
-| `allowlists.includable` | `IncludePath[] \| { exclude: IncludePath[] }`                 | `[]`, no relation includable                                      |
-| `allowlists.searchable` | `FieldPath[] \| { exclude: FieldPath[] }`                     | every own string-kind column                                      |
-| `allowlists.creatable`  | `FieldPath<Entity,1>[] \| { exclude: FieldPath<Entity,1>[] }` | every non-generated own column except the id, plus every relation |
-| `allowlists.updatable`  | same shape                                                    | same default as `creatable`                                       |
+| Key                                      | Type                                                          | Default                                                                                                                 |
+| ---------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `allowlists.filterable`                  | `FieldPath[] \| { exclude: FieldPath[] }`                     | every own column                                                                                                        |
+| `allowlists.sortable`                    | same shape                                                    | every own column                                                                                                        |
+| `allowlists.selectable`                  | same shape                                                    | every own column + computed fields                                                                                      |
+| &nbsp;&nbsp;↳ relation path (array form) | `"<relation>.<field>"` entries                                | none — caps an included relation's fields ([ADR-0044](/internals/adr/0044-relation-projection-ceiling-from-selectable)) |
+| `allowlists.includable`                  | `IncludePath[] \| { exclude: IncludePath[] }`                 | `[]`, no relation includable                                                                                            |
+| `allowlists.searchable`                  | `FieldPath[] \| { exclude: FieldPath[] }`                     | every own string-kind column                                                                                            |
+| `allowlists.creatable`                   | `FieldPath<Entity,1>[] \| { exclude: FieldPath<Entity,1>[] }` | every non-generated own column except the id, plus every relation                                                       |
+| `allowlists.updatable`                   | same shape                                                    | same default as `creatable`                                                                                             |
 
 See [Allowlists](/features/allowlists).
 

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -109,6 +109,7 @@ export function resolveEntityConfig<Entity extends object>(
   const policy = resolvePolicy(entityName, entityConfig, globalPolicy);
   const allowlists = resolveAllowlists(metadata, entityConfig, computed);
   const projection = resolveProjection(metadata, entityConfig, computed, allowlists);
+  const relationProjection = resolveRelationProjection(metadata, entityConfig, allowlists);
   const entitySettings = normalizeSearch(
     mergeSettings(
       BUILT_IN_DEFAULTS,
@@ -166,6 +167,7 @@ export function resolveEntityConfig<Entity extends object>(
     },
     allowlists,
     projection,
+    relationProjection,
     softDelete: resolveSoftDelete(metadata, entitySettings),
     dto: new DefaultDtoResolver<Entity>(entityConfig?.dto),
     computed,
@@ -437,10 +439,22 @@ function resolveAllowlists<Entity extends object>(
           (name) => !compositeIdFields.includes(name),
         ) as unknown as readonly FieldPath<Entity, 1>[]);
   const configured = entityConfig?.allowlists;
+  // Relation-dotted entries on an explicit `selectable` array carry the
+  // per-relation projection ceiling (ADR-0044) — `resolveRelationProjection`
+  // reads them straight off the raw config. They are not root `fields=`
+  // paths (a relation is selected with `fields[<relation>]=`, never
+  // `fields=<relation>.<field>`), so they are stripped from the resolved
+  // `selectable` list, which documents exactly "what a request may name in
+  // `fields=`", and from the derived response `projection` built off it.
+  const relationHeads = new Set(relationNames as readonly string[]);
+  const selectableResolved = resolveFieldSelector(selectableBase, configured?.selectable) as readonly string[];
+  const selectableRootOnly = selectableResolved.filter(
+    (path) => !(path.includes(".") && relationHeads.has(path.split(".")[0]!)),
+  ) as unknown as readonly FieldPath<Entity>[];
   const allowlists = {
     filterable: resolveFieldSelector(ownColumns, configured?.filterable),
     sortable: resolveFieldSelector(ownColumns, configured?.sortable),
-    selectable: resolveFieldSelector(selectableBase, configured?.selectable),
+    selectable: selectableRootOnly,
     includable: resolveIncludableSelector(metadata.name, relationNames, configured?.includable),
     // Unlike `filterable`/`sortable`, its unconfigured default is narrower
     // than "every own column" — a non-string column has nothing an `ILIKE`
@@ -686,6 +700,99 @@ function resolveProjection<Entity extends object>(
 }
 
 /**
+ * Per-relation projection ceilings (ADR-0044), derived from the
+ * relation-dotted entries of an explicitly configured `allowlists.selectable`.
+ *
+ * `selectable: ["id", "title", "dictionary.id"]` yields `{ dictionary: ["id"] }`:
+ * an included `dictionary` is projected to `id` and nothing else, whatever the
+ * `dictionary` entity's own config would otherwise expose. Bare entries stay
+ * the root projection's business (`resolveProjection`); this reads only the
+ * dotted ones. `undefined` when `selectable` names no relation path.
+ *
+ * Every rejected shape is a bootstrap `ConfigurationException` rather than a
+ * silently inert entry — the gap this ADR closes:
+ *   - the `{ exclude }` form cannot carry a relation path at all;
+ *   - a dotted entry whose head is not a real relation of the entity;
+ *   - more than one relation segment (`a.b.c`) — deep projection is out of
+ *     scope (issue #343);
+ *   - a relation that is not on `allowlists.includable`, so the ceiling could
+ *     never take effect.
+ *
+ * The *field* half of an entry is not checked here — the target's metadata is
+ * not in scope at bootstrap, the same laxity `resolveAllowlists` documents for
+ * relation paths on `searchable`. A request that names such a field in
+ * `fields[<relation>]=` gets a 400 (it is not on the target's `selectable`);
+ * on the default path — no request fieldset — a ceiling field that names no
+ * real target column is simply omitted from the embed, not raised.
+ */
+function resolveRelationProjection<Entity extends object>(
+  metadata: EntityMetadata<Entity>,
+  entityConfig: EntityConfig<Entity> | undefined,
+  allowlists: ResolvedQueryAllowlists<Entity>,
+): Readonly<Record<string, readonly string[]>> | undefined {
+  const selector = entityConfig?.allowlists?.selectable;
+  if (selector === undefined) {
+    return undefined;
+  }
+  const entityName = metadata.name;
+  const relationNames = new Set(metadata.relations.map((relation) => relation.name));
+  const isRelationPath = (entry: string): boolean => entry.includes(".") && relationNames.has(entry.split(".")[0]!);
+
+  if ("exclude" in selector) {
+    const offending = (selector.exclude as readonly string[]).find(isRelationPath);
+    if (offending !== undefined) {
+      throw new ConfigurationException(
+        entityName,
+        "allowlists.selectable.exclude",
+        `'${offending}' projects the '${offending.split(".")[0]}' relation, which the { exclude } form cannot ` +
+          `express — move relation projection to the array form of allowlists.selectable`,
+      );
+    }
+    return undefined;
+  }
+
+  const byRelation = new Map<string, string[]>();
+  for (const entry of selector as readonly string[]) {
+    if (!entry.includes(".")) {
+      continue;
+    }
+    const segments = entry.split(".");
+    const head = segments[0]!;
+    if (!relationNames.has(head)) {
+      throw new ConfigurationException(
+        entityName,
+        "allowlists.selectable",
+        `'${entry}' is a dotted path but '${head}' is not a relation of ${entityName} ` +
+          `(relations: ${[...relationNames].join(", ") || "none"})`,
+      );
+    }
+    if (segments.length > 2) {
+      throw new ConfigurationException(
+        entityName,
+        "allowlists.selectable",
+        `'${entry}' projects deeper than one relation segment — a selectable relation path names one ` +
+          `relation and one of its fields ('${head}.<field>'), not a nested path`,
+      );
+    }
+    if (!(allowlists.includable as readonly string[]).includes(head)) {
+      throw new ConfigurationException(
+        entityName,
+        "allowlists.selectable",
+        `'${entry}' projects the '${head}' relation, which is not on allowlists.includable — a relation ` +
+          `must be includable for its projection to ever apply`,
+      );
+    }
+    const fields = byRelation.get(head) ?? [];
+    fields.push(segments[1]!);
+    byRelation.set(head, fields);
+  }
+  if (byRelation.size === 0) {
+    return undefined;
+  }
+  return deepFreeze(Object.fromEntries(byRelation)) as Readonly<Record<string, readonly string[]>>;
+}
+
+/**
  * Generic over the path type so it serves both `QueryFieldSelector`
  * (depth-capped-3 `FieldPath`) and `WritableFieldSelector` (depth-1) — the
  * array-or-`{ exclude }` resolution logic is identical either way.
@@ -761,6 +868,7 @@ export function describeResolvedConfig<Entity>(
     entityName: config.entityName,
     settings: config.settings,
     allowlists: config.allowlists,
+    relationProjection: config.relationProjection ?? null,
     computed: Object.keys(config.computed),
     softDelete: config.softDelete,
     relations: config.relations.all().map((relation) => ({

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -61,6 +61,20 @@ export interface ResolvedEntityConfig<Entity = unknown> {
    */
   readonly projection: readonly FieldPath<Entity>[] | null;
   /**
+   * Per-relation projection ceilings, derived from the relation-dotted
+   * entries of an explicitly configured `allowlists.selectable` (ADR-0044).
+   * `{ dictionary: ["id"] }` from `selectable: [..., "dictionary.id"]`.
+   *
+   * A relation named here is projected to at most these fields when it is
+   * included — a request may narrow further with `fields[<relation>]=` but
+   * a field outside the ceiling is a 400, never served. Enforced in
+   * {@link DefaultIncludeResolver} against the config of the entity that
+   * *owns* the relation, so a nested owner's ceiling applies at its own
+   * level. `undefined` when `allowlists.selectable` names no relation path
+   * (or was not configured, or used the `{ exclude }` form).
+   */
+  readonly relationProjection: Readonly<Record<string, readonly string[]>> | undefined;
+  /**
    * The delete strategy resolved for this scope — `hard` with
    * a `null` field for everything that isn't soft-deletable, so adapters
    * branch on one object instead of re-deriving the decision.

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -921,6 +921,10 @@ export class KavoEngine<Entity extends object> {
       // outside the settings precedence chain, so a per-call override
       // cannot widen what a response serves.
       projection: config.projection,
+      // Structural like `projection`: a per-relation projection ceiling
+      // (ADR-0044) is derived from `allowlists.selectable`, outside the
+      // settings precedence chain, so a per-call scope cannot widen it.
+      relationProjection: config.relationProjection,
       // A narrowed scope may change the delete strategy (an operation that
       // forces `hard` on a soft-deletable entity, say), so it is resolved
       // against the settings actually in force for this call.

--- a/packages/core/src/relations/default-include-resolver.ts
+++ b/packages/core/src/relations/default-include-resolver.ts
@@ -144,7 +144,7 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
       tree[draft.name] = {
         relation,
         path: draft.path,
-        fields: this.fieldsFor(draft, request, target.config, issues),
+        fields: this.fieldsFor(draft, request, owner, target.config, issues),
         strategy:
           relation.strategy === "auto" ? (relation.cardinality === "many" ? "batch" : "join") : relation.strategy,
         softDelete: target.config.softDelete,
@@ -183,19 +183,32 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
   }
 
   /**
-   * A node's sparse fieldset, validated against the *target* entity's
-   * selectable allowlist — never the root's. Stitching keys are not
-   * added here: they are fetched regardless and stripped at serialization.
+   * A node's sparse fieldset. Two gates, both narrowing and neither able to
+   * widen:
+   *
+   *   - the *target* entity's `selectable` allowlist — never the root's;
+   *   - the *owner* entity's per-relation projection ceiling for this
+   *     relation (`allowlists.selectable: [..., "<relation>.<field>"]`,
+   *     ADR-0044), resolved on the config of the entity that declared the
+   *     `include` edge, so a nested owner's ceiling applies at its level.
+   *
+   * With a ceiling and no `fields[<path>]=` in the request, the ceiling *is*
+   * the node's fieldset — the "default and ceiling" the ADR promises. With a
+   * request, a field outside the ceiling is a 400, the same as one outside
+   * `selectable`. Stitching keys are not added here: they are fetched
+   * regardless and stripped at serialization.
    */
   private fieldsFor(
     draft: DraftNode,
     request: IncludeRequest,
+    owner: ResolvedEntityConfig<object>,
     target: ResolvedEntityConfig<object>,
     issues: QueryIssueDto[],
   ): readonly string[] | null {
+    const ceiling = owner.relationProjection?.[draft.name];
     const requested = request.fields[draft.path];
     if (requested === undefined) {
-      return null;
+      return ceiling === undefined ? null : [...ceiling];
     }
     // `IncludeRequest.fields` types this as `readonly string[]`, but the
     // programmatic `QueryContext.fields` entry point can hand a caller's
@@ -216,19 +229,29 @@ export class DefaultIncludeResolver<Entity extends object = object> implements I
     const allowed = target.allowlists.selectable as readonly string[];
     const fields: string[] = [];
     for (const field of requested) {
-      if (allowed.includes(field)) {
-        fields.push(field);
+      if (!allowed.includes(field)) {
+        issues.push({
+          field: `${draft.path}.${field}`,
+          code: "KAVO_QUERY_INVALID_FIELD",
+          detail:
+            `Field '${field}' cannot be used for selection on '${draft.path}'.` +
+            // The allowlist that rejected it is the *target* entity's, so the
+            // config key the developer has to edit is the target's too.
+            allowlistHint(field, "selection", target.entityName, allowed),
+        });
         continue;
       }
-      issues.push({
-        field: `${draft.path}.${field}`,
-        code: "KAVO_QUERY_INVALID_FIELD",
-        detail:
-          `Field '${field}' cannot be used for selection on '${draft.path}'.` +
-          // The allowlist that rejected it is the *target* entity's, so the
-          // config key the developer has to edit is the target's too.
-          allowlistHint(field, "selection", target.entityName, allowed),
-      });
+      if (ceiling !== undefined && !ceiling.includes(field)) {
+        issues.push({
+          field: `${draft.path}.${field}`,
+          code: "KAVO_QUERY_INVALID_FIELD",
+          detail:
+            `Field '${field}' cannot be used for selection on '${draft.path}': the '${owner.entityName}' ` +
+            `config restricts '${draft.name}' to ${nameList(ceiling)}.`,
+        });
+        continue;
+      }
+      fields.push(field);
     }
     return fields;
   }

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -4,6 +4,7 @@ import {
   ConfigurationException,
   QueryValidationException,
   createKavo,
+  resolveEntityConfig,
 } from "@kavo/core";
 import type {
   KavoInstance,
@@ -495,6 +496,206 @@ describe("include rejection messages", () => {
     expect(detail).toContain("Did you mean 'title'?");
     expect(detail).toContain("Selectable fields on Post: id, title.");
     expect(detail).toContain("allowlists.selectable on the Post config");
+  });
+});
+
+describe("relation projection ceiling — allowlists.selectable relation paths (ADR-0044)", () => {
+  const authorCeiling = (): EntityConfig<Author> => ({
+    allowlists: { includable: ["posts"], selectable: ["id", "name", "posts.title"] },
+  });
+
+  it("derives relationProjection from the dotted selectable entries and strips them from the root list", () => {
+    const config = resolveEntityConfig(authorMetadata, authorCeiling() as never, undefined);
+    expect(config.relationProjection).toEqual({ posts: ["title"] });
+    // The relation path is the ceiling, not a root `fields=` path — it must
+    // not leak into the resolved selectable list or the response projection.
+    expect(config.allowlists.selectable).toEqual(["id", "name"]);
+    expect(config.projection).toEqual(["id", "name"]);
+  });
+
+  it("relationProjection is undefined when selectable names no relation path", () => {
+    const config = resolveEntityConfig(
+      authorMetadata,
+      { allowlists: { selectable: ["id", "name"] } } as never,
+      undefined,
+    );
+    expect(config.relationProjection).toBeUndefined();
+  });
+
+  it("projects an included relation to the ceiling with no fields[path] in the request", async () => {
+    const fixture = blog({ author: authorCeiling() });
+    const { authors, authorRows } = fixture;
+    authorRows.push(authorWithPosts());
+
+    const list = await authors.findMany({ include: ["posts"] });
+    // Post's own config would serve id/title/authorId/deletedAt; the ceiling
+    // on the *Author* config cuts the included node to `title` alone.
+    expect((list.items[0] as { posts: unknown[] }).posts[0]).toEqual({ title: "First" });
+  });
+
+  it("applies the ceiling to findOne", async () => {
+    const fixture = blog({ author: authorCeiling() });
+    const { authors, authorRows } = fixture;
+    authorRows.push(authorWithPosts());
+
+    const one = await authors.findOne(1, { include: ["posts"] });
+    expect((one as { posts: unknown[] }).posts[0]).toEqual({ title: "First" });
+  });
+
+  it("lets a request narrow within the ceiling but not past it", async () => {
+    const fixture = blog({
+      author: {
+        allowlists: { includable: ["posts"], selectable: ["id", "name", "posts.id", "posts.title"] },
+      },
+    });
+    const { authors, authorRows } = fixture;
+    authorRows.push(authorWithPosts());
+
+    const narrowed = await authors.findMany({
+      include: ["posts"],
+      fields: { relations: { posts: ["id"] } },
+    });
+    expect((narrowed.items[0] as { posts: unknown[] }).posts[0]).toEqual({ id: 10 });
+
+    await expect(
+      authors.findMany({ include: ["posts"], fields: { relations: { posts: ["title", "authorId"] } } }),
+    ).rejects.toMatchObject({
+      // `title` is on the ceiling; `authorId` is a real Post column but off it.
+      issues: [{ field: "posts.authorId", code: "KAVO_QUERY_INVALID_FIELD" }],
+    });
+  });
+
+  it("blames the owner entity's config when a request escapes the ceiling", async () => {
+    const { authors } = blog({ author: authorCeiling() });
+    const detail = await authors.findMany({ include: ["posts"], fields: { relations: { posts: ["authorId"] } } }).then(
+      () => {
+        throw new Error("expected a QueryValidationException");
+      },
+      (error: unknown) => (error as QueryValidationException).issues[0]!.detail,
+    );
+    expect(detail).toContain("the 'Author' config restricts 'posts' to");
+    expect(detail).toContain("title");
+  });
+
+  it("bounds the ceiling even where the target registers a wider item DTO", async () => {
+    class PostItemDto {
+      id = 0;
+      title = "";
+      authorId = 0;
+    }
+    const fixture = blog({
+      author: authorCeiling(),
+      post: { dto: { item: PostItemDto } as never },
+    });
+    const { authors, authorRows } = fixture;
+    authorRows.push(authorWithPosts());
+
+    const list = await authors.findMany({ include: ["posts"] });
+    expect((list.items[0] as { posts: unknown[] }).posts[0]).toEqual({ title: "First" });
+  });
+
+  it("applies each owner's own ceiling at its own level of a nested include", async () => {
+    const fixture = blog({
+      author: { allowlists: { includable: ["posts"], selectable: ["id", "name", "posts.title"] } },
+      post: { allowlists: { includable: ["comments"], selectable: ["id", "title", "comments.body"] } },
+    });
+    const { authors, authorRows } = fixture;
+    authorRows.push(authorWithPosts());
+
+    const list = await authors.findMany({ include: ["posts.comments"] });
+    const post = (list.items[0] as unknown as { posts: Array<Record<string, unknown>> }).posts[0]!;
+    // Author's ceiling keeps `title`; the `comments` key still rides along
+    // because it is an included child, projected by Post's own ceiling.
+    expect(post["title"]).toBe("First");
+    expect(post["comments"]).toEqual([{ body: "nice" }]);
+  });
+
+  it("holds even when the relation target never went through createCrud", async () => {
+    // Comment's metadata is known to the instance but it is never
+    // `createCrud`-ed, so it gets a derived config that configures nothing
+    // (ADR-0026 §"Decision 4 holds only for registered entities"). The
+    // ceiling still applies, because it rides on Post's `node.fields`, not
+    // on Comment's config.
+    const metadata = new Map<unknown, EntityMetadata<object>>([
+      [Post, postMetadata as EntityMetadata<object>],
+      [Comment, commentMetadata as EntityMetadata<object>],
+    ]);
+    const postAdapter = new SeededAdapter<Post>([
+      Object.assign(new Post(), {
+        id: 10,
+        title: "First",
+        authorId: 1,
+        comments: [Object.assign(new Comment(), { id: 100, body: "nice", postId: 10 })],
+      }),
+    ]);
+    const adapters = new Map<unknown, unknown>([
+      [Post, postAdapter],
+      [Comment, new SeededAdapter<Comment>([])],
+    ]);
+    const kavo = createKavo({
+      infrastructure: {
+        metadataFor: (entity) => metadata.get(entity) as never,
+        adapterFor: (entity) => adapters.get(entity) as never,
+      },
+    });
+    const posts = kavo.createCrud(Post, {
+      allowlists: { includable: ["comments"], selectable: ["id", "title", "comments.body"] },
+    } as never) as DefaultKavoService<Post>;
+
+    const list = await posts.findMany({ include: ["comments"] });
+    // The derived Comment config would serve id/body/postId; the ceiling on
+    // the Post config cuts the embed to `body` alone.
+    expect((list.items[0] as unknown as { comments: unknown[] }).comments[0]).toEqual({ body: "nice" });
+  });
+
+  it("omits a ceiling field that names no real column on the target", async () => {
+    // The field half of a ceiling entry is not checked at bootstrap (the
+    // target's metadata is not in scope). On the default path — no
+    // `fields[posts]=` in the request — an unknown ceiling field is simply
+    // dropped from the embed, not raised as an error.
+    const fixture = blog({
+      author: {
+        allowlists: { includable: ["posts"], selectable: ["id", "name", "posts.title", "posts.ghost" as never] },
+      },
+    });
+    const { authors, authorRows } = fixture;
+    authorRows.push(authorWithPosts());
+
+    const list = await authors.findMany({ include: ["posts"] });
+    expect((list.items[0] as { posts: unknown[] }).posts[0]).toEqual({ title: "First" });
+  });
+
+  describe("bootstrap rejections", () => {
+    const bootstrap =
+      (selectable: readonly string[], includable: readonly string[] = ["posts"]): (() => unknown) =>
+      () =>
+        resolveEntityConfig(authorMetadata, { allowlists: { includable, selectable } } as never, undefined);
+
+    it("rejects a dotted selectable entry whose head is not a relation", () => {
+      expect(bootstrap(["id", "postz.title"])).toThrow(/'postz' is not a relation of Author/);
+    });
+
+    it("rejects a selectable relation path deeper than one segment", () => {
+      expect(bootstrap(["id", "posts.author.name"])).toThrow(/deeper than one relation segment/);
+    });
+
+    it("rejects a relation projected by selectable but not on allowlists.includable", () => {
+      expect(bootstrap(["id", "posts.title"], [])).toThrow(/not on allowlists\.includable/);
+    });
+
+    it("rejects a relation path inside the { exclude } form of selectable", () => {
+      expect(() =>
+        resolveEntityConfig(
+          authorMetadata,
+          { allowlists: { includable: ["posts"], selectable: { exclude: ["posts.title"] } } } as never,
+          undefined,
+        ),
+      ).toThrow(/the \{ exclude \} form cannot/);
+    });
+
+    it("every rejection is a ConfigurationException", () => {
+      expect(bootstrap(["id", "postz.title"])).toThrow(ConfigurationException);
+    });
   });
 });
 

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -284,11 +284,16 @@ export function applySwaggerMetadata(
         }),
       );
       for (const relation of includable) {
+        const ceiling = relationFieldCeiling(config, relation);
         apply(
           swagger.ApiQuery({
             name: `fields[${relation}]`,
             required: false,
             type: String,
+            // A per-relation projection ceiling (ADR-0044) is the one
+            // entity-specific thing worth saying here: the request may
+            // narrow `fields[<relation>]` further but not past this set.
+            ...(ceiling !== undefined ? { description: `Restricted to: ${ceiling.join(", ")}.` } : {}),
           }),
         );
       }
@@ -1508,6 +1513,32 @@ function includableRelations(config: EntityConfig<object> | undefined): readonly
     return null;
   }
   return selector;
+}
+
+/**
+ * The per-relation projection ceiling this entity's config imposes on an
+ * included `<relation>` (`allowlists.selectable: [..., "<relation>.<field>"]`,
+ * ADR-0044) — the field names `fields[<relation>]` is narrowed to, or
+ * `undefined` when the relation carries no ceiling.
+ *
+ * Like `includableRelations`, this is decoration-time-resolvable: the ceiling
+ * is literal strings on `allowlists.selectable`, no ORM metadata needed. The
+ * `{ exclude }` form of `selectable` never carries a relation path (core
+ * rejects it at bootstrap), so it simply yields no ceilings here.
+ */
+function relationFieldCeiling(
+  config: EntityConfig<object> | undefined,
+  relation: string,
+): readonly string[] | undefined {
+  const selector = (config?.allowlists as { selectable?: QueryFieldSelector<object> } | undefined)?.selectable;
+  if (selector === undefined || "exclude" in selector) {
+    return undefined;
+  }
+  const prefix = `${relation}.`;
+  const fields = (selector as readonly string[])
+    .filter((entry) => entry.startsWith(prefix) && !entry.slice(prefix.length).includes("."))
+    .map((entry) => entry.slice(prefix.length));
+  return fields.length > 0 ? fields : undefined;
 }
 
 export function bodyDtoFor(descriptor: OperationDescriptor<object>, dtoResolver: DtoResolver<object>): ClassRef | null {

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -1507,6 +1507,32 @@ describe("@Kavo relation includes", () => {
     expect(response.body.list).toEqual({ id: 7 });
   });
 
+  it("caps an included relation to the allowlists.selectable ceiling with no fields[list] (ADR-0044)", async () => {
+    @Kavo(Todo, { allowlists: { includable: ["list"], selectable: ["id", "title", "list.id"] } })
+    @Controller("todos")
+    class CeilingController {}
+
+    await app.close();
+    await bootstrap(CeilingController);
+    await request(server())
+      .post("/todos")
+      .send({ title: "x", list: { id: 7 } })
+      .expect(201);
+
+    const list = await request(server()).get("/todos?include=list").expect(200);
+    expect(list.body.items[0].list).toEqual({ id: 7 });
+    const one = await request(server()).get("/todos/1?include=list").expect(200);
+    expect(one.body.list).toEqual({ id: 7 });
+
+    // A request may narrow within the ceiling, never past it: `name` is a
+    // real TodoList column but off the ceiling.
+    const rejected = await request(server()).get("/todos/1?include=list&fields[list]=name").expect(400);
+    expect(rejected.body).toMatchObject({ code: "KAVO_QUERY_INVALID" });
+    expect(rejected.body.errors).toContainEqual(
+      expect.objectContaining({ field: "list.name", code: "KAVO_QUERY_INVALID_FIELD" }),
+    );
+  });
+
   it("rejects a relation that is not includable, with problem details", async () => {
     @Kavo(Todo)
     @Controller("todos")
@@ -1579,6 +1605,21 @@ describe("@Kavo relation includes", () => {
     // `fields[relation]`'s relation name is already the param name, so it
     // carries no description at all.
     expect(fieldsList?.description).toBeUndefined();
+  });
+
+  it("names a per-relation projection ceiling on fields[relation] (ADR-0044)", async () => {
+    @Kavo(Todo, { allowlists: { includable: ["list"], selectable: ["id", "title", "list.id"] } })
+    @Controller("todos")
+    class CeilingController {}
+
+    await app.close();
+    await bootstrap(CeilingController);
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    const params = (document.paths["/todos"]?.get?.parameters ?? []) as { name: string; description?: string }[];
+    const fieldsList = params.find((param) => param.name === "fields[list]");
+    // The ceiling is literal strings on `allowlists.selectable` — resolvable
+    // at decoration time (ADR-0012), unlike an `{ exclude }` selector.
+    expect(fieldsList?.description).toBe("Restricted to: id.");
   });
 
   it("omits the include query parameter on an entity that opted nothing in", async () => {


### PR DESCRIPTION
## What & why

Including a relation to surface one or two fields previously leaked its whole row — the root config could not narrow an included relation, and a relation-dotted entry in `allowlists.selectable` (`selectable: ["id", "title", "dictionary.id"]`) type-checked but did nothing. This makes that entry a **projection ceiling**: it is the default fieldset for the included relation when a request sends no `fields[<relation>]=`, and a hard cap when it does — a request may narrow within it, never past it (a field past the ceiling is a 400 naming the owning entity's config). Enforcement lives in `DefaultIncludeResolver` against the config of the entity that owns the include edge, so each level of a nested include applies its own ceiling, and — unlike ADR-0026's projection — the cap holds even for a relation target that never went through `createCrud`/`@Kavo`. The four previously-inert bad shapes (`{ exclude }` form, nested `a.b.c`, non-includable relation, non-relation head) now throw a `ConfigurationException` at bootstrap.

`ADR-0044` records the decision and amends ADR-0026 decision 4.

Closes #343

## Public API impact

`ResolvedEntityConfig` gains a required member `relationProjection` (barrel-exported type; same hand-construction break ADR-0026/0019 already recorded for `projection`/`computed`). **Behavioural breaking change**, scoped to configs that already carried an inert relation path on `selectable`: those now throw at bootstrap instead of silently ignoring the entry — migration is in ADR-0044 Consequences. The resolved `allowlists.selectable` and `projection` no longer contain relation-dotted entries. No barrel export additions.

## Testing

- `packages/core/tests/includes.spec.ts` — ceiling as default projection; `findOne`; narrow-within vs 400-past; owner-named rejection message; bounded under a wider target `item` DTO; per-level ceilings on a nested include; ceiling holds for an unregistered target; unknown ceiling field omitted on the default path; four bootstrap rejections.
- `packages/frameworks/nest/tests/binding.e2e.spec.ts` — `fields[<relation>]` Swagger description; e2e ceiling over HTTP for `findMany`/`findOne` plus a 400 past the ceiling.
- `pnpm check`: build + typecheck + depcruise + lint + tests green (3379 + the 104-test CockroachDB e2e suite, which passes in isolation — it lost the 60s container health-check race under full-suite load, unrelated to this change and not touching typeorm). `pnpm docs:links` green.

## Review notes

- **Write echoes**: the issue's AC named them, but `KavoEngine.execute` normalizes a query for reads only, so a write never resolves `include` and there is no write-echo path to bound. Noted in the ADR; not implemented because it does not exist.
- Field-half of a ceiling entry (`dictionary.id`) is not validated against the target's columns at bootstrap (metadata not in scope) — a request naming a bad field is a 400, the default path just omits an unknown ceiling field. Consistent with the `searchable` relation-path laxity; documented + tested.
- Worth a hard look: the strip of relation-dotted entries from the resolved `allowlists.selectable` / `projection` in `resolveAllowlists`, and that `resolveRelationProjection` reads the raw config (not the stripped list).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relation projection ceilings to limit fields returned for included relations.
  * Included relations now honor both their own field permissions and the owner’s configured ceiling.
  * Request-time field selection can narrow results but cannot exceed configured limits.
* **Bug Fixes**
  * Invalid relation projection configurations are rejected during startup.
  * Prevented configuration overrides from widening relation projections.
* **Documentation**
  * Updated configuration guidance, architecture documentation, ADRs, and Swagger descriptions to explain relation projection ceilings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->