### PR TITLE
fix(example): make the example start scripts compile before running

### DIFF
--- a/examples/nest-mikroorm/README.md
+++ b/examples/nest-mikroorm/README.md
@@ -13,7 +13,7 @@ behaves identically to `nest-typeorm`, that is the seam doing its job; where it
 differs, the difference is real and worth seeing.
 
 ```bash
-pnpm build && pnpm --filter @kavo/example-nest-mikroorm start
+pnpm --filter @kavo/example-nest-mikroorm start
 # → http://localhost:3002/cats   (Swagger at /docs)
 ```
 
@@ -23,7 +23,7 @@ it at a Postgres instead:
 
 ```bash
 docker run --rm -e POSTGRES_PASSWORD=kavo -p 5432:5432 postgres:18-alpine
-pnpm build && PGDATABASE=postgres PGPASSWORD=kavo pnpm --filter @kavo/example-nest-mikroorm start
+PGDATABASE=postgres PGPASSWORD=kavo pnpm --filter @kavo/example-nest-mikroorm start
 ```
 
 Unlike `nest-typeorm`, this app has no CockroachDB flavour: MikroORM has no

--- a/examples/nest-mikroorm/package.json
+++ b/examples/nest-mikroorm/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b",
-    "start": "node dist/main.js"
+    "clean": "tsc -b --clean",
+    "start": "tsc -b --force && node dist/main.js"
   },
   "dependencies": {
     "@kavo/core": "workspace:*",

--- a/examples/nest-mongoose/README.md
+++ b/examples/nest-mongoose/README.md
@@ -13,7 +13,7 @@ decorator, engine, and route generation working over MongoDB.
 
 ```bash
 docker run --rm -p 27017:27017 mongo:8
-pnpm build && MONGO_URL=mongodb://127.0.0.1:27017/kavo pnpm --filter @kavo/example-nest-mongoose start
+MONGO_URL=mongodb://127.0.0.1:27017/kavo pnpm --filter @kavo/example-nest-mongoose start
 # → http://localhost:3001/articles   (Swagger at /docs)
 ```
 

--- a/examples/nest-mongoose/package.json
+++ b/examples/nest-mongoose/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b",
-    "start": "node dist/main.js"
+    "clean": "tsc -b --clean",
+    "start": "tsc -b --force && node dist/main.js"
   },
   "dependencies": {
     "@kavo/core": "workspace:*",

--- a/examples/nest-typeorm/README.md
+++ b/examples/nest-typeorm/README.md
@@ -30,10 +30,13 @@ itself is `class-validator`-decorated) has nothing to fall back to either.
 
 ## SQLite (default)
 
-No setup required — an in-memory database is created fresh on every run.
+No setup required — an in-memory database is created fresh on every run. The
+`start` scripts compile first (`tsc -b --force`), so no separate `pnpm build`
+is needed; run `pnpm --filter @kavo/example-nest-typeorm clean` to reset the
+incremental build state.
 
 ```bash
-pnpm build && pnpm --filter @kavo/example-nest-typeorm start
+pnpm --filter @kavo/example-nest-typeorm start
 # → http://localhost:3000/cats   (Swagger at /docs)
 ```
 
@@ -44,7 +47,7 @@ with connection settings hardcoded to match a single local container:
 
 ```bash
 docker run --rm -e POSTGRES_PASSWORD=kavo -e POSTGRES_DB=kavo -p 5432:5432 postgres:18-alpine
-pnpm build && pnpm --filter @kavo/example-nest-typeorm start:postgres
+pnpm --filter @kavo/example-nest-typeorm start:postgres
 # → http://localhost:3000/cats   (Swagger at /docs)
 ```
 
@@ -62,7 +65,7 @@ connection settings hardcoded to match a single local container:
 
 ```bash
 docker run --rm -e MARIADB_ROOT_PASSWORD=kavo -e MARIADB_DATABASE=kavo -p 3306:3306 mariadb:12
-pnpm build && pnpm --filter @kavo/example-nest-typeorm start:mariadb
+pnpm --filter @kavo/example-nest-typeorm start:mariadb
 # → http://localhost:3000/cats   (Swagger at /docs)
 ```
 
@@ -77,7 +80,7 @@ with connection settings hardcoded to match a single local container:
 
 ```bash
 docker run --rm -e COCKROACH_DATABASE=kavo -e COCKROACH_USER=root -p 26257:26257 cockroachdb/cockroach:v25.2.22 start-single-node --insecure
-pnpm build && pnpm --filter @kavo/example-nest-typeorm start:cockroach
+pnpm --filter @kavo/example-nest-typeorm start:cockroach
 # → http://localhost:3000/cats   (Swagger at /docs)
 ```
 

--- a/examples/nest-typeorm/package.json
+++ b/examples/nest-typeorm/package.json
@@ -7,10 +7,11 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b",
-    "start": "node dist/main.js",
-    "start:postgres": "node dist/main-postgres.js",
-    "start:mariadb": "node dist/main-mariadb.js",
-    "start:cockroach": "node dist/main-cockroach.js"
+    "clean": "tsc -b --clean",
+    "start": "tsc -b --force && node dist/main.js",
+    "start:postgres": "tsc -b --force && node dist/main-postgres.js",
+    "start:mariadb": "tsc -b --force && node dist/main-mariadb.js",
+    "start:cockroach": "tsc -b --force && node dist/main-cockroach.js"
   },
   "dependencies": {
     "@kavo/core": "workspace:*",


### PR DESCRIPTION
## What & why

`pnpm --filter @kavo/example-nest-typeorm start` is `node dist/main.js` with no build step. From a fresh checkout — or any state where `dist/` was removed but the gitignored `tsconfig.tsbuildinfo` next to `tsconfig.json` lingered — it fails with `Cannot find module dist/main.js`: plain `tsc -b` reads the stale buildinfo, reports "up to date", and emits nothing, so `dist/` is never recreated.

Each `start` script now runs `tsc -b --force` first (always re-emits regardless of incremental state, and builds the referenced `@kavo/*` projects transitively), and a new `clean` script wraps `tsc -b --clean`. The three example READMEs drop the now-redundant `pnpm build &&` prefix. Applied to all three nest examples for consistency.

## Public API impact

None. Example package scripts and READMEs only.

## Testing

`pnpm check` green. Verified `pnpm --filter @kavo/example-nest-typeorm start` boots the app after `rm -rf examples/nest-typeorm/dist` (the previously-broken state). `pnpm docs:links` passes.

## Review notes

`tsc -b --force` recompiles the referenced package graph on every `start` (~a few seconds warm). Acceptable for a reference app run occasionally, and there is no watch/dev mode to preserve; the alternative (deleting the stale buildinfo in a pre-step) is less portable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example startup instructions to use each example’s package-scoped start commands directly.
  * Removed redundant workspace build steps from MikroORM, Mongoose, and TypeORM setup instructions.
  * Documented the TypeORM SQLite clean command.

* **Developer Experience**
  * Example start commands now force a fresh TypeScript build before launching.
  * Added clean commands to remove generated build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->