### PR TITLE
fix(core): narrow the per-operation settings scope

### DIFF
--- a/docs/internals/architecture/07-crud-engine.md
+++ b/docs/internals/architecture/07-crud-engine.md
@@ -60,15 +60,15 @@ createCrud(Order, {
 });
 ```
 
-| Key           | Required | Default   | What it decides                                                                                                                           |
-| ------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `handler`     | yes      | —         | The behavior. There is no built-in to fall back to.                                                                                       |
-| `kind`        | no       | `"write"` | `"read"` runs query resolution and takes no body; `@kavo/nest` binds `@Query` instead of `@Body`.                                         |
-| `cardinality` | no       | `"one"`   | `"many"` maps the result through the list envelope, so the handler returns a `FindManyResult`.                                            |
-| `enabled`     | no       | `true`    | `false` registers the entry inert, exactly as it does for a standard id.                                                                  |
-| `dto`         | no       | —         | `input`/`output` on a write, `output`/`query` on a read. The wrong field for the resolved `kind` is a bootstrap `ConfigurationException`. |
-| `meta`        | no       | `{}`      | Framework metadata; in `@kavo/nest` the route (doc 10).                                                                                   |
-| settings keys | no       | —         | The operation scope of the precedence chain, same as any standard id.                                                                     |
+| Key           | Required | Default   | What it decides                                                                                                                                                                                                                |
+| ------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `handler`     | yes      | —         | The behavior. There is no built-in to fall back to.                                                                                                                                                                            |
+| `kind`        | no       | `"write"` | `"read"` runs query resolution and takes no body; `@kavo/nest` binds `@Query` instead of `@Body`.                                                                                                                              |
+| `cardinality` | no       | `"one"`   | `"many"` maps the result through the list envelope, so the handler returns a `FindManyResult`.                                                                                                                                 |
+| `enabled`     | no       | `true`    | `false` registers the entry inert, exactly as it does for a standard id.                                                                                                                                                       |
+| `dto`         | no       | —         | `input`/`output` on a write, `output`/`query` on a read. The wrong field for the resolved `kind` is a bootstrap `ConfigurationException`.                                                                                      |
+| `meta`        | no       | `{}`      | Framework metadata; in `@kavo/nest` the route (doc 10).                                                                                                                                                                        |
+| settings keys | no       | —         | The operation scope of the precedence chain, narrowed by `kind`/`cardinality` (issue #415): `errors`/`cache` always, `delete` on a `kind: "read"`, `pagination` also on `kind: "read", cardinality: "many"`; `realtime` never. |
 
 Everything downstream treats the entry as ordinary. The engine dispatches it
 through the same lifecycle; DTO resolution falls back to the entity's own

--- a/docs/internals/architecture/08-configuration.md
+++ b/docs/internals/architecture/08-configuration.md
@@ -114,6 +114,34 @@ standard one, including the per-operation settings scope: the loop that
 precomputes `settingsFor(operation)` walks `operations` by key and never
 checks the key against the standard table.
 
+**The per-operation settings scope is narrowed at the type level** (issue
+#415). At runtime `settingsFor(operation)` is the whole `KavoSettings`
+subtree, but `OperationConfig` only accepts the keys that operation's
+engine stages actually read, so a key it would ignore is a compile error
+rather than a silently-dropped value:
+
+| key          | accepted on                                                                 |
+| ------------ | --------------------------------------------------------------------------- |
+| `pagination` | `findMany`                                                                  |
+| `realtime`   | `createOne`, `updateOne`, `patchOne`, `deleteOne`, `restoreOne`, `purgeOne` |
+| `delete`     | `findOne`, `findMany`, `deleteOne`, `restoreOne`, `purgeOne`                |
+| `cache`      | every operation                                                             |
+| `errors`     | every operation                                                             |
+
+`delete` is on the reads and the delete family because `configViewFor`
+resolves a soft-delete view for each of them — a per-operation `strategy`
+override (`operations: { deleteOne: { delete: { strategy: "hard" } } }`) is
+a supported way to force `hard` on one operation of a soft-deletable
+entity. It is _not_ accepted on `createOne`/`updateOne`/`patchOne`, which
+consult no soft-delete strategy. `cache` is _not_ narrowed: its `etag` half
+gates `If-Match`/`304` on every single-row operation — the void
+`deleteOne`/`purgeOne` included — not just the two reads its `ttl` half
+caches. For a **custom** operation the accepted subset follows from the
+`kind`/`cardinality` the entry declares: `errors`/`cache` always, `delete`
+on any `kind: "read"`, `pagination` also on a `kind: "read", cardinality:
+"many"` one; `realtime` never, since a custom operation is not a realtime
+event source.
+
 ## 3. Resolution timing and immutability
 
 All merging happens **once at bootstrap** (`resolveEntityConfig`) into a

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -371,6 +371,28 @@ export interface SearchConfig<Entity> {
 }
 
 /**
+ * Every `KavoSettings` key a per-operation (or per-call) scope could carry
+ * — the whole tree except the global `operations` enablement map, which is
+ * boolean-only global state (issue #38).
+ */
+type SettingsSubtreeKey = Exclude<keyof KavoSettings, "operations">;
+
+/**
+ * A per-operation settings scope narrowed to the keys the operation
+ * actually consumes (issue #415). Keys in `Allowed` carry their normal
+ * `DeepPartial<KavoSettings>` value; every other settings key is pinned to
+ * `never`, so naming one on an operation entry is a compile error rather
+ * than a value that resolves into `settingsFor(op)` and is then silently
+ * ignored. The `never` pin — rather than a plain `Pick` of `Allowed` — is
+ * what makes the custom-operation intersection (`Ops[Id] &
+ * CustomOperationConfig<…>`, via {@link CustomOperationsOf}) actually
+ * reject a stray key: `<real value> & never` collapses to `never`.
+ */
+type OperationSettings<Allowed extends SettingsSubtreeKey> = {
+  readonly [K in SettingsSubtreeKey]?: K extends Allowed ? DeepPartial<KavoSettings>[K] : never;
+};
+
+/**
  * Per-operation configuration.
  * Naming a standard id in the parent `operations` record — this object, or
  * the `true`/`false` shorthand — is what enables or disables it (ADR-0038,
@@ -380,14 +402,22 @@ export interface SearchConfig<Entity> {
  *
  * `DtoOverride` is `StandardOperationsConfig`'s per-id `Pick` of
  * `OperationDtoOverride` — only the fields that operation actually
- * supports (issue #131). It defaults to the full override shape so a bare
- * `OperationConfig<Entity>` (used where no specific operation id is in
- * scope) still type-checks.
+ * supports (issue #131). `Allowed` is the same idea for the settings
+ * subtree (issue #415): `StandardOperationsConfig` passes each id only the
+ * `KavoSettings` keys that id's engine stages read — `pagination` to
+ * `findMany` alone, `cache` to the reads, `realtime` to the writes,
+ * `delete` to the reads and the delete family (the operations whose
+ * behavior the resolved soft-delete view changes — `kavo-engine.ts`
+ * `configViewFor`), and `errors` to all. Both parameters default to the
+ * full shape so a bare `OperationConfig<Entity>` (used where no specific
+ * operation id is in scope — the `OperationsConfig` index signature's
+ * permissive upper bound) still type-checks.
  */
-export interface OperationConfig<Entity = unknown, DtoOverride = OperationDtoOverride> extends Omit<
-  DeepPartial<KavoSettings>,
-  "operations"
-> {
+export type OperationConfig<
+  Entity = unknown,
+  DtoOverride = OperationDtoOverride,
+  Allowed extends SettingsSubtreeKey = SettingsSubtreeKey,
+> = OperationSettings<Allowed> & {
   /** Replacement handler — keeps the default DTO/serialization scaffolding. */
   readonly handler?: OperationHandler<Entity>;
   /** Opaque metadata consumed by the framework layer (route options). */
@@ -414,7 +444,7 @@ export interface OperationConfig<Entity = unknown, DtoOverride = OperationDtoOve
    * `findMany` the policy still runs, with `entity: undefined`.
    */
   readonly policy?: Policy<Entity> | false;
-}
+};
 
 /**
  * The `operations` map's per-id DTO override shapes (issue #131): each
@@ -424,6 +454,27 @@ export interface OperationConfig<Entity = unknown, DtoOverride = OperationDtoOve
  * get neither, so setting `dto` on them is a type error before it is ever
  * a bootstrap one. The `true`/`false` shorthand is still accepted at every
  * id (ADR-0038, issue #257), for a plain enable/disable with no settings attached.
+ *
+ * The third `OperationConfig` argument narrows the settings subtree the
+ * same way (issue #415): each id names only the `KavoSettings` keys its
+ * engine stages read —
+ *
+ * - `pagination` on `findMany` alone — the sole operation the query
+ *   normalizer applies a page window for.
+ * - `realtime` on every write (`REALTIME_EVENT_BY_OPERATION`, `purgeOne`
+ *   included); a read emits nothing.
+ * - `delete` on the reads and the delete family — the operations
+ *   `configViewFor` resolves a soft-delete view for; a per-operation
+ *   `strategy` override is a shipped feature (`soft-delete.spec.ts`).
+ *   `createOne`/`updateOne`/`patchOne` consult no soft-delete strategy.
+ * - `cache` and `errors` on every id: `cache` is not narrowed because its
+ *   `etag` half governs `If-Match`/`304` on every single-row operation,
+ *   the void deletes included (`isEtagEnabled`), not just the reads its
+ *   `ttl` half caches (`isCacheableRead`).
+ *
+ * A key an id does not name is pinned to `never`, so `findOne: { pagination:
+ * … }` or `createOne: { delete: false }` is a compile error rather than a
+ * silently-dropped value.
  *
  * Unlike the root `dto` map, a per-operation override is **not** narrowed
  * against the entity's own `CreateDto`/`ItemDto`/etc. — those generics are
@@ -450,16 +501,27 @@ export interface StandardOperationsConfig<
   ItemDto = Entity,
   _ListDto = ItemDto,
 > {
-  readonly createOne?: OperationConfig<Entity, Pick<OperationDtoOverride, "input" | "output">> | boolean;
-  readonly findOne?: OperationConfig<Entity, Pick<OperationDtoOverride, "output" | "query">> | boolean;
-  readonly findMany?: OperationConfig<Entity, Pick<OperationDtoOverride, "output" | "query">> | boolean;
-  readonly updateOne?: OperationConfig<Entity, Pick<OperationDtoOverride, "input" | "output">> | boolean;
-  readonly patchOne?: OperationConfig<Entity, Pick<OperationDtoOverride, "input" | "output">> | boolean;
+  readonly createOne?:
+    OperationConfig<Entity, Pick<OperationDtoOverride, "input" | "output">, "errors" | "cache" | "realtime"> | boolean;
+  readonly findOne?:
+    OperationConfig<Entity, Pick<OperationDtoOverride, "output" | "query">, "errors" | "cache" | "delete"> | boolean;
+  readonly findMany?:
+    | OperationConfig<
+        Entity,
+        Pick<OperationDtoOverride, "output" | "query">,
+        "errors" | "cache" | "delete" | "pagination"
+      >
+    | boolean;
+  readonly updateOne?:
+    OperationConfig<Entity, Pick<OperationDtoOverride, "input" | "output">, "errors" | "cache" | "realtime"> | boolean;
+  readonly patchOne?:
+    OperationConfig<Entity, Pick<OperationDtoOverride, "input" | "output">, "errors" | "cache" | "realtime"> | boolean;
   /** Void result, no query — no `dto` override is representable. */
-  readonly deleteOne?: OperationConfig<Entity, never> | boolean;
-  readonly restoreOne?: OperationConfig<Entity, Pick<OperationDtoOverride, "output">> | boolean;
+  readonly deleteOne?: OperationConfig<Entity, never, "errors" | "cache" | "realtime" | "delete"> | boolean;
+  readonly restoreOne?:
+    OperationConfig<Entity, Pick<OperationDtoOverride, "output">, "errors" | "cache" | "realtime" | "delete"> | boolean;
   /** Void result, no query — no `dto` override is representable. */
-  readonly purgeOne?: OperationConfig<Entity, never> | boolean;
+  readonly purgeOne?: OperationConfig<Entity, never, "errors" | "cache" | "realtime" | "delete"> | boolean;
 }
 
 /**
@@ -485,11 +547,21 @@ export interface StandardOperationsConfig<
  *   query resolution), and the mismatch is a bootstrap
  *   `ConfigurationException` rather than a type error, because `kind` is a
  *   value here and the standard eight's `Pick` is not available.
+ * - the settings subtree it accepts (issue #415) is narrowed by the `Kind`
+ *   and `Cardinality` this entry declares — see {@link CustomOperationSettingsKey}.
+ *   `Ops` carries `kind`/`cardinality` as literals from the caller's own
+ *   object, so {@link CustomOperationsOf} reads them back and passes them
+ *   here, the same route `CustomOperationResult` already uses to type
+ *   `run`'s envelope.
  *
  * A custom operation is reachable over HTTP through `meta.routes`
  * (`@kavo/nest`) and in code through `KavoService.run`.
  */
-export interface CustomOperationConfig<Entity = unknown> extends Omit<DeepPartial<KavoSettings>, "operations"> {
+export type CustomOperationConfig<
+  Entity = unknown,
+  Kind extends OperationKind = OperationKind,
+  Cardinality extends OperationCardinality = OperationCardinality,
+> = OperationSettings<CustomOperationSettingsKey<Kind, Cardinality>> & {
   /** Registered but inert when `false` — the same seam a standard id has. */
   readonly enabled?: boolean;
   /**
@@ -514,7 +586,38 @@ export interface CustomOperationConfig<Entity = unknown> extends Omit<DeepPartia
   readonly dto?: OperationDtoOverride;
   /** Opaque metadata consumed by the framework layer (route options). */
   readonly meta?: OperationMetadata;
-}
+};
+
+/**
+ * The `KavoSettings` keys a *custom* operation's config may carry, from its
+ * declared `kind`/`cardinality` (issue #415). `errors` and `cache` are
+ * always in scope — a custom response is serialized and ETagged like any
+ * other, even though `cache`'s `ttl` half never caches it
+ * (`isCacheableRead` refuses any id but `findOne`/`findMany`). A
+ * `kind: "read"` entry additionally gets `delete` — `configViewFor`
+ * resolves a soft-delete view for every read, custom ones included — and,
+ * when its result goes through the list envelope (`cardinality: "many"`),
+ * `pagination`, the one case the query normalizer applies a page window to.
+ * A `kind: "write"` custom operation drives its own writes through
+ * `context.repository`, so a resolved `delete` view changes nothing for it.
+ * `realtime` is never in scope: `REALTIME_EVENT_BY_OPERATION`'s vocabulary
+ * is closed to the standard writes.
+ *
+ * Both parameters distribute, so the wide default
+ * (`OperationKind`/`OperationCardinality`, used for the bare
+ * `CustomOperationConfig<Entity>` in `OperationsConfig`'s index-signature
+ * upper bound) resolves to `"errors" | "cache" | "delete" | "pagination"` —
+ * permissive enough to be an upper bound, while a concrete entry's own
+ * literals give the exact row.
+ */
+type CustomOperationSettingsKey<
+  Kind extends OperationKind,
+  Cardinality extends OperationCardinality,
+> = Kind extends "read"
+  ? Cardinality extends "many"
+    ? "errors" | "cache" | "delete" | "pagination"
+    : "errors" | "cache" | "delete"
+  : "errors" | "cache";
 
 /**
  * The whole `operations` map: the standard eight at their own precise
@@ -571,10 +674,26 @@ export type OperationsConfig<
  * (`EntityConfig<Book>`, `Parameters<typeof createCrud>[1]`). Mapping over
  * `string` there would demand a handler from *every* key including the
  * standard eight, so those spellings contribute nothing extra.
+ *
+ * Each mapped entry also reads `Ops[Id]`'s own `kind`/`cardinality`
+ * literals and passes them to `CustomOperationConfig`, so the settings
+ * subtree it accepts is the row {@link CustomOperationSettingsKey} names
+ * for that combination (issue #415): `errors`/`cache` always, `delete` on
+ * any `kind: "read"`, `pagination` also on a `kind: "read", cardinality:
+ * "many"` entry, `realtime` never. A missing `kind`/`cardinality` reads as
+ * the `"write"`/`"one"` default, exactly as the engine resolves it.
+ * `Ops` is already inferred here (see above), so this is another read off a
+ * known type, not a constraint that would collapse inference.
  */
 export type CustomOperationsOf<Entity, Ops> = string extends keyof Ops
   ? unknown
-  : { readonly [Id in Exclude<keyof Ops, StandardOperationId>]: CustomOperationConfig<Entity> };
+  : {
+      readonly [Id in Exclude<keyof Ops, StandardOperationId>]: CustomOperationConfig<
+        Entity,
+        Ops[Id] extends { readonly kind: infer K extends OperationKind } ? K : "write",
+        Ops[Id] extends { readonly cardinality: infer C extends OperationCardinality } ? C : "one"
+      >;
+    };
 
 /**
  * Raw entity-scope configuration — the second argument to `createCrud`.

--- a/packages/core/tests/types/operation-settings-scope.test-d.ts
+++ b/packages/core/tests/types/operation-settings-scope.test-d.ts
@@ -1,0 +1,165 @@
+import { createKavo } from "@kavo/core";
+import type { KavoContext } from "@kavo/core";
+import { Author } from "../support/blog-fixture.js";
+
+/**
+ * Per-operation settings scope (issue #415): `operations.<id>` accepts only
+ * the `KavoSettings` keys that id's engine stages actually read — the same
+ * per-id narrowing issue #131 gave the `dto` slot. A key an id ignores is
+ * pinned to `never`, so naming it is a compile error rather than a value
+ * that resolves into `settingsFor(op)` and is then silently dropped.
+ *
+ *   pagination → findMany
+ *   realtime   → createOne, updateOne, patchOne, deleteOne, restoreOne, purgeOne
+ *   delete     → findOne, findMany, deleteOne, restoreOne, purgeOne
+ *   cache      → every operation (its `etag` half gates If-Match/304 on the
+ *                writes and void deletes too, not just the reads it caches)
+ *   errors     → every operation
+ *
+ * For a custom operation the accepted subset follows from the `kind` and
+ * `cardinality` literals the entry declares: `errors`/`cache` always,
+ * `delete` on any `kind: "read"`, `pagination` also on `kind: "read",
+ * cardinality: "many"`, `realtime` never.
+ *
+ * Collected by `*.spec.ts` only, so nothing here runs — `tsc` checks the
+ * `@ts-expect-error` directives, and an unused one is itself an error.
+ */
+
+const kavo = createKavo();
+
+// ── Standard operations — accepted ───────────────────────────────────
+
+void kavo.createCrud(Author, { operations: { findMany: { pagination: { defaultLimit: 20, maxLimit: 100 } } } });
+void kavo.createCrud(Author, { operations: { findMany: { cache: { ttl: 60 } } } });
+void kavo.createCrud(Author, { operations: { findMany: { delete: false } } });
+void kavo.createCrud(Author, { operations: { findOne: { cache: { ttl: 60 } } } });
+void kavo.createCrud(Author, { operations: { findOne: { delete: { strategy: "hard" } } } });
+void kavo.createCrud(Author, { operations: { createOne: { realtime: false } } });
+void kavo.createCrud(Author, { operations: { updateOne: { realtime: false } } });
+void kavo.createCrud(Author, { operations: { patchOne: { realtime: false } } });
+void kavo.createCrud(Author, { operations: { restoreOne: { realtime: false } } });
+void kavo.createCrud(Author, { operations: { purgeOne: { realtime: false } } });
+void kavo.createCrud(Author, { operations: { purgeOne: { delete: false } } });
+// `cache.etag` at operation scope on a write is a shipped feature —
+// `caching.e2e.spec.ts` "reads cache.etag at the operation scope" depends on it.
+void kavo.createCrud(Author, { operations: { updateOne: { cache: { etag: false } } } });
+void kavo.createCrud(Author, { operations: { deleteOne: { cache: { etag: false } } } });
+// `deleteOne: { delete: { strategy } }` is a shipped feature —
+// `soft-delete.spec.ts` "applies a per-operation strategy override".
+void kavo.createCrud(Author, { operations: { deleteOne: { delete: { strategy: "hard" } } } });
+// `errors` is in scope for every id.
+void kavo.createCrud(Author, { operations: { createOne: { errors: { exposeInternals: true } } } });
+void kavo.createCrud(Author, { operations: { findMany: { errors: { exposeInternals: true } } } });
+
+// ── Standard operations — rejected ───────────────────────────────────
+
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — createOne consults no soft-delete strategy (issue #415's motivating case).
+    createOne: { delete: false },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — a single-row findOne has no pagination window (issue #415's motivating case).
+    findOne: { pagination: { defaultLimit: 20, maxLimit: 100 } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — only findMany paginates.
+    createOne: { pagination: { defaultLimit: 20 } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — updateOne mutates by id and consults no soft-delete strategy.
+    updateOne: { delete: { strategy: "hard" } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — patchOne does not paginate.
+    patchOne: { pagination: { defaultLimit: 20 } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — a read emits no realtime event.
+    findOne: { realtime: false },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — a read emits no realtime event.
+    findMany: { realtime: false },
+  },
+});
+
+// ── Custom operations — accepted ─────────────────────────────────────
+
+const handler = { async execute(_input: unknown, _context: KavoContext<Author>) {} };
+
+void kavo.createCrud(Author, {
+  operations: {
+    listArchivedMany: { handler, kind: "read", cardinality: "many", pagination: { defaultLimit: 20, maxLimit: 100 } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: { peekArchivedOne: { handler, kind: "read", delete: false } },
+});
+void kavo.createCrud(Author, {
+  operations: { listArchivedMany: { handler, kind: "read", cardinality: "many", delete: false } },
+});
+void kavo.createCrud(Author, {
+  operations: { peekOne: { handler, kind: "read", cache: { ttl: 60 } } },
+});
+// Implicit write/one — `errors`/`cache` are still in scope.
+void kavo.createCrud(Author, {
+  operations: { markPaidOne: { handler, errors: { exposeInternals: true }, cache: { etag: false } } },
+});
+
+// ── Custom operations — rejected ─────────────────────────────────────
+
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — a read that returns one row has no pagination window.
+    peekArchivedOne: { handler, kind: "read", pagination: { defaultLimit: 20 } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — implicit write/one: pagination is not in scope.
+    markPaidOne: { handler, pagination: { defaultLimit: 20 } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — cardinality "many" without kind "read" is still a write; no pagination.
+    markPaidMany: { handler, cardinality: "many", pagination: { defaultLimit: 20 } },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — a custom operation is never a realtime event source.
+    markPaidOne: { handler, realtime: false },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — a custom operation is never a realtime event source, kind: "write" included.
+    markPaidOne: { handler, kind: "write", realtime: false },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — a custom write drives its own writes; a resolved soft-delete view changes nothing.
+    markPaidOne: { handler, delete: false },
+  },
+});
+void kavo.createCrud(Author, {
+  operations: {
+    // @ts-expect-error — explicit kind: "write" is still no soft-delete scope.
+    markPaidOne: { handler, kind: "write", delete: false },
+  },
+});


### PR DESCRIPTION
## What & why

`OperationConfig` inherited the whole `KavoSettings` subtree, so `operations: { findOne: { pagination: … } }` or `operations: { createOne: { delete: false } }` type-checked and then resolved into `settingsFor(op)` unused — a misplaced key looked applied but did nothing. This gives the settings subtree the same per-id narrowing issue #131 gave the `dto` slot: a third `Allowed` generic on `OperationConfig` pins any key outside it to `never`, and `StandardOperationsConfig` hands each id only the keys its engine stages actually read — `pagination` to `findMany`, `realtime` to the writes, `delete` to the reads and delete family, `cache`/`errors` to all. `CustomOperationConfig` gains `Kind`/`Cardinality` generics that `CustomOperationsOf` infers from the caller's own object literal, so a custom op's accepted subset follows its declared `kind`/`cardinality` without collapsing `Ops` inference.

`cache` and `delete` are deliberately not narrowed away from where they might look inert: `cache.etag` gates `If-Match`/`304` on writes and void deletes (`caching.e2e.spec.ts`), and a per-operation `delete.strategy` override on `deleteOne` is a shipped feature (`soft-delete.spec.ts`).

Closes #415

## Public API impact

`OperationConfig` and `CustomOperationConfig` change from `interface` to `type` (intersection) and each gains further optional generic parameters, all defaulted — `OperationConfig<Entity>` / `CustomOperationConfig<Entity>` still resolve. Both remain `export type` in the core barrel; no barrel entries added or removed. The only behavioural change is stricter compile-time rejection of settings keys an operation never consumed; runtime resolution is untouched. Technically breaking for a caller that was passing an inert key at operation scope (it now fails to compile), which is the intent.

## Testing

- New `packages/core/tests/types/operation-settings-scope.test-d.ts` — accept/reject matrix for standard and custom operations, `@ts-expect-error` on every rejection (an unused one is itself a `tsc` error, so the directives are real).
- `pnpm check`: build + typecheck + depcruise + lint pass; 3045 tests pass. The 5 failing test files are pre-existing `examples/*` testcontainers e2e specs that need a Docker runtime unavailable in this environment ("Could not find a working container runtime strategy") — unrelated to a type-only core change.
- `pnpm docs:links` passes.

## Review notes

- `realtime`-on-reads and `realtime`-on-custom are now compile errors — a rejection beyond the two named in the issue. No test exercised it before; verified that nothing outside `kavo-engine.ts`'s emit path reads `settingsFor(op).realtime` (the SSE transport's field allowlist is its own `SseTransportOptions` callback, not per-operation `RealtimeSettings`).
- The custom `{ handler, delete: false }` rejection rests on "a custom write drives its own writes through `context.repository`". A custom write handler can still read `context.config.delete`, but a `delete` override changes no engine behaviour for it.
- `CustomOperationsOf` now reads `Ops[Id]`'s `kind`/`cardinality` literals — the same route `CustomOperationResult` already uses to type `run`'s envelope, so `Ops` stays inferred from the caller's literal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Operation configuration now accepts only settings supported by each operation type, such as pagination, real-time updates, deletion behavior, caching, and error handling.
  * Custom operations now apply configuration rules based on their operation kind and cardinality, helping catch invalid combinations earlier.

* **Documentation**
  * Clarified which settings apply to standard and custom read, mutation, deletion, pagination, caching, error, and real-time operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->