### PR TITLE
fix(nest): document includable relations in the synthesized response schema

### DIFF
--- a/docs/internals/adr/0044-relation-projection-ceiling-from-selectable.md
+++ b/docs/internals/adr/0044-relation-projection-ceiling-from-selectable.md
@@ -135,6 +135,14 @@ the same break ADR-0026 recorded for `projection` and ADR-0019 for
 decoration time (ADR-0012), because the ceiling is literal strings on
 `allowlists.selectable`, unlike an `{ exclude }` selector.
 
+**The synthesized response schema uses the ceiling too** (issue #349,
+follow-up). `@kavo/nest`'s bind-time fallback `<Entity>Item`/`ListItem`
+schema — the path with no registered `item`/`list` DTO — emits an optional
+property for each `allowlists.includable` relation, and shapes it from
+`ResolvedEntityConfig.relationProjection`: an object limited to the ceiling
+fields when one is set, a generic object otherwise. It never enters
+`required` (present only under `include=`).
+
 ## References
 
 - ADR-0026 (`allowlists.selectable` narrows the response), whose decision

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -490,6 +490,23 @@ relations — a pure join row associated by id — would synthesize an empty
 therefore gated on the synthesized schema ending up with zero properties,
 not on the allowlist being empty.
 
+The **response** fallback has the mirror case for `allowlists.includable`
+(ADR-0028, issue #349): a relation a client may `?include=` is emitted as
+an **optional** property on `<Entity>Item`/`<Entity>ListItem` — appended
+after the scalar columns and the computed fields, never in `required`,
+since it is only in the body when `include=` asks for it. Its shape is the
+per-relation ceiling a relation-dotted `allowlists.selectable` entry
+resolves to (`relationProjection`, ADR-0044) as an object limited to those
+fields, or a generic `{ type: "object" }` with a prose description when the
+relation carries no ceiling — the target's own projection is governed by
+the target entity's config, not this one (ADR-0026), so it is not
+reproduced here. A `-to-many` relation wraps that object in
+`{ type: "array", items }`. The relation object is deliberately left
+unstamped by `withKavoEntity`, so `registerKavoSchemas` keeps it inline on
+`<Entity>Item` rather than hoisting it to its own component. Driven off the
+resolved `allowlists.includable` names, not `RelationDescriptor.includable`
+(which reflects ORM-derived metadata, not the config grant).
+
 Two known over-statements, both narrowing documentation only — the schema
 stays open (no `additionalProperties: false`, matching `allowlists.md`'s
 "narrows silently"), so neither lies about what the route accepts or

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -439,7 +439,9 @@ class KavoBinder implements OnModuleInit {
           // Fallback success-response schema, narrowed to `selectable`
           // (issue #264's response-side counterpart) — `applyResponseSchemaDocs`
           // itself no-ops when a real `item`/`list` DTO or `descriptor.output`
-          // already documented this route at decoration time.
+          // already documented this route at decoration time. `includable` +
+          // `relationProjection` let it emit an optional property per
+          // embeddable relation, capped by any ADR-0044 ceiling (issue #349).
           applyResponseSchemaDocs(
             prototype,
             methodName,
@@ -448,6 +450,8 @@ class KavoBinder implements OnModuleInit {
             service.engine.metadata,
             service.engine.config.allowlists.selectable as readonly string[],
             Object.keys(service.engine.config.computed),
+            service.engine.config.allowlists.includable as readonly string[],
+            service.engine.config.relationProjection,
             dtoResolver,
           );
           // `search[...]` Swagger docs (issue #156) — deferred for the same

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -1345,6 +1345,29 @@ const alreadyResponseSchemaDocumented = new WeakSet<object>();
  * undefined` clears that key in the merge (an explicit `undefined` is still
  * an own property `Object.assign` copies over), so the narrowed `schema`
  * is what the document actually emits.
+ *
+ * A relation on `allowlists.includable` (ADR-0028) can be embedded in the
+ * row (`?include=word`), so it is emitted as an **optional** property —
+ * never in `required`, since it is only present when `include=` asks for
+ * it. Its shape is the ceiling a relation-dotted `selectable` entry imposes
+ * (`selectable: ["word.id"]`, ADR-0044) as an object limited to those
+ * fields, or a generic object when the relation carries no ceiling — the
+ * target's own projection is governed by the target entity's config, not
+ * this one (`entity-catalog.ts`), so it is not reproduced here. A `-to-many`
+ * relation wraps that object in `{ type: "array", items }`. The relation
+ * object is deliberately left unstamped by `withKavoEntity`: a stamped
+ * nested schema would be hoisted to its own component by
+ * `registerKavoSchemas` instead of staying inline on `<Entity>Item`.
+ *
+ * The property rides the shared `item` shape, so it appears on the
+ * `createOne`/`updateOne`/`patchOne` responses too, even though a write
+ * never resolves `include=` (ADR-0044, "reads only"). That is deliberate:
+ * gating it on `descriptor.kind === "read"` would make the read route's
+ * schema structurally differ from the write routes', and
+ * `registerKavoSchemas` only collapses structurally-identical repeats — so
+ * every entity with an includable relation would publish both `<Entity>Item`
+ * and `<Entity>Item_2`. The property is optional, so a write response that
+ * omits it stays valid against the schema.
  */
 export function applyResponseSchemaDocs(
   prototype: Record<string, unknown>,
@@ -1354,6 +1377,8 @@ export function applyResponseSchemaDocs(
   metadata: EntityMetadata<object>,
   selectable: readonly string[],
   computedFieldNames: readonly string[],
+  includable: readonly string[],
+  relationProjection: Readonly<Record<string, readonly string[]>> | undefined,
   dtoResolver: DtoResolver<object>,
 ): void {
   if (route.status === 204) {
@@ -1403,6 +1428,29 @@ export function applyResponseSchemaDocs(
       continue;
     }
     properties[name] = { nullable: true };
+  }
+  // An includable relation (ADR-0028) is embedded only when `include=` asks
+  // for it, so it is an *optional* property — appended after the column and
+  // computed loops so those keep their exact order, and never pushed to
+  // `required`. Driven off the resolved `allowlists.includable` names rather
+  // than `RelationDescriptor.includable`, which reflects the ORM-derived
+  // metadata, not the config grant.
+  for (const relationName of includable) {
+    const relation = metadata.relations.find((edge) => edge.name === relationName);
+    if (relation === undefined) {
+      continue;
+    }
+    const ceiling = relationProjection?.[relationName];
+    const object =
+      ceiling !== undefined
+        ? { type: "object", properties: Object.fromEntries(ceiling.map((name) => [name, {}])) }
+        : {
+            type: "object",
+            description:
+              `Embedded when \`include=${relationName}\` is requested. Its projection is governed by ` +
+              `the ${relationName} target's own config (ADR-0026); no relation-dotted \`selectable\` ceiling is set here.`,
+          };
+    properties[relationName] = relation.cardinality === "many" ? { type: "array", items: object } : object;
   }
   const element = { type: "object" as const, properties, ...(required.length > 0 ? { required } : {}) };
   const schema = isList

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -2607,8 +2607,26 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
     properties?: Record<string, Schema>;
     items?: Schema;
     required?: string[];
+    description?: string;
+    $ref?: string;
     "x-kavo-entity"?: string;
   };
+
+  const stubAdapter = (): RepositoryAdapter<object> =>
+    ({
+      findOneById: async () => null,
+      findOne: async () => null,
+      findMany: async () => [],
+      count: async () => 0,
+      create: async (data: unknown) => data,
+      update: async (_id: unknown, data: unknown) => data,
+      patch: async (_id: unknown, data: unknown) => data,
+      delete: async () => {},
+      restore: async () => {
+        throw new Error("not exercised");
+      },
+      purge: async () => {},
+    }) as unknown as RepositoryAdapter<object>;
 
   const itemBody = (path: string, verb: string, status: string): Schema | undefined =>
     (
@@ -2662,8 +2680,9 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
 
     // `selectable`'s own unconfigured default is every own column
     // (`resolve-entity-config.ts`), and `list` (the to-one relation) isn't
-    // one of `EntityMetadata.fields` — item/list schemas never document
-    // relations, the same way a real `item`/`list` DTO never carries one.
+    // one of `EntityMetadata.fields`. A relation only appears here when it
+    // is on `allowlists.includable` (issue #349), which it is not here, so
+    // the synthesized item schema stays scalar-only.
     expect(Object.keys(itemBody("/todos/{id}", "get", "200")?.properties ?? {})).toEqual([
       "id",
       "title",
@@ -2843,6 +2862,128 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
     await bootstrap(DtoComputedController);
     document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
 
+    expect(Object.keys(itemBody("/todos/{id}", "get", "200")?.properties ?? {})).toEqual(["id", "title"]);
+  });
+
+  it("emits an optional property for an includable relation with no ceiling (issue #349)", async () => {
+    @Kavo(Todo, { allowlists: { includable: ["list"] } })
+    @Controller("todos")
+    class IncludableController {}
+    await bootstrap(IncludableController);
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+
+    const single = itemBody("/todos/{id}", "get", "200");
+    // Appended after the scalar columns, never reordering them.
+    expect(Object.keys(single?.properties ?? {})).toEqual(["id", "title", "done", "priority", "deletedAt", "list"]);
+    // Only present when `include=` asks for it, so it never joins `required`.
+    expect(single?.required ?? []).not.toContain("list");
+    // A to-one relation is documented as the object directly, no array wrap.
+    expect(single?.properties?.list?.type).toBe("object");
+    // No ADR-0044 ceiling here, so the target's own config governs its
+    // projection — this schema does not reproduce it.
+    expect(single?.properties?.list?.properties).toBeUndefined();
+    expect(single?.properties?.list?.description).toContain("include=list");
+
+    // The same optional property rides the list-envelope element (`<Entity>ListItem`).
+    const listElement = itemBody("/todos", "get", "200")?.properties?.items?.items;
+    expect(Object.keys(listElement?.properties ?? {})).toContain("list");
+    expect(listElement?.required ?? []).not.toContain("list");
+  });
+
+  it("caps an includable relation's emitted shape to the allowlists.selectable ceiling (ADR-0044, issue #349)", async () => {
+    @Kavo(Todo, { allowlists: { includable: ["list"], selectable: ["id", "title", "list.id"] } })
+    @Controller("todos")
+    class CeilingController {}
+    await bootstrap(CeilingController);
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+
+    for (const [verb, path, status] of [
+      ["get", "/todos/{id}", "200"],
+      ["post", "/todos", "201"],
+    ] as const) {
+      const schema = itemBody(path, verb, status);
+      // The relation-dotted `list.id` entry is stripped from the root
+      // projection (ADR-0044) and re-applied as the relation object's shape.
+      expect(Object.keys(schema?.properties ?? {})).toEqual(["id", "title", "list"]);
+      expect(schema?.properties?.list).toEqual({ type: "object", properties: { id: {} } });
+      expect(schema?.required ?? []).not.toContain("list");
+    }
+  });
+
+  it("wraps a -to-many includable relation in an array (issue #349)", async () => {
+    class Post {}
+    const postMetadata: EntityMetadata<object> = {
+      entity: Post,
+      name: "Post",
+      idField: "id",
+      fields: [
+        { name: "id", kind: "number", nullable: false, generated: true },
+        { name: "title", kind: "string", nullable: false, generated: false },
+      ],
+      relations: [
+        // `includable: false` on the descriptor deliberately disagrees with
+        // the config grant below — the synthesized schema must follow the
+        // resolved `allowlists.includable`, not the ORM-derived flag.
+        { name: "tags", target: () => class Tag {}, cardinality: "many", includable: false, strategy: "auto" },
+      ],
+    };
+    const infrastructure: KavoInfrastructure = {
+      metadataFor: () => postMetadata as never,
+      adapterFor: () => stubAdapter() as never,
+    };
+
+    @Controller("posts")
+    class PostController {}
+    // `Post` has no declared fields, so the config's relation-name types
+    // infer to `never`; apply the decorator as a plain call with a cast, the
+    // same escape hatch the fallback-body-schema block uses.
+    const postConfig: unknown = { allowlists: { includable: ["tags"] } };
+    Kavo(Post, postConfig as Parameters<typeof Kavo>[1])(PostController);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure }), KavoModule.forFeature([PostController])],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+
+    const single = itemBody("/posts/{id}", "get", "200");
+    expect(Object.keys(single?.properties ?? {})).toEqual(["id", "title", "tags"]);
+    expect(single?.properties?.tags?.type).toBe("array");
+    expect(single?.properties?.tags?.items?.type).toBe("object");
+    expect(single?.required ?? []).not.toContain("tags");
+  });
+
+  it("keeps the embedded relation object inline — registerKavoSchemas hoists no extra component (issue #349)", async () => {
+    @Kavo(Todo, { allowlists: { includable: ["list"], selectable: ["id", "title", "list.id"] } })
+    @Controller("todos")
+    class InlineController {}
+    await bootstrap(InlineController);
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+    registerKavoSchemas(document);
+
+    const schemas = (document.components?.schemas ?? {}) as Record<string, Schema>;
+    // The relation object stays on `TodoItem.properties.list` rather than
+    // being hoisted under a positional component name: it carries no
+    // `x-kavo-entity` stamp, so `registerKavoSchemas` leaves it alone.
+    expect(schemas.TodoItem?.properties?.list?.$ref).toBeUndefined();
+    expect(schemas.TodoItem?.properties?.list?.type).toBe("object");
+    // The list-envelope element is `withKavoEntity`-stamped, so
+    // `registerKavoSchemas` recurses into it — assert the relation object
+    // still resolved inline there, not just that a `$ref` is absent.
+    expect(schemas.TodoListItem?.properties?.list?.type).toBe("object");
+    expect(schemas.TodoListItem?.properties?.list?.$ref).toBeUndefined();
+  });
+
+  it("adds no relation property when nothing is includable (issue #349)", async () => {
+    @Kavo(Todo, { allowlists: { selectable: ["id", "title"] } })
+    @Controller("todos")
+    class NoIncludeController {}
+    await bootstrap(NoIncludeController);
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+
+    // `list` is a relation on `Todo` but not on `allowlists.includable`, so
+    // the synthesized schema stays exactly the scalar `selectable` set.
     expect(Object.keys(itemBody("/todos/{id}", "get", "200")?.properties ?? {})).toEqual(["id", "title"]);
   });
 });


### PR DESCRIPTION
## What & why

The bind-time fallback `<Entity>Item` / `<Entity>ListItem` OpenAPI schema — the path used when a route has no registered `item`/`list` DTO — only iterated the entity's own scalar columns and computed fields. A relation on `allowlists.includable` never matched a `metadata.fields` name, so it was dropped from the doc entirely, even though `?include=word` embeds it in the row. Generated clients had no type for the embedded relation, and the schema claimed a shape the route does not always produce.

`applyResponseSchemaDocs` now also takes the resolved `allowlists.includable` and `ResolvedEntityConfig.relationProjection`, and emits one **optional** property per includable relation: an object capped to the ADR-0044 ceiling fields (`selectable: ["word.id"]`) when a ceiling is configured, a generic object with a prose description otherwise, wrapped in `{ type: "array", items }` for a `-to-many` edge. The property never joins `required` (it is only present when `include=` asks for it), and the relation object is left unstamped by `withKavoEntity` so `registerKavoSchemas` keeps it inline instead of hoisting it to its own component. It is driven off the resolved allowlist rather than `RelationDescriptor.includable`, which reflects ORM-derived metadata, not the config grant.

Closes #349

## Public API impact

None — no barrel changes. `applyResponseSchemaDocs` is an internal `@kavo/nest` function; its two new parameters are supplied by the in-package binder.

## Testing

Five new e2e cases in `packages/frameworks/nest/tests/binding.e2e.spec.ts`: includable relation with no ceiling (optional, object, not required, on both item and list-item), ceiling-limited object on get-item and create routes, `-to-many` array wrap via inline metadata (with an `includable: false` descriptor that deliberately disagrees with the config grant), `registerKavoSchemas` hoists no extra component, and unchanged output when nothing is includable. Docs (ADR-0044, NestJS integration doc) updated for the governed behavior.

`pnpm check` green (128 files, 3488 tests), `pnpm docs:links` and `pnpm docs:build` green.

## Review notes

- The property rides the shared `item` shape, so it also appears on the `createOne`/`updateOne`/`patchOne` responses even though a write never resolves `include=`. This is deliberate — gating on `descriptor.kind === "read"` would make the read route's schema structurally differ from the write routes' and cause `registerKavoSchemas` to emit both `<Entity>Item` and `<Entity>Item_2`. The property is optional, so a write response omitting it stays schema-valid. Rationale is in the `applyResponseSchemaDocs` doc comment.
- Ceiling fields are emitted as untyped `{}` properties — the relation target's column metadata is not in scope in this function, matching how the fallback body schema treats association `id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Swagger fallback response schemas now document configured includable relations.
  - Relation fields are optional and reflect configured projection limits.
  - To-many relations are represented as arrays, while relations without projection limits use generic object schemas.

- **Documentation**
  - Updated architecture documentation to describe relation inclusion and projection behavior.
  - Added an ADR documenting relation projection ceilings for fallback schemas.

- **Tests**
  - Expanded coverage for relation schemas, projections, arrays, and nullable metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->