### PR TITLE
feat(nest): a one-call Swagger setup that gets the route-registration ordering right

### DIFF
--- a/docs/core/routes-and-controllers.md
+++ b/docs/core/routes-and-controllers.md
@@ -103,19 +103,28 @@ export class AppModule {}
 
 When `@nestjs/swagger` is installed, every generated route — standard, custom, and `@Override`d alike — carries an `operationId` (`Book_findOne`), a `tags: ["Book"]` entry, and `x-kavo-entity`/`x-kavo-operation` vendor extensions on the operation object. Every inline DTO schema Kavo builds for a request or response body carries the same `x-kavo-entity`, so a generated OpenAPI document lets tooling recover which Kavo entity/operation an operation or schema came from without parsing `operationId`.
 
-A client generator that splits output by `tags` — [Orval](https://orval.dev) and `openapi-generator` both do — will produce one module per entity out of the box; point it at the app's `/docs-json` (or wherever `SwaggerModule.setup` serves the document) with no extra configuration.
+A client generator that splits output by `tags` — [Orval](https://orval.dev) and `openapi-generator` both do — will produce one module per entity out of the box; point it at the app's `/docs-json` with no extra configuration.
+
+### Serving the document
+
+`setupKavoSwagger(app, { config })` (exported from `@kavo/nest`) is a one-call setup that gets both of Swagger's ordering rules right: it registers the `/docs` + `/docs-json` routes immediately (they must exist before `app.init()`), and defers building the document to the first request (it can't be built until after `KavoModule`'s module-init pass has attached the `search[...]` params, the conditional-request headers, and the query component schemas below).
+
+```ts
+import { DocumentBuilder } from "@nestjs/swagger";
+import { setupKavoSwagger } from "@kavo/nest";
+
+const app = await NestFactory.create(AppModule);
+setupKavoSwagger(app, {
+  config: new DocumentBuilder().setTitle("My API").setVersion("1.0.0").build(),
+});
+await app.listen(3000);
+```
+
+`path` defaults to `"docs"`. The helper throws a descriptive error — not a bare import failure — when the optional `@nestjs/swagger` peer is absent, and when it is called after `app.init()` (when its routes could no longer take effect). Every `nest-*` example wires it in its `src/main.ts`.
 
 ### Named component schemas
 
-By default those DTO schemas are emitted **inline** on each route, so a generator names them anonymously. Wrap the built document in `registerKavoSchemas` (exported from `@kavo/nest`) to hoist every shape Kavo generated into `components.schemas` under a stable, entity-prefixed name and leave a `$ref` behind:
-
-```ts
-import { registerKavoSchemas } from "@kavo/nest";
-
-SwaggerModule.setup("docs", app, registerKavoSchemas(SwaggerModule.createDocument(app, config)));
-```
-
-The `nest-typeorm` example wires exactly this in its `src/main.ts`.
+`setupKavoSwagger` runs the built document through `registerKavoSchemas` for you. By default the DTO schemas Kavo generates are emitted **inline** on each route, so a generator names them anonymously; `registerKavoSchemas` (also exported from `@kavo/nest`, for a hand-rolled `SwaggerModule.setup`) hoists every shape into `components.schemas` under a stable, entity-prefixed name and leaves a `$ref` behind.
 
 For an entity `Ad` you get `AdCreate` / `AdUpdate` / `AdPatch` (request bodies), `AdItem` (single-row response), `AdList` with its `items[]` element `AdListItem` and its `meta` bag `AdListMeta`, the shared `KavoProblemDetails` / `KavoProblemDetailError` error bodies, and `AdValidationError` (the entity-scoped `400`, an `allOf` over `KavoProblemDetails`). Each component keeps its `x-kavo-entity` / `x-kavo-error` extension. This holds for an entity with no `dto` block at all — the schemas synthesized from its columns (see [DTOs](/core/dtos)) are hoisted the same way. A synthesized schema also carries a `required` array derived from column nullability: a non-nullable column is `required` in `AdCreate`, `AdUpdate`, `AdItem`, and the `AdListItem` element, while a nullable column and a computed field stay optional. Database-generated columns aren't writable, so they never appear in `AdCreate` / `AdUpdate` at all; a non-nullable generated column (the primary key, a create-timestamp) _is_ `required` in `AdItem` / `AdListItem`, since every row carries it. `AdPatch` is the deliberate exception — a partial update requires no field, so it carries no `required`. Two documentation-only over-statements: a non-nullable column with a database `default:` is still reported `required` in `AdCreate` even though you may omit it, and the response `required` describes the full row — a [`select=`](/querying/field-selection)-narrowed read returns a subset. The synthesized schema stays open in both cases, so this never changes what the route accepts or returns.
 

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -520,6 +520,41 @@ diverges from the full schema's `properties`. The request side mirrors the
 explicit-DTO path, where `@nestjs/swagger` + class-validator derive
 `required` themselves.
 
+### Serving the document (`setupKavoSwagger`)
+
+Wiring `@nestjs/swagger` into a `@Kavo` app has two ordering rules that
+work against each other, and neither surfaces an error when you get it
+wrong:
+
+- `SwaggerModule.setup()` registers the `/docs` + `/docs-json` routes on
+  the HTTP adapter, and that has to run **before** `app.init()` /
+  `app.listen()` — a `setup()` afterwards registers routes the router scan
+  has already passed, and every `/docs` request then 404s silently;
+- the document itself can't be built until **after** `KavoBinder.onModuleInit`
+  — the `search[...]` params, the conditional-request headers, and the
+  `<Entity>Query`/`Filter`/`Sort`/`Pagination`/`ValidationError` component
+  schemas are all attached there, and that pass fires _inside_ `app.init()`.
+
+The only sequence that satisfies both is: register the routes now, and
+hand `setup()` a **factory** that defers `SwaggerModule.createDocument()`
+to the first request for the docs. `setupKavoSwagger(app, { config })`
+(`swagger-setup.ts`, exported from the barrel) is that sequence packaged as
+one call — it registers the routes, wraps a memoised
+`registerKavoSchemas(createDocument(...))` factory (built once, on first
+`/docs` hit, by which point every `onModuleInit` pass has completed), and
+passes it to `setup()`. The reference apps' `main.ts` use it; `path`
+defaults to `"docs"`, and `documentOptions` / `swaggerOptions` pass
+straight through to `createDocument` / `setup`.
+
+It loads `@nestjs/swagger` through the same `createRequire` probe as
+`swagger.ts`, so it stays a no-op dependency when the optional peer is
+absent — except that calling it then throws a descriptive
+`ConfigurationException` (`KAVO_CONFIG_INVALID`) naming the missing peer
+rather than a bare module-resolution error. Called _after_ the app has
+initialised (`app.isInitialized === true` — read defensively, since Nest
+omits the flag from its `.d.ts`), it throws the same exception naming the
+call-order rule, rather than registering dead routes.
+
 ### Named component schemas (`registerKavoSchemas`)
 
 Everything above emits schemas **inline** on the route — the only identity

--- a/examples/nest-mikroorm/src/main.ts
+++ b/examples/nest-mikroorm/src/main.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
-import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
-import { KAVO_API_GUIDE } from "@kavo/nest";
+import { DocumentBuilder } from "@nestjs/swagger";
+import { KAVO_API_GUIDE, setupKavoSwagger } from "@kavo/nest";
 import { AppModule } from "./app.module.js";
 import { createPostgresOrm, createSqliteOrm } from "./database.js";
 
@@ -29,29 +29,25 @@ async function bootstrap(): Promise<void> {
   // `$ilike` is PostgreSQL-only; on any other driver it is a syntax error.
   const app = await NestFactory.create(AppModule.forRoot({ orm, caseInsensitiveFilters: usePostgres }));
 
-  // `search[...]`/conditional-request Swagger docs finish in `KavoModule`'s
-  // discovery binder, an `onModuleInit` hook that hasn't run yet at this
-  // point in `bootstrap` — it fires inside `app.listen()` below. A factory
-  // here (rather than a plain document) defers `createDocument()` until the
-  // first request for the docs, by which point that hook has completed.
-  const buildDocument = (): ReturnType<typeof SwaggerModule.createDocument> =>
-    SwaggerModule.createDocument(
-      app,
-      new DocumentBuilder()
-        .setTitle("Kavo — Pet example (MikroORM)")
-        .setDescription(
-          "Cats, dogs, owners, tags and addresses: full CRUD over HTTP " +
-            "through @kavo/mikroorm, with single-table inheritance, filtering, " +
-            "sorting, pagination, layered config, RFC 9457 problem-details " +
-            "errors, `?include=owner`/`?include=pets`/`?include=tags` " +
-            "relations loaded by populate, filtering and sorting across a " +
-            "relation path, and soft delete with restore/purge on owners.\n\n" +
-            KAVO_API_GUIDE,
-        )
-        .setVersion("0.0.0")
-        .build(),
-    );
-  SwaggerModule.setup("docs", app, buildDocument);
+  // One call: registers `/docs` + `/docs-json` before `app.listen()`, and
+  // defers the document build to the first request — after `KavoModule`'s
+  // `onModuleInit` binder has attached the `search[...]` params, the
+  // conditional-request headers, and the `<Entity>Query` component schemas.
+  setupKavoSwagger(app, {
+    config: new DocumentBuilder()
+      .setTitle("Kavo — Pet example (MikroORM)")
+      .setDescription(
+        "Cats, dogs, owners, tags and addresses: full CRUD over HTTP " +
+          "through @kavo/mikroorm, with single-table inheritance, filtering, " +
+          "sorting, pagination, layered config, RFC 9457 problem-details " +
+          "errors, `?include=owner`/`?include=pets`/`?include=tags` " +
+          "relations loaded by populate, filtering and sorting across a " +
+          "relation path, and soft delete with restore/purge on owners.\n\n" +
+          KAVO_API_GUIDE,
+      )
+      .setVersion("0.0.0")
+      .build(),
+  });
 
   await app.listen(3002);
 }

--- a/examples/nest-mongoose/src/main.ts
+++ b/examples/nest-mongoose/src/main.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata";
 import mongoose from "mongoose";
 import { NestFactory } from "@nestjs/core";
-import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
-import { KAVO_API_GUIDE } from "@kavo/nest";
+import { DocumentBuilder } from "@nestjs/swagger";
+import { KAVO_API_GUIDE, setupKavoSwagger } from "@kavo/nest";
 import { AppModule } from "./app.module.js";
 
 /**
@@ -16,28 +16,24 @@ async function bootstrap(): Promise<void> {
 
   const app = await NestFactory.create(AppModule.forRoot());
 
-  // `search[...]`/conditional-request Swagger docs finish in `KavoModule`'s
-  // discovery binder, an `onModuleInit` hook that hasn't run yet at this
-  // point in `bootstrap` — it fires inside `app.listen()` below. A factory
-  // here (rather than a plain document) defers `createDocument()` until the
-  // first request for the docs, by which point that hook has completed.
-  const buildDocument = (): ReturnType<typeof SwaggerModule.createDocument> =>
-    SwaggerModule.createDocument(
-      app,
-      new DocumentBuilder()
-        .setTitle("Kavo — Blog example (Mongoose)")
-        .setDescription(
-          "Authors and articles: full CRUD over HTTP through @kavo/mongoose, " +
-            "with filtering, sorting, pagination, layered config, RFC 9457 " +
-            "problem-details errors, an `?include=author` relation loaded by " +
-            "populate, and soft delete with restore/purge. Ids are MongoDB " +
-            "`_id` values, rendered as hex strings.\n\n" +
-            KAVO_API_GUIDE,
-        )
-        .setVersion("0.0.0")
-        .build(),
-    );
-  SwaggerModule.setup("docs", app, buildDocument);
+  // One call: registers `/docs` + `/docs-json` before `app.listen()`, and
+  // defers the document build to the first request — after `KavoModule`'s
+  // `onModuleInit` binder has attached the `search[...]` params, the
+  // conditional-request headers, and the `<Entity>Query` component schemas.
+  setupKavoSwagger(app, {
+    config: new DocumentBuilder()
+      .setTitle("Kavo — Blog example (Mongoose)")
+      .setDescription(
+        "Authors and articles: full CRUD over HTTP through @kavo/mongoose, " +
+          "with filtering, sorting, pagination, layered config, RFC 9457 " +
+          "problem-details errors, an `?include=author` relation loaded by " +
+          "populate, and soft delete with restore/purge. Ids are MongoDB " +
+          "`_id` values, rendered as hex strings.\n\n" +
+          KAVO_API_GUIDE,
+      )
+      .setVersion("0.0.0")
+      .build(),
+  });
 
   await app.listen(3001);
 }

--- a/examples/nest-typeorm/src/main-cockroach.ts
+++ b/examples/nest-typeorm/src/main-cockroach.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
-import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { DocumentBuilder } from "@nestjs/swagger";
+import { setupKavoSwagger } from "@kavo/nest";
 import { AppModule } from "./app.module.js";
 
 // Matches the `docker run` command in examples/nest-typeorm/README.md.
@@ -15,24 +16,22 @@ const COCKROACHDB_OPTIONS = {
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule.forRoot(COCKROACHDB_OPTIONS));
 
-  // See main.ts's own `buildDocument` factory for why this is deferred
-  // rather than built eagerly here.
-  const buildDocument = (): ReturnType<typeof SwaggerModule.createDocument> =>
-    SwaggerModule.createDocument(
-      app,
-      new DocumentBuilder()
-        .setTitle("Kavo — Pet example (CockroachDB)")
-        .setDescription(
-          "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
-            "sorting, pagination, layered config, and RFC 9457 problem-details " +
-            "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
-            "model the schema, with opt-in relation includes " +
-            "(`?include=owner`, `?include=pets`) and soft delete on owners.",
-        )
-        .setVersion("0.0.0")
-        .build(),
-    );
-  SwaggerModule.setup("docs", app, buildDocument);
+  // `setupKavoSwagger` registers `/docs` now and defers the document build
+  // to the first request — see `@kavo/nest`'s `swagger-setup.ts` for why
+  // both halves of that ordering matter.
+  setupKavoSwagger(app, {
+    config: new DocumentBuilder()
+      .setTitle("Kavo — Pet example (CockroachDB)")
+      .setDescription(
+        "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
+          "sorting, pagination, layered config, and RFC 9457 problem-details " +
+          "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
+          "model the schema, with opt-in relation includes " +
+          "(`?include=owner`, `?include=pets`) and soft delete on owners.",
+      )
+      .setVersion("0.0.0")
+      .build(),
+  });
 
   await app.listen(3000);
 }

--- a/examples/nest-typeorm/src/main-mariadb.ts
+++ b/examples/nest-typeorm/src/main-mariadb.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
-import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { DocumentBuilder } from "@nestjs/swagger";
+import { setupKavoSwagger } from "@kavo/nest";
 import { AppModule } from "./app.module.js";
 
 // Matches the `docker run` command in examples/nest-typeorm/README.md.
@@ -16,24 +17,22 @@ const MARIADB_OPTIONS = {
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule.forRoot(MARIADB_OPTIONS));
 
-  // See main.ts's own `buildDocument` factory for why this is deferred
-  // rather than built eagerly here.
-  const buildDocument = (): ReturnType<typeof SwaggerModule.createDocument> =>
-    SwaggerModule.createDocument(
-      app,
-      new DocumentBuilder()
-        .setTitle("Kavo — Pet example (MariaDB)")
-        .setDescription(
-          "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
-            "sorting, pagination, layered config, and RFC 9457 problem-details " +
-            "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
-            "model the schema, with opt-in relation includes " +
-            "(`?include=owner`, `?include=pets`) and soft delete on owners.",
-        )
-        .setVersion("0.0.0")
-        .build(),
-    );
-  SwaggerModule.setup("docs", app, buildDocument);
+  // `setupKavoSwagger` registers `/docs` now and defers the document build
+  // to the first request — see `@kavo/nest`'s `swagger-setup.ts` for why
+  // both halves of that ordering matter.
+  setupKavoSwagger(app, {
+    config: new DocumentBuilder()
+      .setTitle("Kavo — Pet example (MariaDB)")
+      .setDescription(
+        "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
+          "sorting, pagination, layered config, and RFC 9457 problem-details " +
+          "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
+          "model the schema, with opt-in relation includes " +
+          "(`?include=owner`, `?include=pets`) and soft delete on owners.",
+      )
+      .setVersion("0.0.0")
+      .build(),
+  });
 
   await app.listen(3000);
 }

--- a/examples/nest-typeorm/src/main-postgres.ts
+++ b/examples/nest-typeorm/src/main-postgres.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
-import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { DocumentBuilder } from "@nestjs/swagger";
+import { setupKavoSwagger } from "@kavo/nest";
 import { AppModule } from "./app.module.js";
 
 // Matches the `docker run` command in examples/nest-typeorm/README.md.
@@ -16,24 +17,22 @@ const POSTGRES_OPTIONS = {
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule.forRoot(POSTGRES_OPTIONS));
 
-  // See main.ts's own `buildDocument` factory for why this is deferred
-  // rather than built eagerly here.
-  const buildDocument = (): ReturnType<typeof SwaggerModule.createDocument> =>
-    SwaggerModule.createDocument(
-      app,
-      new DocumentBuilder()
-        .setTitle("Kavo — Pet example (Postgres)")
-        .setDescription(
-          "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
-            "sorting, pagination, layered config, and RFC 9457 problem-details " +
-            "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
-            "model the schema, with opt-in relation includes " +
-            "(`?include=owner`, `?include=pets`) and soft delete on owners.",
-        )
-        .setVersion("0.0.0")
-        .build(),
-    );
-  SwaggerModule.setup("docs", app, buildDocument);
+  // `setupKavoSwagger` registers `/docs` now and defers the document build
+  // to the first request — see `@kavo/nest`'s `swagger-setup.ts` for why
+  // both halves of that ordering matter.
+  setupKavoSwagger(app, {
+    config: new DocumentBuilder()
+      .setTitle("Kavo — Pet example (Postgres)")
+      .setDescription(
+        "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
+          "sorting, pagination, layered config, and RFC 9457 problem-details " +
+          "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
+          "model the schema, with opt-in relation includes " +
+          "(`?include=owner`, `?include=pets`) and soft delete on owners.",
+      )
+      .setVersion("0.0.0")
+      .build(),
+  });
 
   await app.listen(3000);
 }

--- a/examples/nest-typeorm/src/main.ts
+++ b/examples/nest-typeorm/src/main.ts
@@ -3,9 +3,9 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NestFactory } from "@nestjs/core";
 import type { NestExpressApplication } from "@nestjs/platform-express";
-import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { DocumentBuilder } from "@nestjs/swagger";
 import type { DefaultKavoService, EntityMetadata, ResolvedEntityConfig } from "@kavo/core";
-import { KAVO_API_GUIDE, getKavoServiceToken, registerKavoSchemas } from "@kavo/nest";
+import { KAVO_API_GUIDE, getKavoServiceToken, setupKavoSwagger } from "@kavo/nest";
 import { createTransport } from "@kavo/sse";
 import { AppModule } from "./app.module.js";
 import { Owner } from "./owner/owner.entity.js";
@@ -52,41 +52,30 @@ async function bootstrap(): Promise<void> {
   // indistinguishable from the server never responding.
   app.enableCors();
 
-  // `search[...]`/conditional-request Swagger docs finish in `KavoModule`'s
-  // discovery binder, an `onModuleInit` hook that hasn't run yet at this
-  // point in `bootstrap` — it fires inside `app.listen()` below. A factory
-  // here (rather than a plain document) defers `createDocument()` until the
-  // first request for the docs, by which point that hook has completed.
-  //
-  // `registerKavoSchemas` then hoists every inline DTO schema Kavo generated
-  // into named `components.schemas` entries (`CatCreate`, `DogItem`, …) so a
-  // client generator gets stable type names — see `@kavo/nest`'s docs. It
-  // works whether or not an entity declares a `dto` block: `Dog` has none,
-  // and still gets `DogCreate` / `DogItem` / `DogList` / `DogValidationError`
-  // from the entity-derived fallback schemas.
-  const buildDocument = (): ReturnType<typeof SwaggerModule.createDocument> =>
-    registerKavoSchemas(
-      SwaggerModule.createDocument(
-        app,
-        new DocumentBuilder()
-          .setTitle("Kavo — Pet example")
-          .setDescription(
-            "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
-              "sorting, pagination, layered config, and RFC 9457 problem-details " +
-              "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
-              "model the schema, with opt-in relation includes " +
-              "(`?include=owner`, `?include=pets`) and soft delete on owners.\n\n" +
-              "### Realtime (SSE)\n\n" +
-              "Owner writes also publish over SSE — see the realtime example " +
-              "in the README (`GET /realtime?channel=Owner` or `Owner.<id>`, " +
-              "optionally `&filter[...]=...`).\n\n" +
-              KAVO_API_GUIDE,
-          )
-          .setVersion("0.0.0")
-          .build(),
-      ),
-    );
-  SwaggerModule.setup("docs", app, buildDocument);
+  // One call: registers `/docs` + `/docs-json` now (before `app.listen()`),
+  // defers the document build to the first request — after `KavoModule`'s
+  // `onModuleInit` binder has attached the `search[...]` params, the
+  // conditional-request headers, and the `<Entity>Query` component schemas —
+  // and hoists every inline DTO schema into named `components.schemas`
+  // entries (`CatCreate`, `DogItem`, …) via `registerKavoSchemas`.
+  setupKavoSwagger(app, {
+    config: new DocumentBuilder()
+      .setTitle("Kavo — Pet example")
+      .setDescription(
+        "Cats, dogs, and owners: full CRUD over HTTP with filtering, " +
+          "sorting, pagination, layered config, and RFC 9457 problem-details " +
+          "errors. Single-table inheritance (Cat/Dog) and an Owner relation " +
+          "model the schema, with opt-in relation includes " +
+          "(`?include=owner`, `?include=pets`) and soft delete on owners.\n\n" +
+          "### Realtime (SSE)\n\n" +
+          "Owner writes also publish over SSE — see the realtime example " +
+          "in the README (`GET /realtime?channel=Owner` or `Owner.<id>`, " +
+          "optionally `&filter[...]=...`).\n\n" +
+          KAVO_API_GUIDE,
+      )
+      .setVersion("0.0.0")
+      .build(),
+  });
 
   // `@kavo/sse` has no authentication of its own and is host-framework-
   // agnostic (plain `IncomingMessage`/`ServerResponse`, which Express's

--- a/packages/frameworks/nest/src/index.ts
+++ b/packages/frameworks/nest/src/index.ts
@@ -23,6 +23,7 @@ export { ConditionalRequest, parseEntityTags } from "./conditional-request.decor
 export { flattenQuery } from "./flatten-query.js";
 export { KAVO_API_GUIDE } from "./swagger.js";
 export { registerKavoSchemas } from "./register-schemas.js";
+export { setupKavoSwagger, type KavoSwaggerOptions } from "./swagger-setup.js";
 export { enumProp, oneOfArray, type SchemaHint } from "./schema-hints.js";
 export type { KavoAppContextExtractor, KavoAppContextRequest } from "./app-context.js";
 export {

--- a/packages/frameworks/nest/src/swagger-setup.ts
+++ b/packages/frameworks/nest/src/swagger-setup.ts
@@ -1,0 +1,146 @@
+import { createRequire } from "node:module";
+import type { INestApplication } from "@nestjs/common";
+import { ConfigurationException } from "@kavo/core";
+import { registerKavoSchemas } from "./register-schemas.js";
+
+/**
+ * `setupKavoSwagger` — one call that serves the Kavo OpenAPI document at
+ * `/{path}` and `/{path}-json`, with both of Swagger's undiscoverable
+ * ordering rules already handled.
+ *
+ * Wiring `@nestjs/swagger` into a `@Kavo` app by hand means threading a
+ * needle:
+ *
+ * - `SwaggerModule.setup()` registers the `/docs` routes on the HTTP
+ *   adapter, and that has to happen **before** `app.init()` /
+ *   `app.listen()` — a `setup()` after init registers routes the router
+ *   scan has already passed, so every `/docs` request 404s with nothing
+ *   to explain why;
+ * - the document itself cannot be built until **after**
+ *   `KavoModule`'s discovery binder has run (`onModuleInit`), which fires
+ *   *inside* `app.init()` — the `search[...]` params, the
+ *   conditional-request headers, and the `<Entity>Query` / `Filter` /
+ *   `Sort` / `Pagination` / `ValidationError` component schemas are all
+ *   attached there.
+ *
+ * The only sequence that satisfies both is: register the routes now, hand
+ * `setup()` a *factory* that defers `createDocument()` to the first
+ * request for the docs (by which point every `onModuleInit` pass has
+ * completed), and memoize its result. This helper is that sequence.
+ *
+ * ```ts
+ * const app = await NestFactory.create(AppModule);
+ * setupKavoSwagger(app, {
+ *   config: new DocumentBuilder().setTitle("My API").setVersion("1.0.0").build(),
+ * });
+ * await app.listen(3000);
+ * ```
+ *
+ * `@nestjs/swagger` is an optional peer: when it is not installed this
+ * throws a descriptive `ConfigurationException` (`KAVO_CONFIG_INVALID`),
+ * not a bare module-resolution error. It also throws — rather than
+ * silently registering dead routes — when it is called after the app has
+ * initialised.
+ */
+export interface KavoSwaggerOptions {
+  /**
+   * The base OpenAPI document, i.e. `new DocumentBuilder()....build()`.
+   * Everything except `paths` — Swagger fills those in from the app.
+   */
+  readonly config: object;
+  /**
+   * URL segment the docs UI is mounted at. Default `"docs"` — so
+   * `GET /docs` (UI) and `GET /docs-json` (the raw document).
+   */
+  readonly path?: string;
+  /** Passed straight through to `SwaggerModule.createDocument`. */
+  readonly documentOptions?: object;
+  /** Passed straight through to `SwaggerModule.setup`. */
+  readonly swaggerOptions?: object;
+}
+
+type SwaggerModuleSurface = {
+  createDocument(app: INestApplication, config: object, options?: object): object;
+  setup(path: string, app: INestApplication, documentOrFactory: object | (() => object), options?: object): void;
+};
+
+let cached: { SwaggerModule: SwaggerModuleSurface } | null | undefined;
+
+/**
+ * Load `@nestjs/swagger` through `createRequire` — the same optional-peer
+ * pattern `swagger.ts` uses, so `tsc -b` never depends on the peer being
+ * present. Returns `null` (rather than throwing) when it is absent; the
+ * caller turns that into a descriptive error.
+ */
+function loadSwaggerModule(): { SwaggerModule: SwaggerModuleSurface } | null {
+  if (cached !== undefined) {
+    return cached;
+  }
+  try {
+    const require = createRequire(import.meta.url);
+    cached = require("@nestjs/swagger") as { SwaggerModule: SwaggerModuleSurface };
+  } catch {
+    cached = null;
+  }
+  return cached;
+}
+
+/**
+ * The `@nestjs/swagger`-is-not-installed error. Factored out so it can be
+ * asserted (code + wording) without uninstalling the workspace peer —
+ * `vi.mock` cannot reach a `createRequire` call.
+ */
+export function swaggerPeerMissingError(): ConfigurationException {
+  return new ConfigurationException(
+    "setupKavoSwagger",
+    "@nestjs/swagger",
+    "the optional peer '@nestjs/swagger' is not installed — run `pnpm add @nestjs/swagger` " +
+      "to serve the Kavo OpenAPI document with setupKavoSwagger()",
+  );
+}
+
+/** The called-too-late error — see `isAlreadyInitialised`. */
+export function swaggerCallOrderError(path: string): ConfigurationException {
+  return new ConfigurationException(
+    "setupKavoSwagger",
+    "call order",
+    `setupKavoSwagger(app, …) was called after app.init()/app.listen(); the '/${path}' routes ` +
+      "can no longer be registered and every request to them would 404. Move the call above " +
+      "`await app.init()` / `await app.listen(...)`",
+  );
+}
+
+/**
+ * Nest's `NestApplication` sets a public `isInitialized` flag in `init()`
+ * (and `listen()` calls `init()`), but the property is absent from the
+ * `.d.ts` — so read it defensively and only act on a strict `true`. If a
+ * future Nest renames or drops it this degrades to "no order guard"
+ * rather than "always throws".
+ */
+function isAlreadyInitialised(app: INestApplication): boolean {
+  return (app as { isInitialized?: boolean }).isInitialized === true;
+}
+
+export function setupKavoSwagger(app: INestApplication, options: KavoSwaggerOptions): void {
+  const path = options.path ?? "docs";
+
+  const loaded = loadSwaggerModule();
+  if (loaded === null) {
+    throw swaggerPeerMissingError();
+  }
+
+  if (isAlreadyInitialised(app)) {
+    throw swaggerCallOrderError(path);
+  }
+
+  const { SwaggerModule } = loaded;
+
+  // Deferred and memoised: `createDocument` runs on the first request for
+  // the docs — after every `onModuleInit` pass — and its result is reused
+  // for every request after that.
+  let built: object | undefined;
+  const buildDocument = (): object =>
+    (built ??= registerKavoSchemas(SwaggerModule.createDocument(app, options.config, options.documentOptions)));
+
+  SwaggerModule.setup(path, app, buildDocument, options.swaggerOptions);
+}

--- a/packages/frameworks/nest/tests/swagger-setup.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/swagger-setup.e2e.spec.ts
@@ -1,0 +1,135 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { Controller, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { ConfigurationException } from "@kavo/core";
+import { Kavo, KavoModule, registerKavoSchemas, setupKavoSwagger } from "@kavo/nest";
+import { swaggerCallOrderError, swaggerPeerMissingError } from "../src/swagger-setup.js";
+import { InMemoryTodoAdapter, Todo, fakeInfrastructure } from "./support/fake-infrastructure.js";
+import { listen } from "./support/listen.js";
+
+/**
+ * `setupKavoSwagger` (issue #348) is the one call that gets both of
+ * Swagger's undiscoverable ordering rules right: register the `/docs`
+ * routes before `app.init()`, but defer building the document until after
+ * `KavoBinder.onModuleInit` has attached the query-schema / validation-
+ * error components. These specs pin that it actually serves a *complete*
+ * document, and that the after-`init()` misuse fails loudly rather than
+ * 404ing in silence.
+ */
+@Kavo(Todo)
+@Controller("todos")
+class TodoController {}
+
+const apps: INestApplication[] = [];
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()));
+});
+
+async function createApp(): Promise<INestApplication> {
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      KavoModule.forRoot({ infrastructure: fakeInfrastructure(new InMemoryTodoAdapter()) }),
+      KavoModule.forFeature([TodoController]),
+    ],
+  }).compile();
+  const app = moduleRef.createNestApplication();
+  apps.push(app);
+  return app;
+}
+
+function baseConfig(): ReturnType<DocumentBuilder["build"]> {
+  return new DocumentBuilder().setTitle("t").setVersion("0").build();
+}
+
+function schemaNames(document: unknown): string[] {
+  return Object.keys((document as { components?: { schemas?: Record<string, unknown> } }).components?.schemas ?? {});
+}
+
+describe("setupKavoSwagger — serves a complete document", () => {
+  it("GET /docs and /docs-json 200, with the onModuleInit passes reflected", async () => {
+    const app = await createApp();
+
+    // Negative control: a document built *before* `app.init()` has not
+    // seen `KavoBinder.onModuleInit`, so `registerKavoSchemas` finds no
+    // `x-kavo-query-schemas` / entity-scoped 400 blob to hoist — no
+    // `TodoQuery` / `TodoValidationError` component. (Pre-init
+    // `createDocument` can also throw outright; either way the pass has
+    // not run.)
+    let beforeInit: string[] = [];
+    try {
+      beforeInit = schemaNames(registerKavoSchemas(SwaggerModule.createDocument(app, baseConfig())));
+    } catch {
+      /* pre-init createDocument threw — the point stands */
+    }
+    expect(beforeInit).not.toContain("TodoValidationError");
+    expect(beforeInit).not.toContain("TodoQuery");
+
+    setupKavoSwagger(app, { config: baseConfig() });
+    const server = await listen(app);
+
+    const json = await request(server).get("/docs-json").expect(200);
+    // Every onModuleInit-only component is present in the *served* document.
+    expect(schemaNames(json.body)).toEqual(
+      expect.arrayContaining(["TodoValidationError", "TodoQuery", "TodoFilter", "TodoSort", "TodoPagination"]),
+    );
+    // And the route bodies `$ref` the hoisted components rather than
+    // carrying an anonymous inline schema.
+    const okSchema = (
+      json.body as {
+        paths: Record<
+          string,
+          { get?: { responses?: Record<string, { content?: Record<string, { schema?: unknown }> }> } }
+        >;
+      }
+    ).paths["/todos/{id}"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema as { $ref?: string };
+    expect(okSchema?.$ref).toMatch(/^#\/components\/schemas\//);
+
+    await request(server).get("/docs").expect(200);
+  });
+
+  it("mounts under a custom path", async () => {
+    const app = await createApp();
+    setupKavoSwagger(app, { config: baseConfig(), path: "api-docs" });
+    const server = await listen(app);
+
+    await request(server).get("/api-docs-json").expect(200);
+    await request(server).get("/docs-json").expect(404);
+  });
+});
+
+describe("setupKavoSwagger — call-order safety", () => {
+  it("throws a descriptive KAVO_CONFIG_INVALID when called after app.init(), never a silent 404", async () => {
+    const app = await createApp();
+    await app.init();
+
+    expect(() => setupKavoSwagger(app, { config: baseConfig() })).toThrow(ConfigurationException);
+    try {
+      setupKavoSwagger(app, { config: baseConfig() });
+      expect.unreachable("setupKavoSwagger should have thrown");
+    } catch (error) {
+      expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
+      expect((error as Error).message).toMatch(/app\.init/);
+    }
+  });
+});
+
+describe("setupKavoSwagger — error helpers", () => {
+  it("swaggerPeerMissingError names the missing peer and how to install it", () => {
+    const error = swaggerPeerMissingError();
+    expect(error).toBeInstanceOf(ConfigurationException);
+    expect(error.code).toBe("KAVO_CONFIG_INVALID");
+    expect(error.message).toMatch(/@nestjs\/swagger/);
+    expect(error.message).toMatch(/install|pnpm add/i);
+  });
+
+  it("swaggerCallOrderError names the offending path and the fix", () => {
+    const error = swaggerCallOrderError("api-docs");
+    expect(error.code).toBe("KAVO_CONFIG_INVALID");
+    expect(error.message).toMatch(/\/api-docs/);
+    expect(error.message).toMatch(/app\.init/);
+  });
+});


### PR DESCRIPTION
## What & why

Wiring `@nestjs/swagger` into a `@Kavo` app has two ordering rules that pull against each other, and neither fails loudly when you get it wrong:

- `SwaggerModule.setup()` must register the `/docs` + `/docs-json` routes **before** `app.init()` — a `setup()` after init registers routes the router scan has already passed, and every `/docs` request then 404s silently;
- the document itself can't be built until **after** `KavoBinder.onModuleInit` (which fires *inside* `app.init()`) has attached the `search[...]` params, conditional-request headers, and the `<Entity>Query`/`Filter`/`Sort`/`Pagination`/`ValidationError` component schemas.

`setupKavoSwagger(app, { config })` (new, exported from `@kavo/nest`) packages the only sequence that satisfies both: register the routes now, hand `setup()` a memoised factory that defers `registerKavoSchemas(createDocument(...))` to the first docs request. It loads the optional peer through the same `createRequire` probe as `swagger.ts`, and throws a descriptive `ConfigurationException` (`KAVO_CONFIG_INVALID`) — never a bare import error — when the peer is absent or when it is called after the app has initialised (the order guard reads Nest's undocumented `isInitialized` defensively, degrading to "no guard" rather than "always throws" if a future Nest drops it).

All six `nest-*` example mains adopt the helper; the mongoose/mikroorm/typeorm-driver variants also pick up `registerKavoSchemas` hoisting, which only `nest-typeorm/main.ts` was doing before. Docs: a new "Serving the document" subsection in `10-nestjs-integration.md`, and the one-liner replaces the hand-rolled snippet in `routes-and-controllers.md`.

Closes #348

## Public API impact

`@kavo/nest` barrel gains `setupKavoSwagger` and the `KavoSwaggerOptions` type. Additive, non-breaking.

## Testing

New `packages/frameworks/nest/tests/swagger-setup.e2e.spec.ts` (5 tests): served `/docs` + `/docs-json` return 200 with every `onModuleInit`-only component present and `$ref` response bodies (paired against a pre-init document that lacks them, proving deferral); custom `path`; setup-after-`init()` throws `KAVO_CONFIG_INVALID` naming the fix; and unit coverage of both error constructors (peer-absent path can't be integration-tested — `createRequire` evades `vi.mock` and the workspace peer can't be uninstalled).

`pnpm check` on a clean isolated worktree: build + typecheck + depcruise + lint pass; **3389 tests pass**, 104 skipped. One suite fails — `examples/nest-typeorm/tests/app-cockroach.e2e.spec.ts`, "Health check not healthy after 60000ms" — a CockroachDB testcontainer/Docker startup timeout, environmental and unrelated (this branch touches no CockroachDB wiring; the parallel Postgres/MariaDB/Mongoose/MikroORM/SQLite e2e suites all pass). `pnpm docs:links` passes.

## Review notes

- The order guard depends on `NestApplication.isInitialized`, which is present in Nest 11's runtime but absent from its `.d.ts` — read through a cast and acted on only when strictly `true` (see the comment on `isAlreadyInitialised`).
- `swaggerPeerMissingError` / `swaggerCallOrderError` are exported from the module (not the barrel) purely so the tests can assert their code + wording without uninstalling the peer.
- Please sanity-check the CockroachDB failure is the known Docker flake and not something this change provokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared Swagger setup helper for Nest applications.
  * Swagger UI and raw OpenAPI documents are available through configurable routes.
  * Documentation generation is deferred until the first request and includes registered Kavo schemas.
  * Added clear configuration errors for missing Swagger support or incorrect setup timing.

* **Documentation**
  * Documented setup options, default paths, validation behavior, and usage examples.
  * Updated Nest example applications to use the shared Swagger setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->