### PR TITLE
fix(nest): type relation reference-object and ceiling fields in synthesized Swagger schemas

### DIFF
--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -480,11 +480,15 @@ A `creatable`/`updatable` name that is a **relation** rather than a scalar
 column has no `metadata.fields` entry, so it is picked up from
 `metadata.relations` and documented as the association-by-id shape the
 deserializer accepts (ADR-0014): a `{ id }` reference object for a to-one,
-a nullable array of them for a to-many, `id` left untyped because the
-target entity's primary-key kind isn't reachable from the binding. A
-relation never joins the body's `required` (`RelationDescriptor` carries no
-nullability). Without this, an entity whose entire writable projection is
-relations — a pure join row associated by id — would synthesize an empty
+a nullable array of them for a to-many. `id` is typed from the target
+entity's own metadata, which the binder resolves through
+`infrastructure.metadataFor(relation.target())`; it stays untyped only when
+that target can't be resolved (no infrastructure, or a root that can't
+derive its metadata) or when the target has a composite key, where a single
+scalar `id` would be wrong rather than merely vague. A relation never joins
+the body's `required` (`RelationDescriptor` carries no nullability). Without
+this, an entity whose entire writable projection is relations — a pure join
+row associated by id — would synthesize an empty
 `properties: {}` a client generator reads as "this route takes no body"
 (issue #339). The description fallback ("No field is writable.") is
 therefore gated on the synthesized schema ending up with zero properties,
@@ -497,10 +501,13 @@ after the scalar columns and the computed fields, never in `required`,
 since it is only in the body when `include=` asks for it. Its shape is the
 per-relation ceiling a relation-dotted `allowlists.selectable` entry
 resolves to (`relationProjection`, ADR-0044) as an object limited to those
-fields, or a generic `{ type: "object" }` with a prose description when the
-relation carries no ceiling — the target's own projection is governed by
-the target entity's config, not this one (ADR-0026), so it is not
-reproduced here. A `-to-many` relation wraps that object in
+fields — each typed from the target entity's own metadata (the same
+`infrastructure.metadataFor(relation.target())` resolution the body side
+uses), falling back to an untyped `{}` for a ceiling entry the target has
+no column for — or a generic `{ type: "object" }` with a prose description
+when the relation carries no ceiling. The target's own projection is
+governed by the target entity's config, not this one (ADR-0026), so it is
+not reproduced here. A `-to-many` relation wraps that object in
 `{ type: "array", items }`. The relation object is deliberately left
 unstamped by `withKavoEntity`, so `registerKavoSchemas` keeps it inline on
 `<Entity>Item` rather than hoisting it to its own component. Driven off the

--- a/packages/frameworks/nest/src/kavo.module.ts
+++ b/packages/frameworks/nest/src/kavo.module.ts
@@ -1,7 +1,7 @@
 import type { DynamicModule, ModuleMetadata, OnModuleInit, Provider, Type } from "@nestjs/common";
 import { Inject, Injectable, Module } from "@nestjs/common";
 import { APP_FILTER, DiscoveryModule, DiscoveryService } from "@nestjs/core";
-import type { ClassRef, KavoInstance, OperationDtoMap } from "@kavo/core";
+import type { ClassRef, EntityMetadata, KavoInstance, OperationDtoMap } from "@kavo/core";
 import {
   ConfigurationException,
   DefaultDtoResolver,
@@ -422,6 +422,41 @@ class KavoBinder implements OnModuleInit {
       if (conditionalDocs !== undefined) {
         const prototype = metatype.prototype as Record<string, unknown>;
         const dtoResolver = new DefaultDtoResolver(metadata.config?.dto as OperationDtoMap<object> | undefined);
+        // The target entity's own metadata for each relation a synthesized
+        // schema references — includable ones for `applyResponseSchemaDocs`'s
+        // ADR-0044 ceiling fields (issue #349), creatable/updatable ones for
+        // `applyBodySchemaDocs`'s `{ id }` reference object (issue #339) — so
+        // both can type those fields instead of emitting an untyped `{}`.
+        // Resolved once per controller, not per route. `metadataFor` may
+        // throw or return `undefined` for a target this root cannot derive
+        // metadata for (a `runtime.metadata` wiring, or an infrastructure
+        // that only knows routed entities); that relation is then left
+        // untyped rather than crashing bootstrap. A null-prototype map so a
+        // relation named `constructor`/`hasOwnProperty` can't resolve a
+        // bracket lookup to an inherited member and blow up outside the
+        // try/catch below.
+        const relationTargetMetadata: Record<string, EntityMetadata<object>> = Object.create(null) as Record<
+          string,
+          EntityMetadata<object>
+        >;
+        const schemaRelationNames = new Set<string>([
+          ...(service.engine.config.allowlists.includable as readonly string[]),
+          ...(service.engine.config.allowlists.creatable as readonly string[]),
+          ...(service.engine.config.allowlists.updatable as readonly string[]),
+        ]);
+        for (const relation of service.engine.metadata.relations) {
+          if (!schemaRelationNames.has(relation.name)) {
+            continue;
+          }
+          try {
+            const targetMetadata = this.options.infrastructure?.metadataFor(relation.target() as ClassRef<object>);
+            if (targetMetadata !== undefined) {
+              relationTargetMetadata[relation.name] = targetMetadata as EntityMetadata<object>;
+            }
+          } catch {
+            // Target metadata unresolvable from this root — leave untyped.
+          }
+        }
         for (const { methodName, descriptor, route } of conditionalDocs) {
           const settings = service.engine.config.settingsFor(descriptor.id);
           applyConditionalRequestDocs(prototype, methodName, descriptor, route, isEtagEnabled(settings.cache));
@@ -431,10 +466,17 @@ class KavoBinder implements OnModuleInit {
           // rather than stashed, since it's a pure function of the
           // decoration-time config already sitting in `metadata.config`.
           if (bodyDtoFor(descriptor, dtoResolver) === null) {
-            applyBodySchemaDocs(prototype, methodName, descriptor, service.engine.metadata, {
-              creatable: service.engine.config.allowlists.creatable as readonly string[],
-              updatable: service.engine.config.allowlists.updatable as readonly string[],
-            });
+            applyBodySchemaDocs(
+              prototype,
+              methodName,
+              descriptor,
+              service.engine.metadata,
+              {
+                creatable: service.engine.config.allowlists.creatable as readonly string[],
+                updatable: service.engine.config.allowlists.updatable as readonly string[],
+              },
+              relationTargetMetadata,
+            );
           }
           // Fallback success-response schema, narrowed to `selectable`
           // (issue #264's response-side counterpart) — `applyResponseSchemaDocs`
@@ -452,6 +494,7 @@ class KavoBinder implements OnModuleInit {
             Object.keys(service.engine.config.computed),
             service.engine.config.allowlists.includable as readonly string[],
             service.engine.config.relationProjection,
+            relationTargetMetadata,
             dtoResolver,
           );
           // `search[...]` Swagger docs (issue #156) — deferred for the same

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -1003,10 +1003,15 @@ const alreadyBodySchemaDocumented = new WeakSet<object>();
  * only — so they are picked up from `metadata.relations` instead and
  * documented as the reference-object shape the deserializer accepts:
  * `{ "id": ... }` for a to-one, an array of them for a to-many, either
- * nullable so `null` can disassociate. The related row's id *type* needs
- * the target entity's own metadata, which this function does not receive,
- * so `id` is left untyped rather than guessed, and a relation never joins
- * the outer `required` list (`RelationDescriptor` carries no nullability).
+ * nullable so `null` can disassociate. The related row's id *type* is taken
+ * from the target entity's own metadata via `relationTargetMetadata` (the
+ * binder resolves it through `infrastructure.metadataFor(relation.target())`);
+ * `id` stays untyped (`{}`) when the target is unresolvable — no
+ * infrastructure, or a root that cannot derive its metadata — and also when
+ * the target is a **composite-key** entity, where a single scalar `id` would
+ * be an outright wrong assertion rather than an honest blank. A relation
+ * never joins the outer `required` list (`RelationDescriptor` carries no
+ * nullability).
  */
 export function applyBodySchemaDocs(
   prototype: Record<string, unknown>,
@@ -1014,6 +1019,7 @@ export function applyBodySchemaDocs(
   descriptor: OperationDescriptor<object>,
   metadata: EntityMetadata<object>,
   allowlists: { readonly creatable: readonly string[]; readonly updatable: readonly string[] },
+  relationTargetMetadata: Readonly<Record<string, EntityMetadata<object>>>,
 ): void {
   const allowed = allowedFieldsFor(descriptor.id, allowlists);
   if (allowed === null) {
@@ -1052,7 +1058,18 @@ export function applyBodySchemaDocs(
     if (!allowed.includes(relation.name)) {
       continue;
     }
-    properties[relation.name] = associationBodySchema(relation.cardinality);
+    const target = relationTargetMetadata[relation.name];
+    // A composite-key target has no single `id` column — `metadata.idField`
+    // is just its first key part — so a typed scalar `id` would be a wrong
+    // assertion; leave it `{}` for that case (finding #261).
+    const idField =
+      target !== undefined && target.compositeIdFields === undefined
+        ? target.fields.find((field) => field.name === target.idField)
+        : undefined;
+    properties[relation.name] = associationBodySchema(
+      relation.cardinality,
+      idField !== undefined ? fieldSchema(idField) : undefined,
+    );
   }
   // `patchOne` is a partial update — every field is optional regardless of
   // column nullability — so it never carries `required`. `createOne` and
@@ -1129,13 +1146,14 @@ function fieldSchema(field: FieldMetadata): object {
 /**
  * The request-body fragment for a write-side relation property (ADR-0014):
  * a `{ id }` reference object for a to-one, an array of them for a to-many,
- * either one nullable so `null` disassociates. `id` is left untyped — the
- * related entity's primary-key kind isn't reachable from here.
+ * either one nullable so `null` disassociates. `idSchema` is the target
+ * entity's primary-key fragment when the caller could resolve it; `{}` (an
+ * untyped id) otherwise.
  */
-function associationBodySchema(cardinality: RelationCardinality): object {
+function associationBodySchema(cardinality: RelationCardinality, idSchema?: object): object {
   const reference = {
     type: "object",
-    properties: { id: {} },
+    properties: { id: idSchema ?? {} },
     required: ["id"],
     description: "Associate by id (ADR-0014); pass `null` to disassociate.",
   };
@@ -1353,7 +1371,15 @@ const alreadyResponseSchemaDocumented = new WeakSet<object>();
  * (`selectable: ["word.id"]`, ADR-0044) as an object limited to those
  * fields, or a generic object when the relation carries no ceiling — the
  * target's own projection is governed by the target entity's config, not
- * this one (`entity-catalog.ts`), so it is not reproduced here. A `-to-many`
+ * this one (`entity-catalog.ts`), so it is not reproduced here. Each ceiling
+ * field is typed from the target entity's own `metadata.fields`, passed in
+ * as `relationTargetMetadata` (the binder resolves it via
+ * `infrastructure.metadataFor(relation.target())`). A ceiling field falls
+ * back to an untyped `{}` rather than a guessed type in two cases: the
+ * target as a whole is unresolvable (no infrastructure, or a root that
+ * cannot derive its metadata), or the target resolves but carries no column
+ * of that name (a ceiling entry naming a field the target does not have).
+ * A `-to-many`
  * relation wraps that object in `{ type: "array", items }`. The relation
  * object is deliberately left unstamped by `withKavoEntity`: a stamped
  * nested schema would be hoisted to its own component by
@@ -1379,6 +1405,7 @@ export function applyResponseSchemaDocs(
   computedFieldNames: readonly string[],
   includable: readonly string[],
   relationProjection: Readonly<Record<string, readonly string[]>> | undefined,
+  relationTargetMetadata: Readonly<Record<string, EntityMetadata<object>>>,
   dtoResolver: DtoResolver<object>,
 ): void {
   if (route.status === 204) {
@@ -1441,9 +1468,18 @@ export function applyResponseSchemaDocs(
       continue;
     }
     const ceiling = relationProjection?.[relationName];
+    const targetFields = relationTargetMetadata[relationName]?.fields;
     const object =
       ceiling !== undefined
-        ? { type: "object", properties: Object.fromEntries(ceiling.map((name) => [name, {}])) }
+        ? {
+            type: "object",
+            properties: Object.fromEntries(
+              ceiling.map((name) => {
+                const field = targetFields?.find((candidate) => candidate.name === name);
+                return [name, field !== undefined ? fieldSchema(field) : {}];
+              }),
+            ),
+          }
         : {
             type: "object",
             description:

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -2463,7 +2463,9 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
       expect(schema?.properties?.list).toEqual({
         type: "object",
         nullable: true,
-        properties: { id: {} },
+        // `id` is typed from `TodoList`'s own metadata (a number column),
+        // not left as a bare `{}` (issue #339 follow-up).
+        properties: { id: { type: "number" } },
         required: ["id"],
         description: "Associate by id (ADR-0014); pass `null` to disassociate.",
       });
@@ -2508,10 +2510,12 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
     // generator as "POST /notes takes no body", which is false.
     expect(Object.keys(schema?.properties ?? {})).toEqual(["word", "tags"]);
     expect(schema?.description).toBeUndefined();
+    // `id` is typed from the resolved target metadata (this fixture's
+    // `metadataFor` yields a string-id entity for every target).
     expect(schema?.properties?.word).toEqual({
       type: "object",
       nullable: true,
-      properties: { id: {} },
+      properties: { id: { type: "string" } },
       required: ["id"],
       description: "Associate by id (ADR-0014); pass `null` to disassociate.",
     });
@@ -2521,7 +2525,7 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
       nullable: true,
       items: {
         type: "object",
-        properties: { id: {} },
+        properties: { id: { type: "string" } },
         required: ["id"],
         description: "Associate by id (ADR-0014); pass `null` to disassociate.",
       },
@@ -2599,6 +2603,149 @@ describe("@Kavo Swagger fallback request-body schema when no DTO is configured (
     // registration happens across repeated `onModuleInit` runs.
     expect(Object.keys(bodySchema("/todos", "post")?.properties ?? {})).toEqual(["title", "done", "priority", "list"]);
   });
+
+  // Boot a relation-only entity against an infrastructure that resolves the
+  // routed entity and each relation target separately, so the `{ id }`
+  // reference object's type can be pinned to the *target's* metadata rather
+  // than the source's (the pre-change code read neither — it emitted `{}`).
+  const withDiscriminatingMetadata = async (
+    source: EntityMetadata<object>,
+    resolve: (entity: unknown) => EntityMetadata<object>,
+    config?: unknown,
+  ) => {
+    const adapter = {
+      findOneById: async () => null,
+      findOne: async () => null,
+      findMany: async () => [],
+      count: async () => 0,
+      create: async (data: unknown) => data,
+      update: async (_id: unknown, data: unknown) => data,
+      patch: async (_id: unknown, data: unknown) => data,
+      delete: async () => {},
+      restore: async () => {
+        throw new Error("not exercised");
+      },
+      purge: async () => {},
+    } as unknown as RepositoryAdapter<object>;
+    const infrastructure: KavoInfrastructure = {
+      metadataFor: ((entity: unknown) => (entity === source.entity ? source : resolve(entity))) as never,
+      adapterFor: () => adapter as never,
+    };
+    @Controller("notes")
+    class NoteController {}
+    Kavo(source.entity as new () => object, config as Parameters<typeof Kavo>[1])(NoteController);
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure }), KavoModule.forFeature([NoteController])],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+  };
+
+  const relationOnlySource = (): EntityMetadata<object> => {
+    class Note {}
+    return {
+      entity: Note,
+      name: "Note",
+      idField: "id",
+      // A number id on the source, so a target with a string id proves the
+      // reference-object `id` is read from the target, not from here.
+      fields: [{ name: "id", kind: "number", nullable: false, generated: true }],
+      relations: [
+        { name: "word", target: () => class Word {}, cardinality: "one", includable: false, strategy: "auto" },
+      ],
+    };
+  };
+
+  it("types the reference-object `id` from the relation target's metadata, not the source entity's (issue #339)", async () => {
+    class Word {}
+    const wordMetadata: EntityMetadata<object> = {
+      entity: Word,
+      name: "Word",
+      idField: "id",
+      fields: [{ name: "id", kind: "string", nullable: false, generated: true }],
+      relations: [],
+    };
+    await withDiscriminatingMetadata(relationOnlySource(), () => wordMetadata, {
+      allowlists: { creatable: ["word"], updatable: ["word"] },
+    });
+
+    expect(bodySchema("/notes", "post")?.properties?.word).toEqual({
+      type: "object",
+      nullable: true,
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      description: "Associate by id (ADR-0014); pass `null` to disassociate.",
+    });
+  });
+
+  it("leaves the reference-object `id` untyped when the relation target's metadata is unresolvable (issue #339)", async () => {
+    await withDiscriminatingMetadata(
+      relationOnlySource(),
+      () => {
+        throw new Error("no metadata for this relation target from this root");
+      },
+      { allowlists: { creatable: ["word"], updatable: ["word"] } },
+    );
+
+    // Bootstrap survived the throw, and the field falls back to the
+    // pre-change untyped shape rather than being dropped.
+    expect(bodySchema("/notes", "post")?.properties?.word).toEqual({
+      type: "object",
+      nullable: true,
+      properties: { id: {} },
+      required: ["id"],
+      description: "Associate by id (ADR-0014); pass `null` to disassociate.",
+    });
+  });
+
+  it("leaves the reference-object `id` untyped for a composite-key relation target (issue #339)", async () => {
+    class Word {}
+    const wordMetadata: EntityMetadata<object> = {
+      entity: Word,
+      name: "Word",
+      idField: "orgId",
+      compositeIdFields: ["orgId", "lemma"],
+      fields: [
+        { name: "orgId", kind: "string", nullable: false, generated: false },
+        { name: "lemma", kind: "string", nullable: false, generated: false },
+      ],
+      relations: [],
+    };
+    await withDiscriminatingMetadata(relationOnlySource(), () => wordMetadata, {
+      allowlists: { creatable: ["word"], updatable: ["word"] },
+    });
+
+    // A single scalar `id` would be a wrong assertion for a two-column key,
+    // so it stays `{}` — honestly vague beats confidently wrong.
+    expect(bodySchema("/notes", "post")?.properties?.word?.properties).toEqual({ id: {} });
+  });
+
+  it.each([
+    {
+      label: "date",
+      field: { name: "id", kind: "date", nullable: false, generated: true },
+      expected: { type: "string", format: "date-time" },
+    },
+    {
+      label: "enum",
+      field: { name: "id", kind: "enum", nullable: false, generated: false, enumValues: ["a", "b"] },
+      expected: { type: "string", enum: ["a", "b"] },
+    },
+  ])("types the reference-object `id` for a $label target id kind (issue #339)", async ({ field, expected }) => {
+    class Word {}
+    const wordMetadata: EntityMetadata<object> = {
+      entity: Word,
+      name: "Word",
+      idField: "id",
+      fields: [field as EntityMetadata<object>["fields"][number]],
+      relations: [],
+    };
+    await withDiscriminatingMetadata(relationOnlySource(), () => wordMetadata, {
+      allowlists: { creatable: ["word"], updatable: ["word"] },
+    });
+    expect(bodySchema("/notes", "post")?.properties?.word?.properties?.id).toEqual(expected);
+  });
 });
 
 describe("@Kavo Swagger fallback success-response schema when no item/list DTO is configured (issue #264)", () => {
@@ -2637,6 +2784,19 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
     )?.[verb]?.responses?.[status]?.content?.["application/json"]?.schema;
 
   let document: ReturnType<typeof SwaggerModule.createDocument>;
+
+  // Boot one `@Kavo` controller against a caller-supplied infrastructure —
+  // for the includable-relation tests that need `metadataFor` to resolve (or
+  // deliberately fail) per target entity, which the shared `fakeInfrastructure`
+  // can't express.
+  const buildDoc = async (infrastructure: KavoInfrastructure, controller: unknown): Promise<void> => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure }), KavoModule.forFeature([controller as never])],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+  };
 
   it("narrows the item response to selectable when no item DTO is registered", async () => {
     @Kavo(Todo, { allowlists: { selectable: ["id", "title"] } })
@@ -2891,7 +3051,7 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
   });
 
   it("caps an includable relation's emitted shape to the allowlists.selectable ceiling (ADR-0044, issue #349)", async () => {
-    @Kavo(Todo, { allowlists: { includable: ["list"], selectable: ["id", "title", "list.id"] } })
+    @Kavo(Todo, { allowlists: { includable: ["list"], selectable: ["id", "title", "list.id", "list.name"] } })
     @Controller("todos")
     class CeilingController {}
     await bootstrap(CeilingController);
@@ -2902,16 +3062,33 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
       ["post", "/todos", "201"],
     ] as const) {
       const schema = itemBody(path, verb, status);
-      // The relation-dotted `list.id` entry is stripped from the root
-      // projection (ADR-0044) and re-applied as the relation object's shape.
+      // The relation-dotted `list.*` entries are stripped from the root
+      // projection (ADR-0044) and re-applied as the relation object's shape,
+      // each field typed from `TodoList`'s own metadata — `id` is a number
+      // column and `name` a string, so a blind `string` guess would be wrong.
       expect(Object.keys(schema?.properties ?? {})).toEqual(["id", "title", "list"]);
-      expect(schema?.properties?.list).toEqual({ type: "object", properties: { id: {} } });
+      expect(schema?.properties?.list).toEqual({
+        type: "object",
+        properties: { id: { type: "number" }, name: { type: "string" } },
+      });
       expect(schema?.required ?? []).not.toContain("list");
     }
   });
 
-  it("wraps a -to-many includable relation in an array (issue #349)", async () => {
+  it("wraps a -to-many includable relation in an array, typing its ceiling fields from the target (issue #349)", async () => {
     class Post {}
+    class Tag {}
+    const tagMetadata: EntityMetadata<object> = {
+      entity: Tag,
+      name: "Tag",
+      idField: "id",
+      fields: [
+        { name: "id", kind: "number", nullable: false, generated: true },
+        { name: "label", kind: "string", nullable: false, generated: false },
+        { name: "archived", kind: "boolean", nullable: false, generated: false },
+      ],
+      relations: [],
+    };
     const postMetadata: EntityMetadata<object> = {
       entity: Post,
       name: "Post",
@@ -2924,11 +3101,11 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
         // `includable: false` on the descriptor deliberately disagrees with
         // the config grant below — the synthesized schema must follow the
         // resolved `allowlists.includable`, not the ORM-derived flag.
-        { name: "tags", target: () => class Tag {}, cardinality: "many", includable: false, strategy: "auto" },
+        { name: "tags", target: () => Tag, cardinality: "many", includable: false, strategy: "auto" },
       ],
     };
     const infrastructure: KavoInfrastructure = {
-      metadataFor: () => postMetadata as never,
+      metadataFor: ((entity: unknown) => (entity === Tag ? tagMetadata : postMetadata)) as never,
       adapterFor: () => stubAdapter() as never,
     };
 
@@ -2937,21 +3114,81 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
     // `Post` has no declared fields, so the config's relation-name types
     // infer to `never`; apply the decorator as a plain call with a cast, the
     // same escape hatch the fallback-body-schema block uses.
-    const postConfig: unknown = { allowlists: { includable: ["tags"] } };
+    const postConfig: unknown = {
+      allowlists: { includable: ["tags"], selectable: ["id", "title", "tags.label", "tags.archived"] },
+    };
     Kavo(Post, postConfig as Parameters<typeof Kavo>[1])(PostController);
-
-    const moduleRef = await Test.createTestingModule({
-      imports: [KavoModule.forRoot({ infrastructure }), KavoModule.forFeature([PostController])],
-    }).compile();
-    app = moduleRef.createNestApplication();
-    await app.init();
-    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+    await buildDoc(infrastructure, PostController);
 
     const single = itemBody("/posts/{id}", "get", "200");
     expect(Object.keys(single?.properties ?? {})).toEqual(["id", "title", "tags"]);
-    expect(single?.properties?.tags?.type).toBe("array");
-    expect(single?.properties?.tags?.items?.type).toBe("object");
+    // The ceiling object is array-wrapped, and each field carries the kind
+    // `Tag`'s own metadata gives it — a `string` guess would miss `archived`.
+    expect(single?.properties?.tags).toEqual({
+      type: "array",
+      items: {
+        type: "object",
+        properties: { label: { type: "string" }, archived: { type: "boolean" } },
+      },
+    });
     expect(single?.required ?? []).not.toContain("tags");
+  });
+
+  it("leaves an includable relation's ceiling fields untyped when the target's metadata is unresolvable (issue #349)", async () => {
+    class Post {}
+    const postMetadata: EntityMetadata<object> = {
+      entity: Post,
+      name: "Post",
+      idField: "id",
+      fields: [
+        { name: "id", kind: "number", nullable: false, generated: true },
+        { name: "title", kind: "string", nullable: false, generated: false },
+      ],
+      relations: [
+        { name: "author", target: () => class Author {}, cardinality: "one", includable: false, strategy: "auto" },
+      ],
+    };
+    const infrastructure: KavoInfrastructure = {
+      metadataFor: ((entity: unknown) => {
+        if (entity === Post) {
+          return postMetadata;
+        }
+        throw new Error("no metadata for this relation target from this root");
+      }) as never,
+      adapterFor: () => stubAdapter() as never,
+    };
+
+    @Controller("posts")
+    class PostController {}
+    const postConfig: unknown = { allowlists: { includable: ["author"], selectable: ["id", "title", "author.id"] } };
+    Kavo(Post, postConfig as Parameters<typeof Kavo>[1])(PostController);
+    // `metadataFor` throwing for the target must not abort bootstrap.
+    await buildDoc(infrastructure, PostController);
+
+    const schema = itemBody("/posts/{id}", "get", "200");
+    // The ceiling still shapes the object, but its one field stays `{}`.
+    expect(schema?.properties?.author).toEqual({ type: "object", properties: { id: {} } });
+    expect(schema?.required ?? []).not.toContain("author");
+  });
+
+  it("leaves a ceiling entry untyped when the target has no such column, still typing its siblings (issue #349)", async () => {
+    // `list.phantom` is off `Todo`'s typed `selectable` union (no such
+    // `TodoList` column), so apply the decorator as a plain cast call.
+    const phantomConfig: unknown = {
+      allowlists: { includable: ["list"], selectable: ["id", "title", "list.id", "list.phantom"] },
+    };
+    @Controller("todos")
+    class PhantomCeilingController {}
+    Kavo(Todo, phantomConfig as Parameters<typeof Kavo>[1])(PhantomCeilingController);
+    await bootstrap(PhantomCeilingController);
+    document = SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build());
+
+    // `phantom` is not a `TodoList` column, so its per-field lookup misses
+    // and it stays `{}` while `id` (a real number column) is typed.
+    expect(itemBody("/todos/{id}", "get", "200")?.properties?.list).toEqual({
+      type: "object",
+      properties: { id: { type: "number" }, phantom: {} },
+    });
   });
 
   it("keeps the embedded relation object inline — registerKavoSchemas hoists no extra component (issue #349)", async () => {


### PR DESCRIPTION
## What & why

Follow-up to #339 / #349 (landed as #340 / #350). The bind-time fallback OpenAPI schemas — the ones `@kavo/nest` synthesizes when a route has no registered `item`/`list`/body DTO — emitted an untyped `{}` for two things:

- an associate-by-id relation's `{ id }` reference object on `<Entity>Create`/`Update`/`Patch` (#339);
- an includable relation's ADR-0044 projection-ceiling fields on `<Entity>Item`/`ListItem` (#349).

A client generator reads `{}` as `any`. Both are now typed.

`KavoBinder.onModuleInit` resolves each schema-referenced relation's target metadata once per controller via `infrastructure.metadataFor(relation.target())` — guarded by `try/catch` and an `undefined` check so an unresolvable target (no infrastructure, `runtime.metadata` wiring, an infra that only knows routed entities) degrades to `{}` rather than aborting bootstrap — and threads a null-prototype `relationTargetMetadata` map into `applyBodySchemaDocs` / `applyResponseSchemaDocs`. Each field is then typed from the target's own `metadata.fields`; it falls back to `{}` when the target is unresolvable, when a ceiling entry names a column the target doesn't have, or — for the reference-object `id` — when the target has a **composite key**, where a single scalar `id` would be an outright wrong assertion rather than an honest blank.

No dedicated issue for the follow-up, and #339 / #349 are already closed, so no `Closes` trailer.

## Public API impact

None. `applyBodySchemaDocs` / `applyResponseSchemaDocs` are `export`ed for `kavo.module.ts` only and are not on the `@kavo/nest` barrel; the added parameter is internal.

## Testing

Added to `packages/frameworks/nest/tests/binding.e2e.spec.ts` (7 new e2e cases):

- reference-object `id` typed from the **target's** metadata, not the source entity's (source id `number`, target id `string` — a source read would fail this);
- `metadataFor` throwing for the target → `{ id: {} }` survives **and bootstrap does not crash**;
- composite-key target → `{ id: {} }`;
- `date` and `enum` target id kinds (`it.each`);
- `-to-many` includable relation: rewrote the previously-weak assertion to a discriminating infra + a typed ceiling with distinct field kinds;
- unresolvable includable target → ceiling field stays `{}`;
- ceiling entry naming a non-existent target column → that entry `{}`, sibling typed.

Local gate: `pnpm build` + `typecheck` + `depcruise` + `lint` pass; `@kavo/nest` suite **433 tests pass**; `pnpm docs:links` passes. `pnpm test` in full additionally fails only the Docker/Testcontainers example e2e suites (`app-postgres`/`mariadb`/`cockroach`, mongoose mongo-memory-server) — Docker is not running on this machine; this change touches no ORM-integration wiring and CI runs those with a runtime available.

## Review notes

- `relationTargetMetadata` is `Object.create(null)` on purpose: a relation named `constructor`/`hasOwnProperty` must not resolve a bracket lookup to a prototype member and throw outside the `try/catch`.
- Deliberately **not** done: gating an `enum`-kind ceiling field's `enumValues` on the *target's* own `selectable`. The ceiling is itself the ADR-0044 grant — the host config author relation-dotted that field into `selectable`, and `?include=rel&select[rel]=field` genuinely returns it — so emitting its accurate type (enum labels included) is correct, not a leak. Flagged by the security auditor as low-severity; hiding a field the ceiling permits would need resolving the target's full config at bind time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved generated Swagger schemas for entity relationships.
  * Association IDs and included relation fields now reflect the related entity’s metadata when available.
  * Added support for typed string, date, enum, and array-based relation fields.
  * Unresolved relationships and composite keys continue to use safe, untyped schemas.
* **Bug Fixes**
  * Prevented unavailable relation metadata from interrupting application startup.
  * Improved schema handling for missing target fields and varying relation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->