### PR TITLE
feat(core)!: add unified defaults block for sort, select, and include

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -414,6 +414,10 @@ const config = defineConfig({
                 text: "0045 — The allowed.selectable allowlist takes root paths only; the relation-dotted ceiling is removed",
                 link: "/internals/adr/0045-relation-projection-ceiling-removed",
               },
+              {
+                text: "0046 — A defaults block covers what a request looks like when the client asks for nothing",
+                link: "/internals/adr/0046-defaults-block-for-omitted-query-axes",
+              },
             ],
           },
         ],

--- a/docs/features/relations.md
+++ b/docs/features/relations.md
@@ -6,11 +6,12 @@
 
 Whether a relation may be included at all is a separate question, answered by `allowed.includable` (entity scope only). See [Allowed](/features/allowed) ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)).
 
-An entry in `edges` tunes loading for a relation that is already includable. It grants no permission by itself: naming a relation in `edges` alone does not open it to `include=`.
+Which includable relations load by default is yet another question, answered by `defaults.include` (see [Settings](/guides/configuration/settings#defaults)) — a flat list of relation names, e.g. `defaults: { include: ["author"] }`. Each entry must also be named in `allowed.includable`, or it's a bootstrap error.
+
+An entry in `edges` tunes loading for a relation that is already includable. It grants no permission and no default by itself: naming a relation in `edges` alone neither opens it to `include=` nor includes it by default.
 
 ## `relations.edges.<name>` (`RelationEdgeSettings`)
 
-- `defaultInclude` (default `false`): includes this relation even when the client doesn't ask for it. It requires the relation to also be named in `allowed.includable`, or it's a bootstrap error.
 - `maxDepth` (default inherits `relations.maxIncludeDepth`): overrides the include-depth limit for the subtree below this relation only.
 - `strategy` (default `"auto"`, or `"join"`/`"batch"`/`"key"`): controls how the relation loads. `join` runs a single query and is correct for to-one relations. `batch` runs a per-level `WHERE parentId IN (...)` and is correct for to-many relations. `auto` picks one of the two based on cardinality. `key` (owning-side to-one only) is the cheapest option when a caller wants nothing but the foreign key: it materializes the edge as `{ <pk>: value }` read straight off the parent row's own FK column — no join — and serializes a `null` FK as `null`. It grants no permission of its own (the edge is still includable only via `allowed.includable`), `select[<rel>]` may name only the primary key, and it is rejected at bootstrap on a to-many edge or an inverse `@OneToOne` (neither has a local FK). A composite-key target is not supported yet. How cheap it is depends on the ORM: MikroORM and Mongoose drop the edge's load entirely, TypeORM reads it from the row it already fetched for a many-to-one (one extra id-only query for an owning one-to-one), and Prisma still issues its own relation query but selects only the id.
 - `write` (default `false`): opts a to-many relation into `arrayMutation` writes (below). Two spellings: `write: true` opts in and inherits the entity's own `arrayMutation.strategy`. `write: { strategy }` opts in and pins this relation's own strategy, independent of the entity default, so two relations on the same entity can use two different strategies.

--- a/docs/guides/configuration/settings.md
+++ b/docs/guides/configuration/settings.md
@@ -24,13 +24,21 @@ Pair either keyset strategy with `count: false`, and index the sort tuple. The G
 
 `maxFilterDepth` (default `3`) is the max nesting depth of the `filter` AST (`and`/`or` groups nested inside each other). `maxInValues` (default `100`) is the max array length for `in`, `notIn`, and `between` filter operators. `maxLikePatternLength` (default `200`) is the max character length of a `like`/`ilike` pattern.
 
-`defaultSort` (default `[]`) is the sort order applied when a request supplies no `sort` of its own. A client-supplied `sort` always wins outright; it never merges with this. It's validated against the sortable allowlist, same as a client-supplied sort.
-
 `search` (default `false`) controls whether `search[query]` is accepted at all. It's a `400` until a scope sets it to an object (`{}` uses the defaults), even though `allowed.searchable` itself defaults to every own string column; set it back to `false` at a narrower scope to disable it there. See [Search](/querying/search). `search.mode` (default `"substring"`, or `"words"`) is the default `search[mode]` when a request doesn't override it per call. `search.driver` (default `"orm"`) is a reserved discriminator for a future pluggable search backend; it's the only value accepted today, and it's config-only (there is no `search[driver]` wire token). A narrower scope re-enabling search from `false` may name only the keys it changes — the rest backfill from these defaults.
 
 ## errors
 
 `exposeInternals` (default `false`) controls whether driver-level error details (raw SQL error messages, stack info) leak into problem-details responses. Keep it `false` in production.
+
+## defaults
+
+What a request looks like when the client specifies nothing — the omission-side counterpart to `allowed` (see [Entity config](/guides/configuration/entity-config)). Applied only when the request omits that axis; a client-supplied value replaces it outright, never merges.
+
+`sort` (default `[]`) is the sort order applied when a request supplies no `sort` of its own, in the same wire shorthand `sort=` accepts (`-field` for descending, comma-separated conceptually but declared as an array — `["​-createdAt", "id"]`). A client-supplied `sort` always wins outright; it never merges with this. It's validated against the sortable allowlist, same as a client-supplied sort. `pagination.strategy: "since"` (ADR-0022) still forces its own sort when active, overriding this.
+
+`select` (default unset) is the default response projection: what a read serves when the request sends no `select=` of its own. Unset, behavior is unchanged — every selectable field is projected. Configured, its fields must be on `allowed.selectable`.
+
+`include` (default `[]`) is the list of relations included even when the client's `include=` doesn't name them. Each entry must also be on `allowed.includable` — naming a relation here that clients cannot ask for is a bootstrap error. See [Relations](/features/relations).
 
 ## relations
 

--- a/docs/guides/migrating-relations-v0-10.md
+++ b/docs/guides/migrating-relations-v0-10.md
@@ -9,10 +9,12 @@ To migrate:
 
 `allowed.includable` is entity-scope-only config; there's no global `defaults` and no per-operation override. So a permission that used to come from a global default now needs its own `createCrud`/`@Kavo` registration per entity.
 
-## `defaultInclude` at global scope needs extra care
+## `defaultInclude` moved again, in v0.18 (issue #375)
 
-Before this change, naming a relation in a global `defaults.relations.edges.<name>` was itself the opt-in, so a global `defaultInclude: true` was safe by construction.
+`relations.edges.<name>.defaultInclude` — the per-relation boolean this guide's earlier revisions covered — is also gone now, replaced by a flat `defaults.include` list ([ADR-0046](/internals/adr/0046-defaults-block-for-omitted-query-axes)): `relations.edges.posts.defaultInclude: true` becomes `defaults: { include: ["posts"] }`, alongside the same `allowed.includable` grant as before.
 
-It is not safe to leave where it was. `allowed.includable` cannot be set globally, so a global `defaultInclude: true` with no entity-level `allowed.includable` naming that relation now crashes at bootstrap (`ConfigurationException`) on every entity that has a relation of that name. It is not a silent no-op.
+## `defaults.include` at global scope needs extra care
 
-Move `defaultInclude: true` down to each entity's own `relations.edges.<name>`, alongside that entity's `allowed.includable` grant, instead of leaving it at global scope.
+`allowed.includable` cannot be set globally — it is entity-scope-only config, same as before. A global `defaults.include: ["posts"]` with no entity-level `allowed.includable` naming that relation crashes at bootstrap (`ConfigurationException`) on every entity that has a relation of that name. It is not a silent no-op.
+
+Move `defaults.include` down to each entity's own `defaults`, alongside that entity's `allowed.includable` grant, instead of leaving it at global scope.

--- a/docs/internals/adr/0028-includable-relations-move-into-allowlists.md
+++ b/docs/internals/adr/0028-includable-relations-move-into-allowlists.md
@@ -161,6 +161,17 @@ through `as never`/erasure, which every ORM adapter's own tests use for
 relation names that don't type-check cleanly against a marker class or a
 lean-document shape (ADR-0017, ADR-0018).
 
+## Amendment (ADR-0046)
+
+`defaultInclude` itself later moved out of `relations.edges` entirely, into
+a flat `defaults.include` list (issue #375) — the cross-check this ADR
+describes (`defaultInclude` vs. `allowed.includable`) still holds verbatim,
+just re-homed: `defaults.include` names must still be on `allowed.includable`,
+checked by the same `validateDefaults` (renamed from `validateDefaultSort`)
+this ADR's `validateIncludableRelations` was folded into. `relations.edges`
+now carries only `maxDepth`/`strategy`/`write` — no permission, no default,
+loading tuning only. See ADR-0046 for the full decision.
+
 ## References
 
 - ADR-0026 (`allowed.selectable` narrows the response projection), the

--- a/docs/internals/adr/0046-defaults-block-for-omitted-query-axes.md
+++ b/docs/internals/adr/0046-defaults-block-for-omitted-query-axes.md
@@ -1,0 +1,149 @@
+# ADR-0046 — A `defaults` block covers what a request looks like when the client asks for nothing
+
+**Status:** accepted
+
+## Context
+
+Request defaults were scattered across three unrelated homes, each with its
+own shape and its own scope rules: default sort lived at `query.defaultSort`
+(`Sort[]` — already the internal AST shape, not the wire shorthand `sort=`
+itself accepts); default include was a per-relation boolean,
+`relations.edges.<name>.defaultInclude`, sitting inside loading tuning it had
+nothing to do with (ADR-0028 already flagged this as an awkward neighbor when
+it moved `includable` out of the same record); and there was no default
+_selection_ at all — an entity with a narrow `allowed.selectable` had no way
+to also narrow what an unadorned `GET` actually returns without either
+forcing every caller to send `select=`, or registering an `item`/`list` DTO
+that also renames the concern for something that is only a projection
+default.
+
+All three answer the same question — "what does this request look like when
+the client specifies nothing for this axis?" — but a reader had to already
+know to look in three different subtrees, one of them fully absent, to find
+the answer. `allowed` (`QueryAllowed`, entity-config.ts) is the equivalent
+single home for the opposite question, "what may a request specify at all?"
+(issue #374 renamed the allowlists block to `allowed`); there was no
+omission-side counterpart.
+
+`defaultInclude`'s placement had a second, sharper problem beyond
+discoverability: it stayed cross-checked against `allowed.includable`
+(ADR-0028) via a name-keyed boolean scattered per relation, which meant
+adding a `defaults.select` in the same idiom would have meant inventing yet
+another per-field boolean map — a shape none of `filterable`/`sortable`/
+`selectable` use for their own omission behavior today, since none of them
+had one yet.
+
+## Decision
+
+**A new `defaults` block lands on `KavoSettings`, with exactly three keys:
+`sort`, `select`, `include`.** Like every other `KavoSettings` subtree, it
+merges through the ordinary precedence chain — `built-in defaults → global →
+entity → operation → per-call` — with the same replace-wholesale array
+algebra `mergeSettings` already applies everywhere else (`merge-settings.ts`).
+The semantics are one sentence, and the same sentence for all three keys:
+**applied only when the request omits that axis; a client-supplied value
+replaces it outright, never merges with it** — the exact rule
+`query.defaultSort` already had, just generalized.
+
+**`query.defaultSort` and `relations.edges.<name>.defaultInclude` are deleted
+outright — no alias, no deprecation shim.** `defaults.sort` and
+`defaults.include` are their replacements, not new names for the same field:
+`defaults.sort` also changes shape (below), and `defaults.include` changes
+the storage granularity from "one boolean per relation record" to "one flat
+list, entity-wide."
+
+**`defaults.sort` takes the same wire shorthand `sort=` does — plain strings,
+`-field` for descending — not the internal `Sort` AST.** Previously
+`query.defaultSort: Sort[]` forced every caller to spell out `{ field,
+direction }` objects for a _default_, while the client-facing spelling of the
+identical concept was a comma-separated string. `defaults: { sort: ["-createdAt",
+"id"] }` reads the same as `?sort=-createdAt,id` because it _is_ the same
+grammar. `QueryNormalizer.defaultSortOf` (`query-normalizer.ts`) parses each
+token with the same per-token logic `parseSort` already uses for the wire
+param — extracted once, as `parseSortToken` — rather than duplicating the
+`-` prefix convention a second time.
+
+**`defaults.select` is new: an entity-wide list, not a DTO.** Absent (the
+default), behavior is unchanged: every selectable field is projected, exactly
+as today. Configured, it becomes the effective `select.root` whenever the
+request sends none — resolved in `QueryNormalizer` on both the wire and
+programmatic paths, the same place `defaultSortOf` already runs, so
+`@kavo/graphql`/`@kavo/mcp` inherit it with no binding-side change (both
+delegate entirely to `QueryNormalizer`, ADR-0016).
+
+**`defaults.include` replaces the per-relation `defaultInclude` boolean with
+one flat list of relation names, entity-wide.** The ADR-0028 cross-check —
+`defaultInclude` on a relation not in `allowed.includable` is a bootstrap
+error, "it would load a relation clients cannot ask for" — moves with it
+unchanged in spirit: every name in `defaults.include` must also be in
+`allowed.includable`. `RelationDescriptor.defaultInclude` (the field the
+include resolver actually reads at request time) still exists and is still
+populated by `DefaultRelationRegistry`, just from the new `defaultIncludes`
+constructor parameter instead of from `edges[name].defaultInclude` —
+`relations.edges` keeps only pure loading tuning (`maxDepth`/`strategy`/
+`write`) now, with nothing permission- or default-shaped left in it.
+
+**All three keys are validated in two stages, following the existing
+pattern.** `validateSettings` (`validate-settings.ts`) checks shape alone —
+each key is an array of non-empty strings, `defaults.select` only when
+present — because it only ever sees `KavoSettings`, which carries no `Entity`
+type parameter and so cannot check field names against real metadata.
+`validateDefaults` (`resolve-entity-config.ts`, the renamed and widened
+`validateDefaultSort`) cross-checks resolved values against the resolved
+`allowed` allowlist — `defaults.sort` fields (after stripping a leading `-`)
+against `sortable`, `defaults.select` fields against `selectable`,
+`defaults.include` relations against `includable` — run at both entity scope
+and per-operation scope, the same two call sites `validateDefaultSort`/
+`validateIncludableRelations` already ran at.
+
+**`KavoSettings` stays entity-agnostic; `defaults` is not entity-typed.** The
+same reasoning ADR-0028 gave for why `includable` had to leave
+`RelationEdgeSettings`(and could not just gain typed keys in place) does not
+apply here in reverse: `defaults` is not moving _out of_ `KavoSettings` the
+way `includable` moved out of it, so there was no equivalent forcing
+function to give it compile-time `FieldPath<Entity>` typing the way `allowed`
+has. Every key stays a plain `readonly string[]`, the same laxity
+`relations.edges`'s keys and `RealtimeFieldSelector` already have, for the
+same reason: `KavoSettings` is one schema for global, entity, operation, and
+per-call scope alike, and only entity scope ever has a concrete `Entity` to
+type against.
+
+## Consequences
+
+**This is a breaking change.** Any app setting `query.defaultSort` or
+`relations.edges.<name>.defaultInclude` needs a mechanical migration:
+`query.defaultSort: [{ field: "createdAt", direction: "desc" }]` becomes
+`defaults: { sort: ["-createdAt"] }`; `relations.edges.<name>.defaultInclude:
+true` becomes `defaults: { include: ["<name>"] }` (with `allowed.includable`
+still granting the relation, unchanged). Neither migration is purely a
+rename — the sort shape changes from AST objects to wire strings, and the
+include default moves from a per-relation record to one flat entity-wide
+list.
+
+**The same global-scope hazard ADR-0028 already documented for
+`defaultInclude` applies unchanged to `defaults.include`.** `allowed` sits
+outside `resolveEntityConfig`'s `SETTINGS_KEYS`, so it can only be set at
+entity scope. A `defaults.include` set at global (`createKavo`) scope with no
+matching entity-level `allowed.includable` grant is a bootstrap
+`ConfigurationException` on every entity that happens to have a relation of
+that name — loud, not a silent no-op, the same posture ADR-0028 chose.
+
+**`DefaultRelationRegistry`'s constructor grew a sixth parameter.**
+`(descriptors, includable, edges, entityName, arrayMutationDefault,
+defaultIncludes)` — appended at the end, not inserted, so existing positional
+callers passing fewer arguments keep compiling if they relied on the
+trailing defaults; any caller constructing one directly and wiring
+`defaultInclude` needs to move that list into the new parameter.
+
+## References
+
+- ADR-0028, the direct precedent this decision generalizes: the two-call-site
+  validation pattern, the "grants nothing, only tunes loading" split for
+  `relations.edges`, and the global-scope hazard `defaults.include` inherits
+  verbatim.
+- ADR-0026 (`allowed.selectable` narrows the response projection), the
+  request/response permission counterpart `defaults.select` is the omission
+  side of.
+- ADR-0022 (`since` pagination forces its own sort), which still overrides
+  `defaults.sort` when active — unchanged by this decision.
+- `docs/internals/architecture/08-configuration.md` §2 and §4.

--- a/docs/internals/architecture/05-query-grammar.md
+++ b/docs/internals/architecture/05-query-grammar.md
@@ -151,7 +151,7 @@ LOWER(:v)`), identical on every driver. Both operators apply to string
 - **Sort:** `sort=-createdAt,name` — comma-separated, `-` prefix =
   descending, list order is priority order. Sortable-allowlist enforced.
   A request that supplies no `sort` falls back to the resolved
-  `query.defaultSort` setting (doc 08) if one is configured; a client- or
+  `defaults.sort` setting (doc 08) if one is configured; a client- or
   caller-supplied `sort` always wins outright over the default rather than
   merging with it. With neither, there is no `ORDER BY` at all — row order
   is DB-dependent.

--- a/docs/internals/architecture/08-configuration.md
+++ b/docs/internals/architecture/08-configuration.md
@@ -17,13 +17,13 @@ built-in defaults → global (createKavo) → entity (createCrud)
 | `pagination.strategy`                                              | `"offset"`                               | `"page"` built in; custom via `paginationStrategies`                                                                                                                                                                                                                                                                            |
 | `pagination.count`                                                 | `true`                                   | `false` skips the count query; envelope reports `total: null`                                                                                                                                                                                                                                                                   |
 | `query.maxFilterDepth` / `maxInValues`                             | 3 / 100                                  |                                                                                                                                                                                                                                                                                                                                 |
-| `query.defaultSort`                                                | `[]` (unset)                             | order applied when a request supplies no `sort` (issue #56); see below                                                                                                                                                                                                                                                          |
 | `query.search`                                                     | `false`                                  | `false` or `{ mode, driver }`; `search[query]` is a 400 until a scope sets an object (issue #156, doc 05 §4). `mode`/`driver` backfill from their defaults when a partial re-enables it                                                                                                                                         |
 | `query.search.mode`                                                | `"substring"`                            | `"substring"` \| `"words"`; per-call override via `search[mode]`                                                                                                                                                                                                                                                                |
 | `query.search.driver`                                              | `"orm"`                                  | reserved discriminator — the only value accepted today; config-only, no wire counterpart                                                                                                                                                                                                                                        |
 | `errors.exposeInternals`                                           | `false`                                  | leak driver detail into responses                                                                                                                                                                                                                                                                                               |
 | `relations.maxIncludeDepth` / `maxIncludedNodes`                   | 2 / 10                                   | include depth budget and total node cap                                                                                                                                                                                                                                                                                         |
-| `relations.edges.<name>`                                           | `{}`                                     | per-relation loading tuning — `defaultInclude` / `maxDepth` / `strategy`; permission is `allowed.includable`, entity scope only (ADR-0028)                                                                                                                                                                                      |
+| `relations.edges.<name>`                                           | `{}`                                     | per-relation loading tuning — `maxDepth` / `strategy` / `write`; permission is `allowed.includable`, default inclusion is `defaults.include`, both entity scope only (ADR-0028, ADR-0046)                                                                                                                                       |
+| `defaults.sort` / `select` / `include`                             | `[]` / unset / `[]`                      | what a request looks like when the client specifies nothing (issue #375); see below                                                                                                                                                                                                                                             |
 | `relations.edges.<name>.write`                                     | unset (`false`)                          | `boolean \| { strategy }` — opts a to-many relation into `arrayMutation` writes, inheriting the entity default (`true`) or pinning its own strategy (`{ strategy }`, issue #223); rejected on a to-one relation                                                                                                                 |
 | `arrayMutation.strategy`                                           | unset — no built-in default (issue #221) | `"replace"` \| `"resource"` \| `"jsonPatch"` — all three are implemented; the entity-wide default a `write: true` relation inherits; a write-opted relation with no strategy resolvable anywhere demands one be declared; `false` disables the feature wholesale and wins over any per-relation override (ADR-0029, issue #223) |
 | `cache.ttl` / `etag`                                               | `0` / `true`                             | TTL result cache for `findOne`/`findMany` (a positive `ttl` turns it on, `0` = off — no separate `enabled` key) + ETag on single-item responses with `If-None-Match`/`If-Match`; the result cache's backing store is **not** here (ADR-0020, ADR-0031)                                                                          |
@@ -183,21 +183,35 @@ if a caller still passes one — fails at bootstrap with a
 `ConfigurationException` naming the entity and the scope's path, the same
 bar every other entry in this section holds to.
 
-### `query.defaultSort`
+### `defaults.sort`
 
 Order applied when a request supplies no `sort` at all — a client- or
 caller-supplied `sort`, when present, always wins outright; the two never
-merge. Each entry is `{ field, direction }` (the same shape as a parsed
-`Sort`), resolved through the full precedence chain like every other
-setting, so it can be set globally, per entity, per operation, or per call.
-Fields are checked against the same sortable allowlist client-supplied
-`sort` fields are checked against, but as soon as the value is set rather
-than when a request uses it: at **bootstrap** (`resolveEntityConfig`) for
-global/entity/operation scope, and when a per-call override is merged
-(`KavoEngine.configViewFor`) for per-call scope — so a bad default fails
-fast at the scope that introduced it instead of producing a broken
-`ORDER BY` on the first request that hits it. Doc 05 covers the
-request-time semantics (client `sort` vs. this fallback).
+merge. Each entry is the same wire shorthand `sort=` accepts (`-field` for
+descending), not the internal `Sort` AST — `QueryNormalizer.defaultSortOf`
+parses each token with the same per-token logic `parseSort` uses for the
+wire param (issue #375). It resolves through the full precedence chain like
+every other setting, so it can be set globally, per entity, per operation,
+or per call. Fields are checked against the same sortable allowlist
+client-supplied `sort` fields are checked against, but as soon as the value
+is set rather than when a request uses it: at **bootstrap**
+(`resolveEntityConfig`) for global/entity/operation scope, and when a
+per-call override is merged (`KavoEngine.configViewFor`) for per-call scope
+— so a bad default fails fast at the scope that introduced it instead of
+producing a broken `ORDER BY` on the first request that hits it. Doc 05
+covers the request-time semantics (client `sort` vs. this fallback).
+
+### `defaults.select` / `defaults.include`
+
+The other two `defaults` keys (issue #375), same posture: applied only on
+omission, checked against the resolved allowlist at the same two points
+`defaults.sort` is. `defaults.select` fields are checked against
+`selectable`; absent, the projection is unchanged (every selectable field).
+`defaults.include` names are checked against `includable`
+([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists),
+[ADR-0046](/internals/adr/0046-defaults-block-for-omitted-query-axes)) — the
+replacement for the old per-relation `relations.edges.<name>.defaultInclude`
+boolean, now one flat entity-wide list.
 
 ### `allowed.searchable`
 
@@ -209,16 +223,14 @@ permitted (unlike `filterable`/`sortable`), reusing the per-path join
 machinery `filter[...]` already resolves for relation filters. See doc 05
 §4 for the wire grammar it gates.
 
-### `relations.edges.<name>.defaultInclude`
-
-`defaultInclude: true` on a relation absent from `allowed.includable` is a
-bootstrap `ConfigurationException` — it would load a relation clients cannot
-ask for ([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)).
+A name in `defaults.include` absent from `allowed.includable` is a bootstrap
+`ConfigurationException` — it would load a relation clients cannot ask for
+([ADR-0028](/internals/adr/0028-includable-relations-move-into-allowlists)).
 `validateSettings` only ever sees `KavoSettings`, which does not carry
-`allowed`, so this cross-check runs separately, in
-`validateIncludableRelations` (`resolve-entity-config.ts`), once `allowed`
-has resolved — the same reason `query.defaultSort` and
-`pagination.since.field` are checked outside `validateSettings` too.
+`allowed`, so this cross-check runs separately, in `validateDefaults`
+(`resolve-entity-config.ts`, renamed from `validateDefaultSort`), once
+`allowed` has resolved — the same reason `pagination.since.field` is checked
+outside `validateSettings` too.
 
 ## 5. Root factory and framework skin
 

--- a/docs/internals/architecture/12-relations-and-includes.md
+++ b/docs/internals/architecture/12-relations-and-includes.md
@@ -12,30 +12,33 @@ query string and the SQL is documented here.
 Inclusion is an **allowlist**, exactly like filtering and sorting: ORM
 metadata supplies the shape of a relation (name, target, cardinality) and
 config supplies permission, which metadata can never know. A relation
-nobody opted in is a 400, never a silent omission. Permission and loading
-tuning are two different config keys (ADR-0028): `allowed.includable`
-(entity-config.ts) grants `include=` access, one relation segment at a time
-from the root; `relations.edges.<name>` (settings.ts) only tunes
-`defaultInclude`/`maxDepth`/`strategy` for a relation once it is already
-includable — naming a relation in `edges` grants nothing by itself.
+nobody opted in is a 400, never a silent omission. Permission, default
+inclusion, and loading tuning are three different config keys (ADR-0028,
+ADR-0046): `allowed.includable` (entity-config.ts) grants `include=` access,
+one relation segment at a time from the root; `defaults.include`
+(settings.ts) names which includable relations load even when the client's
+`include=` doesn't ask; `relations.edges.<name>` (settings.ts) only tunes
+`maxDepth`/`strategy` for a relation once it is already includable — naming
+a relation in `edges` grants nothing by itself, and naming one in
+`defaults.include` still requires the matching `allowed.includable` grant.
 
 ## 1. The registry
 
-`DefaultRelationRegistry` merges three sources at bootstrap into one
+`DefaultRelationRegistry` merges four sources at bootstrap into one
 `RelationDescriptor` per edge:
 
 | Key                             | Source               | Default                                                                                             |
 | ------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
 | `name`, `target`, `cardinality` | metadata             | —                                                                                                   |
 | `includable`                    | `allowed.includable` | `false` — unconfigured means no relation is includable, unlike every other allowlist key (ADR-0028) |
-| `defaultInclude`                | `relations.edges`    | `false`                                                                                             |
+| `defaultInclude`                | `defaults.include`   | `false`                                                                                             |
 | `maxDepth`                      | `relations.edges`    | inherit `relations.maxIncludeDepth`                                                                 |
 | `strategy`                      | `relations.edges`    | `auto`                                                                                              |
 
-A name in `allowed.includable`, or in `relations.edges`, that the entity
-does not have is a bootstrap `ConfigurationException`: an allowlist typo
-that silently permits nothing looks exactly like working config until the
-first client asks.
+A name in `allowed.includable`, `defaults.include`, or `relations.edges`
+that the entity does not have is a bootstrap `ConfigurationException`: an
+allowlist typo that silently permits nothing looks exactly like working
+config until the first client asks.
 
 ## 2. Resolution (`DefaultIncludeResolver`)
 

--- a/docs/querying/field-selection.md
+++ b/docs/querying/field-selection.md
@@ -6,4 +6,4 @@ GET /books?select=id,title
 
 `select` picks a sparse fieldset for the root resource, validated against the `selectable` allowlist. Narrow an included relation the same way: `select[author]=id,name`.
 
-`selectable` also decides what a response carries when no `select=` is sent. It's the one place to keep a column out of every response. See [Allowed](/features/allowed).
+`selectable` also decides what a response carries when no `select=` is sent — unless the entity configures `defaults.select`, a narrower default projection applied only when the request sends no `select=` of its own (a client-supplied `select=` always wins outright, same as `defaults.sort`). `selectable` is the one place to keep a column out of every response, regardless of `defaults.select`. See [Allowed](/features/allowed) and [Settings](/guides/configuration/settings#defaults).

--- a/docs/querying/pagination.md
+++ b/docs/querying/pagination.md
@@ -51,7 +51,7 @@ Pass it straight back as `?cursor=…` to get the next page, and keep every othe
 
 **A cursor is opaque.** It encodes the previous page's last row projected onto the effective sort. Don't parse it, construct one, or store it as a permanent bookmark: the encoding is an implementation detail and may change. It's not signed and isn't a security boundary. Everything inside it is a comparison value against a field the client can already filter on, so forging one grants nothing that `filter[…]` doesn't already.
 
-**The sort must end in the id field.** Keyset paging needs a total order, so `sort` (or the entity's `query.defaultSort`) has to end in the entity's primary key, like `?sort=-createdAt,id`. A request without one is a 400 naming the field it needs. The sort keys must also be plain scalar columns of the entity, not relation paths and not JSON columns.
+**The sort must end in the id field.** Keyset paging needs a total order, so `sort` (or the entity's `defaults.sort`) has to end in the entity's primary key, like `?sort=-createdAt,id`. A request without one is a 400 naming the field it needs. The sort keys must also be plain scalar columns of the entity, not relation paths and not JSON columns.
 
 **Every cursor sort key must be filterable and selectable too, not just sortable.** A cursor turns each sort key into a filter comparison, and reads its value off the raw row into `meta.nextCursor`. So a field on `allowed.sortable` but missing from `allowed.filterable` or `allowed.selectable` gets rejected with a 400 rather than quietly dropped from the sort. If you narrow one of the three allowlists, narrow all three the same way for any column you page by.
 

--- a/docs/querying/sorting.md
+++ b/docs/querying/sorting.md
@@ -6,4 +6,4 @@ GET /books?sort=-publishedAt,title
 
 `sort` takes a comma-separated field list. A `-` prefix means descending, and the order of the fields sets the priority order. Only fields on the `sortable` allowlist can be used.
 
-If a request supplies no `sort` at all, the entity's configured `query.defaultSort` applies, if it has one. A client-supplied `sort` always wins outright over that default. It doesn't merge with it.
+If a request supplies no `sort` at all, the entity's configured `defaults.sort` applies, if it has one — the same wire shorthand, e.g. `defaults: { sort: ["-publishedAt", "title"] }`. A client-supplied `sort` always wins outright over that default. It doesn't merge with it.

--- a/docs/reference/config-keys.md
+++ b/docs/reference/config-keys.md
@@ -23,7 +23,6 @@ See [Pagination](/querying/pagination) and [Settings](/guides/configuration/sett
 | `query.maxFilterDepth`       | `number`                    | `3`           |
 | `query.maxInValues`          | `number`                    | `100`         |
 | `query.maxLikePatternLength` | `number`                    | `200`         |
-| `query.defaultSort`          | `Sort[]`                    | `[]`          |
 | `query.search`               | `{ mode, driver } \| false` | `false`       |
 | `query.search.mode`          | `"substring" \| "words"`    | `"substring"` |
 | `query.search.driver`        | `"orm"`                     | `"orm"`       |
@@ -40,16 +39,25 @@ See [Errors](/reference/errors).
 
 ## relations
 
-| Key                                     | Type                                   | Default                              |
-| --------------------------------------- | -------------------------------------- | ------------------------------------ |
-| `relations.maxIncludeDepth`             | `number`                               | `2`                                  |
-| `relations.maxIncludedNodes`            | `number`                               | `10`                                 |
-| `relations.edges.<name>.defaultInclude` | `boolean`                              | `false`                              |
-| `relations.edges.<name>.maxDepth`       | `number`                               | inherits `relations.maxIncludeDepth` |
-| `relations.edges.<name>.strategy`       | `"auto" \| "join" \| "batch" \| "key"` | `"auto"`                             |
-| `relations.edges.<name>.write`          | `boolean \| { strategy }`              | `false`                              |
+| Key                               | Type                                   | Default                              |
+| --------------------------------- | -------------------------------------- | ------------------------------------ |
+| `relations.maxIncludeDepth`       | `number`                               | `2`                                  |
+| `relations.maxIncludedNodes`      | `number`                               | `10`                                 |
+| `relations.edges.<name>.maxDepth` | `number`                               | inherits `relations.maxIncludeDepth` |
+| `relations.edges.<name>.strategy` | `"auto" \| "join" \| "batch" \| "key"` | `"auto"`                             |
+| `relations.edges.<name>.write`    | `boolean \| { strategy }`              | `false`                              |
 
-Whether a relation is includable at all is `allowed.includable` (entity scope only); see [Reference/Config keys §allowed](#allowed-entity-scope-only). `relations.edges` is loading tuning for a relation that is already includable. `strategy: "key"` is owning-side to-one only (a to-many or an inverse `@OneToOne` has no local FK — bootstrap error): it materializes the edge as `{ <pk>: value }` read from the parent row's own foreign-key column, no join, `null` when the FK is null. `write: true` inherits the entity's own `arrayMutation.strategy`. `write: { strategy }` pins this relation's own strategy instead, independent of the entity default (issue #223). See [Relations](/features/relations).
+Whether a relation is includable at all is `allowed.includable` (entity scope only); see [Reference/Config keys §allowed](#allowed-entity-scope-only). Which includable relations load by default is `defaults.include`, below. `relations.edges` is loading tuning only for a relation that is already includable — no permission, no default. `strategy: "key"` is owning-side to-one only (a to-many or an inverse `@OneToOne` has no local FK — bootstrap error): it materializes the edge as `{ <pk>: value }` read from the parent row's own foreign-key column, no join, `null` when the FK is null. `write: true` inherits the entity's own `arrayMutation.strategy`. `write: { strategy }` pins this relation's own strategy instead, independent of the entity default (issue #223). See [Relations](/features/relations).
+
+## defaults
+
+| Key                | Type                                           | Default                        |
+| ------------------ | ---------------------------------------------- | ------------------------------ |
+| `defaults.sort`    | `(-FieldPath \| FieldPath)[]` (wire shorthand) | `[]`                           |
+| `defaults.select`  | `FieldPath[]` (optional)                       | unset — every selectable field |
+| `defaults.include` | `string[]` (relation names)                    | `[]`                           |
+
+What a request looks like when the client specifies nothing — applied only when the request omits that axis; a client-supplied value replaces it outright, never merges. `defaults.sort` takes the same wire shorthand `sort=` does (`-field` for descending). `defaults.select` fields must be on `allowed.selectable`; `defaults.include` relations must be on `allowed.includable`. See [Sorting](/querying/sorting), [Field selection](/querying/field-selection), [Relations](/features/relations).
 
 ## arrayMutation
 

--- a/examples/nest-typeorm/tests/pagination-caching.e2e.spec.ts
+++ b/examples/nest-typeorm/tests/pagination-caching.e2e.spec.ts
@@ -40,7 +40,7 @@ class Reading {
 
 @Kavo(Reading, {
   pagination: { strategy: "cursor", defaultLimit: 20, maxLimit: 100 },
-  query: { defaultSort: [{ field: "id", direction: "asc" }] },
+  defaults: { sort: ["id"] },
 })
 @Controller("cursor-readings")
 class CursorReadingController {}

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -20,9 +20,6 @@ export const BUILT_IN_DEFAULTS: KavoSettings = Object.freeze({
     maxFilterDepth: 3,
     maxInValues: 100,
     maxLikePatternLength: 200,
-    // Unset: today's no-`sort`-means-no-`ORDER BY` behavior is unchanged
-    // for apps that don't declare a default.
-    defaultSort: Object.freeze([]),
     // Off by default, the same `false` sentinel `softDelete`/`realtime` use:
     // `search[query]` is rejected until an entity or operation scope sets an
     // object, even though `searchable`'s own default is permissive (doc 05
@@ -39,6 +36,13 @@ export const BUILT_IN_DEFAULTS: KavoSettings = Object.freeze({
     // Inclusion is opt-in: with no edges configured, `include=` has
     // nothing to reach.
     edges: Object.freeze({}),
+  }),
+  // Unset: today's no-`sort`-means-no-`ORDER BY`, no-`select=`-means-every-
+  // selectable-field, and no-`include=`-means-nothing-included behavior is
+  // unchanged for apps that don't declare a default (issue #375).
+  defaults: Object.freeze({
+    sort: Object.freeze([]),
+    include: Object.freeze([]),
   }),
   // Off by default. A full object rather than `false` — like `softDelete`'s
   // default — so a partial `cache: { ttl: 60 }` override merges against a

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -109,9 +109,10 @@ export interface QueryAllowed<Entity = unknown, Computed extends string = never>
    * What a request may name in `include=` — which relations, one path
    * segment at a time from the root, a client may embed at all
    * (ADR-0028). `relations.edges.<name>` (`KavoSettings`, settings.ts)
-   * still tunes `defaultInclude`/`maxDepth`/`strategy` for a relation once
-   * it is includable, but grants no permission itself: naming a relation
-   * there without also naming it here does not open it.
+   * still tunes `maxDepth`/`strategy` for a relation once it is includable,
+   * and `defaults.include` (issue #375) names which includable relations
+   * load by default, but neither grants permission itself: naming a
+   * relation there without also naming it here does not open it.
    *
    * **Opt-in, unlike every other key on this interface.**
    * `filterable`/`sortable`/`selectable` default to "every own

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -40,6 +40,7 @@ const SETTINGS_KEYS = [
   "query",
   "errors",
   "relations",
+  "defaults",
   "cache",
   "softDelete",
   "realtime",
@@ -117,15 +118,15 @@ export function resolveEntityConfig<Entity extends object>(
     ),
   );
   validateSettings(entityName, entitySettings);
-  validateDefaultSort(entityName, entitySettings, allowed);
+  validateDefaults(entityName, entitySettings, allowed);
   validateSincePagination(entityName, metadata, entitySettings, allowed);
-  validateIncludableRelations(entityName, entitySettings, allowed);
   const relations = new DefaultRelationRegistry<Entity>(
     metadata.relations,
     allowed.includable as readonly string[],
     entitySettings.relations.edges,
     entityName,
     entitySettings.arrayMutation,
+    entitySettings.defaults.include,
   );
 
   // Per-operation settings views, precomputed for every operation that
@@ -147,9 +148,8 @@ export function resolveEntityConfig<Entity extends object>(
     const merged = normalizeSearch(mergeSettings(entitySettings, settings));
     const scope = `${entityName}.operations.${operation}`;
     validateSettings(scope, merged);
-    validateDefaultSort(scope, merged, allowed);
+    validateDefaults(scope, merged, allowed);
     validateSincePagination(scope, metadata, merged, allowed);
-    validateIncludableRelations(scope, merged, allowed);
     // Resolve for its validation side effect: a per-operation scope that
     // demands soft delete on an entity without a marker field must fail at
     // bootstrap, not on the first request (the engine recomputes the
@@ -548,49 +548,49 @@ function resolveAllowed<Entity extends object>(
 }
 
 /**
- * `query.defaultSort` fields are checked against the same sortable
- * allowlist client-supplied `sort` fields are checked against at request
- * time — but here, at bootstrap, so a misconfigured default fails fast
- * instead of surfacing as a broken `ORDER BY` on the first request.
+ * Cross-checks the `defaults` block against the `allowed` allowlists it
+ * omission-defaults for (issue #375, ADR-0028's precedent for the
+ * `include` half): `defaults.sort` fields against `sortable`,
+ * `defaults.select` fields against `selectable`, and `defaults.include`
+ * relations against `includable` — the same checks each axis's
+ * client-supplied counterpart gets at request time, but here, at
+ * bootstrap, so a misconfigured default fails fast instead of surfacing as
+ * a broken `ORDER BY`, an over-wide response, or a relation clients cannot
+ * ask for on the first request.
  */
-export function validateDefaultSort<Entity>(
+export function validateDefaults<Entity>(
   scope: string,
   settings: KavoSettings,
   allowed: ResolvedQueryAllowed<Entity>,
 ): void {
   const sortable = allowed.sortable as readonly string[];
-  for (const entry of settings.query.defaultSort) {
-    if (!sortable.includes(entry.field)) {
-      throw new ConfigurationException(
-        scope,
-        "query.defaultSort",
-        `field '${entry.field}' is not in the sortable allowlist`,
-      );
+  for (const entry of settings.defaults.sort) {
+    const field = entry.startsWith("-") ? entry.slice(1) : entry;
+    if (!sortable.includes(field)) {
+      throw new ConfigurationException(scope, "defaults.sort", `field '${field}' is not in the sortable allowlist`);
     }
   }
-}
 
-/**
- * Cross-checks `relations.edges.<name>.defaultInclude` against
- * `allowed.includable` (ADR-0028): `defaultInclude: true` on a relation
- * the entity never opted into `include=` would load something clients
- * cannot ask for — the same rule `validate-settings.ts` enforced when
- * `defaultInclude` and `includable` lived on the same `edges` entry, now
- * checked against the allowlist that carries permission instead.
- */
-function validateIncludableRelations<Entity>(
-  scope: string,
-  settings: KavoSettings,
-  allowed: ResolvedQueryAllowed<Entity>,
-): void {
+  if (settings.defaults.select !== undefined) {
+    const selectable = allowed.selectable as readonly string[];
+    for (const field of settings.defaults.select) {
+      if (!selectable.includes(field)) {
+        throw new ConfigurationException(
+          scope,
+          "defaults.select",
+          `field '${field}' is not in the selectable allowlist`,
+        );
+      }
+    }
+  }
+
   const includable = new Set(allowed.includable as readonly string[]);
-  for (const [name, edge] of Object.entries(settings.relations.edges)) {
-    if (edge.defaultInclude === true && !includable.has(name)) {
+  for (const relation of settings.defaults.include) {
+    if (!includable.has(relation)) {
       throw new ConfigurationException(
         scope,
-        `relations.edges.${name}`,
-        `defaultInclude requires an includable relation — '${name}' is not on allowed.includable, ` +
-          `so it would load a relation clients cannot ask for`,
+        "defaults.include",
+        `'${relation}' is not on allowed.includable, so it would load a relation clients cannot ask for`,
       );
     }
   }

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -1,6 +1,5 @@
 import type { RelationLoadStrategy } from "../relations/relation-descriptor.js";
 import type { StandardOperationId } from "../operations/operation.js";
-import type { Sort } from "../query/sort.js";
 import type { RealtimeEventDto, RealtimeEventId } from "../realtime/realtime-event.js";
 import type { RealtimeTransport } from "../realtime/realtime-transport.js";
 
@@ -76,13 +75,6 @@ export interface QuerySettings {
    */
   readonly maxLikePatternLength: number;
   /**
-   * Order applied when a request supplies no `sort` — a client-supplied
-   * `sort` always wins outright, never merges with this. Fields are
-   * validated against the sortable allowlist at bootstrap, the same as
-   * client-supplied sort fields are at request time.
-   */
-  readonly defaultSort: readonly Sort[];
-  /**
    * `search[query]` free-text search (doc 05 §4). `false` (the default)
    * disables it — `search[query]` is rejected with a 400 until an entity or
    * operation scope sets an object. The same `false` sentinel `softDelete`/
@@ -98,6 +90,49 @@ export interface ErrorSettings {
 }
 
 /**
+ * What a request looks like when the client specifies nothing — the
+ * omission-side counterpart to `allowed` (`QueryAllowed`, entity-config.ts),
+ * which governs what a request may specify at all (issue #375). Applied
+ * only when the request omits that axis; a client-supplied value replaces
+ * it outright, never merges with it — the rule `query.defaultSort` used
+ * before this block existed.
+ *
+ * `KavoSettings` carries no `Entity` type parameter (see `RealtimeFieldSelector`'s
+ * doc for why), so every key here is a plain string, wire-shaped, rather
+ * than a `FieldPath<Entity>` — the same laxity `relations.edges`'s keys
+ * already have.
+ */
+export interface DefaultsSettings {
+  /**
+   * Order applied when a request supplies no `sort` — a client-supplied
+   * `sort` always wins outright, never merges with this. The same wire
+   * shorthand a `sort=` query parameter uses (`-field` for descending,
+   * `field` for ascending, comma-separated conceptually but declared as an
+   * array here), normalized to the internal `Sort` shape by the query
+   * normalizer. Fields are validated against the sortable allowlist at
+   * bootstrap, the same as client-supplied sort fields are at request time.
+   * `pagination.since` (ADR-0022) still forces its own sort when active,
+   * overriding this.
+   */
+  readonly sort: readonly string[];
+  /**
+   * The default response projection — what a read serves when the request
+   * sends no `select=` of its own. Absent (the default) leaves today's
+   * behavior unchanged: every selectable field (and, ultimately,
+   * `allowed.selectable`/the entity-derived projection, ADR-0026). Fields
+   * are validated against the selectable allowlist at bootstrap.
+   */
+  readonly select?: readonly string[];
+  /**
+   * Relations included even when the client's `include=` doesn't name them.
+   * Each entry must also be on `allowed.includable` (ADR-0028's cross-check,
+   * moved here from `relations.edges.<name>.defaultInclude`) — naming a
+   * relation here that clients cannot ask for is a bootstrap error.
+   */
+  readonly include: readonly string[];
+}
+
+/**
  * Per-relation *tuning* — the config half of a `RelationDescriptor` other
  * than permission. ORM metadata supplies shape (name, target,
  * cardinality); this supplies loading behavior once a relation is already
@@ -106,8 +141,6 @@ export interface ErrorSettings {
  * a relation in `edges` no longer opts it in.
  */
 export interface RelationEdgeSettings {
-  /** Included even when the client doesn't ask. */
-  readonly defaultInclude?: boolean;
   /** Overrides `maxIncludeDepth` for the subtree below this node. */
   readonly maxDepth?: number;
   readonly strategy?: RelationLoadStrategy;
@@ -118,7 +151,7 @@ export interface RelationEdgeSettings {
    * `write: true`/`write: {...}` on a to-one relation is a bootstrap
    * `ConfigurationException` (`DefaultRelationRegistry`), since association
    * by id already covers to-one writes and there is no array to mutate.
-   * Like `defaultInclude`, this is a permission a relation must be granted
+   * Like `defaults.include`, this is a permission a relation must be granted
    * explicitly — it is independent of `allowed.includable` (a relation
    * can be write-opted-in without being read-includable, or vice versa).
    *
@@ -145,10 +178,11 @@ export interface RelationSettings {
   readonly maxIncludedNodes: number;
   /**
    * Per-relation loading overrides, keyed by relation property name —
-   * `defaultInclude`/`maxDepth`/`strategy` only. Whether a relation is
-   * includable at all is `allowed.includable`'s question, not this
-   * one (ADR-0028); an entry here for a relation `allowed.includable`
-   * never named still validates and applies its tuning, but grants no
+   * `maxDepth`/`strategy`/`write` only. Whether a relation is includable at
+   * all is `allowed.includable`'s question, and whether it defaults into an
+   * empty request is `defaults.include`'s (issue #375) — neither lives here
+   * any more; an entry here for a relation `allowed.includable` never named
+   * still validates and applies its loading tuning, but grants no
    * permission.
    */
   readonly edges: Readonly<Record<string, RelationEdgeSettings>>;
@@ -344,6 +378,8 @@ export interface KavoSettings {
   readonly query: QuerySettings;
   readonly errors: ErrorSettings;
   readonly relations: RelationSettings;
+  /** What a request looks like when the client specifies nothing (issue #375). */
+  readonly defaults: DefaultsSettings;
   /** Result caching + the conditional-request subtree (ADRs 0020/0031). */
   readonly cache: CacheSettings | false;
   readonly softDelete: SoftDeleteSettings | false;

--- a/packages/core/src/config/validate-settings.ts
+++ b/packages/core/src/config/validate-settings.ts
@@ -55,31 +55,6 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
   positiveInt("query.maxInValues", settings.query.maxInValues);
   positiveInt("query.maxLikePatternLength", settings.query.maxLikePatternLength);
 
-  if (!Array.isArray(settings.query.defaultSort)) {
-    throw new ConfigurationException(
-      entityName,
-      "query.defaultSort",
-      `expected an array, got ${JSON.stringify(settings.query.defaultSort)}`,
-    );
-  }
-  for (const [index, entry] of settings.query.defaultSort.entries()) {
-    const path = `query.defaultSort[${index}]`;
-    if (typeof entry !== "object" || entry === null || typeof entry.field !== "string" || entry.field.length === 0) {
-      throw new ConfigurationException(
-        entityName,
-        path,
-        `expected { field: string, direction: "asc" | "desc" }, got ${JSON.stringify(entry)}`,
-      );
-    }
-    if (entry.direction !== "asc" && entry.direction !== "desc") {
-      throw new ConfigurationException(
-        entityName,
-        `${path}.direction`,
-        `expected "asc" or "desc", got ${JSON.stringify(entry.direction)}`,
-      );
-    }
-  }
-
   const search = settings.query.search;
   if (search !== false) {
     if (search.mode !== "substring" && search.mode !== "words") {
@@ -106,9 +81,6 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
     const path = `relations.edges.${name}`;
     if (typeof edge !== "object" || edge === null) {
       throw new ConfigurationException(entityName, path, `expected an object, got ${JSON.stringify(edge)}`);
-    }
-    if (edge.defaultInclude !== undefined) {
-      bool(`${path}.defaultInclude`, edge.defaultInclude);
     }
     if (edge.maxDepth !== undefined) {
       positiveInt(`${path}.maxDepth`, edge.maxDepth);
@@ -137,11 +109,27 @@ export function validateSettings(entityName: string, settings: KavoSettings): vo
         );
       }
     }
-    // `defaultInclude` vs. `allowed.includable` (permission) is cross-
-    // checked in `resolve-entity-config.ts`'s `validateIncludableRelations`,
-    // not here — this function only sees `KavoSettings`, and `allowed`
-    // is entity-typed config outside that schema (ADR-0028).
   }
+
+  const stringArray = (path: string, value: unknown): void => {
+    if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.length === 0)) {
+      throw new ConfigurationException(
+        entityName,
+        path,
+        `expected an array of non-empty strings, got ${JSON.stringify(value)}`,
+      );
+    }
+  };
+  stringArray("defaults.sort", settings.defaults.sort);
+  if (settings.defaults.select !== undefined) {
+    stringArray("defaults.select", settings.defaults.select);
+  }
+  stringArray("defaults.include", settings.defaults.include);
+  // `defaults.sort`/`defaults.select` vs. `allowed.sortable`/`allowed.selectable`,
+  // and `defaults.include` vs. `allowed.includable` (permission, ADR-0028),
+  // are cross-checked in `resolve-entity-config.ts`'s `validateDefaults`, not
+  // here — this function only sees `KavoSettings`, and `allowed` is
+  // entity-typed config outside that schema.
 
   if (settings.cache !== false) {
     const cache = settings.cache;

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -43,7 +43,7 @@ import { WILDCARD, canonicalize, computeEtag, isEtagEnabled, strongMatch, weakMa
 import { createKavoContext, randomUuid } from "../context/default-kavo-context.js";
 import { mergeSettings } from "../config/merge-settings.js";
 import { validateSettings } from "../config/validate-settings.js";
-import { validateDefaultSort } from "../config/resolve-entity-config.js";
+import { validateDefaults } from "../config/resolve-entity-config.js";
 import { HARD_DELETE, resolveSoftDelete } from "../persistence/soft-delete.js";
 import type { FindManyResult } from "./built-in-handlers.js";
 
@@ -906,7 +906,7 @@ export class KavoEngine<Entity extends object> {
       // reject — `validateSettings` below never sees it.
       const scope = `${config.entityName} (per-call)`;
       validateSettings(scope, settings);
-      validateDefaultSort(scope, settings, config.allowed);
+      validateDefaults(scope, settings, config.allowed);
     }
     if (settings === config.settings) {
       return config;

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -78,7 +78,9 @@ export class QueryNormalizer<Entity = unknown> {
 
     const clientSort = parseSort(rawParams["sort"], config, issues);
     let sort = clientSort.length > 0 ? clientSort : defaultSortOf(config);
-    const select = parseSelect(rawParams, config, issues);
+    const parsedSelect = parseSelect(rawParams, config, issues);
+    const select: FieldSelection<Entity> =
+      parsedSelect.root === null ? { ...parsedSelect, root: defaultSelectOf(config) } : parsedSelect;
     const include = this.resolveIncludes(parseIncludePaths(rawParams["include"], issues), select, config, issues);
 
     let pagination: Pagination<Entity> = { limit: 0, offset: 0 };
@@ -172,7 +174,7 @@ export class QueryNormalizer<Entity = unknown> {
       }
     }
     const select: FieldSelection<Entity> = {
-      root: rootFields,
+      root: rootFields ?? defaultSelectOf(config),
       relations: relationFields,
     };
     const include = this.resolveIncludes(input.include ?? [], select, config, issues);
@@ -332,7 +334,7 @@ export class QueryNormalizer<Entity = unknown> {
           `${tiebreaker.length === 1 ? "field" : "fields, in this order,"} '${tiebreakerText}' — ` +
           `e.g. 'sort=-createdAt,${tiebreakerText}'. ` +
           (sort.length === 0
-            ? `This request has no sort and ${config.entityName} declares no 'query.defaultSort'.`
+            ? `This request has no sort and ${config.entityName} declares no 'defaults.sort'.`
             : `This request sorts by '${sort.map((entry) => entry.field as string).join(", ")}'.`),
       });
     }
@@ -361,7 +363,7 @@ export class QueryNormalizer<Entity = unknown> {
    * same treatment a stray `cursor=`/`since=` under the wrong strategy
    * gets, and for the same reason: silently overriding it would leave a
    * client believing its `sort` took effect when it didn't. A configured
-   * `query.defaultSort`, by contrast, is silently overridden — being
+   * `defaults.sort`, by contrast, is silently overridden — being
    * overridden by a more specific setting is what a default is for.
    *
    * The token carries an id precisely because a single-column
@@ -724,13 +726,22 @@ function conflictingSoftDeleteFlagsIssue(): QueryIssueDto {
 }
 
 /**
- * `config.settings.query.defaultSort` — validated against the sortable
- * allowlist wherever it's set (`resolveEntityConfig` at bootstrap for
- * entity/operation scope, `KavoEngine.configViewFor` for per-call scope),
- * so it's applied here as-is rather than re-checked per request.
+ * `config.settings.defaults.sort` — the same `-field`/`field` wire
+ * shorthand `sort=` accepts, validated against the sortable allowlist
+ * wherever it's set (`resolveEntityConfig` at bootstrap for entity/
+ * operation scope, `KavoEngine.configViewFor` for per-call scope) — so each
+ * token is parsed into the internal `Sort` shape here, with no allowlist
+ * re-check, rather than re-validated per request.
  */
 function defaultSortOf<Entity>(config: ResolvedEntityConfig<Entity>): readonly Sort<Entity>[] {
-  return config.settings.query.defaultSort as unknown as readonly Sort<Entity>[];
+  return config.settings.defaults.sort.map((token) => parseSortToken<Entity>(token));
+}
+
+/** `-field` → `{ field, direction: "desc" }`; `field` → `{ field, direction: "asc" }`. */
+function parseSortToken<Entity>(token: string): Sort<Entity> {
+  const descending = token.startsWith("-");
+  const field = descending ? token.slice(1) : token;
+  return { field: field as FieldPath<Entity>, direction: descending ? "desc" : "asc" };
 }
 
 function parseSort<Entity>(
@@ -754,16 +765,23 @@ function parseSort<Entity>(
     if (token === "") {
       continue;
     }
-    const descending = token.startsWith("-");
-    const field = descending ? token.slice(1) : token;
-    if (requireAllowlisted(field, config, "sorting", issues)) {
-      result.push({
-        field: field as FieldPath<Entity>,
-        direction: descending ? "desc" : "asc",
-      });
+    const entry = parseSortToken<Entity>(token);
+    if (requireAllowlisted(entry.field as string, config, "sorting", issues)) {
+      result.push(entry);
     }
   }
   return result;
+}
+
+/**
+ * `config.settings.defaults.select` — validated against the selectable
+ * allowlist at bootstrap, the same as `defaults.sort`. `undefined` means
+ * "no configured default": the caller keeps `root: null`, the existing
+ * "project every selectable field" behavior.
+ */
+function defaultSelectOf<Entity>(config: ResolvedEntityConfig<Entity>): readonly FieldPath<Entity, 1>[] | null {
+  const select = config.settings.defaults.select;
+  return select === undefined ? null : (select as unknown as readonly FieldPath<Entity, 1>[]);
 }
 
 /**

--- a/packages/core/src/relations/default-relation-registry.ts
+++ b/packages/core/src/relations/default-relation-registry.ts
@@ -29,15 +29,16 @@ function resolveArrayMutationStrategy(
 }
 
 /**
- * Map-backed relation registry, built once at bootstrap from three
+ * Map-backed relation registry, built once at bootstrap from four
  * sources: the adapter's ORM metadata supplies *shape* — name, target,
  * cardinality; `allowed.includable` (`EntityConfig`, entity-config.ts)
- * supplies *permission*; `relations.edges` (`KavoSettings`, settings.ts)
- * supplies loading *tuning* (`defaultInclude`/`maxDepth`/`strategy`) for a
- * relation once it is includable (ADR-0028), and array-mutation write
- * policy (`write`) for one opted into it. Inclusion is opt-in, so a
- * relation absent from `includable` stays `includable: false` no matter
- * what `edges` says about it.
+ * supplies *permission*; `defaults.include` (`KavoSettings`, settings.ts)
+ * supplies which includable relations load by default (issue #375,
+ * ADR-0028); `relations.edges` supplies loading *tuning*
+ * (`maxDepth`/`strategy`) for a relation once it is includable, and
+ * array-mutation write policy (`write`) for one opted into it. Inclusion is
+ * opt-in, so a relation absent from `includable` stays `includable: false`
+ * no matter what `edges` or `defaults.include` says about it.
  */
 export class DefaultRelationRegistry<Entity = unknown> implements RelationRegistry<Entity> {
   private readonly relations: ReadonlyMap<string, RelationDescriptor>;
@@ -53,6 +54,10 @@ export class DefaultRelationRegistry<Entity = unknown> implements RelationRegist
     // arrayMutation.strategy" error below on a write-opted relation, not the
     // misleading "arrayMutation is false" one.
     arrayMutationDefault: ArrayMutationSettings | false = {},
+    // `defaults.include` — validated against `includable` at bootstrap
+    // (`resolve-entity-config.ts`'s `validateDefaults`) before this
+    // constructor ever runs, so every name here is already known-includable.
+    defaultIncludes: readonly string[] = [],
   ) {
     const byName = new Map(descriptors.map((descriptor) => [descriptor.name, descriptor]));
     for (const name of includable) {
@@ -67,6 +72,12 @@ export class DefaultRelationRegistry<Entity = unknown> implements RelationRegist
         );
       }
       byName.set(name, { ...descriptor, includable: true });
+    }
+    for (const name of defaultIncludes) {
+      const descriptor = byName.get(name);
+      if (descriptor !== undefined) {
+        byName.set(name, { ...descriptor, defaultInclude: true });
+      }
     }
     for (const [name, edge] of Object.entries(edges)) {
       const descriptor = byName.get(name);
@@ -129,12 +140,10 @@ export class DefaultRelationRegistry<Entity = unknown> implements RelationRegist
         }
       }
       // `edges` tunes loading only — it no longer touches `includable`
-      // (ADR-0028): a relation can be tuned here without being includable,
-      // and `defaultInclude: true` on one that isn't is rejected earlier,
-      // at bootstrap, by `validateIncludableRelations`.
+      // (ADR-0028) or `defaultInclude` (issue #375): a relation can be
+      // tuned here without being includable or defaulted in.
       byName.set(name, {
         ...descriptor,
-        ...(edge.defaultInclude !== undefined && { defaultInclude: edge.defaultInclude }),
         ...(edge.maxDepth !== undefined && { maxDepth: edge.maxDepth }),
         strategy: edge.strategy ?? descriptor.strategy,
         ...(writeRequested && { write: resolvedWrite }),

--- a/packages/core/src/relations/relation-descriptor.ts
+++ b/packages/core/src/relations/relation-descriptor.ts
@@ -46,7 +46,11 @@ export interface RelationDescriptor {
    * filter/sort/select posture.
    */
   readonly includable: boolean;
-  /** Included even when the client doesn't ask. */
+  /**
+   * Included even when the client doesn't ask — granted by
+   * `defaults.include` (`KavoSettings`, settings.ts, issue #375), not by
+   * `relations.edges` (which tunes loading only).
+   */
   readonly defaultInclude?: boolean;
   /** Overrides the configured `maxIncludeDepth` below this node. */
   readonly maxDepth?: number;

--- a/packages/core/tests/caching.spec.ts
+++ b/packages/core/tests/caching.spec.ts
@@ -568,7 +568,7 @@ describe("a write response's tag describes that response, not the canonical read
     });
     const crud = kavo.createCrud(Author, {
       allowed: { includable: ["posts"] },
-      relations: { edges: { posts: { defaultInclude: true } } },
+      defaults: { include: ["posts"] },
     } as never);
     kavo.createCrud(Post);
     return { crud, adapter };

--- a/packages/core/tests/composite-key-pagination.spec.ts
+++ b/packages/core/tests/composite-key-pagination.spec.ts
@@ -20,6 +20,11 @@ const DEFAULT_ALLOWLISTS = {
   selectable: ["userId", "topic", "key"],
 };
 
+/** `{ field: "key", direction: "desc" }` → `"-key"` — the `defaults.sort` wire shorthand. */
+function sortWireToken(entry: Sort<CompositeEntity>): string {
+  return entry.direction === "desc" ? `-${entry.field as string}` : (entry.field as string);
+}
+
 function configWith(
   defaultSort: readonly Sort<CompositeEntity>[],
   strategy = "cursor",
@@ -28,9 +33,10 @@ function configWith(
 ): ResolvedEntityConfig<CompositeEntity> {
   const settings = {
     pagination: { defaultLimit: 20, maxLimit: 100, strategy, count: true, since: { field: sinceField } },
-    query: { maxFilterDepth: 5, maxInValues: 100, defaultSort },
+    query: { maxFilterDepth: 5, maxInValues: 100 },
     errors: { exposeInternals: false },
     relations: { maxIncludeDepth: 3, maxIncludedNodes: 20, edges: {} },
+    defaults: { sort: defaultSort.map(sortWireToken), include: [] },
     softDelete: false,
     operations: {},
   } as unknown as KavoSettings;

--- a/packages/core/tests/config-validation.spec.ts
+++ b/packages/core/tests/config-validation.spec.ts
@@ -92,35 +92,34 @@ describe("validateSettings — query limits", () => {
   it("accepts a depth, value cap, and like-pattern cap of 1", () => {
     expect(() => accept({ query: { maxFilterDepth: 1, maxInValues: 1, maxLikePatternLength: 1 } })).not.toThrow();
   });
+});
 
-  it("rejects a defaultSort that is not an array", () => {
-    for (const value of ["name", null, { field: "name", direction: "asc" }]) {
-      expectRejected({ query: { defaultSort: value } }, "query.defaultSort", value);
+describe("validateSettings — defaults", () => {
+  it("rejects a defaults.sort that is not an array of non-empty strings", () => {
+    for (const value of ["name", null, [1], [""], { field: "name", direction: "asc" }]) {
+      expectRejected({ defaults: { sort: value } }, "defaults.sort", value);
     }
   });
 
-  it("rejects a defaultSort entry missing a field or with a non-string field", () => {
-    for (const entry of [{}, { field: 1, direction: "asc" }, { direction: "asc" }]) {
-      expectRejected({ query: { defaultSort: [entry] } }, "query.defaultSort[0]", entry);
+  it("rejects a defaults.select that is not an array of non-empty strings", () => {
+    for (const value of ["name", null, [1], [""]]) {
+      expectRejected({ defaults: { select: value } }, "defaults.select", value);
     }
   });
 
-  it("rejects a defaultSort entry with an invalid direction", () => {
-    expectRejected(
-      { query: { defaultSort: [{ field: "name", direction: "up" }] } },
-      "query.defaultSort[0].direction",
-      "up",
-    );
+  it("rejects a defaults.include that is not an array of non-empty strings", () => {
+    for (const value of ["posts", null, [1], [""]]) {
+      expectRejected({ defaults: { include: value } }, "defaults.include", value);
+    }
   });
 
-  it("accepts a well-formed defaultSort", () => {
+  it("accepts a well-formed defaults block", () => {
     expect(() =>
       accept({
-        query: {
-          defaultSort: [
-            { field: "createdAt", direction: "desc" },
-            { field: "id", direction: "asc" },
-          ],
+        defaults: {
+          sort: ["-createdAt", "id"],
+          select: ["id", "name"],
+          include: ["posts"],
         },
       }),
     ).not.toThrow();
@@ -222,14 +221,6 @@ describe("validateSettings — relation edges", () => {
     }
   });
 
-  it("rejects a non-boolean defaultInclude", () => {
-    expectRejected(
-      { relations: { edges: { posts: { defaultInclude: 1 } } } },
-      "relations.edges.posts.defaultInclude",
-      1,
-    );
-  });
-
   it("rejects a maxDepth that is not a positive integer", () => {
     for (const value of NOT_POSITIVE_INTEGERS) {
       expectRejected({ relations: { edges: { posts: { maxDepth: value } } } }, "relations.edges.posts.maxDepth", value);
@@ -242,12 +233,12 @@ describe("validateSettings — relation edges", () => {
     }
   });
 
-  // `defaultInclude` vs. permission (`allowed.includable`) is no longer
+  // `defaults.include` vs. permission (`allowed.includable`) is no longer
   // checkable by `validateSettings` alone — permission moved to entity-typed
   // `EntityConfig.allowed` (ADR-0028), outside the `KavoSettings` shape
   // this file exercises. See `config.spec.ts`'s
   // "resolveEntityConfig — allowed.includable" describe block for that
-  // cross-check, now performed by `validateIncludableRelations`.
+  // cross-check, now performed by `validateDefaults`.
 
   it("accepts an edge that configures nothing — every sub-key is optional", () => {
     expect(() => accept({ relations: { edges: { posts: {} } } })).not.toThrow();
@@ -259,10 +250,10 @@ describe("validateSettings — relation edges", () => {
     }
   });
 
-  it("accepts defaultInclude/maxDepth shape regardless of includable permission", () => {
+  it("accepts maxDepth shape regardless of includable permission", () => {
     // `validateSettings` only checks shape now — whether `posts` is actually
     // includable is `resolveEntityConfig`'s `allowed`-aware cross-check.
-    expect(() => accept({ relations: { edges: { posts: { defaultInclude: true, maxDepth: 1 } } } })).not.toThrow();
+    expect(() => accept({ relations: { edges: { posts: { maxDepth: 1 } } } })).not.toThrow();
   });
 });
 

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -331,49 +331,45 @@ describe("resolveEntityConfig — bootstrap", () => {
     }
   });
 
-  it("resolves an entity-scope defaultSort", () => {
-    const config = resolveEntityConfig(
-      userMetadata,
-      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
-      undefined,
-    );
-    expect(config.settings.query.defaultSort).toEqual([{ field: "createdAt", direction: "desc" }]);
+  it("resolves an entity-scope defaults.sort", () => {
+    const config = resolveEntityConfig(userMetadata, { defaults: { sort: ["-createdAt"] } }, undefined);
+    expect(config.settings.defaults.sort).toEqual(["-createdAt"]);
   });
 
-  it("lets an operation override the entity-scope defaultSort", () => {
+  it("lets an operation override the entity-scope defaults.sort", () => {
     const config = resolveEntityConfig(
       userMetadata,
       {
-        query: { defaultSort: [{ field: "createdAt", direction: "desc" }] },
-        operations: { findMany: { query: { defaultSort: [{ field: "name", direction: "asc" }] } } },
+        defaults: { sort: ["-createdAt"] },
+        operations: { findMany: { defaults: { sort: ["name"] } } },
       },
       undefined,
     );
-    expect(config.settingsFor("findMany").query.defaultSort).toEqual([{ field: "name", direction: "asc" }]);
-    expect(config.settingsFor("findOne").query.defaultSort).toEqual([{ field: "createdAt", direction: "desc" }]);
+    expect(config.settingsFor("findMany").defaults.sort).toEqual(["name"]);
+    expect(config.settingsFor("findOne").defaults.sort).toEqual(["-createdAt"]);
   });
 
-  it("applies the precedence chain global -> entity for defaultSort", () => {
+  it("applies the precedence chain global -> entity for defaults.sort", () => {
     const config = resolveEntityConfig(
       userMetadata,
-      { query: { defaultSort: [{ field: "name", direction: "asc" }] } },
-      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
+      { defaults: { sort: ["name"] } },
+      { defaults: { sort: ["-createdAt"] } },
     );
-    expect(config.settings.query.defaultSort).toEqual([{ field: "name", direction: "asc" }]); // entity beats global
+    expect(config.settings.defaults.sort).toEqual(["name"]); // entity beats global
 
     const globalOnly = resolveEntityConfig(userMetadata, undefined, {
-      query: { defaultSort: [{ field: "createdAt", direction: "desc" }] },
+      defaults: { sort: ["-createdAt"] },
     });
-    expect(globalOnly.settings.query.defaultSort).toEqual([{ field: "createdAt", direction: "desc" }]);
+    expect(globalOnly.settings.defaults.sort).toEqual(["-createdAt"]);
   });
 
-  it("rejects an entity-scope defaultSort field outside the sortable allowlist", () => {
+  it("rejects an entity-scope defaults.sort field outside the sortable allowlist", () => {
     try {
       resolveEntityConfig(
         userMetadata,
         {
           allowed: { sortable: ["name"] },
-          query: { defaultSort: [{ field: "email", direction: "asc" }] },
+          defaults: { sort: ["email"] },
         },
         undefined,
       );
@@ -384,13 +380,13 @@ describe("resolveEntityConfig — bootstrap", () => {
     }
   });
 
-  it("rejects an operation-scope defaultSort field outside the sortable allowlist", () => {
+  it("rejects an operation-scope defaults.sort field outside the sortable allowlist", () => {
     try {
       resolveEntityConfig(
         userMetadata,
         {
           allowed: { sortable: ["name"] },
-          operations: { findMany: { query: { defaultSort: [{ field: "email", direction: "asc" }] } } },
+          operations: { findMany: { defaults: { sort: ["email"] } } },
         },
         undefined,
       );
@@ -401,15 +397,15 @@ describe("resolveEntityConfig — bootstrap", () => {
     }
   });
 
-  it("rejects an operation-scope defaultInclude on a relation absent from allowed.includable", () => {
-    // `validateIncludableRelations` runs for the per-operation settings view
-    // too, not only entity scope — an operation override can name
-    // `relations.edges` just as the entity config can.
+  it("rejects an operation-scope defaults.include on a relation absent from allowed.includable", () => {
+    // `validateDefaults` runs for the per-operation settings view too, not
+    // only entity scope — an operation override can name `defaults.include`
+    // just as the entity config can.
     try {
       resolveEntityConfig(
         authorMetadata,
         {
-          operations: { findMany: { relations: { edges: { posts: { defaultInclude: true } } } } },
+          operations: { findMany: { defaults: { include: ["posts"] } } },
         },
         undefined,
       );
@@ -418,7 +414,7 @@ describe("resolveEntityConfig — bootstrap", () => {
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
       expect((error as ConfigurationException).messageParams).toMatchObject({
         entity: "Author.operations.findMany",
-        path: "relations.edges.posts",
+        path: "defaults.include",
       });
       expect((error as ConfigurationException).detail).toContain("posts");
     }
@@ -426,47 +422,48 @@ describe("resolveEntityConfig — bootstrap", () => {
 });
 
 /**
- * ADR-0028: `defaultInclude` vs. permission is cross-checked against
+ * ADR-0028: `defaults.include` vs. permission is cross-checked against
  * `allowed.includable`, not `relations.edges`'s own (now-removed)
- * `includable` key — `validateIncludableRelations` in
- * resolve-entity-config.ts, run after `allowed` is resolved.
+ * `includable` key — `validateDefaults` in resolve-entity-config.ts, run
+ * after `allowed` is resolved.
  */
 describe("resolveEntityConfig — allowed.includable", () => {
-  it("rejects defaultInclude on a relation absent from allowed.includable", () => {
+  it("rejects defaults.include on a relation absent from allowed.includable", () => {
     try {
-      resolveEntityConfig(authorMetadata, { relations: { edges: { posts: { defaultInclude: true } } } }, undefined);
+      resolveEntityConfig(authorMetadata, { defaults: { include: ["posts"] } }, undefined);
       expect.unreachable();
     } catch (error) {
       expect((error as ConfigurationException).code).toBe("KAVO_CONFIG_INVALID");
       expect((error as ConfigurationException).messageParams).toMatchObject({
         entity: "Author",
-        path: "relations.edges.posts",
+        path: "defaults.include",
       });
       expect((error as ConfigurationException).detail).toContain("posts");
     }
   });
 
-  it("rejects defaultInclude set at global scope when no entity opts the relation into allowed.includable", () => {
-    // Migration hazard: `relations.edges.<name>.defaultInclude` at global
-    // `defaults` scope used to be safe — naming the relation at all was the
-    // opt-in before this PR. It is not safe now: `allowed.includable` is
-    // entity-scope-only, so a global defaultInclude with no matching entity
-    // grant is a bootstrap crash on every entity sharing that relation name,
-    // not a silent no-op. Pinning the crash here so a future change to this
-    // cross-check doesn't silently turn it into the no-op adopters might
-    // expect.
-    expect(() =>
-      resolveEntityConfig(authorMetadata, undefined, { relations: { edges: { posts: { defaultInclude: true } } } }),
-    ).toThrow(ConfigurationException);
+  it("rejects defaults.include set at global scope when no entity opts the relation into allowed.includable", () => {
+    // Migration hazard: `defaults.include` at global scope used to be safe
+    // under the old `relations.edges.<name>.defaultInclude` — naming the
+    // relation at all was the opt-in before this PR. It is not safe now:
+    // `allowed.includable` is entity-scope-only, so a global
+    // `defaults.include` with no matching entity grant is a bootstrap crash
+    // on every entity sharing that relation name, not a silent no-op.
+    // Pinning the crash here so a future change to this cross-check doesn't
+    // silently turn it into the no-op adopters might expect.
+    expect(() => resolveEntityConfig(authorMetadata, undefined, { defaults: { include: ["posts"] } })).toThrow(
+      ConfigurationException,
+    );
   });
 
-  it("accepts defaultInclude on a relation allowed.includable named", () => {
+  it("accepts defaults.include on a relation allowed.includable named", () => {
     expect(() =>
       resolveEntityConfig(
         authorMetadata,
         {
           allowed: { includable: ["posts"] },
-          relations: { edges: { posts: { defaultInclude: true, maxDepth: 1 } } },
+          defaults: { include: ["posts"] },
+          relations: { edges: { posts: { maxDepth: 1 } } },
         },
         undefined,
       ),

--- a/packages/core/tests/cursor-pagination.spec.ts
+++ b/packages/core/tests/cursor-pagination.spec.ts
@@ -40,13 +40,18 @@ import { issuesOf } from "./support/query-issues.js";
 
 const SORT_BY_ID: readonly Sort<User>[] = [{ field: "id", direction: "asc" }];
 
+/** `{ field: "age", direction: "desc" }` → `"-age"` — the `defaults.sort` wire shorthand. */
+function sortWireToken(entry: Sort<User>): string {
+  return entry.direction === "desc" ? `-${entry.field as string}` : (entry.field as string);
+}
+
 function cursorCrud(overrides: DeepPartial<KavoSettings> = {}) {
   const adapter = new InMemoryUserAdapter();
   const crud = createKavo({
     defaults: {
       ...overrides,
       pagination: { strategy: "cursor", ...overrides.pagination },
-      query: { defaultSort: SORT_BY_ID, ...overrides.query },
+      defaults: { sort: SORT_BY_ID.map(sortWireToken), ...overrides.defaults },
     },
   } as never).createCrud(User, undefined, { adapter, metadata: userMetadata });
   return { crud, adapter };
@@ -487,9 +492,10 @@ describe("QueryNormalizer — cursor pagination requires a total order", () => {
   ): ResolvedEntityConfig<User> {
     const settings = {
       pagination: { defaultLimit: 20, maxLimit: 100, strategy, count: true },
-      query: { maxFilterDepth: 5, maxInValues: 100, defaultSort },
+      query: { maxFilterDepth: 5, maxInValues: 100 },
       errors: { exposeInternals: false },
       relations: { maxIncludeDepth: 3, maxIncludedNodes: 20, edges: {} },
+      defaults: { sort: defaultSort.map(sortWireToken), include: [] },
       softDelete: false,
       operations: {},
     } as unknown as KavoSettings;
@@ -521,12 +527,12 @@ describe("QueryNormalizer — cursor pagination requires a total order", () => {
     expect(issues[0]).toMatchObject({ field: "sort", code: "KAVO_QUERY_CONFLICTING_PARAMS" });
   });
 
-  it("rejects an empty effective sort and names the missing defaultSort", () => {
+  it("rejects an empty effective sort and names the missing defaults.sort", () => {
     const issues = issuesOf(() => normalizer.normalizeWire({}, configWith([])));
-    expect(issues[0]?.detail).toContain("defaultSort");
+    expect(issues[0]?.detail).toContain("defaults.sort");
   });
 
-  it("falls back to a conforming defaultSort without the client sending sort", () => {
+  it("falls back to a conforming default sort without the client sending sort", () => {
     const query = normalizer.normalizeWire({}, configWith(SORT_BY_ID));
     expect(query.sort).toEqual(SORT_BY_ID);
     expect(isCursorPagination(query.pagination)).toBe(true);
@@ -779,12 +785,7 @@ describe("cursor pagination end to end", () => {
 
   it("pages a descending sort correctly", async () => {
     const { crud } = cursorCrud({
-      query: {
-        defaultSort: [
-          { field: "age", direction: "desc" },
-          { field: "id", direction: "asc" },
-        ],
-      },
+      defaults: { sort: ["-age", "id"] },
     });
     await seed(crud, 5);
 
@@ -794,13 +795,7 @@ describe("cursor pagination end to end", () => {
 
   it("pages a mixed asc/desc sort correctly", async () => {
     const { crud, adapter } = cursorCrud({
-      query: {
-        defaultSort: [
-          { field: "status", direction: "asc" },
-          { field: "age", direction: "desc" },
-          { field: "id", direction: "asc" },
-        ],
-      },
+      defaults: { sort: ["status", "-age", "id"] },
     });
     await seed(crud, 6);
     // Two status buckets, so the leading key really has ties to break.
@@ -885,12 +880,7 @@ describe("cursor pagination end to end", () => {
     // null story — ADR-0021 §4 records the quiet half (a NULLS-LAST
     // ordering omits the null-keyed rows entirely, with no error at all).
     const { crud, adapter } = cursorCrud({
-      query: {
-        defaultSort: [
-          { field: "name", direction: "asc" },
-          { field: "id", direction: "asc" },
-        ],
-      },
+      defaults: { sort: ["name", "id"] },
     });
     await seed(crud, 4);
     // sqlite-style NULLS FIRST: the null-named row sorts to the front and
@@ -920,7 +910,7 @@ describe("cursor pagination end to end", () => {
     const crud = createKavo({
       defaults: {
         pagination: { strategy: "cursor" },
-        query: { defaultSort: SORT_BY_ID },
+        defaults: { sort: SORT_BY_ID.map(sortWireToken) },
       },
     } as never).createCrud(
       User,
@@ -1020,7 +1010,7 @@ describe("cursor pagination fails loudly when a page does not advance (ADR-0021)
     const crud = createKavo({
       defaults: {
         pagination: { strategy: "cursor" },
-        query: { defaultSort: SORT_BY_ID },
+        defaults: { sort: SORT_BY_ID.map(sortWireToken) },
       },
     } as never).createCrud(User, undefined, { adapter, metadata: userMetadata });
     return { crud, adapter };

--- a/packages/core/tests/engine.spec.ts
+++ b/packages/core/tests/engine.spec.ts
@@ -117,10 +117,10 @@ describe("KavoEngine pipeline", () => {
     expect(counted.total).toBe(1);
   });
 
-  it("honors a per-call defaultSort override for one request only", async () => {
+  it("honors a per-call defaults.sort override for one request only", async () => {
     const { crud, adapter } = makeCrud();
     await crud.findMany(undefined, {
-      settings: { query: { defaultSort: [{ field: "name", direction: "asc" }] } },
+      settings: { defaults: { sort: ["name"] } },
     });
     expect(adapter.lastQuery?.sort).toEqual([{ field: "name", direction: "asc" }]);
 
@@ -128,11 +128,11 @@ describe("KavoEngine pipeline", () => {
     expect(adapter.lastQuery?.sort).toEqual([]);
   });
 
-  it("rejects a per-call defaultSort field outside the sortable allowlist", async () => {
+  it("rejects a per-call defaults.sort field outside the sortable allowlist", async () => {
     const { crud } = makeCrud();
     await expect(
       crud.findMany(undefined, {
-        settings: { query: { defaultSort: [{ field: "notAColumn", direction: "asc" }] } },
+        settings: { defaults: { sort: ["notAColumn"] } },
       }),
     ).rejects.toBeInstanceOf(ConfigurationException);
   });

--- a/packages/core/tests/includes.spec.ts
+++ b/packages/core/tests/includes.spec.ts
@@ -250,7 +250,7 @@ describe("include resolution", () => {
     const fixture = blog({
       author: {
         allowed: { includable: ["posts"] },
-        relations: { edges: { posts: { defaultInclude: true } } },
+        defaults: { include: ["posts"] },
       },
     });
     const { authors, authorRows } = fixture;
@@ -680,7 +680,7 @@ describe("defaultInclude", () => {
     const fixture = blog({
       author: {
         allowed: { includable: ["posts"] },
-        relations: { edges: { posts: { defaultInclude: true } } },
+        defaults: { include: ["posts"] },
       },
       post: { allowed: { includable: ["comments"] } },
     } as never);
@@ -699,7 +699,7 @@ describe("defaultInclude", () => {
       author: { allowed: { includable: ["posts"] } },
       post: {
         allowed: { includable: ["comments"] },
-        relations: { edges: { comments: { defaultInclude: true } } },
+        defaults: { include: ["comments"] },
       },
     } as never);
 
@@ -714,8 +714,9 @@ describe("defaultInclude", () => {
  * ADR-0028: permission moved out of `relations.edges` into
  * `allowed.includable`. `relations.edges` naming a relation used to be
  * the opt-in itself (`includable: edge.includable ?? true`); it no longer
- * grants anything — it only tunes `defaultInclude`/`maxDepth`/`strategy`
- * for a relation `allowed.includable` has already opened.
+ * grants anything — it only tunes `maxDepth`/`strategy` for a relation
+ * `allowed.includable` has already opened. Which of those includable
+ * relations load by default is `defaults.include`'s question (issue #375).
  */
 describe("allowed.includable — where inclusion permission now lives", () => {
   it("does not open a relation that relations.edges only tunes", async () => {

--- a/packages/core/tests/list-meta.spec.ts
+++ b/packages/core/tests/list-meta.spec.ts
@@ -407,7 +407,7 @@ describe("withListMeta under cursor pagination — the strategy's key is the bas
     const crud = createKavo({
       defaults: {
         pagination: { strategy: "cursor" },
-        query: { defaultSort: [{ field: "id", direction: "asc" }] },
+        defaults: { sort: ["id"] },
       },
     } as never).createCrud(
       User,

--- a/packages/core/tests/query-normalizer.spec.ts
+++ b/packages/core/tests/query-normalizer.spec.ts
@@ -152,25 +152,16 @@ describe("QueryNormalizer — wire params", () => {
     ]);
   });
 
-  it("falls back to the configured defaultSort when the client supplies no sort", () => {
-    const defaulted = resolveEntityConfig(
-      userMetadata,
-      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
-      undefined,
-    );
+  it("falls back to the configured defaults.sort when the client supplies no sort", () => {
+    const defaulted = resolveEntityConfig(userMetadata, { defaults: { sort: ["-createdAt"] } }, undefined);
     expect(normalizer.normalizeWire({}, defaulted).sort).toEqual([{ field: "createdAt", direction: "desc" }]);
   });
 
-  it("applies a multi-field defaultSort in priority order", () => {
+  it("applies a multi-field defaults.sort in priority order", () => {
     const defaulted = resolveEntityConfig(
       userMetadata,
       {
-        query: {
-          defaultSort: [
-            { field: "createdAt", direction: "desc" },
-            { field: "id", direction: "asc" },
-          ],
-        },
+        defaults: { sort: ["-createdAt", "id"] },
       },
       undefined,
     );
@@ -180,12 +171,8 @@ describe("QueryNormalizer — wire params", () => {
     ]);
   });
 
-  it("lets a client-supplied sort override the configured defaultSort outright", () => {
-    const defaulted = resolveEntityConfig(
-      userMetadata,
-      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
-      undefined,
-    );
+  it("lets a client-supplied sort override the configured defaults.sort outright", () => {
+    const defaulted = resolveEntityConfig(userMetadata, { defaults: { sort: ["-createdAt"] } }, undefined);
     expect(normalizer.normalizeWire({ sort: "name" }, defaulted).sort).toEqual([{ field: "name", direction: "asc" }]);
   });
 });
@@ -603,21 +590,13 @@ describe("QueryNormalizer — programmatic input", () => {
     expect(issues[0]?.code).toBe("KAVO_QUERY_INVALID_FIELD");
   });
 
-  it("falls back to the configured defaultSort when no sort is given", () => {
-    const defaulted = resolveEntityConfig(
-      userMetadata,
-      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
-      undefined,
-    );
+  it("falls back to the configured defaults.sort when no sort is given", () => {
+    const defaulted = resolveEntityConfig(userMetadata, { defaults: { sort: ["-createdAt"] } }, undefined);
     expect(normalizer.normalizeInput({}, defaulted).sort).toEqual([{ field: "createdAt", direction: "desc" }]);
   });
 
-  it("lets a caller-supplied sort override the configured defaultSort outright", () => {
-    const defaulted = resolveEntityConfig(
-      userMetadata,
-      { query: { defaultSort: [{ field: "createdAt", direction: "desc" }] } },
-      undefined,
-    );
+  it("lets a caller-supplied sort override the configured defaults.sort outright", () => {
+    const defaulted = resolveEntityConfig(userMetadata, { defaults: { sort: ["-createdAt"] } }, undefined);
     const query = normalizer.normalizeInput({ sort: [{ field: "name", direction: "asc" }] }, defaulted);
     expect(query.sort).toEqual([{ field: "name", direction: "asc" }]);
   });

--- a/packages/frameworks/nest/tests/binding.e2e.spec.ts
+++ b/packages/frameworks/nest/tests/binding.e2e.spec.ts
@@ -3240,10 +3240,10 @@ describe("@Kavo Swagger recursive includable-relation $ref composition (issue #3
     expectEveryRefResolves(doc);
   });
 
-  it("keeps a defaultInclude relation optional, still $ref'd (write responses carry no relations, ADR-0020)", async () => {
+  it("keeps a defaults.include relation optional, still $ref'd (write responses carry no relations, ADR-0020)", async () => {
     @Kavo(Todo, {
       allowed: { includable: ["list"] },
-      relations: { edges: { list: { defaultInclude: true } } },
+      defaults: { include: ["list"] },
     })
     @Controller("todos")
     class DefaultIncludeC {}

--- a/packages/orms/mikroorm/tests/adapter.spec.ts
+++ b/packages/orms/mikroorm/tests/adapter.spec.ts
@@ -545,19 +545,19 @@ describe("MikroOrmRepositoryAdapter — query translation", () => {
     expect(list.items).toHaveLength(4);
   });
 
-  it("applies the configured defaultSort when the caller supplies no sort", async () => {
+  it("applies the configured defaults.sort when the caller supplies no sort", async () => {
     await seed();
     const withDefault = kavo.createCrud(Author, {
-      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+      defaults: { sort: ["age"] },
     }) as DefaultKavoService<Author>;
     const list = await withDefault.findMany();
     expect(list.items.map((author) => (author as Author).name)).toEqual(["Joan", "Ada", "Alan", "Grace"]);
   });
 
-  it("keeps defaultSort-ordered pages disjoint and stable across offsets", async () => {
+  it("keeps defaults.sort-ordered pages disjoint and stable across offsets", async () => {
     await seed();
     const withDefault = kavo.createCrud(Author, {
-      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+      defaults: { sort: ["age"] },
     }) as DefaultKavoService<Author>;
     const page1 = await withDefault.findMany({ limit: 2, offset: 0 });
     const page2 = await withDefault.findMany({ limit: 2, offset: 2 });

--- a/packages/orms/mikroorm/tests/cursor-pagination.spec.ts
+++ b/packages/orms/mikroorm/tests/cursor-pagination.spec.ts
@@ -68,7 +68,7 @@ beforeAll(async () => {
   kavo = createMikroOrmKavo(orm, {
     defaults: {
       pagination: { strategy: "cursor" },
-      query: { defaultSort: [{ field: "id", direction: "asc" }] },
+      defaults: { sort: ["id"] },
     },
   });
   posts = kavo.createCrud(Post, {

--- a/packages/orms/mongoose/tests/adapter.spec.ts
+++ b/packages/orms/mongoose/tests/adapter.spec.ts
@@ -497,17 +497,17 @@ describe("MongooseRepositoryAdapter — schema constraints hold on every write",
   });
 });
 
-describe("MongooseRepositoryAdapter — query.defaultSort", () => {
+describe("MongooseRepositoryAdapter — defaults.sort", () => {
   function withDefaultSort(direction: "asc" | "desc"): DefaultKavoService<Author> {
     return kavo.createCrud(models.Author, {
-      query: { defaultSort: [{ field: "age", direction }] },
+      defaults: { sort: [direction === "desc" ? "-age" : "age"] },
     } as never) as unknown as DefaultKavoService<Author>;
   }
 
-  it("applies the configured defaultSort when the caller supplies no sort", async () => {
+  it("applies the configured defaults.sort when the caller supplies no sort", async () => {
     // `buildSort` omits the `sort` key entirely for an empty list, so a
-    // regression that stopped defaultSort reaching the adapter would degrade
-    // silently to MongoDB's natural order rather than fail.
+    // regression that stopped defaults.sort reaching the adapter would
+    // degrade silently to MongoDB's natural order rather than fail.
     await seed();
     const list = await withDefaultSort("asc").findMany();
     expect(list.items.map((author) => (author as Author).name)).toEqual(["Joan", "Ada", "Alan", "Grace"]);
@@ -519,7 +519,7 @@ describe("MongooseRepositoryAdapter — query.defaultSort", () => {
     expect(list.items.map((author) => (author as Author).name)).toEqual(["Grace", "Alan", "Ada", "Joan"]);
   });
 
-  it("keeps defaultSort-ordered pages disjoint and stable across offsets", async () => {
+  it("keeps defaults.sort-ordered pages disjoint and stable across offsets", async () => {
     await seed();
     const service = withDefaultSort("asc");
     const first = await service.findMany({ limit: 2, offset: 0 });

--- a/packages/orms/mongoose/tests/cursor-pagination.spec.ts
+++ b/packages/orms/mongoose/tests/cursor-pagination.spec.ts
@@ -64,7 +64,7 @@ beforeAll(async () => {
   kavo = createMongooseKavo(database.connection, {
     defaults: {
       pagination: { strategy: "cursor" },
-      query: { defaultSort: [{ field: "_id", direction: "asc" }] },
+      defaults: { sort: ["_id"] },
     },
   });
   posts = kavo.createCrud(models.Post, {

--- a/packages/orms/prisma/tests/adapter.spec.ts
+++ b/packages/orms/prisma/tests/adapter.spec.ts
@@ -319,19 +319,19 @@ describe("PrismaRepositoryAdapter — query translation", () => {
     expect(list.items).toHaveLength(0);
   });
 
-  it("applies the configured defaultSort when the caller supplies no sort", async () => {
+  it("applies the configured defaults.sort when the caller supplies no sort", async () => {
     await seed();
     const withDefault = kavo.createCrud(Author, {
-      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+      defaults: { sort: ["age"] },
     }) as DefaultKavoService<Author>;
     const list = await withDefault.findMany();
     expect(list.items.map((a) => (a as Author).name)).toEqual(["Joan", "Ada", "Alan", "Grace"]);
   });
 
-  it("lets a caller-supplied sort override the configured defaultSort", async () => {
+  it("lets a caller-supplied sort override the configured defaults.sort", async () => {
     await seed();
     const withDefault = kavo.createCrud(Author, {
-      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+      defaults: { sort: ["age"] },
     }) as DefaultKavoService<Author>;
     const list = await withDefault.findMany({ sort: [{ field: "age", direction: "desc" }] });
     expect(list.items.map((a) => (a as Author).name)).toEqual(["Grace", "Alan", "Ada", "Joan"]);

--- a/packages/orms/prisma/tests/cursor-pagination.spec.ts
+++ b/packages/orms/prisma/tests/cursor-pagination.spec.ts
@@ -44,7 +44,7 @@ beforeAll(() => {
       caseInsensitiveFilters: false,
       defaults: {
         pagination: { strategy: "cursor" },
-        query: { defaultSort: [{ field: "id", direction: "asc" }] },
+        defaults: { sort: ["id"] },
       },
     } as never,
   );

--- a/packages/orms/typeorm/tests/adapter.spec.ts
+++ b/packages/orms/typeorm/tests/adapter.spec.ts
@@ -350,32 +350,27 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
     expect(list.items).toHaveLength(0);
   });
 
-  it("applies the configured defaultSort when the caller supplies no sort", async () => {
+  it("applies the configured defaults.sort when the caller supplies no sort", async () => {
     await seed();
     const withDefault = kavo.createCrud(Author, {
-      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+      defaults: { sort: ["age"] },
     }) as DefaultKavoService<Author>;
     const list = await withDefault.findMany();
     expect(list.items.map((a) => (a as Author).name)).toEqual(["Joan", "Ada", "Alan", "Grace"]);
   });
 
-  it("lets a caller-supplied sort override the configured defaultSort", async () => {
+  it("lets a caller-supplied sort override the configured defaults.sort", async () => {
     await seed();
     const withDefault = kavo.createCrud(Author, {
-      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+      defaults: { sort: ["age"] },
     }) as DefaultKavoService<Author>;
     const list = await withDefault.findMany({ sort: [{ field: "age", direction: "desc" }] });
     expect(list.items.map((a) => (a as Author).name)).toEqual(["Grace", "Alan", "Ada", "Joan"]);
   });
 
-  it("breaks ties on the second field of a multi-field defaultSort", async () => {
+  it("breaks ties on the second field of a multi-field defaults.sort", async () => {
     const withDefault = kavo.createCrud(Author, {
-      query: {
-        defaultSort: [
-          { field: "status", direction: "asc" },
-          { field: "name", direction: "asc" },
-        ],
-      },
+      defaults: { sort: ["status", "name"] },
     }) as DefaultKavoService<Author>;
     await withDefault.createOne({ email: "b@x.io", name: "Bea", age: 30, status: "active" } as never);
     await withDefault.createOne({ email: "c@x.io", name: "Cy", age: 31, status: "active" } as never);
@@ -384,10 +379,10 @@ describe("TypeOrmRepositoryAdapter — query translation", () => {
     expect(list.items.map((a) => (a as Author).name)).toEqual(["Amy", "Bea", "Cy"]);
   });
 
-  it("keeps defaultSort-ordered pages disjoint and stable across offsets", async () => {
+  it("keeps defaults.sort-ordered pages disjoint and stable across offsets", async () => {
     await seed();
     const withDefault = kavo.createCrud(Author, {
-      query: { defaultSort: [{ field: "age", direction: "asc" }] },
+      defaults: { sort: ["age"] },
     }) as DefaultKavoService<Author>;
     const page1 = await withDefault.findMany({ limit: 2, offset: 0 });
     const page2 = await withDefault.findMany({ limit: 2, offset: 2 });

--- a/packages/orms/typeorm/tests/composite-primary-key.spec.ts
+++ b/packages/orms/typeorm/tests/composite-primary-key.spec.ts
@@ -174,13 +174,7 @@ describe("composite primary keys — @kavo/typeorm (issue #261)", () => {
   it("pages stably across a boundary with cursor pagination, using the full composite tiebreaker (issue #263)", async () => {
     const cursorGrants = kavo.createCrud(Grant, {
       pagination: { strategy: "cursor" },
-      query: {
-        defaultSort: [
-          { field: "note", direction: "asc" },
-          { field: "userId", direction: "asc" },
-          { field: "topic", direction: "asc" },
-        ],
-      },
+      defaults: { sort: ["note", "userId", "topic"] },
     } as never) as DefaultKavoService<Grant>;
 
     // Three rows share the same `note` — without the full compositeIdFields

--- a/packages/orms/typeorm/tests/cursor-pagination.spec.ts
+++ b/packages/orms/typeorm/tests/cursor-pagination.spec.ts
@@ -82,7 +82,7 @@ beforeAll(async () => {
   kavo = createTypeOrmKavo(dataSource, {
     defaults: {
       pagination: { strategy: "cursor" },
-      query: { defaultSort: [{ field: "id", direction: "asc" }] },
+      defaults: { sort: ["id"] },
     },
   });
   posts = kavo.createCrud(Post, {

--- a/packages/protocols/graphql/tests/graphql-schema.spec.ts
+++ b/packages/protocols/graphql/tests/graphql-schema.spec.ts
@@ -292,7 +292,7 @@ describe("cursor-paginated entities are refused at bootstrap", () => {
     return createKavo({
       defaults: {
         pagination: { strategy: "cursor" },
-        query: { defaultSort: [{ field: "id", direction: "asc" }] },
+        defaults: { sort: ["id"] },
       },
     } as never).createCrud(Todo, undefined, { adapter: new InMemoryTodoAdapter(), metadata: todoMetadata });
   }

--- a/packages/protocols/mcp/tests/mcp-tools.spec.ts
+++ b/packages/protocols/mcp/tests/mcp-tools.spec.ts
@@ -207,7 +207,7 @@ describe("cursor-paginated entities are refused at bootstrap", () => {
     return createKavo({
       defaults: {
         pagination: { strategy: "cursor" },
-        query: { defaultSort: [{ field: "id", direction: "asc" }] },
+        defaults: { sort: ["id"] },
       },
     } as never).createCrud(Todo, undefined, { adapter: new InMemoryTodoAdapter(), metadata: todoMetadata });
   }


### PR DESCRIPTION
## What & why

Request defaults were scattered across three unrelated homes — `query.defaultSort` (`Sort[]`, not the wire shorthand `sort=` itself accepts), a per-relation `relations.edges.<name>.defaultInclude` boolean buried inside loading tuning, and no default selection at all. This adds a single `defaults` block on `KavoSettings` (`sort`, `select`, `include`) — the omission-side counterpart to `allowed`: what a request looks like when the client specifies nothing. `defaults.sort` takes the same wire-shorthand strings `sort=` does; `defaults.include` replaces the per-relation boolean with one flat entity-wide list, still cross-checked against `allowed.includable` (ADR-0028); `defaults.select` is new, validated against `allowed.selectable`. Applied centrally in `QueryNormalizer` on both the wire and programmatic paths, so `@kavo/graphql`/`@kavo/mcp` inherit it for free. `query.defaultSort` and `relations.edges.<name>.defaultInclude` are removed outright, no alias.

Closes #375

## Public API impact

Breaking change to `KavoSettings` (`packages/core/src/index.ts` barrel, ADR-0010): `QuerySettings.defaultSort` and `RelationEdgeSettings.defaultInclude` are removed; `KavoSettings.defaults: DefaultsSettings` is added. `DefaultRelationRegistry`'s constructor gains a `defaultIncludes` parameter, appended at the end. See the `feat!` commit's `BREAKING CHANGE:` footer for the mechanical migration.

## Testing

New/updated tests cover: `defaults.sort`/`defaults.select`/`defaults.include` shape validation (`validate-settings.ts`), the `validateDefaults` cross-check against `allowed.sortable`/`selectable`/`includable` at entity, per-operation, and per-call scope, the global-scope `defaults.include` hazard (ADR-0028's precedent), wire-shorthand sort parsing/fallback in `QueryNormalizer`, and `defaults.include`'s effect on the relation registry — plus migrated fixtures across `packages/core`, every ORM adapter package, `@kavo/graphql`/`@kavo/mcp`, `@kavo/nest`, and the `nest-typeorm` example.

`pnpm check`: generate, build, typecheck, depcruise, and lint all pass. Test suite: 2934 passed, 633 skipped, 0 failures caused by this change — the only 12 failing suites are this sandbox's pre-existing environment gaps (no Docker/testcontainers runtime, blocked MongoDB memory-server binary download), unrelated to the diff. `pnpm docs:links` passes.

## Review notes

Worth a close look: `defaultSortOf`/`defaultSelectOf` in `query-normalizer.ts` (the new wire-shorthand parsing and the `select.root` fallback), and `resolve-entity-config.ts`'s `validateDefaults` (the folded sort/select/include cross-checks). Not done: no deprecation shim was added, per the issue's explicit "no alias, no deprecation shim" acceptance criterion.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VNEQc6UDUwttceBHZryJQ6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added request defaults for sorting, field selection, and relation inclusion when clients omit those query options.
  - Client-provided values override configured defaults.
  - Defaults are validated against permitted fields and relations.
  - Added documentation describing configuration behavior and migration guidance.

- **Breaking Changes**
  - Replaced `query.defaultSort` with `defaults.sort`.
  - Replaced relation-level `defaultInclude` with `defaults.include`.
  - Relation edge settings now tune loading behavior without granting inclusion permission or establishing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->