### PR TITLE
feat(core): let a custom operation publish a realtime event

### DIFF
--- a/docs/core/custom-operations.md
+++ b/docs/core/custom-operations.md
@@ -54,6 +54,7 @@ A custom entry needs a `handler` (there's no built-in to fall back to) and accep
 - **`cardinality`** (`"one"` | `"many"`, default `"one"`): `"many"` returns the list envelope, so the handler must return `{ entities, total }` the way `findMany` does.
 - **`dto`**: since a custom operation has no root `dto` slot, this is the only way to give it a shape. With no `dto.output`, the result is projected through the entity's own columns. A result sharing nothing with them raises a `KAVO_CONFIG_INVALID` naming the operation, rather than silently serializing to `{}`.
 - **`meta.routes`**: same route options every standard operation gets. With none, the route defaults to `POST /<operation id>`.
+- **`realtimeEvent`** (one of `RealtimeEventId`, unset by default): which realtime event this operation's write publishes as — see [Realtime events](/features/realtime-events). Only valid on `kind: "write"`, `cardinality: "one"`; declaring it anywhere else is a bootstrap error. Unset, the operation publishes nothing.
 
 Naming follows the same convention as the built-ins: camelCase, always spelling out cardinality (`markPaidOne`, not `markPaid`).
 

--- a/docs/features/realtime-events.md
+++ b/docs/features/realtime-events.md
@@ -8,6 +8,20 @@
 
 Publishing needs both halves: `realtime` set to an object on the entity (set here or via `defaults`), and at least one transport in `realtimeTransports` (see [Module setup's global config](/guides/configuration/module-setup#global-config-kavomodule-forroot-forrootasync)). Either alone is a no-op.
 
+A custom operation ([Custom operations](/core/custom-operations)) publishes nothing by default. A `kind: "write"`, `cardinality: "one"` custom operation can opt in by naming which of the five event ids its write counts as:
+
+```ts
+operations: {
+  markPaidOne: {
+    kind: "write",
+    handler: { execute: (input, context) => context.repository.patch(input.id, { paidAt: new Date() }) },
+    realtimeEvent: "updated",
+  },
+}
+```
+
+Declaring `realtimeEvent` on a read, or on a `cardinality: "many"` operation, is a bootstrap error — a realtime event describes exactly one row.
+
 See [Realtime](/internals/architecture/18-realtime) for the full event and channel model, and `@kavo/sse`'s own README for the first transport implementation: collection channels, subscribe-time filtering, and `subscribableFields` payload narrowing.
 
 See [Settings](/guides/configuration/settings) for the rest of `KavoSettings`.

--- a/docs/guides/configuration/operations.md
+++ b/docs/guides/configuration/operations.md
@@ -89,6 +89,7 @@ A custom-operation entry accepts:
 - **`enabled`** (`boolean`, default: `true`): `false` registers the entry inert: no route, and calling it answers `405 KAVO_OPERATION_DISABLED`.
 - **`dto`** (`{ input?, output?, query? }`): `input`/`output` on a write, `output`/`query` on a read. A custom operation has no root DTO slot of its own, so this is where it gets a shape.
 - **`meta`** (`OperationMetadata`, default: `{}`): the route, as above. Without it the operation is routed `POST /<operation id>`.
+- **`realtimeEvent`** (`RealtimeEventId`, unset by default): which of the five standard event ids this operation's write publishes as ([Realtime events](/features/realtime-events)). Only valid on `kind: "write"`, `cardinality: "one"` — declaring it on a read or a `"many"` write is a bootstrap error. Unset, the operation publishes nothing.
 - **any settings key** (same shape as global `KavoSettings`): the operation scope of the precedence chain, exactly as for a standard id.
 
 Naming follows the same convention the built-ins do: camelCase, always spelling out cardinality (`markPaidOne`, `findPendingMany`). An id that differs from a standard one only by case is refused at bootstrap, since `deleteone` is a slip rather than a name.

--- a/docs/internals/adr/0025-handlers-reach-persistence-through-the-context.md
+++ b/docs/internals/adr/0025-handlers-reach-persistence-through-the-context.md
@@ -97,6 +97,11 @@ every handler reaches persistence, built-in and custom alike.
   config-supplied handler could not write through the framework at all.
   Widening the realtime vocabulary to custom ids is its own decision
   (which event id would `markPaidOne` publish?) and is not taken here.
+  **Resolved by issue #175**: `CustomOperationConfig.realtimeEvent` lets a
+  `kind: "write"`, `cardinality: "one"` custom operation declare which of
+  the five standard event ids its write publishes as — the vocabulary
+  itself stays closed (doc 18 §1), only which id an operation maps to
+  widened.
 - **Not taken: resolving a handler through the host's container**, so that
   `operations.markPaidOne.handler` could name a class Nest instantiates.
   That reaches injected application services, which this decision does not,

--- a/docs/internals/architecture/18-realtime.md
+++ b/docs/internals/architecture/18-realtime.md
@@ -21,9 +21,43 @@ closed, five-member vocabulary — `"created" | "updated" | "patched" |
 "deleted" | "restored"` — one per standard write outcome.
 `REALTIME_EVENT_BY_OPERATION` (`kavo-engine.ts`) maps `deleteOne` and
 `purgeOne` both to `"deleted"`: a subscriber only needs to know the row is
-gone, not which delete strategy produced that. A custom operation never
-emits — the vocabulary stays closed until a future issue decides what one
-publishes as.
+gone, not which delete strategy produced that.
+
+A custom operation has no fixed mapping — its `kind`/`cardinality` don't
+say what it means the way the standard eight's do — so it declares which of
+the five ids its write publishes as, via `operations.<id>.realtimeEvent`
+(issue #175):
+
+```ts
+operations: {
+  markPaidOne: {
+    kind: "write",
+    handler: { execute: (input, context) => context.repository.patch(input.id, { paidAt: new Date() }) },
+    realtimeEvent: "updated",
+  },
+}
+```
+
+Only meaningful on a `kind: "write"`, `cardinality: "one"` entry — a
+`RealtimeEventDto` describes one row, and those are the only custom
+operations that write exactly one. Declaring it on a read or a `"many"`
+write is a bootstrap `ConfigurationException`
+(`registerCustomOperation`). An entry that declares nothing still emits
+nothing, same as before this field existed — the vocabulary itself stays
+closed: a custom operation publishes as one of the five standard ids, never
+under its own name, so a subscriber can still learn the whole vocabulary
+from `RealtimeEventId` alone. Once declared, the same `realtime` settings
+subtree a standard write reads (§2 below, and doc 04's config precedence
+chain) applies to a custom operation's publish too — `realtime.events.
+updated: false` mutes `markPaidOne`'s `"updated"` the same way it mutes
+`updateOne`'s.
+
+The event's `id` and `changed` follow the same rules a standard write's do:
+`id` comes off the request when the operation targeted one (`markPaidOne`
+patching `/orders/7`), or off the written row's id field otherwise (a
+custom operation that creates a row, the same fallback `createOne` uses);
+`changed` (`"updated"`/`"patched"` only) is the field names present in the
+write payload.
 
 ## 2. The engine's publish hook
 

--- a/packages/core/src/config/entity-config.ts
+++ b/packages/core/src/config/entity-config.ts
@@ -9,6 +9,7 @@ import type { EntityInput } from "../types/utility.js";
 import type { OperationHandler, OperationMetadata } from "../operations/operation-handler.js";
 import type { OperationCardinality, OperationKind, StandardOperationId } from "../operations/operation.js";
 import type { Policy } from "../policy/kavo-policy.js";
+import type { RealtimeEventId } from "../realtime/realtime-event.js";
 import type { FilterApply, IncludeApply, SelectApply, SortApply } from "../policy/kavo-apply.js";
 import type { FilterExpression, FilterOperatorToken } from "../query/filter.js";
 
@@ -591,6 +592,20 @@ export type CustomOperationConfig<
    * slot — so this is the only way to give it a shape of its own.
    */
   readonly dto?: OperationDtoOverride;
+  /**
+   * Which realtime event this operation's write publishes as (issue #175).
+   * The standard eight derive theirs from a fixed vocabulary
+   * (`REALTIME_EVENT_BY_OPERATION`); a custom operation's semantics are
+   * whatever the application said, so it has to say which of the five
+   * `RealtimeEventId`s applies — there is no way to infer `markPaidOne`'s
+   * event from its name or its `kind`. Only meaningful on a `kind: "write"`,
+   * `cardinality: "one"` operation (a single-row write is the only shape a
+   * `RealtimeEventDto` can describe — one `id`, one `item`); declaring it on
+   * a read or a `"many"` write is a bootstrap `ConfigurationException`.
+   * Omitted, the operation emits nothing — the same silent default every
+   * custom operation had before this field existed.
+   */
+  readonly realtimeEvent?: RealtimeEventId;
   /** Opaque metadata consumed by the framework layer (route options). */
   readonly meta?: OperationMetadata;
 };
@@ -607,15 +622,19 @@ export type CustomOperationConfig<
  * `pagination`, the one case the query normalizer applies a page window to.
  * A `kind: "write"` custom operation drives its own writes through
  * `context.repository`, so a resolved `delete` view changes nothing for it.
- * `realtime` is never in scope: `REALTIME_EVENT_BY_OPERATION`'s vocabulary
- * is closed to the standard writes.
+ * A `kind: "write"`, `cardinality: "one"` entry additionally gets
+ * `realtime` (issue #175): the same settings a standard write's `realtime`
+ * narrows apply to whatever event id the entry's own `realtimeEvent` names.
+ * `cardinality: "many"` gets no `realtime` — a `RealtimeEventDto` describes
+ * one row, and a custom operation cannot declare `realtimeEvent` at that
+ * cardinality in the first place (`registerCustomOperation`).
  *
  * Both parameters distribute, so the wide default
  * (`OperationKind`/`OperationCardinality`, used for the bare
  * `CustomOperationConfig<Entity>` in `OperationsConfig`'s index-signature
- * upper bound) resolves to `"errors" | "cache" | "delete" | "pagination"` —
- * permissive enough to be an upper bound, while a concrete entry's own
- * literals give the exact row.
+ * upper bound) resolves to `"errors" | "cache" | "delete" | "pagination" |
+ * "realtime"` — permissive enough to be an upper bound, while a concrete
+ * entry's own literals give the exact row.
  */
 type CustomOperationSettingsKey<
   Kind extends OperationKind,
@@ -624,7 +643,9 @@ type CustomOperationSettingsKey<
   ? Cardinality extends "many"
     ? "errors" | "cache" | "delete" | "pagination"
     : "errors" | "cache" | "delete"
-  : "errors" | "cache";
+  : Cardinality extends "many"
+    ? "errors" | "cache"
+    : "errors" | "cache" | "realtime";
 
 /**
  * The whole `operations` map: the standard eight at their own precise

--- a/packages/core/src/engine/kavo-engine.ts
+++ b/packages/core/src/engine/kavo-engine.ts
@@ -136,9 +136,11 @@ const INPUT_SLOTS: Readonly<Partial<Record<StandardOperationId, DtoSlot>>> = {
 /**
  * Which realtime event a standard write operation's success maps to.
  * `deleteOne`/`purgeOne` share `"deleted"` — a subscriber only needs to
- * know the row is gone, not which delete strategy produced that. Absent
- * ids (every read, and any custom operation) never emit — the vocabulary
- * is closed to what `RealtimeEventId` names.
+ * know the row is gone, not which delete strategy produced that. Every read
+ * is absent and never emits. A custom operation isn't looked up here at all
+ * — `emitRealtimeEvent` reads its `descriptor.realtimeEvent` instead
+ * (issue #175), which is `undefined` (never emits) unless the operation's
+ * own config declared one.
  */
 const REALTIME_EVENT_BY_OPERATION: Readonly<Partial<Record<StandardOperationId, RealtimeEventId>>> = {
   createOne: "created",
@@ -506,7 +508,8 @@ export class KavoEngine<Entity extends object> {
    *
    * Every check before the transport loop is ordered cheapest-first and
    * returns immediately, so an entity with realtime off (the default) or a
-   * write that only maps to `undefined` (every read, any custom operation)
+   * write that only maps to `undefined` (every read, and a custom operation
+   * that declared no `realtimeEvent`, issue #175)
    * pays for nothing beyond one map lookup and a couple of property reads
    * — no `RealtimeEventDto` is even constructed.
    */
@@ -518,7 +521,9 @@ export class KavoEngine<Entity extends object> {
     response: KavoResponse,
     context: KavoContext<Entity>,
   ): Promise<void> {
-    const eventId = REALTIME_EVENT_BY_OPERATION[descriptor.id as StandardOperationId];
+    const eventId = isStandardOperationId(descriptor.id)
+      ? REALTIME_EVENT_BY_OPERATION[descriptor.id]
+      : descriptor.realtimeEvent;
     if (eventId === undefined) {
       return;
     }
@@ -535,7 +540,7 @@ export class KavoEngine<Entity extends object> {
       return;
     }
 
-    const id = this.realtimeEntityId(descriptor.id as StandardOperationId, request, result);
+    const id = this.realtimeEntityId(descriptor, request, result);
     if (id === undefined) {
       return;
     }
@@ -741,37 +746,46 @@ export class KavoEngine<Entity extends object> {
    * `createOne` has no request id — its id comes off the created row via
    * the entity's own id field. Every other write op targets an id the
    * request already carries, already coerced to the id column's kind by
-   * `resolveInput`'s earlier call.
+   * `resolveInput`'s earlier call. A custom operation (issue #175) follows
+   * the same rule by request shape rather than by id: one that targets a
+   * row (`request.id` set, the `markPaidOne` case) uses that id; one that
+   * doesn't (the `createOne` case — a custom create, or any other handler
+   * that manufactures a new row) falls back to reading the id field off its
+   * result, exactly as `createOne` does.
    */
   private realtimeEntityId(
-    operationId: StandardOperationId,
+    descriptor: OperationDescriptor<Entity>,
     request: KavoRequest<Entity>,
     result: unknown,
   ): string | number | undefined {
-    if (operationId === "createOne") {
-      const { compositeIdFields } = this.deps.metadata;
-      const row = result as Record<string, unknown> | null;
-      if (compositeIdFields !== undefined) {
-        const values = compositeIdFields.map((field) => row?.[field]);
-        if (values.some((value) => typeof value !== "string" && typeof value !== "number")) {
-          return undefined;
-        }
-        return encodeCompositeId(values as readonly (string | number)[]);
-      }
-      const value = row?.[this.deps.metadata.idField];
-      return typeof value === "string" || typeof value === "number" ? value : undefined;
+    if (descriptor.id !== "createOne" && request.id !== null && request.id !== undefined) {
+      const id = this.coerceId(request.id);
+      return typeof id === "string" || typeof id === "number" ? id : undefined;
     }
-    const id = this.coerceId(request.id);
-    return typeof id === "string" || typeof id === "number" ? id : undefined;
+    const { compositeIdFields } = this.deps.metadata;
+    const row = result as Record<string, unknown> | null;
+    if (compositeIdFields !== undefined) {
+      const values = compositeIdFields.map((field) => row?.[field]);
+      if (values.some((value) => typeof value !== "string" && typeof value !== "number")) {
+        return undefined;
+      }
+      return encodeCompositeId(values as readonly (string | number)[]);
+    }
+    const value = row?.[this.deps.metadata.idField];
+    return typeof value === "string" || typeof value === "number" ? value : undefined;
   }
 
   /**
    * `"updated"`/`"patched"` only: the field names present in the write
    * payload — see `RealtimeEventDto.changed`'s doc for why this is not a
-   * diff against the row's previous value.
+   * diff against the row's previous value. `updateOne`/`patchOne`'s input
+   * nests the body under `data`; a custom operation's (issue #175) nests it
+   * under `body` when the request carried an id, or is the bare body itself
+   * when it didn't (`resolveInput`'s `createOne`-and-custom-writes branch).
    */
   private changedFields(input: unknown): readonly string[] {
-    const data = (input as { data?: unknown } | null)?.data;
+    const wrapped = input as { data?: unknown; body?: unknown } | null;
+    const data = wrapped?.data ?? wrapped?.body ?? wrapped;
     if (typeof data !== "object" || data === null) {
       return [];
     }

--- a/packages/core/src/operations/default-operation-registry.ts
+++ b/packages/core/src/operations/default-operation-registry.ts
@@ -436,6 +436,15 @@ function registerCustomOperation<Entity extends object>(
   const cardinality =
     requireOneOf(entityName, id, "cardinality", custom.cardinality, ["one", "many"] as const) ?? "one";
 
+  if (custom.realtimeEvent !== undefined && (kind !== "write" || cardinality !== "one")) {
+    throw new ConfigurationException(
+      entityName,
+      `operations.${id}.realtimeEvent`,
+      `'${id}' declares 'realtimeEvent' but is ${kind === "read" ? "a read" : "a 'many' write"} — only a ` +
+        `'kind: "write"', 'cardinality: "one"' operation writes a single row a 'RealtimeEventDto' can describe`,
+    );
+  }
+
   registry.register({
     id,
     kind,
@@ -444,6 +453,7 @@ function registerCustomOperation<Entity extends object>(
     handler,
     ...resolveDtoOverride(entityName, id, CUSTOM_DTO_OVERRIDE_FIELDS[kind], custom),
     meta: custom.meta ?? {},
+    ...(custom.realtimeEvent !== undefined ? { realtimeEvent: custom.realtimeEvent } : {}),
   });
 }
 

--- a/packages/core/src/operations/operation-registry.ts
+++ b/packages/core/src/operations/operation-registry.ts
@@ -1,6 +1,7 @@
 import type { OperationCardinality, OperationId, OperationKind } from "./operation.js";
 import type { OperationHandler, OperationMetadata } from "./operation-handler.js";
 import type { DtoClass } from "../dto/dto.js";
+import type { RealtimeEventId } from "../realtime/realtime-event.js";
 
 /** One registered operation: the unit the engine dispatches through. */
 export interface OperationDescriptor<Entity = unknown, Input = unknown, Output = unknown> {
@@ -21,6 +22,16 @@ export interface OperationDescriptor<Entity = unknown, Input = unknown, Output =
   /** Explicit query DTO; `null`/absent = the slot default. Typing only — see doc 04 §8. */
   readonly query?: DtoClass | null;
   readonly meta: OperationMetadata;
+  /**
+   * The realtime event a **custom** operation's write publishes as (issue
+   * #175) — `CustomOperationConfig.realtimeEvent`, carried through
+   * unvalidated at this layer (`createOperationRegistry` already checked it
+   * against `kind`/`cardinality` at bootstrap). Absent on every standard id,
+   * whose event comes from `REALTIME_EVENT_BY_OPERATION` instead — the two
+   * never overlap because a standard id is never routed through
+   * `registerCustomOperation`.
+   */
+  readonly realtimeEvent?: RealtimeEventId;
 }
 
 /**

--- a/packages/core/src/realtime/realtime-event.ts
+++ b/packages/core/src/realtime/realtime-event.ts
@@ -4,9 +4,13 @@ import type { EntityId } from "../types/entity-id.js";
  * Realtime event ids — the closed vocabulary a `RealtimeTransport` publishes
  * under. One per standard write outcome; `deleteOne` and `purgeOne` both map
  * to `"deleted"` (a subscriber only needs to know the row is gone, not which
- * delete strategy produced that). There is deliberately no id for a custom
- * operation — the vocabulary stays closed until a future issue decides what
- * a non-standard write publishes as.
+ * delete strategy produced that). A custom operation has no fixed mapping —
+ * its `kind`/`cardinality` don't say what it means the way the standard
+ * eight's do — so it declares which of these five it publishes as via
+ * `CustomOperationConfig.realtimeEvent` (issue #175); one that declares
+ * nothing emits nothing, the same silent default every custom operation had
+ * before that field existed. The vocabulary itself stays closed: a custom
+ * operation publishes as one of these five, never under its own id.
  *
  * Issue #160 / ADR-0024 (filtered collection subscriptions) considered, and rejected,
  * adding ids for a row entering/leaving a filtered subscriber's view on an

--- a/packages/core/tests/realtime.spec.ts
+++ b/packages/core/tests/realtime.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { RealtimeEventDto, RealtimeTransport } from "@kavo/core";
+import type { KavoContext, RealtimeEventDto, RealtimeTransport } from "@kavo/core";
 import { ConfigurationException, createKavo } from "@kavo/core";
 import { InMemoryUserAdapter, User, userMetadata } from "./support/user-fixture.js";
 import { Account, InMemoryAccountAdapter, accountMetadata } from "./support/account-fixture.js";
@@ -265,6 +265,157 @@ describe("realtime — engine emit hook", () => {
     expect(transport.events).toHaveLength(2);
     expect(Object.isFrozen(transport)).toBe(false);
     expect(Object.isFrozen(transport.events)).toBe(false);
+  });
+});
+
+describe("realtime — custom operations (issue #175)", () => {
+  it("publishes nothing for a custom write that declares no realtimeEvent (unchanged default)", async () => {
+    const transport = new FakeTransport();
+    const { crud } = makeCrud(
+      {
+        realtime: { events: {} },
+        operations: {
+          createOne: true,
+          markPaidOne: {
+            kind: "write",
+            handler: {
+              async execute(input: { id: number }, context: KavoContext<User>) {
+                return context.repository.patch(input.id, { status: "paid" } as never, context);
+              },
+            },
+          },
+        },
+      } as never,
+      [transport],
+    );
+    await crud.createOne({ name: "Ada", email: "a@x.io", age: 36 } as never);
+    transport.events.splice(0, transport.events.length);
+
+    await crud.run("markPaidOne", { id: 1 } as never);
+
+    expect(transport.events).toHaveLength(0);
+  });
+
+  it("publishes the declared event, using the request id, for a custom write on an existing row", async () => {
+    const transport = new FakeTransport();
+    const { crud } = makeCrud(
+      {
+        realtime: { events: {} },
+        operations: {
+          createOne: true,
+          markPaidOne: {
+            kind: "write",
+            realtimeEvent: "updated",
+            handler: {
+              async execute(input: { id: number; body: { status: string } }, context: KavoContext<User>) {
+                return context.repository.patch(input.id, { status: input.body.status } as never, context);
+              },
+            },
+          },
+        },
+      } as never,
+      [transport],
+    );
+    await crud.createOne({ name: "Ada", email: "a@x.io", age: 36 } as never);
+    transport.events.splice(0, transport.events.length);
+
+    await crud.run("markPaidOne", { id: 1, body: { status: "active" } } as never);
+
+    expect(transport.events).toHaveLength(1);
+    const event = transport.events[0]!;
+    expect(event.event).toBe("updated");
+    expect(event.id).toBe(1);
+    expect(event.channel).toBe("User.1");
+    expect(event.item).toMatchObject({ id: 1, status: "active" });
+    expect(event.changed).toEqual(["status"]);
+  });
+
+  it("derives the id from the written row when a custom write op takes no request id (createOne-style)", async () => {
+    const transport = new FakeTransport();
+    const { crud } = makeCrud(
+      {
+        realtime: { events: {} },
+        operations: {
+          createOne: true,
+          adoptOne: {
+            kind: "write",
+            realtimeEvent: "created",
+            handler: {
+              async execute(input: { name: string; email: string; age: number }, context: KavoContext<User>) {
+                return context.repository.create(input as never, context);
+              },
+            },
+          },
+        },
+      } as never,
+      [transport],
+    );
+
+    await crud.run("adoptOne", { body: { name: "Grace", email: "g@x.io", age: 40 } } as never);
+
+    expect(transport.events).toHaveLength(1);
+    const event = transport.events[0]!;
+    expect(event.event).toBe("created");
+    expect(event.id).toBe(1);
+    expect(event.channel).toBe("User.1");
+    expect(event.item).toMatchObject({ name: "Grace" });
+  });
+
+  it("honors realtime.events: { <id>: false } for a custom operation's declared event", async () => {
+    const transport = new FakeTransport();
+    const { crud } = makeCrud(
+      {
+        realtime: { events: { updated: false } },
+        operations: {
+          createOne: true,
+          markPaidOne: {
+            kind: "write",
+            realtimeEvent: "updated",
+            handler: {
+              async execute(input: { id: number }, context: KavoContext<User>) {
+                return context.repository.patch(input.id, { status: "active" } as never, context);
+              },
+            },
+          },
+        },
+      } as never,
+      [transport],
+    );
+    await crud.createOne({ name: "Ada", email: "a@x.io", age: 36 } as never);
+    transport.events.splice(0, transport.events.length);
+
+    await crud.run("markPaidOne", { id: 1 } as never);
+
+    expect(transport.events).toHaveLength(0);
+  });
+
+  it("rejects realtimeEvent declared on a kind: 'read' custom operation at bootstrap", () => {
+    expect(() =>
+      makeCrud({
+        operations: {
+          findPendingMany: { kind: "read", cardinality: "many", realtimeEvent: "updated" },
+        },
+      } as never),
+    ).toThrowError(ConfigurationException);
+  });
+
+  it("rejects realtimeEvent declared on a cardinality: 'many' custom write at bootstrap", () => {
+    expect(() =>
+      makeCrud({
+        operations: {
+          bulkTouchMany: {
+            kind: "write",
+            cardinality: "many",
+            realtimeEvent: "updated",
+            handler: {
+              async execute() {
+                return { entities: [], total: 0 };
+              },
+            },
+          },
+        },
+      } as never),
+    ).toThrowError(ConfigurationException);
   });
 });
 

--- a/packages/core/tests/types/operation-settings-scope.test-d.ts
+++ b/packages/core/tests/types/operation-settings-scope.test-d.ts
@@ -22,7 +22,9 @@ import { Author } from "../support/blog-fixture.js";
  * For a custom operation the accepted subset follows from the `kind` and
  * `cardinality` literals the entry declares: `errors`/`cache` always,
  * `delete` on any `kind: "read"`, `pagination` also on `kind: "read",
- * cardinality: "many"`, `realtime` never.
+ * cardinality: "many"`, `realtime` on `kind: "write", cardinality: "one"`
+ * (issue #175 — the entry also has to declare `realtimeEvent` for it to do
+ * anything, but the settings key is in scope either way), never otherwise.
  *
  * Collected by `*.spec.ts` only, so nothing here runs — `tsc` checks the
  * `@ts-expect-error` directives, and an unused one is itself an error.
@@ -133,6 +135,13 @@ void kavo.createCrud(Author, {
 void kavo.createCrud(Author, {
   operations: { markPaidOne: { handler, errors: { exposeInternals: true }, cache: { etag: false } } },
 });
+// A `kind: "write"`, `cardinality: "one"` custom operation is a realtime event source (issue #175).
+void kavo.createCrud(Author, {
+  operations: { markPaidOne: { handler, realtime: false, realtimeEvent: "updated" } },
+});
+void kavo.createCrud(Author, {
+  operations: { markPaidOne: { handler, kind: "write", realtime: false, realtimeEvent: "updated" } },
+});
 
 // ── Custom operations — rejected ─────────────────────────────────────
 
@@ -156,14 +165,14 @@ void kavo.createCrud(Author, {
 });
 void kavo.createCrud(Author, {
   operations: {
-    // @ts-expect-error — a custom operation is never a realtime event source.
-    markPaidOne: { handler, realtime: false },
+    // @ts-expect-error — a read emits no realtime event, custom ids included.
+    peekArchivedOne: { handler, kind: "read", realtime: false },
   },
 });
 void kavo.createCrud(Author, {
   operations: {
-    // @ts-expect-error — a custom operation is never a realtime event source, kind: "write" included.
-    markPaidOne: { handler, kind: "write", realtime: false },
+    // @ts-expect-error — a "many" write has no single row for a RealtimeEventDto to describe.
+    markPaidMany: { handler, cardinality: "many", realtime: false },
   },
 });
 void kavo.createCrud(Author, {


### PR DESCRIPTION
## What & why

A custom operation's write emitted no realtime event, while the same column change through a standard write (e.g. `PATCH`) did — `REALTIME_EVENT_BY_OPERATION` was keyed by `StandardOperationId` alone, so `markPaidOne` setting `paidAt` through `context.repository.patch` notified no subscriber. Per the issue's three options (derive from `kind`/`cardinality`, let the operation declare it, or widen the vocabulary to custom ids), we went with **letting the operation declare it**: a `kind: "write"`, `cardinality: "one"` custom operation can now name which of the five standard `RealtimeEventId`s its write counts as, via `operations.<id>.realtimeEvent`. Declaring it on a read or a `"many"` write is a bootstrap `ConfigurationException`. The vocabulary itself stays closed — a custom operation publishes as one of the five standard ids, never under its own name, so a subscriber can still learn the whole vocabulary from `RealtimeEventId` alone.

Also generalized the engine's row-id/changed-fields extraction so it works for a custom operation the same way it already does for the standard eight (falling back to the written row's id field when the request carried none, and reading `changed` off either a standard `{data}` or a custom `{body}`/bare-body input shape).

Closes #175

## Public API impact

`CustomOperationConfig` gains an optional `realtimeEvent` field; `CustomOperationSettingsKey` widens to accept `realtime` for `kind: "write"`, `cardinality: "one"` entries. Additive only — no barrel changes (`packages/core/src/index.ts` untouched), not breaking for an existing consumer.

## Testing

Added 7 cases to `packages/core/tests/realtime.spec.ts`: declares-and-publishes with the request id, id-from-result fallback (create-like custom write), no-op when `realtimeEvent` is undeclared, muting via `realtime.events.<id>: false`, and the two bootstrap-rejection cases (`kind: "read"`, `cardinality: "many"`). Updated `packages/core/tests/types/operation-settings-scope.test-d.ts`'s `@ts-expect-error` cases to match the widened settings scope.

`pnpm check`: build, typecheck, depcruise, and lint all pass; 2858/2858 runnable tests pass. The 13 mongoose/testcontainers e2e suites fail in this sandbox only on missing Docker/network (pre-existing, confirmed unrelated by running the full suite with them excluded — all green). `pnpm docs:links` passes.

## Review notes

Doc 18, ADR-0025's Consequences section, and the adopter-facing docs (`features/realtime-events.md`, `core/custom-operations.md`, `guides/configuration/operations.md`) were updated to match. No follow-up left open by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NMPgFppfDFbhXEvb9Gnb9s)_