### PR TITLE
Add apply to create/update config — force write-body values the client cannot override

### DIFF
--- a/docs/features/apply.md
+++ b/docs/features/apply.md
@@ -1,6 +1,6 @@
 # Apply
 
-`apply` is a mandatory, context-dependent constraint on one of the four query axes — `filter`, `sort`, `select`, `include` — evaluated on every request and composed with whatever the client itself supplied, never replaced by it. It's the seam for row scoping: user ownership, tenant isolation, published-only records, and similar server-side restrictions that must hold regardless of what a caller asks for ([ADR-0048](/internals/adr/0048-apply-server-side-query-constraint)).
+`apply` is a mandatory, context-dependent constraint evaluated on every request and composed with whatever the client itself supplied, never replaced by it. It's the seam for row scoping: user ownership, tenant isolation, published-only records, and similar server-side restrictions that must hold regardless of what a caller asks for. It comes in two forms: one on each of the four query axes — `filter`, `sort`, `select`, `include` ([ADR-0048](/internals/adr/0048-apply-server-side-query-constraint)) — and one on `create`/`update`, forcing values into the write body itself ([ADR-0049](/internals/adr/0049-write-apply-forces-create-update-body-values)).
 
 ```ts
 import type { FilterApply } from "@kavo/core";
@@ -119,6 +119,25 @@ filter: {
   },
 },
 ```
+
+## Writing forced values: `create.apply`/`update.apply`
+
+The four query axes above scope which rows a request may read or reach by id — they say nothing about the values a `createOne`/`updateOne` body may set. A tenant-scoped entity with `filter.apply` restricting every read and existing-row write to `tenantId = context.app.tenantId` still lets a client `POST` a body naming a different `tenantId` outright, since there's no existing row for `filter.apply` to scope on `createOne`. `create.apply`/`update.apply` close that gap, living next to `create`/`update`'s own `default`:
+
+```ts
+@Kavo(Order, {
+  create: {
+    apply: ({ context }) => ({ tenantId: context.app.tenantId }),
+  },
+  update: {
+    apply: ({ context }) => ({ tenantId: context.app.tenantId }),
+  },
+})
+```
+
+Same `ApplyArgs<Entity>` argument every other `apply` takes; the return shape is `Partial<Entity> | undefined` instead of a query-axis type. Composition is the write-side version of the same rule: a forced field **overwrites** whatever the client sent for it, the opposite of `default`, which only fills a field the client omitted. Configuring both `default` and `apply` for the same field is legal — `apply` wins, since it's the unconditional constraint and `default` only a fallback for an absent value.
+
+Scope matches `default`'s own: `create.apply` runs on `createOne`, `update.apply` on `updateOne` only — never `patchOne`, whose omitting a field means "leave it unchanged" rather than "reset it," the same reasoning that already keeps `update.default` off `patchOne`.
 
 ## Non-goals
 

--- a/docs/internals/adr/0049-write-apply-forces-create-update-body-values.md
+++ b/docs/internals/adr/0049-write-apply-forces-create-update-body-values.md
@@ -1,0 +1,100 @@
+# ADR-0049 — `create.apply`/`update.apply` force write-body values
+
+**Status:** accepted
+
+## Context
+
+ADR-0048 gave `filter`/`sort`/`select`/`include` an `apply` callback: an
+unconditional, per-request constraint that composes with whatever the client
+sent rather than being replaced by it. For single-row writes
+(`updateOne`/`patchOne`/`deleteOne`/`restoreOne`/`purgeOne`) it folds
+`filter.apply`'s result into the same pre-fetch-by-id the `policy` stage
+already pays for, so a row outside the constraint answers `404` before any
+handler runs.
+
+That covers which **existing row** a write may reach. It says nothing about
+the **values** a `createOne`/`updateOne` body may set. A tenant-scoped
+`Order` entity can have `filter.apply` restrict every read and every
+existing-row write to `tenantId = ctx.tenantId`, and a client can still
+`POST /orders` with `{ tenantId: "some-other-tenant", ... }` and create a row
+outside its own scope outright — there is no existing row for `filter.apply`
+to scope on `createOne`.
+
+`EntityConfig.create`/`.update` (`WriteFieldsConfig`, issue #388) already
+carry `default`, but `default` is client-overridable by design: it fills a
+field the body omits, and a body that sends the field wins outright. That is
+exactly wrong for a forced invariant — an app cannot express "this field is
+always `ctx.tenantId`, no matter what the client sends" with a mechanism
+whose whole contract is that the client's own value always wins. ADR-0048's
+own "`apply` is not `default`" section already reserved this distinction for
+exactly this case.
+
+## Decision
+
+`WriteFieldsConfig` (`create`/`update`) gains an `apply` callback, next to
+`fields`/`default`:
+
+```ts
+create: {
+  apply: (args) => ({ tenantId: args.context.app?.tenantId }),
+},
+update: {
+  apply: (args) => ({ tenantId: args.context.app?.tenantId }),
+},
+```
+
+**Shape.** Reuses `ApplyArgs<Entity>` — the same argument shape
+`filter.apply`/`sort.apply`/`select.apply`/`include.apply` already take
+(`context`, `resource`, `operation`, `params`) — rather than inventing a
+second callback shape. `WriteApply<Entity>` is
+`(args: ApplyArgs<Entity>) => Partial<EntityInput<Entity>> | undefined | Promise<...>`.
+A key the returned object omits (or a call returning `undefined`) is left
+alone, not reset to anything.
+
+**Composition is the opposite of `default`'s.** `apply`'s result overwrites
+whatever the client sent for that key — the same one-way relationship
+`filter.apply` already has with the client's own filter, applied to an
+object merge instead of an `AND`. When a field is named by both `default`
+and `apply`, `apply` wins: it is the unconditional constraint, `default` only
+a fallback for an absent value.
+
+**Scope, matching `default`'s own.** `create.apply` runs on `createOne`
+only (and `createMany`, once #137 lands); `update.apply` runs on `updateOne`
+only, never `patchOne` — a `PATCH` omitting a field means "leave it
+unchanged," the same reasoning that already keeps `update.default` off
+`patchOne`. Whether a forced value should ever override that omission
+semantics is a separate decision, left out here.
+
+**Where it runs.** After `resolveInput` has produced the deserialized body
+(`KavoEngine.run`), so the forced values reach the adapter exactly as if the
+client had sent them, and `filter.apply`'s own single-row scoping (which
+runs earlier, during the pre-fetch) is untouched by this change.
+`applyWriteApply` mutates the already-deserialized body in place rather than
+reconstructing `resolveInput`'s two write shapes (`createOne`'s input _is_
+the body; `updateOne`'s wraps it under `data`).
+
+**Not bootstrap-validated**, for the same reason ADR-0048 already gives
+`filter.apply`/`select.apply`/`sort.apply`: it is evaluated per request with
+an arbitrary runtime value, so there is nothing to check ahead of time
+beyond "is it callable at all" (`resolveWriteApply`, mirroring
+`assertIsPolicyFunction`'s treatment of a non-function `policy`).
+
+## Non-goals
+
+- **`patchOne` gaining `apply`/`default` semantics.** Left for a future
+  decision if the omission-means-unchanged contract ever needs revisiting.
+- **A per-operation `apply` scope beyond `create`/`update`'s own entity-wide
+  config** — matches ADR-0048's own "entity-wide, not per-operation (yet)"
+  scope note.
+- **Field-level visibility or masking.** Unrelated to forcing write values;
+  ADR-0048 already carves this out for the read-side `apply`s.
+
+## Consequences
+
+- Closes the write-side half of issue #138: an entity with `filter.apply`
+  scoping its reads and existing-row writes, plus `create.apply`/
+  `update.apply` forcing the same scoping key on write bodies, has no gap
+  left for a client to create or relabel a row outside its own scope.
+- `default` and `apply` remain two visibly different keys with different
+  composition rules on the same `WriteFieldsConfig`, exactly as ADR-0048
+  anticipated.

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -35,7 +35,7 @@ import { STANDARD_OPERATION_IDS } from "../operations/operation.js";
 import { BUILT_IN_DEFAULTS } from "./defaults.js";
 import { deepFreeze, mergeSettings } from "./merge-settings.js";
 import { validateSettings } from "./validate-settings.js";
-import type { DtoClass, WriteFieldsConfig } from "../dto/dto.js";
+import type { DtoClass, WriteApply, WriteFieldsConfig } from "../dto/dto.js";
 import { dtoShapeKeys } from "../dto/dto-shape.js";
 import { dtoClassFromFields, resolveDtoSlot } from "../dto/dto-fields-shorthand.js";
 import { DefaultDtoResolver } from "../dto/default-dto-resolver.js";
@@ -122,6 +122,8 @@ export function resolveEntityConfig<Entity extends object>(
   );
   const createDefault = resolveWriteDefault(entityName, "create.default", entityConfig?.create, ownColumnNames);
   const updateDefault = resolveWriteDefault(entityName, "update.default", entityConfig?.update, ownColumnNames);
+  const createApply = resolveWriteApply(entityName, "create.apply", entityConfig?.create);
+  const updateApply = resolveWriteApply(entityName, "update.apply", entityConfig?.update);
 
   const entitySettings = mergeSettings(
     BUILT_IN_DEFAULTS,
@@ -194,6 +196,8 @@ export function resolveEntityConfig<Entity extends object>(
     policy,
     createDefault,
     updateDefault,
+    createApply,
+    updateApply,
   };
   return Object.freeze(resolved);
 }
@@ -235,6 +239,34 @@ function resolveWriteDefault<Entity extends object>(
 }
 
 const EMPTY_WRITE_DEFAULT: Readonly<Record<string, never>> = Object.freeze({});
+
+/**
+ * Resolve `create.apply`/`update.apply` (issue #391): a plain function
+ * reference, passed through unresolved — the same treatment `filter.apply`/
+ * `sort.apply`/`select.apply`/`include.apply` already get (ADR-0048), for
+ * the same reason: it is evaluated per request with an arbitrary runtime
+ * value, so there is nothing here to validate ahead of time beyond "is it
+ * callable at all," which catches a JS or dynamically-built config the type
+ * system can't see.
+ */
+function resolveWriteApply<Entity extends object>(
+  entityName: string,
+  scope: string,
+  writeConfig: WriteFieldsConfig<Entity> | undefined,
+): WriteApply<Entity> | undefined {
+  const value = writeConfig?.apply;
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "function") {
+    throw new ConfigurationException(
+      entityName,
+      scope,
+      `'${scope}' must be a function — (args: ApplyArgs) => Partial<Entity> | undefined, got '${typeof value}'.`,
+    );
+  }
+  return value;
+}
 
 /**
  * Reject a `policy` value that isn't a function — TypeScript callers get a

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -3,7 +3,7 @@ import type { SearchDriver, SearchMode } from "./entity-config.js";
 import type { ComputedFieldMap } from "./computed-field.js";
 import type { FieldPath } from "../types/field-path.js";
 import type { IncludePath } from "../types/include-path.js";
-import type { DtoResolver } from "../dto/dto.js";
+import type { DtoResolver, WriteApply } from "../dto/dto.js";
 import type { FilterOperator } from "../query/filter.js";
 import type { Sort } from "../query/sort.js";
 import type { OperationId, StandardOperationId } from "../operations/operation.js";
@@ -163,4 +163,16 @@ export interface ResolvedEntityConfig<Entity = unknown> {
    * omission means "leave unchanged" rather than "reset").
    */
   readonly updateDefault: Readonly<Partial<Entity>>;
+  /**
+   * `create.apply` (issue #391), passed through unresolved — the write-side
+   * sibling of `filter.apply`/`sort.apply`/`select.apply`/`include.apply`
+   * (ADR-0048): forces field values into `createOne`'s body, overwriting
+   * whatever the client sent. `undefined` when unconfigured.
+   */
+  readonly createApply?: WriteApply<Entity>;
+  /**
+   * `update.apply` — same idea, `updateOne` only (never `patchOne`, matching
+   * {@link ResolvedEntityConfig.updateDefault}'s own scope).
+   */
+  readonly updateApply?: WriteApply<Entity>;
 }

--- a/packages/core/src/dto/dto.ts
+++ b/packages/core/src/dto/dto.ts
@@ -2,6 +2,7 @@ import type { EntityInput } from "../types/utility.js";
 import type { QueryContext } from "../query/query-context.js";
 import type { OperationId } from "../operations/operation.js";
 import type { FieldPath } from "../types/field-path.js";
+import type { ApplyArgs } from "../policy/kavo-apply.js";
 
 /**
  * Marker for anything usable as a DTO: any non-primitive object shape.
@@ -32,11 +33,25 @@ export interface FieldsShorthand<Entity> {
 }
 
 /**
+ * `create.apply`/`update.apply` (issue #391, ADR-0048's write-side sibling):
+ * forces field values into a `createOne`/`updateOne` body, overwriting
+ * whatever the client sent for that key — the opposite composition rule
+ * from `default`'s. Reuses `ApplyArgs`, the same argument shape
+ * `filter.apply`/`sort.apply`/`select.apply`/`include.apply` already take,
+ * rather than inventing a second callback shape. A key the returned object
+ * omits (or a call returning `undefined`) is left alone — untouched by
+ * `apply`, not reset to anything.
+ */
+export type WriteApply<Entity = unknown> = (
+  args: ApplyArgs<Entity>,
+) => Partial<EntityInput<Entity>> | undefined | Promise<Partial<EntityInput<Entity>> | undefined>;
+
+/**
  * `EntityConfig.create`/`.update`'s own config shape (issue #388, extended
- * with `default`). Unlike {@link FieldsShorthand}, `fields` is optional here
- * — a caller may configure only `default` and leave the writable-field list
- * at its entity-derived default, which a bare `{ fields: [...] }` shorthand
- * can't express.
+ * with `default` and, per issue #391, `apply`). Unlike {@link FieldsShorthand},
+ * `fields` is optional here — a caller may configure only `default`/`apply`
+ * and leave the writable-field list at its entity-derived default, which a
+ * bare `{ fields: [...] }` shorthand can't express.
  *
  * `default` fills in a value for any writable field the request body omits
  * — `createOne` only for `create.default`, `updateOne` only (never
@@ -46,11 +61,24 @@ export interface FieldsShorthand<Entity> {
  * the field always wins outright — `default` never overrides an explicit
  * value, the same one-way relationship `sort.default`/`select.default`/
  * `include.default` already have with their own client-supplied values.
+ *
+ * `apply` is `default`'s opposite: an unconditional, per-request constraint
+ * that overwrites whatever the client sent, the same relationship
+ * `filter.apply` already has with the client's own filter (ADR-0048). Scoped
+ * the same way `default` is — `create.apply` on `createOne`, `update.apply`
+ * on `updateOne` only, never `patchOne`. When a field is named by both,
+ * `apply` wins: it is the unconditional constraint, `default` only a
+ * fallback for an absent value. Unlike `default`, `apply`'s return value is
+ * not validated at bootstrap against the entity's writable columns — it is
+ * evaluated per request with an arbitrary runtime value, the same non-goal
+ * ADR-0048 already states for `filter.apply`/`select.apply`/`sort.apply`.
  */
 export interface WriteFieldsConfig<Entity> {
   readonly fields?: readonly FieldPath<Entity, 1>[];
   /** Values for fields the request body doesn't set. Validated at bootstrap against the entity's own writable columns. */
   readonly default?: Partial<EntityInput<Entity>>;
+  /** Values forced into the request body, overwriting whatever the client sent (issue #391). Not bootstrap-validated — see class doc. */
+  readonly apply?: WriteApply<Entity>;
 }
 
 /** The six DTO positions, one per REST verb/context. */

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -310,6 +310,7 @@ export class KavoEngine<Entity extends object> {
     }
 
     const input = this.resolveInput(request, descriptor, context);
+    await this.applyWriteApply(request, descriptor, configView, context, input);
 
     const result = await descriptor.handler.execute(input, context);
     if (descriptor.id === "findOne") {
@@ -990,6 +991,10 @@ export class KavoEngine<Entity extends object> {
       // a per-call override cannot widen what a write is defaulted from.
       createDefault: config.createDefault,
       updateDefault: config.updateDefault,
+      // Same reasoning: a per-call override cannot loosen the unconditional
+      // constraint `create.apply`/`update.apply` forces (issue #391).
+      createApply: config.createApply,
+      updateApply: config.updateApply,
     };
   }
 
@@ -1058,6 +1063,48 @@ export class KavoEngine<Entity extends object> {
       include.apply?.(args),
     ]);
     return { filter: filterResult, sort: sortResult, select: selectResult, include: includeResult };
+  }
+
+  /**
+   * `create.apply`/`update.apply` (issue #391, ADR-0048's write-side
+   * sibling): evaluated once per `createOne`/`updateOne`, after
+   * `resolveInput` has already produced the deserialized body, so its
+   * result can overwrite whatever the client sent for a forced field —
+   * `default` only fills a gap, `apply` always wins. `patchOne` never
+   * consults it, matching `update.default`'s own scope. Mutates `input` in
+   * place rather than returning a new object: `resolveInput`'s two write
+   * shapes differ (`createOne`'s input *is* the body; `updateOne`'s wraps it
+   * under `data`), and mutating the body object either shape already holds
+   * is simpler than reconstructing either wrapper.
+   */
+  private async applyWriteApply(
+    request: KavoRequest<Entity>,
+    descriptor: OperationDescriptor<Entity>,
+    configView: ResolvedEntityConfig<Entity>,
+    context: KavoContext<Entity>,
+    input: unknown,
+  ): Promise<void> {
+    const apply =
+      descriptor.id === "createOne"
+        ? configView.createApply
+        : descriptor.id === "updateOne"
+          ? configView.updateApply
+          : undefined;
+    if (apply === undefined) {
+      return;
+    }
+    const body = descriptor.id === "updateOne" ? (input as { data: object }).data : (input as object);
+    const id = request.id === null ? null : (this.coerceId(request.id) as EntityId);
+    const args: ApplyArgs<Entity> = {
+      context,
+      resource: context.entityName,
+      operation: descriptor.id,
+      params: { id },
+    };
+    const forced = await apply(args);
+    if (forced !== undefined) {
+      Object.assign(body, forced);
+    }
   }
 
   private resolveInput(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export type {
   DtoResolver,
   FieldsShorthand,
   WriteFieldsConfig,
+  WriteApply,
   OperationDtoMap,
   OperationDtoOverride,
   DtoInputOf,

--- a/packages/core/tests/apply.spec.ts
+++ b/packages/core/tests/apply.spec.ts
@@ -461,3 +461,134 @@ describe("QueryNormalizer — composing a resolved apply result directly (both e
     expect(query.filter.root).toBeNull();
   });
 });
+
+describe("create.apply/update.apply — force write-body values the client cannot override (issue #391)", () => {
+  it("createOne: forces a value the client never sent", async () => {
+    const { crud, adapter } = makeCrud({
+      create: { apply: () => ({ authorId: 7 }) },
+    } as never);
+    await crud.createOne({ title: "hello" } as never);
+    expect(adapter.rows[0]).toMatchObject({ title: "hello", authorId: 7 });
+  });
+
+  it("createOne: overwrites a value the client did send", async () => {
+    const { crud, adapter } = makeCrud({
+      create: { apply: () => ({ authorId: 7 }) },
+    } as never);
+    await crud.createOne({ title: "hello", authorId: 999 } as never);
+    expect(adapter.rows[0]).toMatchObject({ authorId: 7 });
+  });
+
+  it("createOne: receives the same ApplyArgs shape filter.apply gets, with a null id", async () => {
+    let seen: ApplyArgs<Post> | undefined;
+    const { crud } = makeCrud({
+      create: {
+        apply: (args: ApplyArgs<Post>) => {
+          seen = args;
+          return undefined;
+        },
+      },
+    } as never);
+    await crud.createOne({ title: "hello" } as never, { app: { userId: "u-1" } as never });
+    expect(seen?.resource).toBe("Post");
+    expect(seen?.operation).toBe("createOne");
+    expect(seen?.params.id).toBeNull();
+    expect(appOf(seen?.context as KavoContext<Post>).userId).toBe("u-1");
+  });
+
+  it("updateOne: forces a value the client never sent, alongside the fields it did", async () => {
+    const { crud, adapter } = makeCrud({
+      update: { apply: () => ({ authorId: 7 }) },
+    } as never);
+    adapter.rows.push(
+      ...posts([{ id: 1, title: "old", authorId: 1 as never, author: null, comments: [], deletedAt: null }]),
+    );
+    await crud.updateOne(1, { title: "new" } as never);
+    expect(adapter.rows[0]).toMatchObject({ title: "new", authorId: 7 });
+  });
+
+  it("updateOne: overwrites a value the client did send", async () => {
+    const { crud, adapter } = makeCrud({
+      update: { apply: () => ({ authorId: 7 }) },
+    } as never);
+    adapter.rows.push(
+      ...posts([{ id: 1, title: "old", authorId: 1 as never, author: null, comments: [], deletedAt: null }]),
+    );
+    await crud.updateOne(1, { title: "new", authorId: 999 } as never);
+    expect(adapter.rows[0]).toMatchObject({ authorId: 7 });
+  });
+
+  it("updateOne: receives the coerced id in params, unlike createOne", async () => {
+    let seen: ApplyArgs<Post> | undefined;
+    const { crud, adapter } = makeCrud({
+      update: {
+        apply: (args: ApplyArgs<Post>) => {
+          seen = args;
+          return undefined;
+        },
+      },
+    } as never);
+    adapter.rows.push(
+      ...posts([{ id: 1, title: "old", authorId: 1 as never, author: null, comments: [], deletedAt: null }]),
+    );
+    await crud.updateOne(1, { title: "new" } as never);
+    expect(seen?.params.id).toBe(1);
+  });
+
+  it("patchOne never consults update.apply, matching update.default's own scope", async () => {
+    const { crud, adapter } = makeCrud({
+      update: { apply: () => ({ authorId: 7 }) },
+    } as never);
+    adapter.rows.push(
+      ...posts([{ id: 1, title: "old", authorId: 1 as never, author: null, comments: [], deletedAt: null }]),
+    );
+    await crud.patchOne(1, { title: "new" } as never);
+    expect(adapter.rows[0]).toMatchObject({ title: "new", authorId: 1 });
+  });
+
+  it("create.apply is never consulted on updateOne, and update.apply never on createOne", async () => {
+    const { crud, adapter } = makeCrud({
+      create: { apply: () => ({ authorId: 1 }) },
+      update: { apply: () => ({ authorId: 2 }) },
+    } as never);
+    adapter.rows.push(
+      ...posts([{ id: 1, title: "old", authorId: 9 as never, author: null, comments: [], deletedAt: null }]),
+    );
+    await crud.updateOne(1, { title: "new" } as never);
+    expect(adapter.rows[0]).toMatchObject({ authorId: 2 });
+    await crud.createOne({ title: "another" } as never);
+    expect(adapter.rows[1]).toMatchObject({ authorId: 1 });
+  });
+
+  it("a key apply returns undefined for is left alone rather than reset", async () => {
+    const { crud, adapter } = makeCrud({
+      create: { apply: () => undefined },
+    } as never);
+    await crud.createOne({ title: "hello", authorId: 3 } as never);
+    expect(adapter.rows[0]).toMatchObject({ title: "hello", authorId: 3 });
+  });
+
+  it("apply wins over default when both configure the same field", async () => {
+    const { crud, adapter } = makeCrud({
+      create: { default: { authorId: 1 }, apply: () => ({ authorId: 2 }) },
+    } as never);
+    await crud.createOne({ title: "hello" } as never);
+    expect(adapter.rows[0]).toMatchObject({ authorId: 2 });
+  });
+
+  it("an unconfigured apply changes nothing (backward compatible)", async () => {
+    const { crud, adapter } = makeCrud();
+    await crud.createOne({ title: "hello", authorId: 5 } as never);
+    expect(adapter.rows[0]).toMatchObject({ title: "hello", authorId: 5 });
+  });
+});
+
+describe("create.apply/update.apply — bootstrap validation", () => {
+  it("rejects a non-function create.apply", () => {
+    expect(() => makeCrud({ create: { apply: "nope" } } as never)).toThrow(/create\.apply/);
+  });
+
+  it("rejects a non-function update.apply", () => {
+    expect(() => makeCrud({ update: { apply: "nope" } } as never)).toThrow(/update\.apply/);
+  });
+});

--- a/packages/core/tests/barrel.spec.ts
+++ b/packages/core/tests/barrel.spec.ts
@@ -255,6 +255,7 @@ const PUBLIC_SURFACE: readonly string[] = [
   "UnresolvedRelationException",
   "WhenParams",
   "WireQuery",
+  "WriteApply",
   "assertNever",
   "builtInHandlers",
   "builtInPaginationStrategies",


### PR DESCRIPTION
## What & why

`filter.apply` (ADR-0048) already scopes which *existing* row a read or single-row write may reach, but it never runs on `createOne`, so a client could still `POST`/`PUT` a body naming a value (e.g. `tenantId`) outside its own scope — the write-side half of the row-scoping question issue #138 asked about was still open. This adds `apply` to `create`/`update` (`WriteFieldsConfig`), reusing `ApplyArgs` (the same shape every other `apply` already takes): it forces field values into the request body, overwriting whatever the client sent — the opposite composition rule from `default`, which only fills a field the client omitted. Scoped the same way `default` already is: `create.apply` on `createOne`, `update.apply` on `updateOne` only, never `patchOne`.

Recorded as ADR-0049, a direct follow-on to ADR-0048.

Closes #391
Closes #138

## Public API impact

Additive only. `packages/core/src/index.ts` gains one new export, `WriteApply` (the type of `create.apply`/`update.apply`'s callback). `WriteFieldsConfig` gains an optional `apply` key; `ResolvedEntityConfig` gains optional `createApply`/`updateApply`. Nothing existing changes shape or behavior when `apply` is left unconfigured.

## Testing

- `packages/core/tests/apply.spec.ts` — new `describe` blocks: `createOne`/`updateOne` forcing an unset field, overwriting a client-sent value, receiving the same `ApplyArgs` shape (with `params.id` null on create, coerced on update), `patchOne` never consulting `update.apply`, `create.apply`/`update.apply` never crossing operations, `apply` winning over `default` on the same field, and bootstrap rejecting a non-function `apply`.
- `packages/core/tests/barrel.spec.ts` — manifest updated for the new `WriteApply` export.
- Verified `pnpm check` (build + typecheck + depcruise + lint + test) — clean, aside from pre-existing container-dependent e2e suites that don't run in this environment (no Docker/testcontainers) and one unrelated pre-existing `swagger.json` formatting warning, neither touched by this change.

## Review notes

`patchOne` deliberately gets no `apply`/`default` semantics here, matching `update.default`'s existing scope — left as a documented non-goal in ADR-0049 rather than assumed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6BWuKgCMiiFnZxk27HL7C


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6BWuKgCMiiFnZxk27HL7C)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added write-time `apply` callbacks for `createOne` and `updateOne`.
  * Applied callback values override client-provided values and defaults.
  * Added the public `WriteApply` type for configuring these callbacks.
  * Callbacks receive request context and may return synchronous or asynchronous values.

* **Documentation**
  * Documented write-side apply behavior, including its exclusion from `patchOne`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->