### PR TITLE
fix(ci): lint commits with this repo's own commitlint, not a bundled one

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,4 +25,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: wagoid/commitlint-github-action@v6
+      # Lint with this repo's own pinned commitlint (the one `pnpm install`
+      # just produced, and what `tests/commitlint-config.spec.ts` exercises),
+      # not a version bundled inside a third-party GitHub Action's Docker
+      # image — that bundled parser was found to fail to parse a
+      # `type(scope)!: subject` header at all (`type`/`subject` both come
+      # back empty), even though this repo's own commitlint accepts it
+      # (issue #384).
+      - run: pnpm exec commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/tests/commitlint-config.spec.ts
+++ b/tests/commitlint-config.spec.ts
@@ -52,6 +52,11 @@ describe("commitlint.config.mjs", () => {
     expect(result.ok, result.output).toBe(true);
   });
 
+  it("accepts a breaking-change header combined with a comma-separated multiple-scope header", () => {
+    const result = lint("fix(core,nest)!: align pagination defaults across packages");
+    expect(result.ok, result.output).toBe(true);
+  });
+
   it("still rejects a type outside the allowed vocabulary", () => {
     const result = lint("wip(core): should not be an allowed type");
     expect(result.ok).toBe(false);

--- a/tests/commitlint-workflow.spec.ts
+++ b/tests/commitlint-workflow.spec.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `wagoid/commitlint-github-action` bundles its own `@commitlint/*` inside
+ * its Docker image, separate from the `commitlint` `pnpm install` puts in
+ * this repo's `node_modules` — the one `commitlint.config.mjs` is written
+ * against and `tests/commitlint-config.spec.ts` actually exercises. That
+ * bundled parser fails to extract `type`/`subject` from a
+ * `type(scope)!: subject` header at all (`type-empty`/`subject-empty`),
+ * even though this repo's own pinned `commitlint` accepts it — so a commit
+ * `commitlint-config.spec.ts` swears is fine could still fail the real CI
+ * check (issue #384). This file pins that the workflow lints with the
+ * repo's own tool instead of a third-party action's bundled one, so the
+ * local test's claim is actually true of CI as run.
+ */
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const WORKFLOW_PATH = resolve(REPO_ROOT, ".github/workflows/commitlint.yml");
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+describe("commitlint.yml wiring", () => {
+  it("never delegates to a third-party action bundling its own commitlint", () => {
+    expect(workflow).not.toContain("wagoid/commitlint-github-action");
+  });
+
+  it("installs dependencies before linting, so `commitlint` resolves to this repo's pinned version", () => {
+    const installIndex = workflow.indexOf("pnpm install");
+    const lintIndex = workflow.indexOf("pnpm exec commitlint");
+
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(lintIndex).toBeGreaterThanOrEqual(0);
+    expect(installIndex).toBeLessThan(lintIndex);
+  });
+
+  it("lints the pull request's own commit range, not just HEAD", () => {
+    // A bare `pnpm exec commitlint` with no --from/--to lints nothing (it
+    // reads stdin), and `--last`/`--edit` would lint only the tip commit,
+    // missing every other commit in a multi-commit PR.
+    expect(workflow).toMatch(/pnpm exec commitlint --from \S.* --to \S/);
+    expect(workflow).toContain("github.event.pull_request.base.sha");
+    expect(workflow).toContain("github.event.pull_request.head.sha");
+  });
+
+  it("still fetches full history, which --from/--to needs to walk the commit range", () => {
+    expect(workflow).toMatch(/fetch-depth:\s*0/);
+  });
+});


### PR DESCRIPTION
## What & why

`wagoid/commitlint-github-action` bundles its own `@commitlint/*` inside its Docker image, separate from the `commitlint` `pnpm install` already puts in this repo's `node_modules` — the one `commitlint.config.mjs` is written against and `tests/commitlint-config.spec.ts` actually exercises. That bundled parser fails to extract `type`/`subject` from a `type(scope)!: subject` header at all (`type-empty`/`subject-empty`), even though this repo's own pinned `commitlint` accepts it fine — so a commit `commitlint-config.spec.ts` swears is fine could still fail the real CI check, as happened landing #383. This replaces the action with `pnpm exec commitlint --from/--to` over the PR's base/head SHAs, covering the same commit range `fetch-depth: 0` already pulls.

Closes #384

## Public API impact

None — repo CI wiring only.

## Testing

Added `tests/commitlint-workflow.spec.ts` to pin the workflow wiring itself (no third-party action, install runs before lint, the lint step covers the PR's actual commit range, `fetch-depth: 0` retained) so this can't silently regress back to the bundled tool. Extended `tests/commitlint-config.spec.ts` with a case combining the `!` breaking-change marker and the comma-separated multi-scope convention (`fix(core,nest)!: ...`). Manually verified `pnpm exec commitlint --from HEAD~1 --to HEAD --verbose` against real repo history.

`pnpm check`: build, typecheck, depcruise, and lint all pass clean. Test suite: 2944 passed, 633 skipped; the only 12 failing suites are pre-existing sandbox-environment failures unrelated to this change (no container runtime for testcontainers-backed Postgres/MariaDB/CockroachDB/Mongo e2e suites, and the MongoDB memory-server binary download is blocked in this environment — same failures seen on #383). `pnpm docs:links` passes (no doc changes needed; this is CI wiring only).

## Review notes

None outstanding.


---
_Generated by [Claude Code](https://claude.ai/code/session_016z5oRHYR3ug1o5TXGKjW2e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pull request validation to use the repository’s pinned commit-linting setup.
  - Commit messages are now checked across the complete pull request commit range with verbose validation.

- **Tests**
  - Added coverage for commit messages containing breaking-change markers with multiple scopes.
  - Added checks to ensure workflow configuration validates the full commit history and installs required dependencies before linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->