### PR TITLE
docs(commit-lint): document multiple comma-separated scopes

### DIFF
--- a/.claude/skills/conventions/SKILL.md
+++ b/.claude/skills/conventions/SKILL.md
@@ -42,6 +42,11 @@ obvious. A breaking change adds `!` right before the colon —
 `type(scope)!: subject` — instead of (or alongside) a `BREAKING CHANGE:`
 footer.
 
+When a change spans more than one package, comma-separate the scopes with no
+space — `type(scope1,scope2): subject` (e.g. `fix(core,nest): align pagination
+defaults`) — rather than picking one package to name or writing separate
+commits for what is really one logical change.
+
 `commitlint.config.mjs` additionally accepts `build`, `revert`, and `style`
 as commit types, since @commitlint/config-conventional supports them out of
 the box. They have no issue label or branch prefix — those three surfaces

--- a/tests/commitlint-config.spec.ts
+++ b/tests/commitlint-config.spec.ts
@@ -47,6 +47,11 @@ describe("commitlint.config.mjs", () => {
     }
   });
 
+  it("accepts a comma-separated multiple-scope header", () => {
+    const result = lint("fix(core,nest): align pagination defaults across packages");
+    expect(result.ok, result.output).toBe(true);
+  });
+
   it("still rejects a type outside the allowed vocabulary", () => {
     const result = lint("wip(core): should not be an allowed type");
     expect(result.ok).toBe(false);


### PR DESCRIPTION
commitlint already accepts type(scope1,scope2): subject via its default
scope regex, with no scope-enum restriction; pin that behavior with a
test and document it as the convention for multi-package changes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015hWUc3dQ2TtQ2Ly1BCRTuU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for formatting Conventional Commit scopes when changes span multiple packages.
  - Clarified that multiple scopes should be comma-separated without spaces.

- **Tests**
  - Added coverage confirming that comma-separated scopes are accepted in commit headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->