### PR TITLE
feat(nest): compose nested includable relations in the synthesized schema via shared $ref

### DIFF
--- a/docs/internals/adr/0044-relation-projection-ceiling-from-selectable.md
+++ b/docs/internals/adr/0044-relation-projection-ceiling-from-selectable.md
@@ -135,13 +135,21 @@ the same break ADR-0026 recorded for `projection` and ADR-0019 for
 decoration time (ADR-0012), because the ceiling is literal strings on
 `allowlists.selectable`, unlike an `{ exclude }` selector.
 
-**The synthesized response schema uses the ceiling too** (issue #349,
-follow-up). `@kavo/nest`'s bind-time fallback `<Entity>Item`/`ListItem`
-schema — the path with no registered `item`/`list` DTO — emits an optional
-property for each `allowlists.includable` relation, and shapes it from
-`ResolvedEntityConfig.relationProjection`: an object limited to the ceiling
-fields when one is set, a generic object otherwise. It never enters
-`required` (present only under `include=`).
+**The synthesized response schema uses the ceiling too** (issue #349, then
+#356). `@kavo/nest`'s bind-time fallback `<Entity>Item`/`ListItem` schema —
+the path with no registered `item`/`list` DTO — emits an optional property
+for each `allowlists.includable` relation. When the parent sets a one-hop
+`selectable` ceiling for that relation, the parent wins: an inline object
+limited to the ceiling fields, from `ResolvedEntityConfig.relationProjection`.
+When it sets **no** ceiling, the property defers wholly to the target and is
+composed by shared component — `registerKavoSchemas` resolves it to
+`{ $ref: "#/components/schemas/<Target>Item" }` (a degraded `{ type: "object" }`
+when the target publishes no synthesized item schema). Nested `include=a.b.c`
+therefore types transitively, bounded on the request side by the existing
+`relations.maxIncludeDepth` — there is no separate Swagger depth control.
+The property never enters `required` (present only under `include=`), and a
+`defaultInclude: true` relation is not promoted either: the shape is shared
+with write responses, which carry no relations (ADR-0020).
 
 ## References
 

--- a/docs/internals/architecture/10-nestjs-integration.md
+++ b/docs/internals/architecture/10-nestjs-integration.md
@@ -495,24 +495,40 @@ therefore gated on the synthesized schema ending up with zero properties,
 not on the allowlist being empty.
 
 The **response** fallback has the mirror case for `allowlists.includable`
-(ADR-0028, issue #349): a relation a client may `?include=` is emitted as
-an **optional** property on `<Entity>Item`/`<Entity>ListItem` — appended
-after the scalar columns and the computed fields, never in `required`,
-since it is only in the body when `include=` asks for it. Its shape is the
-per-relation ceiling a relation-dotted `allowlists.selectable` entry
-resolves to (`relationProjection`, ADR-0044) as an object limited to those
-fields — each typed from the target entity's own metadata (the same
-`infrastructure.metadataFor(relation.target())` resolution the body side
-uses), falling back to an untyped `{}` for a ceiling entry the target has
-no column for — or a generic `{ type: "object" }` with a prose description
-when the relation carries no ceiling. The target's own projection is
-governed by the target entity's config, not this one (ADR-0026), so it is
-not reproduced here. A `-to-many` relation wraps that object in
-`{ type: "array", items }`. The relation object is deliberately left
-unstamped by `withKavoEntity`, so `registerKavoSchemas` keeps it inline on
-`<Entity>Item` rather than hoisting it to its own component. Driven off the
-resolved `allowlists.includable` names, not `RelationDescriptor.includable`
-(which reflects ORM-derived metadata, not the config grant).
+(ADR-0028, issue #349, then #356): a relation a client may `?include=` is
+emitted as an **optional** property on `<Entity>Item`/`<Entity>ListItem` —
+appended after the scalar columns and the computed fields, never in
+`required`, since it is only in the body when `include=` asks for it, and
+the shape is shared with the write responses, which resolve no `include=`
+at all (ADR-0020). Its shape depends on whether the parent narrowed it:
+
+- **Parent one-hop `selectable` ceiling** (`relationProjection`, ADR-0044):
+  an inline object limited to those fields, each typed from the target
+  entity's own metadata (the same `infrastructure.metadataFor(relation.target())`
+  resolution the body side uses), falling back to an untyped `{}` for a
+  ceiling entry the target has no column for. Left unstamped by
+  `withKavoEntity`, so `registerKavoSchemas` keeps it inline rather than
+  hoisting it as its own component.
+- **No parent ceiling**: the relation defers wholly to the target, so
+  `applyResponseSchemaDocs` emits an unstamped `x-kavo-includable-ref`
+  marker carrying only the target entity's resolved name (bind time cannot
+  name the final component — `registerKavoSchemas` owns naming and a
+  cross-entity clash can bump `<Target>Item` to `<Target>Item_2`).
+  `registerKavoSchemas` then rewrites each marker, in a post-pass over
+  every registered component, to `{ $ref: "#/components/schemas/<Target>Item" }`
+  — or, when the target published no synthesized item schema (its own read
+  route registered an explicit `item` DTO, or it has no read route), to a
+  plain `{ type: "object" }` with a prose description, so the document never
+  carries a dangling `$ref`. Nested `include=a.b.c` types transitively this
+  way, and `$ref` cycles (mutual or self relations) are valid OpenAPI 3.x
+  and left as-is. A document that never runs `registerKavoSchemas` keeps
+  the marker inline — still a valid object schema, just not `$ref`-composed.
+
+A `-to-many` relation wraps whichever shape in `{ type: "array", items }`.
+The request-side nesting bound is the existing `relations.maxIncludeDepth`;
+there is no separate Swagger depth control. Driven off the resolved
+`allowlists.includable` names, not `RelationDescriptor.includable` (which
+reflects ORM-derived metadata, not the config grant).
 
 Two known over-statements, both narrowing documentation only — the schema
 stays open (no `additionalProperties: false`, matching `allowlists.md`'s

--- a/examples/nest-typeorm/src/app.module.ts
+++ b/examples/nest-typeorm/src/app.module.ts
@@ -13,6 +13,7 @@ import { PhotoController } from "./photo/photo.controller.js";
 import { AddressController } from "./address/address.controller.js";
 import { PetTagController } from "./pet-tag/pet-tag.controller.js";
 import { OwnerSettingController } from "./owner-setting/owner-setting.controller.js";
+import { LandmarkController, RegionController, ZoneController } from "./nested-demo/nested-demo.controllers.js";
 
 /**
  * Reference wiring: the app hands `@kavo/nest` its infrastructure (here
@@ -86,6 +87,9 @@ export class AppModule {
         AddressController,
         PetTagController,
         OwnerSettingController,
+        RegionController,
+        ZoneController,
+        LandmarkController,
       ],
       providers: [
         {

--- a/examples/nest-typeorm/src/database.module.ts
+++ b/examples/nest-typeorm/src/database.module.ts
@@ -9,10 +9,11 @@ import { Photo } from "./photo/photo.entity.js";
 import { Address } from "./address/address.entity.js";
 import { PetTag } from "./pet-tag/pet-tag.entity.js";
 import { OwnerSetting } from "./owner-setting/owner-setting.entity.js";
+import { Landmark, Region, Zone } from "./nested-demo/nested-demo.entities.js";
 
 export const DATA_SOURCE = Symbol("DATA_SOURCE");
 
-const entities = [Owner, Pet, Cat, Dog, Tag, Photo, Address, PetTag, OwnerSetting];
+const entities = [Owner, Pet, Cat, Dog, Tag, Photo, Address, PetTag, OwnerSetting, Region, Zone, Landmark];
 
 interface ConnectionOptions {
   host: string;

--- a/examples/nest-typeorm/src/nested-demo/nested-demo.controllers.ts
+++ b/examples/nest-typeorm/src/nested-demo/nested-demo.controllers.ts
@@ -1,0 +1,22 @@
+import { Controller } from "@nestjs/common";
+import { Kavo } from "@kavo/nest";
+import { Landmark, Region, Zone } from "./nested-demo.entities.js";
+
+/**
+ * See `nested-demo.entities.ts`. Each controller opts its outgoing
+ * relation(s) into `include=` and nothing else — no `dto` block, no
+ * `selectable` ceiling — so the synthesized `<Entity>Item` schema composes
+ * the next hop by `$ref` (issue #356).
+ */
+
+@Kavo(Region, { allowlists: { includable: ["zones"] } })
+@Controller("regions")
+export class RegionController {}
+
+@Kavo(Zone, { allowlists: { includable: ["region", "landmarks"] } })
+@Controller("zones")
+export class ZoneController {}
+
+@Kavo(Landmark, { allowlists: { includable: ["zone"] } })
+@Controller("landmarks")
+export class LandmarkController {}

--- a/examples/nest-typeorm/src/nested-demo/nested-demo.entities.ts
+++ b/examples/nest-typeorm/src/nested-demo/nested-demo.entities.ts
@@ -1,0 +1,50 @@
+import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+
+/**
+ * A three-hop includable-relation chain — `Region → Zone → Landmark` — used
+ * only to show issue #356's recursive `$ref` schema composition in the
+ * generated OpenAPI document. None of these controllers registers an `item`
+ * DTO and none sets a relation-dotted `allowlists.selectable` ceiling, so
+ * every includable relation defers wholly to its target and is emitted as a
+ * `$ref` to that entity's own `<Entity>Item` component. `GET
+ * /regions/:id?include=zones.landmarks` therefore types transitively, and
+ * `Zone.region ↔ Region.zones` is a legal `$ref` cycle.
+ */
+@Entity()
+export class Region {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  name!: string;
+
+  @OneToMany("Zone", (zone: Zone) => zone.region)
+  zones!: Zone[];
+}
+
+@Entity()
+export class Zone {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  name!: string;
+
+  @ManyToOne("Region", (region: Region) => region.zones, { nullable: true })
+  region!: Region | null;
+
+  @OneToMany("Landmark", (landmark: Landmark) => landmark.zone)
+  landmarks!: Landmark[];
+}
+
+@Entity()
+export class Landmark {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("varchar")
+  name!: string;
+
+  @ManyToOne("Zone", (zone: Zone) => zone.landmarks, { nullable: true })
+  zone!: Zone | null;
+}

--- a/examples/nest-typeorm/tests/nested-demo.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/nested-demo.e2e.spec.ts
@@ -26,7 +26,10 @@ type Schema = {
 };
 type Document = {
   components?: { schemas?: Record<string, Schema> };
-  paths: Record<string, Record<string, { responses?: Record<string, { content?: Record<string, { schema?: Schema }> }> }> | undefined>;
+  paths: Record<
+    string,
+    Record<string, { responses?: Record<string, { content?: Record<string, { schema?: Schema }> }> }> | undefined
+  >;
 };
 
 let app: INestApplication;
@@ -99,7 +102,10 @@ describe("nested includable-relation $ref composition in the Pet example (issue 
   it("returns a nested tree over include=zones.landmarks that matches the advertised shape", async () => {
     const server = app.getHttpServer();
     const region = await request(server).post("/regions").send({ name: "North" }).expect(201);
-    const zone = await request(server).post("/zones").send({ name: "N-1", region: { id: region.body.id } }).expect(201);
+    const zone = await request(server)
+      .post("/zones")
+      .send({ name: "N-1", region: { id: region.body.id } })
+      .expect(201);
     await request(server)
       .post("/landmarks")
       .send({ name: "Tower", zone: { id: zone.body.id } })

--- a/examples/nest-typeorm/tests/nested-demo.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/nested-demo.e2e.spec.ts
@@ -1,0 +1,115 @@
+import "reflect-metadata";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { registerKavoSchemas } from "@kavo/nest";
+import request from "supertest";
+import { AppModule } from "../src/app.module.js";
+
+/**
+ * The `Region → Zone → Landmark` chain (`src/nested-demo/`) exists to show
+ * issue #356's recursive `$ref` schema composition: no controller registers
+ * an item DTO and none sets a relation-dotted `selectable` ceiling, so every
+ * includable relation is emitted as a `$ref` to its target's own
+ * `<Entity>Item` component. This spec pins that in the generated document and
+ * checks the runtime response actually matches the advertised shape.
+ */
+
+type Schema = {
+  $ref?: string;
+  type?: string;
+  description?: string;
+  required?: string[];
+  properties?: Record<string, Schema>;
+  items?: Schema;
+};
+type Document = {
+  components?: { schemas?: Record<string, Schema> };
+  paths: Record<string, Record<string, { responses?: Record<string, { content?: Record<string, { schema?: Schema }> }> }> | undefined>;
+};
+
+let app: INestApplication;
+let document: Document;
+
+const collectRefs = (node: unknown, acc: string[] = []): string[] => {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      collectRefs(child, acc);
+    }
+    return acc;
+  }
+  if (node !== null && typeof node === "object") {
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$ref" && typeof value === "string") {
+        acc.push(value);
+      } else {
+        collectRefs(value, acc);
+      }
+    }
+  }
+  return acc;
+};
+
+beforeAll(async () => {
+  const moduleRef = await Test.createTestingModule({ imports: [AppModule.forRoot()] }).compile();
+  app = moduleRef.createNestApplication();
+  await app.init();
+
+  document = registerKavoSchemas(
+    SwaggerModule.createDocument(app, new DocumentBuilder().setTitle("t").setVersion("0").build()),
+  ) as unknown as Document;
+});
+
+afterAll(async () => {
+  if (app !== undefined) {
+    await app.close();
+  }
+});
+
+describe("nested includable-relation $ref composition in the Pet example (issue #356)", () => {
+  const schemas = (): Record<string, Schema> => document.components?.schemas ?? {};
+
+  it("composes RegionItem → ZoneItem → LandmarkItem by $ref", () => {
+    expect(schemas().RegionItem?.properties?.zones).toEqual({
+      type: "array",
+      items: { $ref: "#/components/schemas/ZoneItem" },
+    });
+    expect(schemas().ZoneItem?.properties?.landmarks).toEqual({
+      type: "array",
+      items: { $ref: "#/components/schemas/LandmarkItem" },
+    });
+    expect(schemas().LandmarkItem?.properties?.zone).toEqual({ $ref: "#/components/schemas/ZoneItem" });
+  });
+
+  it("emits the Zone ↔ Region cycle as a mutual $ref, still a valid document", () => {
+    expect(schemas().ZoneItem?.properties?.region).toEqual({ $ref: "#/components/schemas/RegionItem" });
+    // RegionItem.zones → ZoneItem.region → RegionItem — a cycle in the
+    // component graph, legal OpenAPI 3.x.
+    const names = new Set(Object.keys(schemas()));
+    const dangling = collectRefs(document).filter((ref) => !names.has(ref.replace("#/components/schemas/", "")));
+    expect(dangling).toEqual([]);
+  });
+
+  it("keeps the relation properties optional (never in required)", () => {
+    expect(schemas().RegionItem?.required ?? []).not.toContain("zones");
+    expect(schemas().ZoneItem?.required ?? []).not.toContain("region");
+  });
+
+  it("returns a nested tree over include=zones.landmarks that matches the advertised shape", async () => {
+    const server = app.getHttpServer();
+    const region = await request(server).post("/regions").send({ name: "North" }).expect(201);
+    const zone = await request(server).post("/zones").send({ name: "N-1", region: { id: region.body.id } }).expect(201);
+    await request(server)
+      .post("/landmarks")
+      .send({ name: "Tower", zone: { id: zone.body.id } })
+      .expect(201);
+
+    const fetched = await request(server).get(`/regions/${region.body.id}?include=zones.landmarks`).expect(200);
+    expect(fetched.body).toMatchObject({
+      id: region.body.id,
+      name: "North",
+      zones: [{ name: "N-1", landmarks: [{ name: "Tower" }] }],
+    });
+  });
+});

--- a/packages/frameworks/nest/src/register-schemas.ts
+++ b/packages/frameworks/nest/src/register-schemas.ts
@@ -64,6 +64,18 @@
  * component; the same shape under two names (`<Entity>Update` /
  * `<Entity>Patch` when no `dto.patch` is set) is emitted under both.
  *
+ * **Includable-relation `$ref`s (issue #356).** `applyResponseSchemaDocs`
+ * leaves an `x-kavo-includable-ref: "<Target>"` marker on any includable
+ * relation the parent set no one-hop `selectable` ceiling for — bind time
+ * cannot name the target component, since naming happens here. After every
+ * response has hoisted, a final pass (`resolveIncludableRefs`) walks every
+ * registered component and rewrites each marker to a `$ref` to that entity's
+ * real `<Target>Item` (first-wins name, `_2` and all), or — when the target
+ * published no synthesized item schema (an explicit `item` DTO, or no read
+ * route) — to a plain `{ type: "object" }`, so the document never carries a
+ * dangling `$ref`. `$ref` cycles from mutual/self relations are valid
+ * OpenAPI 3.x and left as-is.
+ *
  * The helper mutates and returns the document, so it composes inline:
  *
  * ```ts
@@ -84,8 +96,17 @@ interface SchemaObject {
   properties?: Record<string, SchemaObject>;
   items?: SchemaObject;
   allOf?: SchemaObject[];
+  /**
+   * Bind-time marker (`applyResponseSchemaDocs`) on an includable relation
+   * the parent set no `selectable` ceiling for: the target entity's resolved
+   * name. `resolveIncludableRefs` swaps the whole object for a `$ref` to that
+   * entity's `<Target>Item` component once every component name is known.
+   */
+  "x-kavo-includable-ref"?: string;
   [key: string]: unknown;
 }
+
+const REF_PREFIX = "#/components/schemas/";
 
 interface MediaType {
   schema?: SchemaObject;
@@ -123,6 +144,11 @@ export function registerKavoSchemas<T extends object>(document: T): T {
   const components = (doc.components ??= {});
   const schemas = (components.schemas ??= {});
   const registry = new SchemaRegistry(schemas);
+  // Entity name -> the actual component name its synthesized single-row
+  // `<Entity>Item` landed on (`<Entity>Item`, or `<Entity>Item_2` on a
+  // cross-entity collision). Filled as responses hoist; read afterwards to
+  // resolve `x-kavo-includable-ref` markers to real `$ref`s.
+  const itemComponentByEntity = new Map<string, string>();
 
   for (const pathItem of Object.values(doc.paths ?? {})) {
     if (pathItem === undefined) {
@@ -137,12 +163,101 @@ export function registerKavoSchemas<T extends object>(document: T): T {
         continue;
       }
       hoistRequestBody(registry, operation, entity);
-      hoistResponses(registry, operation, entity);
+      hoistResponses(registry, operation, entity, itemComponentByEntity);
       hoistQuerySchemas(registry, operation, entity);
     }
   }
 
+  // Every `<Entity>Item` name is now known, so an includable-relation marker
+  // (`applyResponseSchemaDocs`, no parent ceiling) can be resolved to a
+  // `$ref` to its target's item component — or degraded to a plain object
+  // when that target has no synthesized item schema. Runs over every
+  // registered component so a marker on `<Entity>Item` and its structural
+  // twin on `<Entity>ListItem` are both rewritten.
+  resolveIncludableRefs(schemas, itemComponentByEntity);
+
   return document;
+}
+
+/**
+ * Rewrite the `x-kavo-includable-ref` markers `applyResponseSchemaDocs`
+ * leaves on includable relations that have no parent `selectable` ceiling.
+ * Bind time cannot name the target component (this pass owns naming, and a
+ * cross-entity clash can bump it to `<Target>Item_2`), so it records only
+ * the target entity name; here each marker becomes either a `$ref` to that
+ * entity's real item component or — when the entity published no synthesized
+ * item schema (an explicit `item` DTO, or no read route) — a plain
+ * `{ type: "object" }` with a prose description, so the document never
+ * carries a dangling `$ref`. `$ref` cycles (mutual or self relations) are
+ * valid OpenAPI 3.x and are left as-is.
+ */
+function resolveIncludableRefs(
+  schemas: Record<string, SchemaObject>,
+  itemComponentByEntity: Map<string, string>,
+): void {
+  for (const schema of Object.values(schemas)) {
+    walkIncludableRefs(schema, itemComponentByEntity);
+  }
+}
+
+function walkIncludableRefs(node: unknown, itemComponentByEntity: Map<string, string>): void {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      walkIncludableRefs(child, itemComponentByEntity);
+    }
+    return;
+  }
+  if (node === null || typeof node !== "object") {
+    return;
+  }
+  const record = node as Record<string, unknown>;
+  const properties = record.properties;
+  if (properties !== null && typeof properties === "object") {
+    for (const [key, value] of Object.entries(properties as Record<string, unknown>)) {
+      const replacement = resolvedIncludableRef(value, itemComponentByEntity);
+      if (replacement === undefined) {
+        walkIncludableRefs(value, itemComponentByEntity);
+      } else {
+        (properties as Record<string, unknown>)[key] = replacement;
+      }
+    }
+  }
+  // A `-to-many` relation is `{ type: "array", items: <marker> }`, so the
+  // marker can sit directly on `items` as well as on a `properties` entry.
+  if (record.items !== undefined) {
+    const replacement = resolvedIncludableRef(record.items, itemComponentByEntity);
+    if (replacement === undefined) {
+      walkIncludableRefs(record.items, itemComponentByEntity);
+    } else {
+      record.items = replacement;
+    }
+  }
+  for (const key of ["allOf", "anyOf", "oneOf"]) {
+    if (Array.isArray(record[key])) {
+      walkIncludableRefs(record[key], itemComponentByEntity);
+    }
+  }
+}
+
+function resolvedIncludableRef(value: unknown, itemComponentByEntity: Map<string, string>): SchemaObject | undefined {
+  if (value === null || typeof value !== "object") {
+    return undefined;
+  }
+  const target = (value as Record<string, unknown>)["x-kavo-includable-ref"];
+  if (typeof target !== "string") {
+    return undefined;
+  }
+  const component = itemComponentByEntity.get(target);
+  if (component !== undefined) {
+    return { $ref: `${REF_PREFIX}${component}` };
+  }
+  return {
+    type: "object",
+    description:
+      `Embedded when \`include=\` names this relation; its shape mirrors the ${target}Item component. ` +
+      `That component is not published — the ${target} entity has no synthesized item schema ` +
+      `(an explicit item DTO, or no read route).`,
+  };
 }
 
 function hoistRequestBody(registry: SchemaRegistry, operation: OperationObject, entity: string): void {
@@ -175,7 +290,12 @@ function detach(schema: SchemaObject): SchemaObject {
   return clone(schema);
 }
 
-function hoistResponses(registry: SchemaRegistry, operation: OperationObject, entity: string): void {
+function hoistResponses(
+  registry: SchemaRegistry,
+  operation: OperationObject,
+  entity: string,
+  itemComponentByEntity: Map<string, string>,
+): void {
   const isMany = operation["x-kavo-cardinality"] === "many";
   for (const response of Object.values(operation.responses ?? {})) {
     const media = response?.content?.[JSON_MEDIA];
@@ -208,7 +328,19 @@ function hoistResponses(registry: SchemaRegistry, operation: OperationObject, en
       }
       media.schema = registry.register(schema, scoped ? `${entity}${opName}List` : `${entity}List`);
     } else {
-      media.schema = registry.register(schema, scoped ? `${entity}${opName}` : `${entity}Item`);
+      const ref = registry.register(schema, scoped ? `${entity}${opName}` : `${entity}Item`);
+      media.schema = ref;
+      // The shared root `<Entity>Item` is what an includable-relation marker
+      // on another entity resolves a `$ref` to — record the name it actually
+      // landed on. A per-operation `<Entity><Operation>` shape is a different
+      // component and never a relation target. First-wins, to agree with
+      // `SchemaRegistry`'s own collision policy: two `@Kavo` classes over one
+      // entity with different configs (a pattern @kavo/nest's own tests use)
+      // register `<Entity>Item` then `<Entity>Item_2`, and a marker should
+      // point at the first.
+      if (!scoped && typeof ref.$ref === "string" && !itemComponentByEntity.has(entity)) {
+        itemComponentByEntity.set(entity, ref.$ref.slice(REF_PREFIX.length));
+      }
     }
   }
 }

--- a/packages/frameworks/nest/src/swagger.ts
+++ b/packages/frameworks/nest/src/swagger.ts
@@ -1367,33 +1367,51 @@ const alreadyResponseSchemaDocumented = new WeakSet<object>();
  * A relation on `allowlists.includable` (ADR-0028) can be embedded in the
  * row (`?include=word`), so it is emitted as an **optional** property —
  * never in `required`, since it is only present when `include=` asks for
- * it. Its shape is the ceiling a relation-dotted `selectable` entry imposes
- * (`selectable: ["word.id"]`, ADR-0044) as an object limited to those
- * fields, or a generic object when the relation carries no ceiling — the
- * target's own projection is governed by the target entity's config, not
- * this one (`entity-catalog.ts`), so it is not reproduced here. Each ceiling
- * field is typed from the target entity's own `metadata.fields`, passed in
- * as `relationTargetMetadata` (the binder resolves it via
- * `infrastructure.metadataFor(relation.target())`). A ceiling field falls
- * back to an untyped `{}` rather than a guessed type in two cases: the
- * target as a whole is unresolvable (no infrastructure, or a root that
- * cannot derive its metadata), or the target resolves but carries no column
- * of that name (a ceiling entry naming a field the target does not have).
- * A `-to-many`
- * relation wraps that object in `{ type: "array", items }`. The relation
- * object is deliberately left unstamped by `withKavoEntity`: a stamped
- * nested schema would be hoisted to its own component by
- * `registerKavoSchemas` instead of staying inline on `<Entity>Item`.
+ * it, and this shape is shared with the write responses, which never
+ * resolve `include=` at all (ADR-0020: "a write resolves no query, so a
+ * write response never carries relations"). Its shape depends on whether
+ * the parent narrowed it:
+ *
+ * - **Parent one-hop `selectable` ceiling** (`selectable: ["word.id"]`,
+ *   ADR-0044) — an inline object limited to those fields, each typed from
+ *   the target entity's own `metadata.fields`, passed in as
+ *   `relationTargetMetadata` (the binder resolves it via
+ *   `infrastructure.metadataFor(relation.target())`). A ceiling field falls
+ *   back to an untyped `{}` in two cases: the target as a whole is
+ *   unresolvable (no infrastructure, or a root that cannot derive its
+ *   metadata), or the target resolves but carries no column of that name.
+ *   Left unstamped by `withKavoEntity` so `registerKavoSchemas` keeps it
+ *   inline rather than hoisting it as its own component.
+ *
+ * - **No parent ceiling** — the parent defers wholly to the target, so
+ *   this emits an unstamped marker (`x-kavo-includable-ref: "<Target>"`)
+ *   carrying only the target entity's resolved name. It is *not* a `$ref`
+ *   yet: bind time does not know the final component name
+ *   (`registerKavoSchemas` owns naming and may land on `<Target>Item_2` on
+ *   a collision). `registerKavoSchemas` resolves each marker in a post-pass
+ *   to `{ $ref: "#/components/schemas/<Target>Item" }`, or — when the
+ *   target has no synthesized item component (its own read route registered
+ *   an explicit DTO, or it has no read route) — to a degraded
+ *   `{ type: "object" }` with a prose description. A document that never
+ *   runs `registerKavoSchemas` keeps the marker inline, which is still a
+ *   valid schema (an object with a vendor extension and a description),
+ *   just not `$ref`-composed. When the target's name cannot be resolved at
+ *   bind time, no marker is emitted and the property stays a generic
+ *   `{ type: "object" }` with a description.
+ *
+ * A `-to-many` relation wraps whichever shape in `{ type: "array", items }`.
  *
  * The property rides the shared `item` shape, so it appears on the
- * `createOne`/`updateOne`/`patchOne` responses too, even though a write
- * never resolves `include=` (ADR-0044, "reads only"). That is deliberate:
+ * `createOne`/`updateOne`/`patchOne` responses too. That is deliberate:
  * gating it on `descriptor.kind === "read"` would make the read route's
  * schema structurally differ from the write routes', and
  * `registerKavoSchemas` only collapses structurally-identical repeats — so
  * every entity with an includable relation would publish both `<Entity>Item`
  * and `<Entity>Item_2`. The property is optional, so a write response that
- * omits it stays valid against the schema.
+ * omits it stays valid against the schema. For the same reason a
+ * `defaultInclude: true` relation is **not** promoted to `required`: it is
+ * carried only by reads, and a `required` property a write response omits
+ * would make the shared schema lie.
  */
 export function applyResponseSchemaDocs(
   prototype: Record<string, unknown>,
@@ -1468,24 +1486,45 @@ export function applyResponseSchemaDocs(
       continue;
     }
     const ceiling = relationProjection?.[relationName];
-    const targetFields = relationTargetMetadata[relationName]?.fields;
-    const object =
-      ceiling !== undefined
-        ? {
-            type: "object",
-            properties: Object.fromEntries(
-              ceiling.map((name) => {
-                const field = targetFields?.find((candidate) => candidate.name === name);
-                return [name, field !== undefined ? fieldSchema(field) : {}];
-              }),
-            ),
-          }
-        : {
-            type: "object",
-            description:
-              `Embedded when \`include=${relationName}\` is requested. Its projection is governed by ` +
-              `the ${relationName} target's own config (ADR-0026); no relation-dotted \`selectable\` ceiling is set here.`,
-          };
+    const targetMetadata = relationTargetMetadata[relationName];
+    const targetFields = targetMetadata?.fields;
+    let object: object;
+    if (ceiling !== undefined) {
+      // Parent narrowed this relation with a one-hop `selectable` ceiling
+      // (ADR-0044) — reproduce exactly those fields, typed from the target.
+      object = {
+        type: "object",
+        properties: Object.fromEntries(
+          ceiling.map((name) => {
+            const field = targetFields?.find((candidate) => candidate.name === name);
+            return [name, field !== undefined ? fieldSchema(field) : {}];
+          }),
+        ),
+      };
+    } else if (targetMetadata !== undefined) {
+      // No parent ceiling — defer wholly to the target. Emit a marker
+      // carrying the target entity's resolved name; `registerKavoSchemas`
+      // turns it into a `$ref` to `<Target>Item` (or a degraded object when
+      // that component was never synthesized). Unstamped by `withKavoEntity`
+      // so the marker itself is not hoisted as an entity component.
+      object = {
+        type: "object",
+        "x-kavo-includable-ref": targetMetadata.name,
+        description:
+          `Embedded when \`include=${relationName}\` is requested; its shape is the ` +
+          `${targetMetadata.name}Item component. Its projection is governed by the target entity's own ` +
+          `config (ADR-0026), not this one.`,
+      };
+    } else {
+      // Target metadata unresolvable from this root — no name to reference,
+      // so fall back to a generic object rather than a dangling marker.
+      object = {
+        type: "object",
+        description:
+          `Embedded when \`include=${relationName}\` is requested. Its projection is governed by ` +
+          `the ${relationName} target's own config (ADR-0026); no relation-dotted \`selectable\` ceiling is set here.`,
+      };
+    }
     properties[relationName] = relation.cardinality === "many" ? { type: "array", items: object } : object;
   }
   const element = { type: "object" as const, properties, ...(required.length > 0 ? { required } : {}) };

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -34,7 +34,7 @@ import {
   oneOfArray,
   registerKavoSchemas,
 } from "@kavo/nest";
-import { InMemoryTodoAdapter, Todo, TodoList, fakeInfrastructure } from "./support/fake-infrastructure.js";
+import { InMemoryTodoAdapter, Todo, TodoList, TodoTag, fakeInfrastructure } from "./support/fake-infrastructure.js";
 import { boundServer, listen, type SupertestTarget } from "./support/listen.js";
 
 let app: INestApplication;
@@ -3222,6 +3222,291 @@ describe("@Kavo Swagger fallback success-response schema when no item/list DTO i
     // `list` is a relation on `Todo` but not on `allowlists.includable`, so
     // the synthesized schema stays exactly the scalar `selectable` set.
     expect(Object.keys(itemBody("/todos/{id}", "get", "200")?.properties ?? {})).toEqual(["id", "title"]);
+  });
+});
+
+describe("@Kavo Swagger recursive includable-relation $ref composition (issue #356)", () => {
+  type Schema = {
+    type?: string;
+    properties?: Record<string, Schema>;
+    items?: Schema;
+    required?: string[];
+    description?: string;
+    $ref?: string;
+    "x-kavo-entity"?: string;
+    "x-kavo-includable-ref"?: string;
+  };
+  type Doc = {
+    paths: Record<
+      string,
+      Record<string, { responses?: Record<string, { content?: Record<string, { schema?: Schema }> }> }>
+    >;
+    components?: { schemas?: Record<string, Schema> };
+  };
+
+  const stubAdapter = (): RepositoryAdapter<object> =>
+    ({
+      findOneById: async () => null,
+      findOne: async () => null,
+      findMany: async () => [],
+      count: async () => 0,
+      create: async (data: unknown) => data,
+      update: async (_id: unknown, data: unknown) => data,
+      patch: async (_id: unknown, data: unknown) => data,
+      delete: async () => {},
+      restore: async () => {
+        throw new Error("not exercised");
+      },
+      purge: async () => {},
+    }) as unknown as RepositoryAdapter<object>;
+
+  const buildDoc = async (infrastructure: KavoInfrastructure, controllers: unknown[]): Promise<Doc> => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [KavoModule.forRoot({ infrastructure }), KavoModule.forFeature(controllers as never[])],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    return SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle("t").setVersion("0").build(),
+    ) as unknown as Doc;
+  };
+
+  const itemSchema = (doc: Doc, path: string, verb: string, status: string): Schema | undefined =>
+    doc.paths[path]?.[verb]?.responses?.[status]?.content?.["application/json"]?.schema;
+
+  /** Every `$ref` anywhere in the document points at a component that exists. */
+  const collectRefs = (node: unknown, acc: string[] = []): string[] => {
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        collectRefs(child, acc);
+      }
+      return acc;
+    }
+    if (node !== null && typeof node === "object") {
+      for (const [key, value] of Object.entries(node)) {
+        if (key === "$ref" && typeof value === "string") {
+          acc.push(value);
+        } else {
+          collectRefs(value, acc);
+        }
+      }
+    }
+    return acc;
+  };
+  const expectEveryRefResolves = (doc: Doc): void => {
+    const names = Object.keys(doc.components?.schemas ?? {});
+    for (const ref of collectRefs(doc)) {
+      expect(ref.startsWith("#/components/schemas/")).toBe(true);
+      expect(names).toContain(ref.slice("#/components/schemas/".length));
+    }
+  };
+
+  /** Follow a `{ $ref }` (or an array's `items.$ref`) to the named component. */
+  const deref = (doc: Doc, node: Schema | undefined): Schema | undefined => {
+    const ref = node?.$ref ?? node?.items?.$ref;
+    if (ref === undefined) {
+      return undefined;
+    }
+    return doc.components?.schemas?.[ref.slice("#/components/schemas/".length)];
+  };
+
+  it("resolves an unbounded includable relation to a $ref to the target's <Entity>Item, recursively", async () => {
+    // `Todo.list -> TodoList`, `TodoList.list -> TodoTag` — all three routed,
+    // none carries a relation-dotted `selectable` ceiling, so each relation
+    // defers wholly to its target and composes by shared component. Exact
+    // component names are not asserted: entity `TodoList` collides with
+    // `Todo`'s own `<Entity>ListItem` envelope element, so `registerKavoSchemas`
+    // legitimately lands `TodoList`'s item on `TodoListItem_2` — the marker
+    // resolution records whichever name it actually got.
+    @Kavo(Todo, { allowlists: { includable: ["list"] } })
+    @Controller("todos")
+    class TodoC {}
+    @Kavo(TodoList, { allowlists: { includable: ["list"] } })
+    @Controller("lists")
+    class ListC {}
+    @Kavo(TodoTag, {})
+    @Controller("tags")
+    class TagC {}
+
+    adapter = new InMemoryTodoAdapter();
+    const doc = await buildDoc(fakeInfrastructure(adapter), [TodoC, ListC, TagC]);
+    registerKavoSchemas(doc);
+
+    // `TodoItem.list` -> entity TodoList's item component (has `name`, TodoList's
+    // own scalar) -> its `list` -> entity TodoTag's item component.
+    const todoListItem = deref(doc, doc.components?.schemas?.TodoItem?.properties?.list);
+    expect(todoListItem?.["x-kavo-entity"]).toBe("TodoList");
+    expect(Object.keys(todoListItem?.properties ?? {})).toContain("name");
+
+    const todoTagItem = deref(doc, todoListItem?.properties?.list);
+    expect(todoTagItem?.["x-kavo-entity"]).toBe("TodoTag");
+
+    expectEveryRefResolves(doc);
+  });
+
+  it("keeps a parent-ceilinged relation inline and does not $ref the target (ADR-0044)", async () => {
+    @Kavo(Todo, { allowlists: { includable: ["list"], selectable: ["id", "title", "list.id"] } })
+    @Controller("todos")
+    class CeilingC {}
+    @Kavo(TodoList, {})
+    @Controller("lists")
+    class ListC {}
+
+    adapter = new InMemoryTodoAdapter();
+    const doc = await buildDoc(fakeInfrastructure(adapter), [CeilingC, ListC]);
+    registerKavoSchemas(doc);
+
+    const list = doc.components?.schemas?.TodoItem?.properties?.list;
+    // Parent narrowed it to `{ id }`, so the parent wins: an inline object,
+    // never a `$ref` to `TodoListItem` (which would re-widen it).
+    expect(list?.$ref).toBeUndefined();
+    expect(list).toEqual({ type: "object", properties: { id: { type: "number" } } });
+    expectEveryRefResolves(doc);
+  });
+
+  it("degrades to a plain object when the relation target has no synthesized item component", async () => {
+    // `TodoList` is not routed, so no `TodoListItem` is ever registered.
+    @Kavo(Todo, { allowlists: { includable: ["list"] } })
+    @Controller("todos")
+    class TodoOnlyC {}
+
+    adapter = new InMemoryTodoAdapter();
+    const doc = await buildDoc(fakeInfrastructure(adapter), [TodoOnlyC]);
+    registerKavoSchemas(doc);
+
+    const list = doc.components?.schemas?.TodoItem?.properties?.list;
+    expect(list?.$ref).toBeUndefined();
+    expect(list?.type).toBe("object");
+    expect(list?.description).toContain("not published");
+    // No dangling reference anywhere.
+    expectEveryRefResolves(doc);
+  });
+
+  it("produces a valid document for a relation cycle (mutual $ref)", async () => {
+    class Author {}
+    class Book {}
+    const authorMetadata: EntityMetadata<object> = {
+      entity: Author,
+      name: "Author",
+      idField: "id",
+      fields: [
+        { name: "id", kind: "number", nullable: false, generated: true },
+        { name: "name", kind: "string", nullable: false, generated: false },
+      ],
+      relations: [{ name: "books", target: () => Book, cardinality: "many", includable: true, strategy: "auto" }],
+    };
+    const bookMetadata: EntityMetadata<object> = {
+      entity: Book,
+      name: "Book",
+      idField: "id",
+      fields: [
+        { name: "id", kind: "number", nullable: false, generated: true },
+        { name: "title", kind: "string", nullable: false, generated: false },
+      ],
+      relations: [{ name: "author", target: () => Author, cardinality: "one", includable: true, strategy: "auto" }],
+    };
+    const infrastructure: KavoInfrastructure = {
+      metadataFor: ((entity: unknown) => (entity === Author ? authorMetadata : bookMetadata)) as never,
+      adapterFor: () => stubAdapter() as never,
+    };
+
+    @Controller("authors")
+    class AuthorC {}
+    @Controller("books")
+    class BookC {}
+    // `Author`/`Book` have no declared fields, so the config's relation-name
+    // types infer to `never`; apply the decorator as a plain cast call, the
+    // same escape hatch the fallback-schema blocks above use.
+    const authorConfig: unknown = { allowlists: { includable: ["books"] } };
+    const bookConfig: unknown = { allowlists: { includable: ["author"] } };
+    Kavo(Author, authorConfig as Parameters<typeof Kavo>[1])(AuthorC);
+    Kavo(Book, bookConfig as Parameters<typeof Kavo>[1])(BookC);
+
+    const doc = await buildDoc(infrastructure, [AuthorC, BookC]);
+    registerKavoSchemas(doc);
+
+    const schemas = doc.components?.schemas ?? {};
+    expect(schemas.AuthorItem?.properties?.books).toEqual({
+      type: "array",
+      items: { $ref: "#/components/schemas/BookItem" },
+    });
+    expect(schemas.BookItem?.properties?.author).toEqual({ $ref: "#/components/schemas/AuthorItem" });
+    // The component graph is cyclic — legal OpenAPI 3.x — and every ref still
+    // resolves.
+    expectEveryRefResolves(doc);
+  });
+
+  it("keeps a defaultInclude relation optional, still $ref'd (write responses carry no relations, ADR-0020)", async () => {
+    @Kavo(Todo, {
+      allowlists: { includable: ["list"] },
+      relations: { edges: { list: { defaultInclude: true } } },
+    })
+    @Controller("todos")
+    class DefaultIncludeC {}
+    @Kavo(TodoList, {})
+    @Controller("lists")
+    class ListC {}
+
+    adapter = new InMemoryTodoAdapter();
+    const doc = await buildDoc(fakeInfrastructure(adapter), [DefaultIncludeC, ListC]);
+    registerKavoSchemas(doc);
+
+    const item = doc.components?.schemas?.TodoItem;
+    expect(item?.properties?.list?.$ref).toBeDefined();
+    expect(deref(doc, item?.properties?.list)?.["x-kavo-entity"]).toBe("TodoList");
+    // Shared with the create/update/patch responses, which never resolve
+    // `include=`, so promoting it to `required` would make those lie.
+    expect(item?.required ?? []).not.toContain("list");
+    expectEveryRefResolves(doc);
+  });
+
+  it("composes to the target's configured item shape when it registers a plain-class item DTO", async () => {
+    // A plain-class `item` DTO is still hoisted by Kavo under the target's
+    // `<Entity>Item` name (from the DTO's runtime shape), so the marker
+    // resolves to it — the relation reflects whatever the target publishes,
+    // not the raw column set.
+    class TodoListItemDto {
+      id = 0;
+      name = "";
+    }
+    @Kavo(Todo, { allowlists: { includable: ["list"] } })
+    @Controller("todos")
+    class TodoC {}
+    @Kavo(TodoList, { dto: { item: TodoListItemDto } })
+    @Controller("lists")
+    class ListC {}
+
+    adapter = new InMemoryTodoAdapter();
+    const doc = await buildDoc(fakeInfrastructure(adapter), [TodoC, ListC]);
+    registerKavoSchemas(doc);
+
+    const list = doc.components?.schemas?.TodoItem?.properties?.list;
+    expect(list?.$ref).toBeDefined();
+    const target = deref(doc, list);
+    expect(target?.["x-kavo-entity"]).toBe("TodoList");
+    // The DTO's shape, not `TodoList`'s full column set.
+    expect(Object.keys(target?.properties ?? {})).toEqual(["id", "name"]);
+    expectEveryRefResolves(doc);
+  });
+
+  it("leaves the marker inline (and valid) when registerKavoSchemas is not run", async () => {
+    @Kavo(Todo, { allowlists: { includable: ["list"] } })
+    @Controller("todos")
+    class TodoC {}
+    @Kavo(TodoList, {})
+    @Controller("lists")
+    class ListC {}
+
+    adapter = new InMemoryTodoAdapter();
+    const doc = await buildDoc(fakeInfrastructure(adapter), [TodoC, ListC]);
+
+    const list = itemSchema(doc, "/todos/{id}", "get", "200")?.properties?.list;
+    // Un-hoisted: the marker rides inline as a plain object schema plus a
+    // vendor extension — still a valid schema, just not `$ref`-composed.
+    expect(list?.["x-kavo-includable-ref"]).toBe("TodoList");
+    expect(list?.type).toBe("object");
+    expect(list?.description).toContain("include=list");
   });
 });
 


### PR DESCRIPTION
## What & why

The synthesized `<Entity>Item` Swagger schema stopped one hop deep: an includable relation with no parent one-hop `selectable` ceiling was emitted as a bare `{ type: "object" }`, so `include=word.dictionary` — valid at runtime — produced a schema that stopped at `word`, with no way for a client generator to type the nested node.

An includable relation with no parent ceiling now defers wholly to its target. `applyResponseSchemaDocs` emits an unstamped `x-kavo-includable-ref` marker carrying the target entity's resolved name, and `registerKavoSchemas`, after every response has hoisted, rewrites each marker to a `$ref` to that entity's own `<Target>Item` component. Nested include paths therefore type transitively by composing shared components, and `$ref` cycles from mutual or self relations are valid OpenAPI 3.x and left as-is. Bind time cannot name the target component itself (naming happens in `registerKavoSchemas`, and a cross-entity clash can bump `<Target>Item` to `<Target>Item_2`), so it records only the entity name and the post-pass resolves to whichever name the item component actually landed on, first-wins. When the target published no synthesized item schema, the marker degrades to a plain object with a description rather than a dangling `$ref`.

The parent one-hop `selectable` ceiling still wins where set (ADR-0044) — unchanged. A `defaultInclude: true` relation stays **optional**, not `required`: `<Entity>Item` is shared with write responses, which resolve no `include=` and carry no relations (ADR-0020), so a `required` property they omit would make the shared schema lie. No `@kavo/core` change — the request-side nesting bound stays `relations.maxIncludeDepth`, with no separate Swagger depth control.

Closes #356 (issue #357 was closed as superseded — its bounded-walk premise does not apply to `$ref` composition).

## Public API impact

None. No barrel export added or changed. The new `x-kavo-includable-ref` marker is internal plumbing, stripped or rewritten before the published document.

## Testing

New describe block in `packages/frameworks/nest/tests/binding.e2e.spec.ts` (7 tests): nested `$ref` chain (2 hops), parent-ceiling stays inline, degraded fallback when the target is not routed, plain-class item DTO composes to the DTO shape, mutual-relation cycle produces a valid document, `defaultInclude` stays optional and still `$ref`'d, and the marker stays inline and valid when `registerKavoSchemas` is not run. A reusable `expectEveryRefResolves` helper asserts every `$ref` in each hoisted document resolves.

`pnpm check`: build, typecheck, depcruise, lint, and **2989** unit/e2e tests pass. The only failures are 5 testcontainers e2e specs (`app-postgres`, `app-mariadb`, `app-cockroach`, `app-mongo`, mikroorm `app-postgres`) — all `Could not find a working container runtime strategy`, i.e. no Docker daemon in the local environment. Pre-existing and unrelated to this change; they run in CI. `pnpm docs:links` passes.

## Review notes

- **`defaultInclude` -> `required` was deliberately not implemented.** ADR-0020 states a write resolves no query and carries no relations, and `<Entity>Item` is shared read/write, so promoting to `required` would produce an invalid write-response schema. The revised #356 §4 calls for exactly this negative branch.
- The `itemComponentByEntity` map is **first-wins**, to agree with `SchemaRegistry`'s own collision policy when two `@Kavo` classes over one entity register `<Entity>Item` then `<Entity>Item_2`.
- No formal OpenAPI 3.x meta-schema validation in the cycle test — that needs a new dependency; the load-bearing checks (every `$ref` resolves, generation terminates) are asserted instead.
- The "target registers a *decorated* DTO that `@nestjs/swagger` hoists as its own `$ref`" sub-case has no dedicated fixture: Kavo hoists plain-class DTOs under `<Entity>Item` itself (covered), and the genuine no-component path is covered by the not-routed test, which exercises the same `itemComponentByEntity` miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Swagger documentation for included relationships.
  * Added support for nested and recursive relationship includes, including cyclic relationships.
  * Included relationships now use target item schemas when available, with safe object fallbacks otherwise.
  * Relationship projections remain supported, and relationship fields stay optional.
  * Added a nested Region, Zone, and Landmark example demonstrating multi-level includes.

* **Tests**
  * Expanded validation for generated schemas, references, projections, fallbacks, optional relationships, and cyclic structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Reference app.** `examples/nest-typeorm` gains a `Region -> Zone -> Landmark` chain (`src/nested-demo/`) -- three `@Kavo` controllers, no item DTOs, no ceilings -- so `/docs` shows the composition live: `RegionItem.zones` is an array of `$ref ZoneItem`, `ZoneItem.landmarks` an array of `$ref LandmarkItem`, and `ZoneItem.region` a `$ref` back to `RegionItem` (a legal cycle). `tests/nested-demo.e2e.spec.ts` pins the `$ref` chain, asserts no dangling reference anywhere in the generated document, and round-trips `GET /regions/:id?include=zones.landmarks`.
