### PR TITLE
feat(core): raise FieldPath default recursion cap from 3 to 5

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -431,6 +431,10 @@ const config = defineConfig({
                 text: "0050 — Derived fields come from ORM metadata; core stays expression-agnostic",
                 link: "/internals/adr/0050-derived-fields-come-from-orm-metadata",
               },
+              {
+                text: "0051 — FieldPath's default recursion cap raised from 3 to 5",
+                link: "/internals/adr/0051-fieldpath-default-cap-raised-to-five",
+              },
             ],
           },
         ],

--- a/docs/internals/adr/0008-field-path-recursion-cap.md
+++ b/docs/internals/adr/0008-field-path-recursion-cap.md
@@ -1,6 +1,6 @@
-# ADR-0008 — `FieldPath` recursion cap (default 3, max 5)
+# ADR-0008 — `FieldPath` recursion cap (max 5)
 
-**Status:** accepted
+**Status:** accepted — the default cap was raised from 3 to 5 by [ADR-0051](/internals/adr/0051-fieldpath-default-cap-raised-to-five) (issue #417). The mechanism below (tuple-decrement counter, hard maximum 5, degrade-to-`string`) is unchanged; only the default value moved. The "default 3" and the `FieldPath<T, 4|5>` opt-in phrasing in the sections below are pre-ADR-0051 and read as history.
 
 ## Context
 

--- a/docs/internals/adr/0051-fieldpath-default-cap-raised-to-five.md
+++ b/docs/internals/adr/0051-fieldpath-default-cap-raised-to-five.md
@@ -1,0 +1,66 @@
+# ADR-0051 — `FieldPath`'s default recursion cap is raised from 3 to 5
+
+**Status:** accepted (issue #417) — amends [ADR-0008](/internals/adr/0008-field-path-recursion-cap), whose mechanism (tuple-decrement counter, hard maximum 5, degrade-to-`string`) is kept intact; only the default value changes.
+
+## Context
+
+`FieldPath<Entity>` and its relation-only sibling `IncludePath<Entity>`
+expand an entity shape into a template-literal union of dot-paths, used to
+spell-check `sort.fields`, `filter.fields`, `select.fields` (at depth 1),
+and the programmatic `QueryContext.include`. ADR-0008 capped the **default**
+depth at 3 — a path deeper than `posts.comments.text` was a type error at
+the config call site unless the caller wrote an explicit `FieldPath<T, 4|5>`,
+which config blocks give no way to do.
+
+Depth-4 paths are a real integrator need — an entity reachable as
+`owner.address.owner.id` across a mutually-referential relation pair is
+ordinary. ADR-0008 set the default at 3 rather than the `FieldPathDepth`
+hard maximum of 5 purely for compiler cost: the union grows combinatorially
+with depth, and `FilterOperatorMap` (`entity-config.ts`) builds a mapped
+type over the whole `FieldPath` union per entity.
+
+We considered threading a per-block or single-knob generic depth parameter
+that config could opt into, and rejected it as too much permanent API
+surface (a generic parameter on `createCrud` and `@Kavo`, inferred from a
+config literal) for the size of the need.
+
+Measured cost of moving the default to 5 across the whole `pnpm typecheck`
+matrix (root + every package + all three example apps, which include the
+mutually-referential TypeORM entities): user CPU time went from ~34.7s to
+~36.1s (≈4%), wall time ~19s to ~20s, with no "type instantiation is
+excessively deep" error anywhere. The combinatorial blow-up ADR-0008 warned
+about does not materialise at depth 5 on the schemas in this repo.
+
+## Decision
+
+`FieldPath<Entity, MaxDepth extends FieldPathDepth = 5>` and
+`IncludePath<Entity, MaxDepth extends FieldPathDepth = 5>` — the default is
+now 5, which equals the hard maximum. Everything else ADR-0008 decided is
+unchanged:
+
+- `FieldPathDepth` still bounds `MaxDepth` to `1 | 2 | 3 | 4 | 5`; a
+  depth-6 path is still a type error, and `FieldPath<T, 6>` still fails to
+  compile.
+- The `MaxDepth` parameter stays — its remaining job is **lowering** the cap
+  below the default for a specific use (`FieldPath<Entity, 1>` for
+  root-only selectors, `IncludePath<Entity, 1>` for `include.fields` per
+  ADR-0028). No consumer needs to raise it any more.
+- `any` / `unknown` / index-signature shapes still degrade to `string`.
+- Compile-time depth stays independent of the runtime limits
+  (`filter.limits.maxDepth`, `include.limits.maxDepth`) — the runtime
+  remains the security gate.
+- Still "one policy, not a pattern": `IncludePath` reuses `FieldPath`'s
+  `Prev` counter, default and maximum rather than declaring its own.
+
+## Consequences
+
+- No opt-in mechanism is added. If a consumer with a large
+  mutually-referential schema reports slow type checking, the fix is to
+  add a way to **lower** the cap per project (or per block), not to
+  reintroduce a raise-it knob — the default would move back down and this
+  ADR would be revised again.
+- `select.fields` is untouched: it is `FieldPath<Entity, 1>` by explicit
+  argument (ADR-0045), not the default.
+- `include.fields` / `include.default` are untouched: `IncludePath<Entity, 1>`
+  by explicit argument (ADR-0028). The `IncludePath` default only reaches
+  `QueryContext.include`.

--- a/docs/internals/architecture/01-system-architecture.md
+++ b/docs/internals/architecture/01-system-architecture.md
@@ -269,23 +269,23 @@ Kavo is **not**:
 
 ## 9. ADR index
 
-| ADR                                                              | Decision                                                  |
-| ---------------------------------------------------------------- | --------------------------------------------------------- |
-| [0001](../adr/0001-clean-architecture-core-owns-contracts.md)    | Clean architecture: core owns all contracts               |
-| [0002](../adr/0002-package-topology.md)                          | Three packages under `orms/` / `frameworks/` parents      |
-| [0003](../adr/0003-pnpm-plain-scripts-tsc-build.md)              | pnpm workspaces, plain scripts, `tsc -b` — no task runner |
-| [0004](../adr/0004-lockstep-versioning.md)                       | Lockstep versioning                                       |
-| [0005](../adr/0005-core-zero-runtime-dependencies.md)            | Zero runtime dependencies in `@kavo/core`                 |
-| [0006](../adr/0006-registry-driven-operations.md)                | Registry-driven operation dispatch                        |
-| [0007](../adr/0007-module-augmentable-operation-metadata.md)     | Module-augmentable `OperationMetadata`                    |
-| [0008](../adr/0008-field-path-recursion-cap.md)                  | `FieldPath` recursion cap (default 3, max 5)              |
-| [0009](../adr/0009-problem-details-error-shape.md)               | RFC 9457 problem details as the wire error shape          |
-| [0010](../adr/0010-explicit-named-barrel.md)                     | Explicit named barrel in core                             |
-| [0011](../adr/0011-entity-metadata-infrastructure-seam.md)       | Entity-metadata & infrastructure seam                     |
-| [0012](../adr/0012-decoration-time-route-generation.md)          | Decoration-time route generation in `@kavo/nest`          |
-| [0013](../adr/0013-config-declared-soft-delete-operations.md)    | Soft-delete operations enabled from config, not metadata  |
-| [0014](../adr/0014-associate-by-id-not-deep-writes.md)           | Write-side relations: associate by id, no deep writes     |
-| [0015](../adr/0015-global-operation-defaults-are-engine-only.md) | Global operation defaults are engine-only, not routing    |
+| ADR                                                              | Decision                                                       |
+| ---------------------------------------------------------------- | -------------------------------------------------------------- |
+| [0001](../adr/0001-clean-architecture-core-owns-contracts.md)    | Clean architecture: core owns all contracts                    |
+| [0002](../adr/0002-package-topology.md)                          | Three packages under `orms/` / `frameworks/` parents           |
+| [0003](../adr/0003-pnpm-plain-scripts-tsc-build.md)              | pnpm workspaces, plain scripts, `tsc -b` — no task runner      |
+| [0004](../adr/0004-lockstep-versioning.md)                       | Lockstep versioning                                            |
+| [0005](../adr/0005-core-zero-runtime-dependencies.md)            | Zero runtime dependencies in `@kavo/core`                      |
+| [0006](../adr/0006-registry-driven-operations.md)                | Registry-driven operation dispatch                             |
+| [0007](../adr/0007-module-augmentable-operation-metadata.md)     | Module-augmentable `OperationMetadata`                         |
+| [0008](../adr/0008-field-path-recursion-cap.md)                  | `FieldPath` recursion cap (max 5; default raised to 5 by 0051) |
+| [0009](../adr/0009-problem-details-error-shape.md)               | RFC 9457 problem details as the wire error shape               |
+| [0010](../adr/0010-explicit-named-barrel.md)                     | Explicit named barrel in core                                  |
+| [0011](../adr/0011-entity-metadata-infrastructure-seam.md)       | Entity-metadata & infrastructure seam                          |
+| [0012](../adr/0012-decoration-time-route-generation.md)          | Decoration-time route generation in `@kavo/nest`               |
+| [0013](../adr/0013-config-declared-soft-delete-operations.md)    | Soft-delete operations enabled from config, not metadata       |
+| [0014](../adr/0014-associate-by-id-not-deep-writes.md)           | Write-side relations: associate by id, no deep writes          |
+| [0015](../adr/0015-global-operation-defaults-are-engine-only.md) | Global operation defaults are engine-only, not routing         |
 
 ## 10. Tradeoff analysis
 

--- a/docs/internals/architecture/03-core-contracts-and-type-system.md
+++ b/docs/internals/architecture/03-core-contracts-and-type-system.md
@@ -82,16 +82,18 @@ checked against its entity.
 
 ## 2. `FieldPath` implementation notes
 
-`FieldPath<TEntity, TMaxDepth = 3>` (`types/field-path.ts`) produces the
+`FieldPath<TEntity, TMaxDepth = 5>` (`types/field-path.ts`) produces the
 union of dot-paths into an entity — `'name' | 'profile.city' |
 'posts.comments.text'` — used by filter, sort, and selection typings so
 relation paths are spell-checked at compile time.
 
-- **Recursion cap:** default depth 3, hard maximum 5 (`FieldPathDepth`),
-  decremented through a tuple table (`Prev`). The cap exists because the
-  union grows combinatorially with depth — entities with many relations
-  would otherwise produce unions large enough to slow or crash the
-  compiler (ADR-0008).
+- **Recursion cap:** default depth 5 (equal to the hard maximum;
+  originally 3, raised by ADR-0051), decremented through a tuple table
+  (`Prev`). `FieldPathDepth` bounds `TMaxDepth` to `1 | 2 | 3 | 4 | 5`; the
+  parameter's remaining use is _lowering_ the cap (`FieldPath<T, 1>` for
+  root-only selectors). The ceiling exists because the union grows
+  combinatorially with depth — entities with many relations would otherwise
+  produce unions large enough to slow or crash the compiler (ADR-0008).
 - **`any` / `unknown`:** degrade to `string` (detected via the `0 extends
 1 & T` probe) — untyped entities get no spell-checking but stay usable;
   the runtime allowlist remains the actual gate.
@@ -107,9 +109,11 @@ relation paths are spell-checked at compile time.
 
 ### `IncludePath` — the relation-only sibling
 
-`IncludePath<TEntity, TMaxDepth = 3>` (`types/include-path.ts`) types
+`IncludePath<TEntity, TMaxDepth = 5>` (`types/include-path.ts`) types
 `QueryContext.include`, so `include: ['posts.commentz']` is a compile
-error rather than a runtime 400.
+error rather than a runtime 400. (`include.fields`/`include.default` in
+`EntityConfig` pin `TMaxDepth` to 1 — top-level relation names only,
+ADR-0028.)
 
 It reuses `FieldPath`'s `Prev` counter, cap, and every degradation rule
 above — ADR-0008's cap is one policy, not a pattern each path type

--- a/packages/core/src/types/field-path.ts
+++ b/packages/core/src/types/field-path.ts
@@ -1,11 +1,12 @@
 import type { IsAny, IsUnknown, Primitive } from "./utility.js";
 
 /**
- * Allowed recursion depths for {@link FieldPath}. The default cap is 3 and
- * the hard maximum is 5 — see ADR-0008. The cap exists because template-
- * literal path types grow combinatorially with depth: on entities with many
- * relations an uncapped (or deeply capped) expansion produces union types
- * large enough to slow or crash the compiler.
+ * Allowed recursion depths for {@link FieldPath}. The default cap and the
+ * hard maximum are both 5 — see ADR-0008, revised by ADR-0051 (the default
+ * was originally 3). The ceiling exists because template-literal path types
+ * grow combinatorially with depth: on entities with many relations an
+ * uncapped (or deeply capped) expansion produces union types large enough
+ * to slow or crash the compiler.
  */
 export type FieldPathDepth = 1 | 2 | 3 | 4 | 5;
 
@@ -60,5 +61,9 @@ type PathInto<T, Depth extends 0 | FieldPathDepth> =
  *
  * This is a *typing* aid, not a security boundary — the runtime allowlist
  * decides what a request may actually filter, sort, or select on.
+ *
+ * `MaxDepth` defaults to 5, the hard maximum (ADR-0051). Pass a lower value
+ * to tighten spell-checking to shallower paths for a specific use
+ * (`FieldPath<Entity, 1>` for root-only selectors).
  */
-export type FieldPath<Entity, MaxDepth extends FieldPathDepth = 3> = PathInto<Entity, MaxDepth>;
+export type FieldPath<Entity, MaxDepth extends FieldPathDepth = 5> = PathInto<Entity, MaxDepth>;

--- a/packages/core/src/types/include-path.ts
+++ b/packages/core/src/types/include-path.ts
@@ -47,8 +47,9 @@ type IncludeInto<T, Depth extends 0 | FieldPathDepth> =
  * `'posts.comments'`, `'posts.author.posts'`.
  *
  * The relation-only sibling of {@link FieldPath} — same recursion counter,
- * same default depth 3 and hard maximum 5 (ADR-0008), same degradation to
- * `string` for `any`/`unknown`/index-signature entities. Scalar properties
+ * same default depth and hard maximum, both 5 (ADR-0008, revised by
+ * ADR-0051), same degradation to `string` for `any`/`unknown`/
+ * index-signature entities. Scalar properties
  * are excluded: `include` addresses relations, and `'name'` being rejected
  * at compile time is the point.
  *
@@ -56,4 +57,4 @@ type IncludeInto<T, Depth extends 0 | FieldPathDepth> =
  * a relation may actually be included is decided at runtime by the relation
  * registry's `includable` flag and the include-depth budget.
  */
-export type IncludePath<Entity, MaxDepth extends FieldPathDepth = 3> = IncludeInto<Entity, MaxDepth>;
+export type IncludePath<Entity, MaxDepth extends FieldPathDepth = 5> = IncludeInto<Entity, MaxDepth>;

--- a/packages/core/tests/types/deep-path-config.test-d.ts
+++ b/packages/core/tests/types/deep-path-config.test-d.ts
@@ -1,0 +1,37 @@
+import { createKavo } from "@kavo/core";
+import { Author } from "../support/blog-fixture.js";
+
+/**
+ * ADR-0051: `sort.fields` and `filter.fields` accept a relation path up to
+ * depth 5 with no cast, because both are typed against `FieldPath` whose
+ * default cap is now 5. The map form of `filter.fields` already widened
+ * every string via `(string & {})`, so this exercises the **array** form,
+ * where the depth change is observable.
+ *
+ * `include.fields` is deliberately *not* covered here: it is
+ * `IncludePath<Entity, 1>` (ADR-0028) — top-level relation names only — and
+ * the default-cap change does not reach it. Nested include depth stays a
+ * runtime concern (`include.limits.maxDepth`).
+ *
+ * Blog fixture: `Author 1—* Post *—1 Author` back-edge — `posts.author.…`
+ * revisits `Author`, so `posts.author.posts.author.name` is a real depth-5
+ * path.
+ */
+
+const kavo = createKavo({});
+
+kavo.createCrud(Author, {
+  // Depth-4 and depth-5 paths, array form, no cast.
+  sort: { fields: ["name", "posts.author.posts.title", "posts.author.posts.author.name"] },
+  filter: { fields: ["posts.author.posts.title", "posts.author.posts.author.name"] },
+});
+
+kavo.createCrud(Author, {
+  // @ts-expect-error — depth 6 exceeds the default cap of 5.
+  sort: { fields: ["posts.author.posts.author.posts.title"] },
+});
+
+kavo.createCrud(Author, {
+  // @ts-expect-error — depth 6 exceeds the default cap of 5.
+  filter: { fields: ["posts.author.posts.author.posts.title"] },
+});

--- a/packages/core/tests/types/field-path.test-d.ts
+++ b/packages/core/tests/types/field-path.test-d.ts
@@ -1,0 +1,55 @@
+import { expectTypeOf } from "vitest";
+import type { FieldPath } from "@kavo/core";
+import { Author } from "../support/blog-fixture.js";
+
+/**
+ * Type-level acceptance tests for spell-checked dot-paths (ADR-0008's
+ * recursion cap; ADR-0051 raised its default from 3 to 5). See
+ * entity-input.test-d.ts for why these files are `.test-d.ts` and how the
+ * `@ts-expect-error` directives are enforced.
+ *
+ * The blog fixture is `Author 1—* Post 1—* Comment` with a `Post.author`
+ * back-edge, so a path can revisit a type and exercise the depth guard.
+ * `FieldPath` (unlike `IncludePath`) admits scalar leaves, so the full
+ * depth-5 union is large — these assertions probe its edges rather than
+ * pinning the whole expansion.
+ */
+
+// Own scalar, and relation paths up to the depth-5 default cap.
+const own: FieldPath<Author> = "name";
+const d2: FieldPath<Author> = "posts.title";
+const d3: FieldPath<Author> = "posts.author.name";
+const d4: FieldPath<Author> = "posts.author.posts.title";
+const d5: FieldPath<Author> = "posts.author.posts.author.name";
+void own;
+void d2;
+void d3;
+void d4;
+void d5;
+
+// @ts-expect-error — depth 6 exceeds the default cap of 5 (ADR-0051).
+const d6: FieldPath<Author> = "posts.author.posts.author.posts.title";
+void d6;
+
+// @ts-expect-error — a misspelled segment is a compile error at any depth.
+const typo: FieldPath<Author> = "posts.titel";
+void typo;
+
+// The knob still lowers the cap below the default: a tightened
+// `FieldPath<Author, 3>` rejects the depth-4 path the default admits.
+const stillOk: FieldPath<Author, 3> = "posts.author.name";
+void stillOk;
+// @ts-expect-error — depth 4 exceeds the explicitly lowered cap of 3.
+const lowered: FieldPath<Author, 3> = "posts.author.posts.title";
+void lowered;
+
+// Untyped entities degrade to `string` rather than erroring — the runtime
+// allowlist stays the real gate.
+expectTypeOf<FieldPath<any>>().toEqualTypeOf<string>();
+expectTypeOf<FieldPath<unknown>>().toEqualTypeOf<string>();
+
+// An index-signature bag has unknowable keys — same degradation.
+interface Bag {
+  [key: string]: unknown;
+}
+expectTypeOf<FieldPath<Bag>>().toEqualTypeOf<string>();

--- a/packages/core/tests/types/include-path.test-d.ts
+++ b/packages/core/tests/types/include-path.test-d.ts
@@ -11,9 +11,18 @@ import { Author, Comment, Post } from "../support/blog-fixture.js";
  * back-edge, so a path can revisit a type and exercise the depth guard.
  */
 
-// The whole depth-3 expansion, pinned. Scalars (`name`, `title`, `body`) are
-// absent: `include` addresses relations, never fields.
-expectTypeOf<IncludePath<Author>>().toEqualTypeOf<"posts" | "posts.author" | "posts.comments" | "posts.author.posts">();
+// The whole depth-5 expansion, pinned (ADR-0051 raised the default cap from
+// 3 to 5). Scalars (`name`, `title`, `body`) are absent: `include` addresses
+// relations, never fields.
+expectTypeOf<IncludePath<Author>>().toEqualTypeOf<
+  | "posts"
+  | "posts.author"
+  | "posts.comments"
+  | "posts.author.posts"
+  | "posts.author.posts.author"
+  | "posts.author.posts.comments"
+  | "posts.author.posts.author.posts"
+>();
 
 // A leaf entity with no relations can include nothing at all.
 expectTypeOf<IncludePath<Comment>>().toEqualTypeOf<never>();
@@ -36,13 +45,21 @@ void typo;
 const scalar: IncludePath<Author> = "name";
 void scalar;
 
-// @ts-expect-error — depth 4 exceeds the default cap of 3.
-const tooDeep: IncludePath<Author> = "posts.author.posts.comments";
+// A depth-4 path is now within the default cap (ADR-0051): depth 5 is the
+// default and the hard maximum both.
+const withinDefault: IncludePath<Author> = "posts.author.posts.comments";
+void withinDefault;
+
+// @ts-expect-error — depth 6 exceeds the default cap of 5.
+const tooDeep: IncludePath<Author> = "posts.author.posts.author.posts.author";
 void tooDeep;
 
-// Raising the cap admits it — same knob as FieldPath, same hard maximum.
-const deepened: IncludePath<Author, 5> = "posts.author.posts.comments";
-void deepened;
+// The knob's remaining job is lowering the cap below the default — a
+// tightened `IncludePath<Author, 3>` rejects the depth-4 path the default
+// admits.
+// @ts-expect-error — depth 4 exceeds the explicitly lowered cap of 3.
+const lowered: IncludePath<Author, 3> = "posts.author.posts.comments";
+void lowered;
 
 // Untyped entities degrade to `string` rather than erroring: the runtime
 // relation registry stays the real gate.


### PR DESCRIPTION
## What & why

`FieldPath<Entity>` and `IncludePath<Entity>` defaulted their `MaxDepth` type parameter to 3 (ADR-0008), so a legitimate depth-4 config path such as `"owner.address.owner.id"` was a compile error at the `createCrud` / `@Kavo` call site, with no way for a config block to widen it. This raises the default to 5 — already the `FieldPathDepth` hard maximum — so deeper relation paths spell-check out of the box. The tuple-decrement mechanism, the `1 | 2 | 3 | 4 | 5` bound (depth 6 is still an error), and the `any`/`unknown`/index-signature degrade-to-`string` rule are all unchanged; the `MaxDepth` parameter stays, now only for *lowering* the cap (e.g. `FieldPath<Entity, 1>` for root-only selectors).

Measured cost across the full `pnpm typecheck` matrix (root + every package + all three example apps, including the mutually-referential TypeORM entities): user CPU ~34.7s → ~36.1s (~4%), no `"type instantiation is excessively deep"`. Recorded in the new ADR.

Two notes on scope vs. the issue:
- The issue asked to amend ADR-0008 in place; the `add-adr` convention forbids that, so this adds **ADR-0051 amending ADR-0008** instead (same net effect, history stays legible — cf. ADR-0043).
- `include.fields` / `include.default` are `IncludePath<Entity, 1>` by explicit argument (ADR-0028) and are **not** affected. The `IncludePath` default change only reaches `QueryContext.include`; it was raised anyway to keep ADR-0008's "one policy, not a pattern" stance.

Closes #417

## Public API impact

None. No barrel additions or removals — `FieldPath` / `IncludePath` are already exported; only their default type argument changed. Not breaking: every path valid before is still valid, and existing explicit `FieldPath<T, N>` uses are untouched.

## Testing

- `packages/core/tests/types/field-path.test-d.ts` — **new** (no direct `FieldPath` type test existed): depth-5 accepted, depth-6 rejected, typo rejected, explicit `FieldPath<T, 3>` still rejects depth 4, degrade-to-`string` cases.
- `packages/core/tests/types/deep-path-config.test-d.ts` — **new**: a depth-4/5 relation path type-checks in `sort.fields` and `filter.fields` **array** form with no cast; depth 6 rejected.
- `packages/core/tests/types/include-path.test-d.ts` — pinned expansion moved to the depth-5 union; `@ts-expect-error` moved from depth 4 to depth 6; the now-redundant `IncludePath<Author, 5>` line reworked into `IncludePath<Author, 3>` exercising the lowering role.
- `pnpm check`: build, typecheck, depcruise, lint pass; **3045 tests pass, 518 skipped**. The 5 failing files are all `examples/nest-*/tests/app-*.e2e.spec.ts` failing with `"Could not find a working container runtime strategy"` — testcontainers needs Docker, unavailable in this local environment; unrelated to a type-only change and expected to pass in CI.
- `pnpm docs:links` and `pnpm docs:build` pass.

## Review notes

- Worth a hard look: the compiler-cost trade-off and whether ~4% typecheck-time growth on this repo's fixtures is an acceptable proxy for consumer projects with larger schemas. ADR-0051's "Consequences" section commits to a lower-the-cap escape hatch (not a raise-it knob) if a consumer reports slowness.
- The `docs/internals/architecture/01-system-architecture.md` diff is larger than the one-cell edit because Prettier reflowed the ADR-index table column width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Field and include path type checking now supports nested paths up to five levels by default.
  * Lower recursion limits can still be configured when needed.
* **Documentation**
  * Added ADR-0051 and updated architecture and type-system documentation to describe the revised path-depth behavior.
* **Tests**
  * Added coverage for valid depth-4 and depth-5 paths, rejected depth-6 or invalid paths, and configurable lower limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->