### PR TITLE
feat(core): add filter.default for symmetry with sort/select/include

### DIFF
--- a/docs/features/apply.md
+++ b/docs/features/apply.md
@@ -31,10 +31,11 @@ With that config, `GET /posts?filter[status][eq]=published` runs as if the calle
 
 ## `apply` is not `default`
 
-`sort.default`/`select.default`/`include.default` answer "what does a request that supplied nothing on this axis get" — a client-supplied value on that axis replaces the default outright, no composition. `apply` answers a different question: "what does **every** request get, regardless of what it supplied." It composes with a client value rather than being replaced by one, and (for `filter`) it composes even when the client sent nothing at all. There is no `filter.default` today — only `apply` — because a filter has no natural "value when absent" the way a sort order or a projection does.
+`filter.default`/`sort.default`/`select.default`/`include.default` answer "what does a request that supplied nothing on this axis get" — a client-supplied value on that axis replaces the default outright, no composition. `apply` answers a different question: "what does **every** request get, regardless of what it supplied." It composes with a client value rather than being replaced by one, and (for `filter`) it composes even when the client sent nothing at all — including when a `filter.default` supplied the base filter that request is scored against.
 
 | Key                | Runs when the client sends nothing | Runs when the client sends its own value | Can the client override it   |
 | ------------------ | ---------------------------------- | ---------------------------------------- | ---------------------------- |
+| `filter.default`   | yes                                | no — replaced                            | yes, by supplying `filter=`  |
 | `sort.default`     | yes                                | no — replaced                            | yes, by supplying `sort=`    |
 | `select.default`   | yes                                | no — replaced                            | yes, by supplying `select=`  |
 | `include.default`  | yes                                | no — replaced                            | yes, by supplying `include=` |

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -10,7 +10,7 @@ import type { OperationCardinality, OperationKind, StandardOperationId } from ".
 import type { ComputedFieldDescriptor } from "./computed-field.js";
 import type { Policy } from "../policy/kavo-policy.js";
 import type { FilterApply, IncludeApply, SelectApply, SortApply } from "../policy/kavo-apply.js";
-import type { FilterOperatorToken } from "../query/filter.js";
+import type { FilterExpression, FilterOperatorToken } from "../query/filter.js";
 
 /**
  * One allowlist key's raw configuration: either the explicit set of paths
@@ -124,6 +124,17 @@ export interface FilterConfig<Entity> {
    * new capability) — unconfigured, every own column, every operator.
    */
   readonly fields?: FilterFieldSelector<Entity>;
+  /**
+   * The predicate applied when a request supplies no `filter=` at all — a
+   * client-supplied `filter=` always wins outright, never merges with this
+   * (mirroring `sort.default`/`select.default`/`include.default`, issue
+   * #394). Composes with `search` (ADR'd into the same tree) and with
+   * `apply` below, which still `AND`s in afterward regardless of which of
+   * the two produced the base filter. Fields named here are validated
+   * against `fields` at bootstrap, the same as client-supplied filters are
+   * at request time.
+   */
+  readonly default?: FilterExpression<Entity>;
   /**
    * A mandatory server-side predicate (ADR-0048), `AND`ed into the client's
    * own `filter=` on every read, and into the id lookup of every single-row

--- a/packages/core/src/config/resolve-entity-config.ts
+++ b/packages/core/src/config/resolve-entity-config.ts
@@ -24,7 +24,7 @@ import type {
 import type { EntityMetadata } from "../metadata/entity-metadata.js";
 import type { FieldPath } from "../types/field-path.js";
 import type { IncludePath } from "../types/include-path.js";
-import type { FilterOperator, FilterOperatorToken } from "../query/filter.js";
+import type { FilterExpression, FilterOperator, FilterOperatorToken } from "../query/filter.js";
 import type { Sort } from "../query/sort.js";
 import type { OperationId, StandardOperationId } from "../operations/operation.js";
 import type { RealtimeTransport } from "../realtime/realtime-transport.js";
@@ -626,6 +626,40 @@ function parseSortToken<Entity>(token: string): Sort<Entity> {
   return { field: field as FieldPath<Entity>, direction: descending ? "desc" : "asc" };
 }
 
+/** Bootstrap-validate every field named inside a `filter.default` expression against `filter.fields`. */
+function validateFilterDefaultFields<Entity>(
+  entityName: string,
+  expression: FilterExpression<Entity>,
+  filterable: ReadonlySet<string>,
+): void {
+  if (expression.kind === "condition") {
+    if (!filterable.has(expression.field as string)) {
+      throw new ConfigurationException(
+        entityName,
+        "filter.default",
+        `field '${expression.field as string}' is not in 'filter.fields'`,
+      );
+    }
+    return;
+  }
+  for (const child of expression.children) {
+    validateFilterDefaultFields(entityName, child, filterable);
+  }
+}
+
+/** Resolve and bootstrap-validate `filter.default` against `filter.fields`. */
+function resolveFilterDefault<Entity extends object>(
+  entityName: string,
+  expression: FilterExpression<Entity> | undefined,
+  filterable: readonly FieldPath<Entity>[],
+): FilterExpression<Entity> | null {
+  if (expression === undefined) {
+    return null;
+  }
+  validateFilterDefaultFields(entityName, expression, new Set(filterable as readonly string[]));
+  return expression;
+}
+
 /** Resolve and bootstrap-validate `sort.default` against `sort.fields`. */
 function resolveSortDefault<Entity extends object>(
   entityName: string,
@@ -862,6 +896,7 @@ function resolveFieldGroups<Entity extends object>(
   const filter: ResolvedFilterConfig<Entity> = deepFreeze({
     fields: filterFields,
     operators,
+    default: resolveFilterDefault(entityName, filterConfig?.default, filterFields),
     apply: filterConfig?.apply,
     limits: resolveFilterLimits(entityName, filterConfig?.limits),
   });

--- a/packages/core/src/config/resolved-entity-config.ts
+++ b/packages/core/src/config/resolved-entity-config.ts
@@ -4,7 +4,7 @@ import type { ComputedFieldMap } from "./computed-field.js";
 import type { FieldPath } from "../types/field-path.js";
 import type { IncludePath } from "../types/include-path.js";
 import type { DtoResolver, WriteApply } from "../dto/dto.js";
-import type { FilterOperator } from "../query/filter.js";
+import type { FilterExpression, FilterOperator } from "../query/filter.js";
 import type { Sort } from "../query/sort.js";
 import type { OperationId, StandardOperationId } from "../operations/operation.js";
 import type { Policy } from "../policy/kavo-policy.js";
@@ -19,6 +19,8 @@ export interface ResolvedFilterConfig<Entity = unknown> {
   readonly fields: readonly FieldPath<Entity>[];
   /** Per-field allowed operators (the map form), or `null` when every allowed field permits every operator. */
   readonly operators: ReadonlyMap<string, ReadonlySet<FilterOperator>> | null;
+  /** `filter.default` (issue #394), bootstrap-validated against `fields`. `null` when unconfigured. */
+  readonly default: FilterExpression<Entity> | null;
   /** `filter.apply` (ADR-0048), passed through unresolved — see that ADR for composition. `undefined` when unconfigured. */
   readonly apply?: FilterApply<Entity>;
   readonly limits: {

--- a/packages/core/src/query/query-normalizer.ts
+++ b/packages/core/src/query/query-normalizer.ts
@@ -76,6 +76,9 @@ export class QueryNormalizer<Entity = unknown> {
     } catch (error) {
       collectIssues(error, issues);
     }
+    if (filter.root === null && config.filter.default !== null) {
+      filter = { root: config.filter.default };
+    }
     filter = parseSearch(rawParams, filter, config, issues);
     filter = applyServerFilter(filter, serverApply?.filter);
 
@@ -167,10 +170,11 @@ export class QueryNormalizer<Entity = unknown> {
       issues.push(conflictingSoftDeleteFlagsIssue());
     }
 
-    const root = input.filter ?? null;
-    if (root !== null) {
-      validateExpression(root, config, issues);
+    const clientFilterRoot = input.filter ?? null;
+    if (clientFilterRoot !== null) {
+      validateExpression(clientFilterRoot, config, issues);
     }
+    const root = clientFilterRoot ?? config.filter.default;
     const filter = applyServerFilter({ root }, serverApply?.filter);
 
     const clientSort = input.sort ?? [];

--- a/packages/core/tests/filter-default.spec.ts
+++ b/packages/core/tests/filter-default.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type { FilterExpression, NormalizedQueryContext } from "@kavo/core";
+import { QueryNormalizer, createKavo, resolveEntityConfig } from "@kavo/core";
+import {
+  Author,
+  Comment,
+  Post,
+  SeededAdapter,
+  authorMetadata,
+  commentMetadata,
+  postMetadata,
+} from "./support/blog-fixture.js";
+
+function makeCrud(config?: Parameters<ReturnType<typeof createKavo>["createCrud"]>[1]) {
+  const adapter = new SeededAdapter<Post>([]);
+  const kavo = createKavo();
+  kavo.createCrud(Author, undefined, { adapter: new SeededAdapter<Author>(), metadata: authorMetadata });
+  kavo.createCrud(Comment, undefined, { adapter: new SeededAdapter<Comment>(), metadata: commentMetadata });
+  const crud = kavo.createCrud(Post, config as never, { adapter, metadata: postMetadata });
+  return { crud, adapter, kavo };
+}
+
+const statusFilter: FilterExpression<Post> = {
+  kind: "condition",
+  field: "title" as never,
+  operator: "EQ",
+  value: "default-title",
+};
+
+describe("filter.default — applies only when the client sends no filter=", () => {
+  it("is used for findMany when the request carries no filter", async () => {
+    const { crud, adapter } = makeCrud({
+      filter: { fields: ["title", "authorId"], default: statusFilter },
+    } as never);
+    await crud.findMany(undefined);
+    expect(adapter.lastQuery?.filter.root).toEqual(statusFilter);
+  });
+
+  it("is fully overridden — not merged — by a client-supplied filter", async () => {
+    const { crud, adapter } = makeCrud({
+      filter: { fields: ["title", "authorId"], default: statusFilter },
+    } as never);
+    const clientFilter: FilterExpression<Post> = {
+      kind: "condition",
+      field: "authorId" as never,
+      operator: "EQ",
+      value: "u-1",
+    };
+    await crud.findMany({ filter: clientFilter } as never);
+    expect(adapter.lastQuery?.filter.root).toEqual(clientFilter);
+  });
+
+  it("composes with filter.apply — apply still AND's in over the default", async () => {
+    const { crud, adapter } = makeCrud({
+      filter: {
+        fields: ["title", "authorId"],
+        default: statusFilter,
+        apply: () => ({ kind: "condition", field: "authorId" as never, operator: "EQ", value: "u-1" }),
+      },
+    } as never);
+    await crud.findMany(undefined);
+    expect(adapter.lastQuery?.filter.root).toEqual({
+      kind: "group",
+      operator: "AND",
+      children: [statusFilter, { kind: "condition", field: "authorId", operator: "EQ", value: "u-1" }],
+    });
+  });
+
+  it("has no effect when unconfigured", async () => {
+    const { crud, adapter } = makeCrud();
+    await crud.findMany(undefined);
+    expect(adapter.lastQuery?.filter.root).toBeNull();
+  });
+});
+
+describe("filter.default — bootstrap validation", () => {
+  it("rejects a default naming a field not in filter.fields", () => {
+    expect(() =>
+      makeCrud({
+        filter: {
+          fields: ["title"],
+          default: { kind: "condition", field: "authorId" as never, operator: "EQ", value: "u-1" },
+        },
+      } as never),
+    ).toThrow(/filter\.default/);
+  });
+
+  it("validates fields nested inside groups", () => {
+    expect(() =>
+      makeCrud({
+        filter: {
+          fields: ["title"],
+          default: {
+            kind: "group",
+            operator: "AND",
+            children: [
+              { kind: "condition", field: "title" as never, operator: "EQ", value: "a" },
+              { kind: "condition", field: "authorId" as never, operator: "EQ", value: "u-1" },
+            ],
+          },
+        },
+      } as never),
+    ).toThrow(/filter\.default/);
+  });
+});
+
+describe("QueryNormalizer — filter.default via both entry points", () => {
+  const config = resolveEntityConfig(
+    postMetadata,
+    {
+      filter: { fields: ["title", "authorId"], default: statusFilter },
+      select: { fields: ["title", "authorId"] },
+    },
+    undefined,
+  );
+  const normalizer = new QueryNormalizer<Post>(postMetadata);
+
+  it("normalizeWire substitutes the default when no filter[...] param is present", () => {
+    const result: NormalizedQueryContext<Post> = normalizer.normalizeWire({}, config);
+    expect(result.filter.root).toEqual(statusFilter);
+  });
+
+  it("normalizeInput substitutes the default when input.filter is absent", () => {
+    const result = normalizer.normalizeInput(undefined, config);
+    expect(result.filter.root).toEqual(statusFilter);
+  });
+
+  it("normalizeWire lets a client filter[...] param override the default outright", () => {
+    const result = normalizer.normalizeWire({ "filter[title][eq]": "hello" }, config);
+    expect(result.filter.root).toEqual({ kind: "condition", field: "title", operator: "EQ", value: "hello" });
+  });
+});


### PR DESCRIPTION
## What and why

`sort.default`, `select.default`, and `include.default` all let a request that supplies nothing on that axis fall back to a configured value, fully overridden by a client-supplied value on the same axis. `filter` never got this — only `fields` (allowlist) and ADR-0048's `apply` (mandatory, always ANDed, never overridable). The only way to give an entity a default filter was to misuse `apply`, which cannot be relaxed by a client's own `filter=`.

This adds `filter.default: FilterExpression<Entity>`, applied only when the request carries no `filter=` at all, replaced outright by a client-supplied one, and still composed under `filter.apply` and `search` exactly as before.

Closes #394

## Public API impact

`@kavo/core` barrel: no new exports (the new field lives on the existing `FilterConfig`/`ResolvedFilterConfig` interfaces). Not breaking — additive, optional config key.

## Testing

Added `packages/core/tests/filter-default.spec.ts` (9 tests): default applies when the client sends nothing, is fully overridden (not merged) by a client filter, composes correctly with `filter.apply`, is a no-op unconfigured, bootstrap rejects a default naming a field outside `filter.fields` (top-level and nested in a group), and both `QueryNormalizer.normalizeWire`/`normalizeInput` entry points directly.

`pnpm check`: build, typecheck, depcruise (no violations), lint, and the full suite — 136 files / 3632 tests — all passed. `pnpm docs:links` also passed.

## Review notes

- No new ADR was written — the issue flagged this as optional since it closes a gap ADR-0048 explicitly left rather than making a new load-bearing decision. `docs/features/apply.md`'s comparison table and prose were updated instead (it previously claimed "there is no `filter.default` today"). Flag if you'd rather this get a short ADR addendum.
- `filter.default` is a static `FilterExpression`, not a function of request context like `apply` — matching `sort.default`'s static-value shape rather than `apply`'s dynamic one, since "value when the client asked for nothing" is inherently static.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a default filter when clients do not provide one.
  - Default filters now work across wire and programmatic query inputs.
  - Client-provided filters override the default, while configured filter composition continues to apply.
  - Invalid default filter fields are reported during configuration validation.

- **Documentation**
  - Clarified how default filters interact with client filters and composed filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->