### PR TITLE
Add relation-path filtering tests for TypeORM adapter

### DIFF
--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -462,6 +462,82 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
     expect(list.items.map((b) => (b as Book).title)).toEqual(["Notes"]);
   });
 
+  it("filters a to-one relation path with an operator other than EQ", async () => {
+    const scoped = kavo.createCrud(Book, {
+      allowlists: { filterable: ["title", "author.name" as never] },
+    }) as DefaultKavoService<Book>;
+    await seed();
+    const ada = (await authors.findMany()).items.map((a) => a as Author).find((a) => a.name === "Ada")!;
+    const grace = (await authors.findMany()).items.map((a) => a as Author).find((a) => a.name === "Grace")!;
+    await dataSource.getRepository(Book).save([
+      { title: "Notes", author: { id: ada.id } },
+      { title: "Other", author: { id: grace.id } },
+    ] as never);
+
+    const list = await scoped.findMany({
+      filter: {
+        kind: "condition",
+        field: "author.name" as never,
+        operator: "LIKE",
+        value: "A%",
+      },
+    });
+    expect(list.items.map((b) => (b as Book).title)).toEqual(["Notes"]);
+  });
+
+  it("filters through the reverse one-to-many relation path", async () => {
+    // Author -> books is the OneToMany side; a filter on `books.title`
+    // still joins and restricts, it just doesn't select the relation
+    // (that's what `include=` is for).
+    const scoped = kavo.createCrud(Author, {
+      allowlists: { filterable: ["name", "books.title" as never] },
+    }) as DefaultKavoService<Author>;
+    await seed();
+    const ada = (await authors.findMany()).items.map((a) => a as Author).find((a) => a.name === "Ada")!;
+    await dataSource.getRepository(Book).save([{ title: "Dune", author: { id: ada.id } }] as never);
+
+    const list = await scoped.findMany({
+      filter: { kind: "condition", field: "books.title" as never, operator: "EQ", value: "Dune" },
+    });
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Ada"]);
+  });
+
+  it("combines a relation-path condition with an own-field condition under AND", async () => {
+    const scoped = kavo.createCrud(Book, {
+      allowlists: { filterable: ["title", "author.name" as never] },
+    }) as DefaultKavoService<Book>;
+    await seed();
+    const ada = (await authors.findMany()).items.map((a) => a as Author).find((a) => a.name === "Ada")!;
+    await dataSource.getRepository(Book).save([
+      { title: "Notes", author: { id: ada.id } },
+      { title: "Other Notes", author: { id: ada.id } },
+    ] as never);
+
+    const list = await scoped.findMany({
+      filter: {
+        kind: "group",
+        operator: "AND",
+        children: [
+          { kind: "condition", field: "author.name" as never, operator: "EQ", value: "Ada" },
+          { kind: "condition", field: "title", operator: "EQ", value: "Notes" },
+        ],
+      },
+    });
+    expect(list.items.map((b) => (b as Book).title)).toEqual(["Notes"]);
+  });
+
+  it("rejects a relation-path filter that isn't on the filterable allowlist", async () => {
+    const scoped = kavo.createCrud(Book, {
+      allowlists: { filterable: ["title"] },
+    }) as DefaultKavoService<Book>;
+
+    await expect(
+      scoped.findMany({
+        filter: { kind: "condition", field: "author.name" as never, operator: "EQ", value: "Ada" },
+      }),
+    ).rejects.toBeInstanceOf(QueryValidationException);
+  });
+
   // Issue #371: a user reported that `allowlists.filterable: { exclude }`
   // silently does nothing end-to-end and only the plain array form works.
   // `resolveEntityConfig` already covers `{ exclude }` in isolation

--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -461,6 +461,31 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
     });
     expect(list.items.map((b) => (b as Book).title)).toEqual(["Notes"]);
   });
+
+  // Issue #371: a user reported that `allowlists.filterable: { exclude }`
+  // silently does nothing end-to-end and only the plain array form works.
+  // `resolveEntityConfig` already covers `{ exclude }` in isolation
+  // (packages/core/tests/config.spec.ts) — this exercises the same shape
+  // through a real `createCrud` + TypeORM adapter + `findMany`, the path the
+  // report actually hit.
+  it("still rejects a filter on a field named in allowlists.filterable's { exclude } form (issue #371)", async () => {
+    const excluded = kavo.createCrud(Author, {
+      allowlists: { filterable: { exclude: ["status"] } },
+    }) as DefaultKavoService<Author>;
+    await seed();
+
+    await expect(
+      excluded.findMany({
+        filter: { kind: "condition", field: "status", operator: "EQ", value: "active" },
+      }),
+    ).rejects.toBeInstanceOf(QueryValidationException);
+
+    // A field not named in `exclude` still filters normally.
+    const list = await excluded.findMany({
+      filter: { kind: "condition", field: "name", operator: "EQ", value: "Ada" },
+    });
+    expect(list.items.map((a) => (a as Author).name)).toEqual(["Ada"]);
+  });
 });
 
 /** A normalized query with no filter — what a custom handler hands the reader. */


### PR DESCRIPTION
## What & why

Adds comprehensive test coverage for relation-path filtering in the TypeORM adapter, including:

- Filtering through to-one relations with non-EQ operators (e.g., `LIKE`)
- Filtering through reverse one-to-many relations
- Combining relation-path conditions with own-field conditions under AND
- Validation that relation-path filters respect the filterable allowlist
- End-to-end validation of the `{ exclude }` form of `allowlists.filterable` (issue #371)

These tests exercise the query translation layer to ensure relation joins and restrictions work correctly across different filter scenarios and allowlist configurations.

## Public API impact

None

## Testing

Added 5 new test cases to `packages/orms/typeorm/tests/adapter.spec.ts` covering relation-path filtering scenarios. All tests pass with `pnpm check`.

## Review notes

The tests validate both happy-path filtering (various operators and relation directions) and rejection cases (unauthorized fields via allowlist). Issue #371 is specifically addressed with an end-to-end test confirming that the `{ exclude }` form of `allowlists.filterable` properly rejects excluded fields while allowing others.

https://claude.ai/code/session_01CHyCkhsYxVERiGP2YSMwS2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for filtering across related records, including multiple comparison operators and reverse one-to-many relationships.
  * Added tests for combining relationship filters with local fields.
  * Added coverage confirming excluded fields are rejected while permitted fields remain filterable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->